### PR TITLE
docs: document group-based RBAC for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,55 @@
 The server reads Kubernetes secrets from the namespace specified by the `--namespace` flag. The default namespace is `holos-console`.
 
 Secrets must have the label `app.kubernetes.io/managed-by=console.holos.run` to appear in the UI.
+
+## Group-Based Access Control for Secrets
+
+Access to secrets is controlled by comparing the user's OIDC groups with allowed groups specified on each secret.
+
+### How It Works
+
+1. **User Groups**: When a user logs in via OIDC, their group memberships are extracted from the `groups` claim in the ID token.
+
+2. **Secret Allowed Groups**: Each secret specifies which groups can access it via the `holos.run/allowed-groups` annotation. This annotation must contain a JSON array of group names.
+
+3. **Access Decision**: A user can read a secret if they belong to at least one group listed in the secret's `holos.run/allowed-groups` annotation. If the annotation is missing or empty, no users can access the secret.
+
+### Secret Configuration
+
+To make a secret accessible through the console, configure it with:
+
+1. **Required label** (makes the secret visible in the UI):
+   ```yaml
+   labels:
+     app.kubernetes.io/managed-by: console.holos.run
+   ```
+
+2. **Required annotation** (controls who can read the secret data):
+   ```yaml
+   annotations:
+     holos.run/allowed-groups: '["admin", "developers"]'
+   ```
+
+### Example Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-app-credentials
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    holos.run/allowed-groups: '["platform-team", "my-app-owners"]'
+stringData:
+  API_KEY: secret-value
+type: Opaque
+```
+
+In this example, users in either the `platform-team` or `my-app-owners` groups can view the secret.
+
+### UI Behavior
+
+- **Secrets List**: The `/secrets` page shows all console-managed secrets. Secrets the user cannot access display a "No access" indicator with a tooltip showing which groups are allowed.
+- **Secret Detail**: The `/secrets/:name` page displays the secret data in environment variable format (`KEY=value`) for authorized users. Unauthorized users receive a permission denied error.


### PR DESCRIPTION
## Summary
- Documents how group-based access control works for listing and reading secrets
- Explains the required label and annotation configuration
- Provides example secret configuration
- Describes UI behavior for accessible and inaccessible secrets

## Test plan
- [ ] Review documentation for accuracy and clarity
- [ ] Verify annotation format matches implementation (`holos.run/allowed-groups` with JSON array)

🤖 Generated with [Claude Code](https://claude.com/claude-code)