### PR TITLE
Add configurable OIDC group-to-role mapping

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/holos-run/holos-console/console"
+	"github.com/holos-run/holos-console/console/rbac"
 )
 
 var (
@@ -26,6 +27,9 @@ var (
 	refreshTokenTTL string
 	namespace       string
 	logLevel        string
+	viewerGroups    string
+	editorGroups    string
+	ownerGroups     string
 )
 
 // Command returns the root cobra command for the CLI.
@@ -78,6 +82,11 @@ func Command() *cobra.Command {
 
 	// Kubernetes flags
 	cmd.Flags().StringVar(&namespace, "namespace", "holos-console", "Kubernetes namespace for secrets")
+
+	// RBAC group mapping flags
+	cmd.Flags().StringVar(&viewerGroups, "viewer-groups", "", "Comma-separated OIDC groups that map to the viewer role (default: viewer)")
+	cmd.Flags().StringVar(&editorGroups, "editor-groups", "", "Comma-separated OIDC groups that map to the editor role (default: editor)")
+	cmd.Flags().StringVar(&ownerGroups, "owner-groups", "", "Comma-separated OIDC groups that map to the owner role (default: owner)")
 
 	// Logging flags
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
@@ -194,6 +203,9 @@ func Run(cmd *cobra.Command, args []string) error {
 		IDTokenTTL:      idTTL,
 		RefreshTokenTTL: refreshTTL,
 		Namespace:       namespace,
+		ViewerGroups:    rbac.ParseGroups(viewerGroups),
+		EditorGroups:    rbac.ParseGroups(editorGroups),
+		OwnerGroups:     rbac.ParseGroups(ownerGroups),
 	}
 
 	server := console.New(cfg)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -119,6 +119,41 @@ func TestDeriveIssuer(t *testing.T) {
 	}
 }
 
+func TestGroupFlags(t *testing.T) {
+	t.Run("viewer-groups flag is registered", func(t *testing.T) {
+		cmd := Command()
+		f := cmd.Flags().Lookup("viewer-groups")
+		if f == nil {
+			t.Fatal("expected --viewer-groups flag to be registered")
+		}
+		if f.DefValue != "" {
+			t.Errorf("expected empty default, got %q", f.DefValue)
+		}
+	})
+
+	t.Run("editor-groups flag is registered", func(t *testing.T) {
+		cmd := Command()
+		f := cmd.Flags().Lookup("editor-groups")
+		if f == nil {
+			t.Fatal("expected --editor-groups flag to be registered")
+		}
+		if f.DefValue != "" {
+			t.Errorf("expected empty default, got %q", f.DefValue)
+		}
+	})
+
+	t.Run("owner-groups flag is registered", func(t *testing.T) {
+		cmd := Command()
+		f := cmd.Flags().Lookup("owner-groups")
+		if f == nil {
+			t.Fatal("expected --owner-groups flag to be registered")
+		}
+		if f.DefValue != "" {
+			t.Errorf("expected empty default, got %q", f.DefValue)
+		}
+	})
+}
+
 func TestTTLParsing(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/console/secrets/authz.go
+++ b/console/secrets/authz.go
@@ -10,26 +10,26 @@ import (
 
 // CheckReadAccess verifies that the user has permission to read secrets.
 // Uses role-based access control with the PERMISSION_SECRETS_READ permission.
-func CheckReadAccess(userGroups, allowedRoles []string) error {
-	return rbac.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsRead)
+func CheckReadAccess(gm *rbac.GroupMapping, userGroups, allowedRoles []string) error {
+	return gm.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsRead)
 }
 
 // CheckWriteAccess verifies that the user has permission to write secrets.
 // Uses role-based access control with the PERMISSION_SECRETS_WRITE permission.
-func CheckWriteAccess(userGroups, allowedRoles []string) error {
-	return rbac.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsWrite)
+func CheckWriteAccess(gm *rbac.GroupMapping, userGroups, allowedRoles []string) error {
+	return gm.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsWrite)
 }
 
 // CheckDeleteAccess verifies that the user has permission to delete secrets.
 // Uses role-based access control with the PERMISSION_SECRETS_DELETE permission.
-func CheckDeleteAccess(userGroups, allowedRoles []string) error {
-	return rbac.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsDelete)
+func CheckDeleteAccess(gm *rbac.GroupMapping, userGroups, allowedRoles []string) error {
+	return gm.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsDelete)
 }
 
 // CheckListAccess verifies that the user has permission to list secrets.
 // Uses role-based access control with the PERMISSION_SECRETS_LIST permission.
