### PR TITLE
Rename platform role flags and wire up system-level RBAC

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -27,9 +27,9 @@ var (
 	refreshTokenTTL string
 	namespace       string
 	logLevel        string
-	viewerGroups    string
-	editorGroups    string
-	ownerGroups     string
+	platformViewers string
+	platformEditors string
+	platformOwners  string
 )
 
 // Command returns the root cobra command for the CLI.
@@ -83,10 +83,10 @@ func Command() *cobra.Command {
 	// Kubernetes flags
 	cmd.Flags().StringVar(&namespace, "namespace", "holos-console", "Kubernetes namespace for secrets")
 
-	// RBAC group mapping flags
-	cmd.Flags().StringVar(&viewerGroups, "viewer-groups", "", "Comma-separated OIDC groups that map to the viewer role (default: viewer)")
-	cmd.Flags().StringVar(&editorGroups, "editor-groups", "", "Comma-separated OIDC groups that map to the editor role (default: editor)")
-	cmd.Flags().StringVar(&ownerGroups, "owner-groups", "", "Comma-separated OIDC groups that map to the owner role (default: owner)")
+	// RBAC platform role flags
+	cmd.Flags().StringVar(&platformViewers, "platform-viewers", "", "OIDC groups with platform viewer role (default: viewer)")
+	cmd.Flags().StringVar(&platformEditors, "platform-editors", "", "OIDC groups with platform editor role (default: editor)")
+	cmd.Flags().StringVar(&platformOwners, "platform-owners", "", "OIDC groups with platform owner role (default: owner)")
 
 	// Logging flags
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
@@ -203,9 +203,9 @@ func Run(cmd *cobra.Command, args []string) error {
 		IDTokenTTL:      idTTL,
 		RefreshTokenTTL: refreshTTL,
 		Namespace:       namespace,
-		ViewerGroups:    rbac.ParseGroups(viewerGroups),
-		EditorGroups:    rbac.ParseGroups(editorGroups),
-		OwnerGroups:     rbac.ParseGroups(ownerGroups),
+		PlatformViewers: rbac.ParseGroups(platformViewers),
+		PlatformEditors: rbac.ParseGroups(platformEditors),
+		PlatformOwners:  rbac.ParseGroups(platformOwners),
 	}
 
 	server := console.New(cfg)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -119,34 +119,34 @@ func TestDeriveIssuer(t *testing.T) {
 	}
 }
 
