### PR TITLE
Rename annotation prefix to console.holos.run/ (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ To make a secret accessible through the console, configure it with:
 2. **Sharing annotations** (controls who can access the secret):
    ```yaml
    annotations:
-     holos.run/share-users: '{"alice@example.com":"owner","bob@example.com":"viewer"}'
-     holos.run/share-groups: '{"dev-team":"editor"}'
+     console.holos.run/share-users: '{"alice@example.com":"owner","bob@example.com":"viewer"}'
+     console.holos.run/share-groups: '{"dev-team":"editor"}'
    ```
 
 ### Example Secret
@@ -66,8 +66,8 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: console.holos.run
   annotations:
-    holos.run/share-users: '{"alice@example.com":"owner"}'
-    holos.run/share-groups: '{"platform-team":"editor"}'
+    console.holos.run/share-users: '{"alice@example.com":"owner"}'
+    console.holos.run/share-groups: '{"platform-team":"editor"}'
 stringData:
   API_KEY: secret-value
 type: Opaque

--- a/console/secrets/k8s.go
+++ b/console/secrets/k8s.go
@@ -13,11 +13,11 @@ import (
 
 // ShareUsersAnnotation is the annotation key for per-user sharing grants.
 // Value is a JSON object mapping email address → role name.
-const ShareUsersAnnotation = "holos.run/share-users"
+const ShareUsersAnnotation = "console.holos.run/share-users"
 
 // ShareGroupsAnnotation is the annotation key for per-group sharing grants.
 // Value is a JSON object mapping OIDC group name → role name.
-const ShareGroupsAnnotation = "holos.run/share-groups"
+const ShareGroupsAnnotation = "console.holos.run/share-groups"
 
 // ManagedByLabel is the label key used to identify secrets managed by the console.
 const ManagedByLabel = "app.kubernetes.io/managed-by"
@@ -153,7 +153,7 @@ func (c *K8sClient) UpdateSharing(ctx context.Context, name string, shareUsers, 
 	return c.client.CoreV1().Secrets(c.namespace).Update(ctx, secret, metav1.UpdateOptions{})
 }
 
-// GetShareUsers parses the holos.run/share-users annotation from a secret.
+// GetShareUsers parses the console.holos.run/share-users annotation from a secret.
 // Returns an empty map if the annotation is missing.
 // Returns an error if the annotation contains invalid JSON.
 func GetShareUsers(secret *corev1.Secret) (map[string]string, error) {
@@ -171,7 +171,7 @@ func GetShareUsers(secret *corev1.Secret) (map[string]string, error) {
 	return users, nil
 }
 
-// GetShareGroups parses the holos.run/share-groups annotation from a secret.
+// GetShareGroups parses the console.holos.run/share-groups annotation from a secret.
 // Returns an empty map if the annotation is missing.
 // Returns an error if the annotation contains invalid JSON.
 func GetShareGroups(secret *corev1.Secret) (map[string]string, error) {

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -37,8 +37,8 @@ Sharing grants provide fine-grained access to individual secrets. They are store
 
 | Annotation | Format | Description |
 |---|---|---|
-| `holos.run/share-users` | `{"email":"role"}` | Per-user grants |
-| `holos.run/share-groups` | `{"group":"role"}` | Per-group grants |
+| `console.holos.run/share-users` | `{"email":"role"}` | Per-user grants |
+| `console.holos.run/share-groups` | `{"group":"role"}` | Per-group grants |
 
 ### Example
 
@@ -51,8 +51,8 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: console.holos.run
   annotations:
-    holos.run/share-users: '{"alice@example.com":"owner","bob@example.com":"viewer"}'
-    holos.run/share-groups: '{"dev-team":"editor"}'
+    console.holos.run/share-users: '{"alice@example.com":"owner","bob@example.com":"viewer"}'
+    console.holos.run/share-groups: '{"dev-team":"editor"}'
 ```
 
 ## How Roles Combine


### PR DESCRIPTION
## Summary

- Rename `holos.run/share-users` → `console.holos.run/share-users`
- Rename `holos.run/share-groups` → `console.holos.run/share-groups`
- Update README.md and docs/rbac.md annotation references

Phase 1 of #43.

## Test plan

- [x] `make test-go` — all Go tests pass
- [x] Annotation constants updated in `k8s.go`
- [x] All test fixtures use constants (auto-updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)