### PR TITLE
Add sharing to create dialog and list summary

### DIFF
--- a/console/ui/index.html
+++ b/console/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Holos Console</title>
-    <script type="module" crossorigin src="/ui/assets/index-C75YnvKn.js"></script>
+    <script type="module" crossorigin src="/ui/assets/index-BrlK2yea.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/SecretsListPage.tsx
+++ b/ui/src/components/SecretsListPage.tsx
@@ -31,8 +31,15 @@ import { secretsClient } from '../client'
 import { Role } from '../gen/holos/console/v1/rbac_pb'
 import type { SecretMetadata } from '../gen/holos/console/v1/secrets_pb'
 
+function sharingSummary(userCount: number, groupCount: number): string | undefined {
+  const parts: string[] = []
+  if (userCount > 0) parts.push(`${userCount} user${userCount !== 1 ? 's' : ''}`)
+  if (groupCount > 0) parts.push(`${groupCount} group${groupCount !== 1 ? 's' : ''}`)
+  return parts.length > 0 ? parts.join(', ') : undefined
+}
+
 export function SecretsListPage() {
-  const { isAuthenticated, isLoading: authLoading, login, getAccessToken } = useAuth()
+  const { user, isAuthenticated, isLoading: authLoading, login, getAccessToken } = useAuth()
 
   const [secrets, setSecrets] = useState<SecretMetadata[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -160,7 +167,7 @@ export function SecretsListPage() {
         {
           name: createName.trim(),
           data,
-          userGrants: [{ principal: 'creator@placeholder', role: Role.OWNER }],
+          userGrants: [{ principal: (user?.profile?.email as string) || '', role: Role.OWNER }],
         },
         {
           headers: {
@@ -255,7 +262,10 @@ export function SecretsListPage() {
                     to={`/secrets/${secret.name}`}
                     disabled={!secret.accessible}
                   >
-                    <ListItemText primary={secret.name} />
+                    <ListItemText
+                      primary={secret.name}
+                      secondary={sharingSummary(secret.userGrants.length, secret.groupGrants.length)}
+                    />
                   </ListItemButton>
                 </ListItem>
               ))}


### PR DESCRIPTION
## Summary
- Use actual user email (from OIDC profile) as owner grant when creating secrets, replacing placeholder
- Show sharing grant counts (e.g., "2 users, 1 group") as secondary text in secrets list items
- No secondary text shown when a secret has no sharing grants

## Test plan
- [x] Test: create dialog sends actual user email as owner grant
- [x] Test: list shows sharing summary counts
- [x] Test: no summary text when no grants
- [x] All 52 UI tests pass (`make test`)
- [x] `make generate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)