### PR TITLE
Add SharingPanel component and integrate into SecretPage

### DIFF
--- a/console/ui/index.html
+++ b/console/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Holos Console</title>
-    <script type="module" crossorigin src="/ui/assets/index-BZQ-2BBa.js"></script>
+    <script type="module" crossorigin src="/ui/assets/index-C75YnvKn.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/SharingPanel.test.tsx
+++ b/ui/src/components/SharingPanel.test.tsx
@@ -1,0 +1,253 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SharingPanel } from './SharingPanel'
+import { Role } from '../gen/holos/console/v1/rbac_pb'
+import { vi } from 'vitest'
+
+function grant(principal: string, role: Role) {
+  return { principal, role }
+}
+
+describe('SharingPanel', () => {
+  describe('rendering grants', () => {
+    it('renders user grants', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER), grant('bob@example.com', Role.VIEWER)]}
+          groupGrants={[]}
+          isOwner={false}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+      expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+    })
+
+    it('renders group grants', () => {
+      render(
+        <SharingPanel
+          userGrants={[]}
+          groupGrants={[grant('dev-team', Role.EDITOR), grant('platform-team', Role.OWNER)]}
+          isOwner={false}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      expect(screen.getByText('dev-team')).toBeInTheDocument()
+      expect(screen.getByText('platform-team')).toBeInTheDocument()
+    })
+
+    it('shows empty state when no grants', () => {
+      render(
+        <SharingPanel
+          userGrants={[]}
+          groupGrants={[]}
+          isOwner={false}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      expect(screen.getByText(/no sharing grants/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('owner edit mode', () => {
+    it('shows edit button for owners', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER)]}
+          groupGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
+    })
+
+    it('does not show edit button for non-owners', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER)]}
+          groupGrants={[]}
+          isOwner={false}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument()
+    })
+
+    it('shows save and cancel buttons in edit mode', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER)]}
+          groupGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('add grant', () => {
+    it('adds a new user grant in edit mode', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER)]}
+          groupGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+      fireEvent.click(screen.getByRole('button', { name: /add user/i }))
+
+      // Should show a new empty row
+      const principalInputs = screen.getAllByPlaceholderText(/email/i)
+      expect(principalInputs.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('adds a new group grant in edit mode', () => {
+      render(
+        <SharingPanel
+          userGrants={[]}
+          groupGrants={[grant('dev-team', Role.EDITOR)]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+      fireEvent.click(screen.getByRole('button', { name: /add group/i }))
+
+      const principalInputs = screen.getAllByPlaceholderText(/group/i)
+      expect(principalInputs.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('remove grant', () => {
+    it('removes a grant in edit mode', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER), grant('bob@example.com', Role.VIEWER)]}
+          groupGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      // Remove bob
+      const removeButtons = screen.getAllByLabelText(/remove/i)
+      fireEvent.click(removeButtons[1]) // second user
+
+      expect(screen.queryByDisplayValue('bob@example.com')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('save', () => {
+    it('calls onSave with updated grants', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER)]}
+          groupGrants={[grant('dev-team', Role.EDITOR)]}
+          isOwner={true}
+          onSave={onSave}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          [{ principal: 'alice@example.com', role: Role.OWNER }],
+          [{ principal: 'dev-team', role: Role.EDITOR }],
+        )
+      })
+    })
+
+    it('disables save button while saving', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER)]}
+          groupGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={true}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled()
+    })
+
+    it('exits edit mode after successful save', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER)]}
+          groupGrants={[]}
+          isOwner={true}
+          onSave={onSave}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('cancel', () => {
+    it('reverts changes on cancel', () => {
+      render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.OWNER), grant('bob@example.com', Role.VIEWER)]}
+          groupGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      // Remove bob
+      const removeButtons = screen.getAllByLabelText(/remove/i)
+      fireEvent.click(removeButtons[1])
+
+      // Cancel
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+      // Bob should be back
+      expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+    })
+  })
+})

