### PR TITLE
Default --org-creator-groups to 'owner' to match Dex admin group

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -85,7 +85,7 @@ func Command() *cobra.Command {
 
 	// Organization creation permission flags
 	cmd.Flags().StringVar(&orgCreatorUsers, "org-creator-users", "", "Comma-separated email addresses allowed to create organizations")
-	cmd.Flags().StringVar(&orgCreatorGroups, "org-creator-groups", "", "Comma-separated OIDC group names allowed to create organizations")
+	cmd.Flags().StringVar(&orgCreatorGroups, "org-creator-groups", "owner", "Comma-separated OIDC group names allowed to create organizations")
 
 	// Logging flags
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -130,6 +130,17 @@ func TestPlatformRoleFlagsRemoved(t *testing.T) {
 	}
 }
 
+func TestDefaultOrgCreatorGroups(t *testing.T) {
+	cmd := Command()
+	f := cmd.Flags().Lookup("org-creator-groups")
+	if f == nil {
+		t.Fatal("--org-creator-groups flag not found")
+	}
+	if got := f.DefValue; got != "owner" {
+		t.Errorf("default org-creator-groups = %q, want %q", got, "owner")
+	}
+}
+
 func TestTTLParsing(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Default `--org-creator-groups` CLI flag from `""` to `"owner"` so the embedded Dex admin user can create organizations out of the box
- Add `TestDefaultOrgCreatorGroups` test asserting the default value

Closes: #95

## Test plan
- [x] `make test-go` passes (except pre-existing TLS cert issue in `TestScripts/grpc_reflection`)
- [x] `make generate` passes
- [x] Manual: start the server with no flags, log in as admin, create an organization — succeeds without needing `--org-creator-groups`

🤖 Generated with [Claude Code](https://claude.com/claude-code)