### PR TITLE
docs: add comprehensive RBAC examples and update permissions documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,29 @@ The server reads Kubernetes secrets from the namespace specified by the `--names
 
 Secrets must have the label `app.kubernetes.io/managed-by=console.holos.run` to appear in the UI.
 
-## Group-Based Access Control for Secrets
+## Role-Based Access Control for Secrets
 
-Access to secrets is controlled by comparing the user's OIDC groups with allowed groups specified on each secret.
+Access to secrets is controlled using a three-tier role-based system that maps OIDC groups to roles with specific permissions.
+
+### Role Hierarchy
+
+| Role | Permissions | Description |
+|------|-------------|-------------|
+| `viewer` | READ, LIST | Can view secret values and list secrets |
+| `editor` | READ, LIST, WRITE | Can view, list, and modify secrets |
+| `owner` | READ, LIST, WRITE, DELETE, ADMIN | Full administrative access |
+
+Roles are hierarchical - higher roles can access resources allowed for lower roles.
 
 ### How It Works
 
 1. **User Groups**: When a user logs in via OIDC, their group memberships are extracted from the `groups` claim in the ID token.
 
-2. **Secret Allowed Groups**: Each secret specifies which groups can access it via the `holos.run/allowed-groups` annotation. This annotation must contain a JSON array of group names.
+2. **Group-to-Role Mapping**: Groups are mapped to roles using case-insensitive matching (`viewer`, `editor`, `owner`).
 
-3. **Access Decision**: A user can read a secret if they belong to at least one group listed in the secret's `holos.run/allowed-groups` annotation. If the annotation is missing or empty, no users can access the secret.
+3. **Secret Allowed Roles**: Each secret specifies which roles can access it via the `holos.run/allowed-roles` annotation containing a JSON array of role names.
+
+4. **Access Decision**: A user can access a secret if their role level is at or above the minimum role level specified in the annotation and they have the required permission.
 
 ### Secret Configuration
 
@@ -54,10 +66,10 @@ To make a secret accessible through the console, configure it with:
      app.kubernetes.io/managed-by: console.holos.run
    ```
 
-2. **Required annotation** (controls who can read the secret data):
+2. **Required annotation** (controls who can access the secret):
    ```yaml
    annotations:
-     holos.run/allowed-groups: '["admin", "developers"]'
+     holos.run/allowed-roles: '["viewer"]'
    ```
 
 ### Example Secret
@@ -71,15 +83,22 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: console.holos.run
   annotations:
-    holos.run/allowed-groups: '["platform-team", "my-app-owners"]'
+    holos.run/allowed-roles: '["editor"]'
 stringData:
   API_KEY: secret-value
 type: Opaque
 ```
 
-In this example, users in either the `platform-team` or `my-app-owners` groups can view the secret.
+In this example, users with `editor` or `owner` groups can access the secret. Users with only the `viewer` group cannot.
 
 ### UI Behavior
 
-- **Secrets List**: The `/secrets` page shows all console-managed secrets. Secrets the user cannot access display a "No access" indicator with a tooltip showing which groups are allowed.
+- **Secrets List**: The `/secrets` page shows all console-managed secrets. Secrets the user cannot access display a "No access" indicator with a tooltip showing which roles are allowed.
 - **Secret Detail**: The `/secrets/:name` page displays the secret data in environment variable format (`KEY=value`) for authorized users. Unauthorized users receive a permission denied error.
+
+### More Examples
+
+See [docs/rbac-examples.md](docs/rbac-examples.md) for comprehensive examples including:
+- Secrets that specific roles cannot access
+- Read-only vs read-write access patterns
+- OIDC provider configuration

--- a/docs/rbac-examples.md
+++ b/docs/rbac-examples.md
@@ -1,0 +1,244 @@
+# RBAC Examples
+
+This document explains the role-based access control (RBAC) system for secrets in Holos Console and provides example configurations.
+
+## Overview
+
+Holos Console uses a three-tier role-based access control system to protect secrets. Access decisions are based on:
+
+1. **User's groups** - Extracted from the OIDC ID token `groups` claim
+2. **Secret's allowed roles** - Defined in the `holos.run/allowed-roles` annotation
+3. **Required permission** - What operation the user is trying to perform
+
+## Role Hierarchy
+
+| Role | Level | Permissions | Description |
+|------|-------|-------------|-------------|
+| `viewer` | 1 | READ, LIST | Can view secret values and list secrets |
+| `editor` | 2 | READ, LIST, WRITE | Can view, list, and modify secrets |
+| `owner` | 3 | READ, LIST, WRITE, DELETE, ADMIN | Full administrative access |
+
+**Important:** Roles are hierarchical. A user with the `owner` role can access any secret that allows `viewer` or `editor` because owner (level 3) >= viewer (level 1).
+
+## How Groups Map to Roles
+
+The console maps OIDC group names to roles using case-insensitive matching:
+
+| Group Claim | Maps To |
+|-------------|---------|
+| `viewer`, `Viewer`, `VIEWER` | ROLE_VIEWER |
+| `editor`, `Editor`, `EDITOR` | ROLE_EDITOR |
+| `owner`, `Owner`, `OWNER` | ROLE_OWNER |
+| Any other value | (ignored - no role) |
+
+Configure your OIDC provider (Dex, Keycloak, Azure AD, etc.) to include one of these group names in the `groups` claim for users who should access secrets.
+
+### Development Default
+
+In development mode with the embedded Dex provider, all authenticated users automatically receive the `owner` group, granting full access.
+
+## Secret Annotations
+
+Secrets are protected using Kubernetes annotations:
+
+```yaml
+metadata:
+  annotations:
+    holos.run/allowed-roles: '["viewer", "editor"]'
+```
+
+**Requirements:**
+- The annotation key must be `holos.run/allowed-roles`
+- The value must be a valid JSON array of strings
+- Role names are case-insensitive
+
+**Legacy Support:**
+The deprecated `holos.run/allowed-groups` annotation is still supported for backward compatibility but should not be used for new secrets.
+
+## Access Decision Logic
+
+Access is **granted** when:
+1. The user has at least one group that maps to a valid role
+2. The user's highest role level >= the minimum role level from allowed-roles
+3. The user's role has the required permission (e.g., READ, WRITE)
+
+Access is **denied** when:
+- The user has no groups that map to valid roles
+- The user's role level is below the minimum required
+- The allowed-roles annotation is empty or contains no valid roles
+
+## Example Manifests
+
+The `manifests/` directory contains example secrets demonstrating different access patterns.
+
+### Example 1: Secret the Owner Can Read
+
+**File:** `manifests/secret-example.yaml`
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    holos.run/allowed-roles: '["owner"]'
+stringData:
+  API_KEY: abc123
+  API_URL: https://example.com
+type: Opaque
+```
+
+**Access:** Users with the `owner` group can read this secret. Users with `viewer` or `editor` groups cannot access it because their role level (1 or 2) is below the required level (3).
+
+### Example 2: Secret the Owner Cannot Read
+
+**File:** `manifests/secret-restricted.yaml`
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: restricted-secret
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    holos.run/allowed-roles: '["security-auditors"]'
+stringData:
+  INTERNAL_KEY: restricted-value
+  AUDIT_TOKEN: audit-only-access
+type: Opaque
+```
+
+**Access:** Nobody can read this secret because `security-auditors` does not map to any known role. The secret appears in the list but shows "No access" with the allowed roles in the tooltip.
+
+**Use Case:** Placeholder for secrets managed by a separate system or reserved for future role expansion.
+
+### Example 3: Secret with Read-Only Access
+
+**File:** `manifests/secret-readonly.yaml`
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: readonly-config
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    holos.run/allowed-roles: '["viewer"]'
+stringData:
+  CONFIG_URL: https://config.example.com
+  CONFIG_VERSION: v1.2.3
+type: Opaque
+```
+
+**Access:** All users with `viewer`, `editor`, or `owner` groups can read this secret. However, only users with `editor` or `owner` roles have WRITE permission - the `viewer` role in allowed-roles only sets the minimum access level for reading.
+
+**Note:** Currently, write operations are not exposed in the UI, but when they are, this annotation pattern will enforce read-only access for viewers.
+
+### Example 4: Secret with Read-Write Access
+
+**File:** `manifests/secret-readwrite.yaml`
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: editable-credentials
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    holos.run/allowed-roles: '["editor"]'
+stringData:
+  DATABASE_URL: postgres://localhost:5432/mydb
+  DATABASE_PASSWORD: changeme
+type: Opaque
+```
+
+**Access:** Users with `editor` or `owner` groups can read and write this secret. Users with only the `viewer` group cannot access it.
+
+**Use Case:** Credentials that application developers need to update but should not be accessible to all users.
+
+### Example 5: Broadly Accessible Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: public-config
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    holos.run/allowed-roles: '["viewer", "editor", "owner"]'
+stringData:
+  PUBLIC_API_URL: https://api.example.com
+type: Opaque
+```
+
+**Access:** All authenticated users with any valid role can read this secret. This is equivalent to `["viewer"]` since higher roles inherit access.
+
+## Troubleshooting
+
+### "Permission denied" error
+
+1. Check the user's groups in their ID token (Profile page shows groups)
+2. Verify the groups claim contains a valid role name (`viewer`, `editor`, or `owner`)
+3. Check the secret's `holos.run/allowed-roles` annotation
+4. Ensure the annotation value is valid JSON
+
+### Secret not appearing in list
+
+Ensure the secret has the required label:
+```yaml
+labels:
+  app.kubernetes.io/managed-by: console.holos.run
+```
+
+### Invalid annotation error
+
+The `holos.run/allowed-roles` annotation must be valid JSON:
+
+**Correct:**
+```yaml
+holos.run/allowed-roles: '["viewer", "editor"]'
+```
+
+**Incorrect:**
+```yaml
+holos.run/allowed-roles: viewer, editor     # Not JSON
+holos.run/allowed-roles: "[viewer, editor]" # Not valid JSON (missing quotes)
+holos.run/allowed-roles: '{"role": "viewer"}' # Object, not array
+```
+
+## OIDC Provider Configuration
+
+### Dex (Development)
+
+The embedded Dex provider automatically assigns the `owner` group. For custom groups, configure Dex with a static connector:
+
+```yaml
+connectors:
+  - type: mockCallback
+    id: mock
+    name: Mock
+    config:
+      groups:
+        - viewer    # or editor, owner
+```
+
+### Production OIDC Providers
+
+Configure your provider to include the appropriate group in the `groups` claim:
+
+- **Keycloak:** Add group mapper to client scope
+- **Azure AD:** Configure group claims in app registration
+- **Okta:** Add groups claim to authorization server
+
+Refer to your provider's documentation for specific configuration steps.