-func CheckListAccess(userGroups, allowedRoles []string) error {
-	return rbac.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsList)
+func CheckListAccess(gm *rbac.GroupMapping, userGroups, allowedRoles []string) error {
+	return gm.CheckAccess(userGroups, allowedRoles, rbac.PermissionSecretsList)
 }
 
 // CheckAccess verifies that the user has at least one group in common with the allowed groups.

--- a/console/secrets/authz_test.go
+++ b/console/secrets/authz_test.go
@@ -5,14 +5,22 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/holos-run/holos-console/console/rbac"
 )
 
+// defaultGM returns the default GroupMapping for tests.
+func defaultGM() *rbac.GroupMapping {
+	return rbac.NewGroupMapping(nil, nil, nil)
+}
+
 func TestCheckReadAccess(t *testing.T) {
+	gm := defaultGM()
+
 	t.Run("allows read access for viewer role", func(t *testing.T) {
 		userGroups := []string{"viewer"}
 		allowedRoles := []string{"viewer"}
 
-		err := CheckReadAccess(userGroups, allowedRoles)
+		err := CheckReadAccess(gm, userGroups, allowedRoles)
 		if err != nil {
 			t.Errorf("expected nil error (access granted), got %v", err)
 		}
@@ -22,7 +30,7 @@ func TestCheckReadAccess(t *testing.T) {
 		userGroups := []string{"owner"}
 		allowedRoles := []string{"viewer"}
 
-		err := CheckReadAccess(userGroups, allowedRoles)
+		err := CheckReadAccess(gm, userGroups, allowedRoles)
 		if err != nil {
 			t.Errorf("expected nil error (access granted for owner), got %v", err)
 		}
@@ -32,7 +40,7 @@ func TestCheckReadAccess(t *testing.T) {
 		userGroups := []string{"developers"}
 		allowedRoles := []string{"viewer", "editor"}
 
-		err := CheckReadAccess(userGroups, allowedRoles)
+		err := CheckReadAccess(gm, userGroups, allowedRoles)
 		if err == nil {
 			t.Fatal("expected PermissionDenied error, got nil")
 		}
@@ -47,11 +55,13 @@ func TestCheckReadAccess(t *testing.T) {
 }
 
 func TestCheckWriteAccess(t *testing.T) {
+	gm := defaultGM()
+
 	t.Run("allows write access for editor role", func(t *testing.T) {
 		userGroups := []string{"editor"}
 		allowedRoles := []string{"editor"}
 
-		err := CheckWriteAccess(userGroups, allowedRoles)
+		err := CheckWriteAccess(gm, userGroups, allowedRoles)
 		if err != nil {
 			t.Errorf("expected nil error (access granted), got %v", err)
 		}
@@ -61,7 +71,7 @@ func TestCheckWriteAccess(t *testing.T) {
 		userGroups := []string{"owner"}
 		allowedRoles := []string{"editor"}
 
-		err := CheckWriteAccess(userGroups, allowedRoles)
+		err := CheckWriteAccess(gm, userGroups, allowedRoles)
 		if err != nil {
 			t.Errorf("expected nil error (access granted for owner), got %v", err)
 		}
@@ -71,7 +81,7 @@ func TestCheckWriteAccess(t *testing.T) {
 		userGroups := []string{"viewer"}
 		allowedRoles := []string{"editor"}
 
-		err := CheckWriteAccess(userGroups, allowedRoles)
+		err := CheckWriteAccess(gm, userGroups, allowedRoles)
 		if err == nil {
 			t.Fatal("expected PermissionDenied error, got nil")
 		}
@@ -86,11 +96,13 @@ func TestCheckWriteAccess(t *testing.T) {
 }
 
 func TestCheckDeleteAccess(t *testing.T) {
+	gm := defaultGM()
+
 	t.Run("allows delete access for owner role", func(t *testing.T) {
 		userGroups := []string{"owner"}
 		allowedRoles := []string{"owner"}
 
-		err := CheckDeleteAccess(userGroups, allowedRoles)
+		err := CheckDeleteAccess(gm, userGroups, allowedRoles)
 		if err != nil {
 			t.Errorf("expected nil error (access granted), got %v", err)
 		}
@@ -100,7 +112,7 @@ func TestCheckDeleteAccess(t *testing.T) {
 		userGroups := []string{"editor"}
 		allowedRoles := []string{"owner"}
 
-		err := CheckDeleteAccess(userGroups, allowedRoles)
+		err := CheckDeleteAccess(gm, userGroups, allowedRoles)
 		if err == nil {
 			t.Fatal("expected PermissionDenied error, got nil")
 		}
@@ -117,7 +129,7 @@ func TestCheckDeleteAccess(t *testing.T) {
 		userGroups := []string{"viewer"}
 		allowedRoles := []string{"owner"}
 
-		err := CheckDeleteAccess(userGroups, allowedRoles)
+		err := CheckDeleteAccess(gm, userGroups, allowedRoles)
 		if err == nil {
 			t.Fatal("expected PermissionDenied error, got nil")
 		}
@@ -125,11 +137,13 @@ func TestCheckDeleteAccess(t *testing.T) {
 }
 
 func TestCheckListAccess(t *testing.T) {
+	gm := defaultGM()
+
 	t.Run("allows list access for viewer role", func(t *testing.T) {
 		userGroups := []string{"viewer"}
 		allowedRoles := []string{"viewer"}
 
-		err := CheckListAccess(userGroups, allowedRoles)
+		err := CheckListAccess(gm, userGroups, allowedRoles)
 		if err != nil {
 			t.Errorf("expected nil error (access granted), got %v", err)
 		}
@@ -139,7 +153,7 @@ func TestCheckListAccess(t *testing.T) {
 		userGroups := []string{"developers"}
 		allowedRoles := []string{"viewer"}
 
-		err := CheckListAccess(userGroups, allowedRoles)
+		err := CheckListAccess(gm, userGroups, allowedRoles)
 		if err == nil {
 			t.Fatal("expected PermissionDenied error, got nil")
 		}

--- a/console/secrets/handler_test.go
+++ b/console/secrets/handler_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -71,7 +72,7 @@ func TestHandler_GetSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		// Create authenticated context with matching role group
 		claims := &rpc.Claims{
@@ -113,7 +114,7 @@ func TestHandler_GetSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		// Context without claims
 		ctx := context.Background()
@@ -153,7 +154,7 @@ func TestHandler_GetSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		// Create authenticated context with non-matching role group
 		claims := &rpc.Claims{
@@ -187,7 +188,7 @@ func TestHandler_GetSecret(t *testing.T) {
 		// Given: Authenticated user, secret does not exist
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -220,7 +221,7 @@ func TestHandler_GetSecret(t *testing.T) {
 		// Given: Request with empty secret name
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -267,7 +268,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		// Capture logs
 		logHandler := &testLogHandler{}
@@ -341,7 +342,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		// Capture logs
 		logHandler := &testLogHandler{}
@@ -416,7 +417,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -437,7 +438,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 	t.Run("returns Unauthenticated for missing auth", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		ctx := context.Background()
 		req := connect.NewRequest(&consolev1.DeleteSecretRequest{Name: "my-secret"})
@@ -472,7 +473,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -512,7 +513,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -540,7 +541,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 	t.Run("returns NotFound for non-existent secret", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -568,7 +569,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 	t.Run("returns InvalidArgument for empty name", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -610,7 +611,7 @@ func TestHandler_DeleteSecret_AuditLogging(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		logHandler := &testLogHandler{}
 		oldLogger := slog.Default()
@@ -655,7 +656,7 @@ func TestHandler_DeleteSecret_AuditLogging(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		logHandler := &testLogHandler{}
 		oldLogger := slog.Default()
@@ -691,7 +692,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 		// Given: No secrets exist, user is editor
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -721,7 +722,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 	t.Run("returns Unauthenticated for missing auth", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		ctx := context.Background()
 		req := connect.NewRequest(&consolev1.CreateSecretRequest{
@@ -747,7 +748,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 	t.Run("returns PermissionDenied for viewer", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -779,7 +780,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 	t.Run("returns InvalidArgument for empty name", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -811,7 +812,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 	t.Run("returns InvalidArgument for empty allowed_roles", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -849,7 +850,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(existing)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -883,7 +884,7 @@ func TestHandler_CreateSecret_AuditLogging(t *testing.T) {
 	t.Run("logs secret_create on success", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		logHandler := &testLogHandler{}
 		oldLogger := slog.Default()
@@ -920,7 +921,7 @@ func TestHandler_CreateSecret_AuditLogging(t *testing.T) {
 	t.Run("logs secret_create_denied on RBAC failure", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		logHandler := &testLogHandler{}
 		oldLogger := slog.Default()
@@ -975,7 +976,7 @@ func TestHandler_UpdateSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1004,7 +1005,7 @@ func TestHandler_UpdateSecret(t *testing.T) {
 		// Given: Request without claims
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		ctx := context.Background()
 		req := connect.NewRequest(&consolev1.UpdateSecretRequest{
@@ -1045,7 +1046,7 @@ func TestHandler_UpdateSecret(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1079,7 +1080,7 @@ func TestHandler_UpdateSecret(t *testing.T) {
 		// Given: Secret does not exist
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1113,7 +1114,7 @@ func TestHandler_UpdateSecret(t *testing.T) {
 		// Given: Request with empty name
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1147,7 +1148,7 @@ func TestHandler_UpdateSecret(t *testing.T) {
 		// Given: Request with empty data
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1196,7 +1197,7 @@ func TestHandler_UpdateSecret_AuditLogging(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		logHandler := &testLogHandler{}
 		oldLogger := slog.Default()
@@ -1248,7 +1249,7 @@ func TestHandler_UpdateSecret_AuditLogging(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		logHandler := &testLogHandler{}
 		oldLogger := slog.Default()
@@ -1303,7 +1304,7 @@ func TestHandler_GetSecret_MultipleKeys(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1364,7 +1365,7 @@ func TestHandler_ListSecrets(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secretWithLabel, secretWithoutLabel)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1427,7 +1428,7 @@ func TestHandler_ListSecrets(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(accessibleSecret, inaccessibleSecret)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",
@@ -1485,7 +1486,7 @@ func TestHandler_ListSecrets(t *testing.T) {
 		// Given: Request without claims in context
 		fakeClient := fake.NewClientset()
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		ctx := context.Background()
 		req := connect.NewRequest(&consolev1.ListSecretsRequest{})
@@ -1516,7 +1517,7 @@ func TestHandler_ListSecrets(t *testing.T) {
 		}
 		fakeClient := fake.NewClientset(secretWithoutLabel)
 		k8sClient := NewK8sClient(fakeClient, "test-namespace")
-		handler := NewHandler(k8sClient)
+		handler := NewHandler(k8sClient, rbac.NewGroupMapping(nil, nil, nil))
 
 		claims := &rpc.Claims{
 			Sub:    "user-123",


### PR DESCRIPTION
## Summary
- Add `--viewer-groups`, `--editor-groups`, and `--owner-groups` CLI flags that accept comma-separated OIDC group names to map to each built-in role
- Introduce `GroupMapping` struct in the `rbac` package, replacing the hardcoded switch statement with a configurable map
- Wire the mapping through `console.Config` → `Server` → secrets `Handler` → authorization checks
- When flags are unset, defaults to the original group names (`viewer`, `editor`, `owner`) — fully backward compatible

## Test plan
- [x] RED: Wrote failing tests for `NewGroupMapping`, `ParseGroups`, `GroupMapping.MapGroupToRole`, `GroupMapping.CheckAccess`, and CLI flag registration
- [x] GREEN: Implemented `GroupMapping` type, `ParseGroups` helper, CLI flags, and full wiring
- [x] All existing tests pass (rbac, secrets authz, secrets handler, CLI)
- [x] Race detector passes
- [x] No new lint issues introduced
- [ ] Trigger Container workflow to validate build

🤖 Generated with [Claude Code](https://claude.com/claude-code)