-func TestGroupFlags(t *testing.T) {
-	t.Run("viewer-groups flag is registered", func(t *testing.T) {
+func TestPlatformRoleFlags(t *testing.T) {
+	t.Run("platform-viewers flag is registered", func(t *testing.T) {
 		cmd := Command()
-		f := cmd.Flags().Lookup("viewer-groups")
+		f := cmd.Flags().Lookup("platform-viewers")
 		if f == nil {
-			t.Fatal("expected --viewer-groups flag to be registered")
+			t.Fatal("expected --platform-viewers flag to be registered")
 		}
 		if f.DefValue != "" {
 			t.Errorf("expected empty default, got %q", f.DefValue)
 		}
 	})
 
-	t.Run("editor-groups flag is registered", func(t *testing.T) {
+	t.Run("platform-editors flag is registered", func(t *testing.T) {
 		cmd := Command()
-		f := cmd.Flags().Lookup("editor-groups")
+		f := cmd.Flags().Lookup("platform-editors")
 		if f == nil {
-			t.Fatal("expected --editor-groups flag to be registered")
+			t.Fatal("expected --platform-editors flag to be registered")
 		}
 		if f.DefValue != "" {
 			t.Errorf("expected empty default, got %q", f.DefValue)
 		}
 	})
 
-	t.Run("owner-groups flag is registered", func(t *testing.T) {
+	t.Run("platform-owners flag is registered", func(t *testing.T) {
 		cmd := Command()
-		f := cmd.Flags().Lookup("owner-groups")
+		f := cmd.Flags().Lookup("platform-owners")
 		if f == nil {
-			t.Fatal("expected --owner-groups flag to be registered")
+			t.Fatal("expected --platform-owners flag to be registered")
 		}
 		if f.DefValue != "" {
 			t.Errorf("expected empty default, got %q", f.DefValue)

--- a/console/console.go
+++ b/console/console.go
@@ -79,17 +79,17 @@ type Config struct {
 	// Default: "holos-console"
 	Namespace string
 
-	// ViewerGroups are the OIDC groups that map to the viewer role.
+	// PlatformViewers are the OIDC groups with platform viewer role.
 	// When nil, defaults to ["viewer"].
-	ViewerGroups []string
+	PlatformViewers []string
 
-	// EditorGroups are the OIDC groups that map to the editor role.
+	// PlatformEditors are the OIDC groups with platform editor role.
 	// When nil, defaults to ["editor"].
-	EditorGroups []string
+	PlatformEditors []string
 
-	// OwnerGroups are the OIDC groups that map to the owner role.
+	// PlatformOwners are the OIDC groups with platform owner role.
 	// When nil, defaults to ["owner"].
-	OwnerGroups []string
+	PlatformOwners []string
 }
 
 // OIDCConfig is the OIDC configuration injected into the frontend.
@@ -200,7 +200,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 
 	// Create RBAC group mapping from configuration
-	groupMapping := rbac.NewGroupMapping(s.cfg.ViewerGroups, s.cfg.EditorGroups, s.cfg.OwnerGroups)
+	groupMapping := rbac.NewGroupMapping(s.cfg.PlatformViewers, s.cfg.PlatformEditors, s.cfg.PlatformOwners)
 
 	// Register SecretsService (protected - requires auth)
 	secretsHandler := secrets.NewHandler(secretsK8s, groupMapping)

--- a/console/secrets/authz_test.go
+++ b/console/secrets/authz_test.go
@@ -110,3 +110,47 @@ func TestCheckAdminAccessSharing(t *testing.T) {
 		}
 	})
 }
+
+func TestPlatformRoleThroughWrappers(t *testing.T) {
+	gm := defaultGM()
+
+	t.Run("platform viewer grants read via wrapper", func(t *testing.T) {
+		err := CheckReadAccessSharing(gm, "nobody@example.com", []string{"viewer"},
+			nil, nil)
+		if err != nil {
+			t.Errorf("expected access granted via platform viewer role, got: %v", err)
+		}
+	})
+
+	t.Run("platform editor grants write via wrapper", func(t *testing.T) {
+		err := CheckWriteAccessSharing(gm, "nobody@example.com", []string{"editor"},
+			nil, nil)
+		if err != nil {
+			t.Errorf("expected access granted via platform editor role, got: %v", err)
+		}
+	})
+
+	t.Run("platform owner grants delete via wrapper", func(t *testing.T) {
+		err := CheckDeleteAccessSharing(gm, "nobody@example.com", []string{"owner"},
+			nil, nil)
+		if err != nil {
+			t.Errorf("expected access granted via platform owner role, got: %v", err)
+		}
+	})
+
+	t.Run("platform viewer grants list via wrapper", func(t *testing.T) {
+		err := CheckListAccessSharing(gm, "nobody@example.com", []string{"viewer"},
+			nil, nil)
+		if err != nil {
+			t.Errorf("expected access granted via platform viewer role, got: %v", err)
+		}
+	})
+
+	t.Run("platform owner grants admin via wrapper", func(t *testing.T) {
+		err := CheckAdminAccessSharing(gm, "nobody@example.com", []string{"owner"},
+			nil, nil)
+		if err != nil {
+			t.Errorf("expected access granted via platform owner role, got: %v", err)
+		}
+	})
+}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -77,6 +77,9 @@ export HOLOS_DEX_INITIAL_ADMIN_USERNAME=myuser
 | `--listen` | `:8443` | Address to listen on |
 | `--cert-file` | (auto-generated) | TLS certificate file |
 | `--key-file` | (auto-generated) | TLS key file |
+| `--platform-viewers` | `viewer` | OIDC groups with platform viewer role |
+| `--platform-editors` | `editor` | OIDC groups with platform editor role |
+| `--platform-owners` | `owner` | OIDC groups with platform owner role |
 
 ## Using an External OIDC Provider
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,84 @@
+# Role-Based Access Control (RBAC)
+
+holos-console uses a two-tier access control model combining **platform roles** and **per-secret sharing grants**.
+
+## Platform Roles
+
+Platform roles provide baseline access across all secrets. They are assigned by mapping OIDC groups to roles via CLI flags.
+
+| Platform Role | Permissions | Use Case |
+|---|---|---|
+| Viewer | List, Read | Audit, read-only users |
+| Editor | List, Read, Write | Developers who create and update secrets |
+| Owner | List, Read, Write, Delete, Admin | Platform administrators |
+
+### Configuration
+
+```bash
+holos-console \
+  --platform-viewers=audit-team,readonly-users \
+  --platform-editors=developers,sre-team \
+  --platform-owners=platform-admins
+```
+
+| Flag | Default Group | Description |
+|---|---|---|
+| `--platform-viewers` | `viewer` | OIDC groups with platform viewer role |
+| `--platform-editors` | `editor` | OIDC groups with platform editor role |
+| `--platform-owners` | `owner` | OIDC groups with platform owner role |
+
+When a flag is not set, the default group name is used (e.g., users in the OIDC group `viewer` automatically get the viewer platform role).
+
+## Per-Secret Sharing Grants
+
+Sharing grants provide fine-grained access to individual secrets. They are stored as Kubernetes annotations on the secret.
+
+### Annotations
+
+| Annotation | Format | Description |
+|---|---|---|
+| `holos.run/share-users` | `{"email":"role"}` | Per-user grants |
+| `holos.run/share-groups` | `{"group":"role"}` | Per-group grants |
+
+### Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-app-credentials
+  namespace: holos-console
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+  annotations:
+    holos.run/share-users: '{"alice@example.com":"owner","bob@example.com":"viewer"}'
+    holos.run/share-groups: '{"dev-team":"editor"}'
+```
+
+## How Roles Combine
+
+When a user has roles from multiple sources, the **highest role wins**.
+
+Evaluation order:
+1. Check per-user sharing grants (`share-users` annotation)
+2. Check per-group sharing grants (`share-groups` annotation)
+3. Check platform roles (OIDC group mapping)
+
+The highest role found across all three sources determines access.
+
+### Example
+
+Alice is in the OIDC group `viewer` (platform viewer role). A secret has `share-users: {"alice@example.com":"editor"}`. Alice gets **editor** access to that secret because editor > viewer.
+
+Bob is in the OIDC group `owner` (platform owner role). A secret has no sharing grants for Bob. Bob still gets **owner** access via his platform role.
+
+## Permission Matrix
+
+| Permission | Viewer | Editor | Owner |
+|---|---|---|---|
+| List secrets | Yes | Yes | Yes |
+| Read secret data | Yes | Yes | Yes |
+| Create secrets | - | Yes | Yes |
+| Update secret data | - | Yes | Yes |
+| Delete secrets | - | - | Yes |
+| Update sharing grants | - | - | Yes |


### PR DESCRIPTION
## Summary

- Rename `--viewer-groups`/`--editor-groups`/`--owner-groups` flags to `--platform-viewers`/`--platform-editors`/`--platform-owners`
- Wire platform roles into `CheckAccessSharing` as step 3: after per-user and per-group sharing grants, check OIDC group → role mapping so platform roles serve as a baseline across all secrets
- Add `docs/rbac.md` documenting the two-tier access model (platform roles + per-secret sharing grants)

## Test plan

- [x] `make test` — all Go + UI tests pass
- [x] `make generate` — builds successfully
- [x] `--help` shows new flag names and help text
- [ ] Manual: verify platform viewer can read secrets without per-secret grants
- [ ] Manual: verify platform editor can create secrets without per-secret grants

🤖 Generated with [Claude Code](https://claude.com/claude-code)