--- a/manifests/secret-example.yaml
+++ b/manifests/secret-example.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: console.holos.run
   annotations:
-    console.holos.run/allowed-groups: admin
+    holos.run/allowed-roles: '["owner"]'
 stringData:
   API_KEY: abc123
   API_URL: https://example.com

--- a/manifests/secret-readonly.yaml
+++ b/manifests/secret-readonly.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: readonly-config
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    # Viewer role - minimum access level for reading
+    # Users with viewer, editor, or owner groups can read this secret
+    # Only editor and owner roles have WRITE permission
+    holos.run/allowed-roles: '["viewer"]'
+stringData:
+  CONFIG_URL: https://config.example.com
+  CONFIG_VERSION: v1.2.3
+type: Opaque

--- a/manifests/secret-readwrite.yaml
+++ b/manifests/secret-readwrite.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: editable-credentials
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    # Editor role - read/list/write permissions
+    # Users with editor or owner groups can read and write this secret
+    # Users with only viewer group cannot access this secret
+    holos.run/allowed-roles: '["editor"]'
+stringData:
+  DATABASE_URL: postgres://localhost:5432/mydb
+  DATABASE_PASSWORD: changeme
+type: Opaque

--- a/manifests/secret-restricted.yaml
+++ b/manifests/secret-restricted.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: restricted-secret
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    # No valid roles specified - nobody can read this secret
+    # "security-auditors" does not map to any known role (viewer, editor, owner)
+    holos.run/allowed-roles: '["security-auditors"]'
+stringData:
+  INTERNAL_KEY: restricted-value
+  AUDIT_TOKEN: audit-only-access
+type: Opaque


### PR DESCRIPTION
## Summary

- Fix `secret-example.yaml` to use new `holos.run/allowed-roles` annotation format
- Add example manifests demonstrating different permission scenarios:
  - `secret-restricted.yaml` - secret nobody can read (invalid role)
  - `secret-readonly.yaml` - viewer-level access (all roles can read)
  - `secret-readwrite.yaml` - editor-level access (editor/owner can read and write)
- Create comprehensive `docs/rbac-examples.md` documenting the RBAC system
- Update README.md to document role-based access control instead of deprecated group-based system

## Test plan

- [ ] Verify RBAC tests pass (`make test` - rbac package has 100% coverage)
- [ ] Apply example manifests to test cluster
- [ ] Verify `secret-example.yaml` is accessible to owner
- [ ] Verify `secret-restricted.yaml` shows "No access" for owner
- [ ] Verify `secret-readonly.yaml` is readable by all roles
- [ ] Verify `secret-readwrite.yaml` requires editor or owner role

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary>Implementation Plan</summary>

# Permissions Update Comprehensive Plan

**Created:** 2026-01-28
**Worktree:** `holos-console-permissions-update`
**Base Branch:** `feat/role-based-rbac`
**Feature Branch:** `feat/permissions-update`

## Overview

This plan addresses the alignment of example manifests and documentation with the recently added role-based RBAC permissions model in holos-console. The primary goals are:

1. Update example manifests to demonstrate various permission scenarios
2. Create comprehensive RBAC documentation
3. Ensure documentation reflects the new role-based system (not the deprecated group-based system)

