### PR TITLE
Add console.holos.run/organization label to Organization namespaces

### DIFF
--- a/console/organizations/k8s.go
+++ b/console/organizations/k8s.go
@@ -99,6 +99,7 @@ func (c *K8sClient) CreateOrganization(ctx context.Context, name, displayName, d
 			Labels: map[string]string{
 				secrets.ManagedByLabel:     secrets.ManagedByValue,
 				resolver.ResourceTypeLabel: resolver.ResourceTypeOrganization,
+				resolver.OrganizationLabel: name,
 			},
 			Annotations: annotations,
 		},

--- a/console/organizations/k8s_test.go
+++ b/console/organizations/k8s_test.go
@@ -166,6 +166,19 @@ func TestCreateOrganization_CreatesNamespaceWithPrefixAndLabels(t *testing.T) {
 	}
 }
 
+func TestCreateOrganization_SetsOrganizationLabel(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	result, err := k8s.CreateOrganization(context.Background(), "acme", "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Labels[resolver.OrganizationLabel] != "acme" {
+		t.Errorf("expected organization label 'acme', got %q", result.Labels[resolver.OrganizationLabel])
+	}
+}
+
 func TestCreateOrganization_ReturnsAlreadyExists(t *testing.T) {
 	existing := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/console/resolver/resolver.go
+++ b/console/resolver/resolver.go
@@ -12,7 +12,7 @@ const (
 	ResourceTypeOrganization = "organization"
 	// ResourceTypeProject is the resource-type label value for project namespaces.
 	ResourceTypeProject = "project"
-	// OrganizationLabel stores the organization name on project namespaces.
+	// OrganizationLabel stores the organization name on organization and project namespaces.
 	OrganizationLabel = "console.holos.run/organization"
 	// ProjectLabel stores the project name on project namespaces.
 	ProjectLabel = "console.holos.run/project"


### PR DESCRIPTION
## Summary
- Set `console.holos.run/organization` label on organization namespaces at creation time, matching how project namespaces carry `console.holos.run/project`
- Add `TestCreateOrganization_SetsOrganizationLabel` test
- Update `OrganizationLabel` doc comment to reflect broader usage

Closes: #86

## Test plan
- [x] `make test-go` passes (new test + existing tests)
- [x] `make generate` passes
- [x] Manual: create an organization, inspect the backing namespace — `console.holos.run/organization` label is present with the org name

🤖 Generated with [Claude Code](https://claude.com/claude-code)