--- a/ui/src/components/SharingPanel.tsx
+++ b/ui/src/components/SharingPanel.tsx
@@ -1,0 +1,231 @@
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import DeleteIcon from '@mui/icons-material/Delete'
+import { Role } from '../gen/holos/console/v1/rbac_pb'
+
+interface Grant {
+  principal: string
+  role: Role
+}
+
+export interface SharingPanelProps {
+  userGrants: Grant[]
+  groupGrants: Grant[]
+  isOwner: boolean
+  onSave: (userGrants: Grant[], groupGrants: Grant[]) => Promise<void>
+  isSaving: boolean
+}
+
+function roleName(role: Role): string {
+  switch (role) {
+    case Role.OWNER:
+      return 'Owner'
+    case Role.EDITOR:
+      return 'Editor'
+    case Role.VIEWER:
+      return 'Viewer'
+    default:
+      return 'Unknown'
+  }
+}
+
+export function SharingPanel({ userGrants, groupGrants, isOwner, onSave, isSaving }: SharingPanelProps) {
+  const [editing, setEditing] = useState(false)
+  const [editUserGrants, setEditUserGrants] = useState<Grant[]>([])
+  const [editGroupGrants, setEditGroupGrants] = useState<Grant[]>([])
+
+  const handleEdit = () => {
+    setEditUserGrants(userGrants.map((g) => ({ ...g })))
+    setEditGroupGrants(groupGrants.map((g) => ({ ...g })))
+    setEditing(true)
+  }
+
+  const handleCancel = () => {
+    setEditing(false)
+  }
+
+  const handleSave = async () => {
+    // Filter out empty principals
+    const users = editUserGrants.filter((g) => g.principal.trim() !== '')
+    const groups = editGroupGrants.filter((g) => g.principal.trim() !== '')
+    await onSave(users, groups)
+    setEditing(false)
+  }
+
+  const handleAddUser = () => {
+    setEditUserGrants([...editUserGrants, { principal: '', role: Role.VIEWER }])
+  }
+
+  const handleAddGroup = () => {
+    setEditGroupGrants([...editGroupGrants, { principal: '', role: Role.VIEWER }])
+  }
+
+  const handleRemoveUser = (index: number) => {
+    setEditUserGrants(editUserGrants.filter((_, i) => i !== index))
+  }
+
+  const handleRemoveGroup = (index: number) => {
+    setEditGroupGrants(editGroupGrants.filter((_, i) => i !== index))
+  }
+
+  const handleUserChange = (index: number, field: 'principal' | 'role', value: string | Role) => {
+    const updated = [...editUserGrants]
+    if (field === 'principal') {
+      updated[index] = { ...updated[index], principal: value as string }
+    } else {
+      updated[index] = { ...updated[index], role: value as Role }
+    }
+    setEditUserGrants(updated)
+  }
+
+  const handleGroupChange = (index: number, field: 'principal' | 'role', value: string | Role) => {
+    const updated = [...editGroupGrants]
+    if (field === 'principal') {
+      updated[index] = { ...updated[index], principal: value as string }
+    } else {
+      updated[index] = { ...updated[index], role: value as Role }
+    }
+    setEditGroupGrants(updated)
+  }
+
+  const hasGrants = userGrants.length > 0 || groupGrants.length > 0
+
+  if (!editing) {
+    return (
+      <Box sx={{ mt: 3 }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="subtitle1">Sharing</Typography>
+          {isOwner && (
+            <Button size="small" onClick={handleEdit}>
+              Edit
+            </Button>
+          )}
+        </Stack>
+        {!hasGrants ? (
+          <Typography variant="body2" color="text.secondary">
+            No sharing grants configured.
+          </Typography>
+        ) : (
+          <>
+            {userGrants.length > 0 && (
+              <>
+                <Typography variant="caption" color="text.secondary">
+                  Users
+                </Typography>
+                <List dense>
+                  {userGrants.map((g) => (
+                    <ListItem key={g.principal} disablePadding>
+                      <ListItemText primary={g.principal} secondary={roleName(g.role)} />
+                    </ListItem>
+                  ))}
+                </List>
+              </>
+            )}
+            {groupGrants.length > 0 && (
+              <>
+                <Typography variant="caption" color="text.secondary">
+                  Groups
+                </Typography>
+                <List dense>
+                  {groupGrants.map((g) => (
+                    <ListItem key={g.principal} disablePadding>
+                      <ListItemText primary={g.principal} secondary={roleName(g.role)} />
+                    </ListItem>
+                  ))}
+                </List>
+              </>
+            )}
+          </>
+        )}
+      </Box>
+    )
+  }
+
+  // Edit mode
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography variant="subtitle1">Sharing</Typography>
+
+      <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+        Users
+      </Typography>
+      {editUserGrants.map((g, i) => (
+        <Stack key={i} direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
+          <TextField
+            size="small"
+            placeholder="Email address"
+            value={g.principal}
+            onChange={(e) => handleUserChange(i, 'principal', e.target.value)}
+            sx={{ flex: 1 }}
+          />
+          <Select
+            size="small"
+            value={g.role}
+            onChange={(e) => handleUserChange(i, 'role', e.target.value as Role)}
+          >
+            <MenuItem value={Role.VIEWER}>Viewer</MenuItem>
+            <MenuItem value={Role.EDITOR}>Editor</MenuItem>
+            <MenuItem value={Role.OWNER}>Owner</MenuItem>
+          </Select>
+          <IconButton size="small" aria-label="remove" onClick={() => handleRemoveUser(i)}>
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      ))}
+      <Button size="small" onClick={handleAddUser} sx={{ mt: 1 }}>
+        Add User
+      </Button>
+
+      <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+        Groups
+      </Typography>
+      {editGroupGrants.map((g, i) => (
+        <Stack key={i} direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
+          <TextField
+            size="small"
+            placeholder="Group name"
+            value={g.principal}
+            onChange={(e) => handleGroupChange(i, 'principal', e.target.value)}
+            sx={{ flex: 1 }}
+          />
+          <Select
+            size="small"
+            value={g.role}
+            onChange={(e) => handleGroupChange(i, 'role', e.target.value as Role)}
+          >
+            <MenuItem value={Role.VIEWER}>Viewer</MenuItem>
+            <MenuItem value={Role.EDITOR}>Editor</MenuItem>
+            <MenuItem value={Role.OWNER}>Owner</MenuItem>
+          </Select>
+          <IconButton size="small" aria-label="remove" onClick={() => handleRemoveGroup(i)}>
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      ))}
+      <Button size="small" onClick={handleAddGroup} sx={{ mt: 1 }}>
+        Add Group
+      </Button>
+
+      <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+        <Button variant="contained" size="small" onClick={handleSave} disabled={isSaving}>
+          {isSaving ? 'Saving...' : 'Save'}
+        </Button>
+        <Button size="small" onClick={handleCancel}>
+          Cancel
+        </Button>
+      </Stack>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- New `SharingPanel` component renders user and group sharing grants with role labels
- Owners can edit sharing: add/remove grants, change roles, save via `updateSharing` RPC
- `SecretPage` fetches metadata via `listSecrets` to populate sharing panel
- Determines ownership by matching user email against `userGrants` with `ROLE_OWNER`

## Test plan
- [x] 13 unit tests for `SharingPanel` (rendering, edit mode, add/remove, save/cancel)
- [x] 3 integration tests for `SecretPage` sharing (renders grants, owner edit, save calls RPC)
- [x] All 49 UI tests pass (`make test`)
- [x] `make generate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)