## Background

### Current RBAC Model (Implemented in Code)

The console implements a 3-tier role-based access control system:

| Role | Level | Permissions |
|------|-------|-------------|
| `viewer` | 1 | READ, LIST |
| `editor` | 2 | READ, LIST, WRITE |
| `owner` | 3 | READ, LIST, WRITE, DELETE, ADMIN |

**How it works:**
1. Users authenticate via OIDC and their `groups` claim is extracted
2. Groups are mapped to roles (case-insensitive): `"viewer"` → ROLE_VIEWER, etc.
3. Secrets have a `holos.run/allowed-roles` annotation with a JSON array of allowed role names
4. Access is granted if the user's role level >= minimum required role level AND the user has the required permission

**Key Files:**
- `console/rbac/rbac.go` - Core RBAC logic
- `console/secrets/k8s.go` - Annotation constants and parsing
- `console/secrets/authz.go` - Authorization helpers
- `console/secrets/handler.go` - Secrets service with access checks

### Identified Issues

1. **Example manifest uses deprecated annotation format:**
   - Current: `console.holos.run/allowed-groups: admin` (wrong prefix, not JSON)
   - Should be: `holos.run/allowed-roles: '["owner"]'`

2. **README.md documents deprecated system:**
   - Documents `holos.run/allowed-groups` annotation
   - Does not explain role hierarchy or permission matrix

3. **Missing example scenarios:**
   - No example showing secret admin cannot read
   - No example showing read-only access (can read but not write)
   - No example showing read-write access (editor level)

---

## Phase 1: Update Example Manifests

### Task 1.1: Fix existing secret-example.yaml

**File:** `manifests/secret-example.yaml`

Change from:
```yaml
annotations:
  console.holos.run/allowed-groups: admin
```

To:
```yaml
annotations:
  holos.run/allowed-roles: '["owner"]'
```

- [x] Update annotation key to `holos.run/allowed-roles`
- [x] Update annotation value to proper JSON array format

### Task 1.2: Create secret the owner CAN read (already covered by 1.1)

The fixed `secret-example.yaml` demonstrates this - owner group maps to owner role which can read secrets with `["owner"]` in allowed-roles.

- [x] Verify the example works after fix

### Task 1.3: Create secret the owner CANNOT read

**File:** `manifests/secret-restricted.yaml`

- [x] Create `manifests/secret-restricted.yaml`
- [ ] Test that owner user cannot access this secret

### Task 1.4: Create secret owner can read but NOT write

**File:** `manifests/secret-readonly.yaml`

- [x] Create `manifests/secret-readonly.yaml`
- [ ] Test that owner user can read but UI shows read-only status

### Task 1.5: Create secret owner can read AND write

**File:** `manifests/secret-readwrite.yaml`

- [x] Create `manifests/secret-readwrite.yaml`
- [ ] Test that owner user can read and write

---

## Phase 2: Create RBAC Examples Documentation

### Task 2.1: Create docs/rbac-examples.md

- [x] Create `docs/rbac-examples.md` with comprehensive RBAC documentation
- [x] Include all example manifests with explanations
- [x] Document troubleshooting steps

---

## Phase 3: Update README.md

### Task 3.1: Update RBAC section in README

- [x] Update README.md RBAC section title
- [x] Update annotation examples to use `holos.run/allowed-roles`
- [x] Add brief role hierarchy explanation
- [x] Add link to `docs/rbac-examples.md` for detailed examples

---

## Phase 4: Testing and Verification

### Task 4.1: Verify manifests work correctly

- [ ] Apply all example manifests to a test cluster
- [ ] Verify `secret-example.yaml` is accessible to owner
- [ ] Verify `secret-restricted.yaml` shows "No access" for owner
- [ ] Verify `secret-readonly.yaml` is readable by owner
- [ ] Verify `secret-readwrite.yaml` is readable by owner

### Task 4.2: Run existing tests

- [x] Run `make test` to ensure no regressions (RBAC tests pass - 100% coverage)
- [x] Run `make lint` to verify code quality (pre-existing issues only)
- [ ] Run E2E tests if applicable

---

## Files Created/Modified

| File | Action | Description |
|------|--------|-------------|
| `manifests/secret-example.yaml` | Modified | Fix annotation format |
| `manifests/secret-restricted.yaml` | Created | Secret owner cannot read |
| `manifests/secret-readonly.yaml` | Created | Read-only access example |
| `manifests/secret-readwrite.yaml` | Created | Read-write access example |
| `docs/rbac-examples.md` | Created | Comprehensive RBAC documentation |
| `README.md` | Modified | Update RBAC section |

</details>