### PR TITLE
Add scripts/dispatch to create worktrees and spawn Claude Code agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ make tools          # Install pinned tool dependencies (buf)
 make certs          # Generate TLS certificates with mkcert (one-time setup)
 make run            # Build and run server with generated certificates
 make dev            # Start Vite dev server with hot reload (use alongside make run)
+make dispatch ISSUE=N  # Dispatch a plan issue to a Claude Code agent in a new worktree
 make fmt            # Format code
 make vet            # Run go vet
 make lint           # Run golangci-lint
@@ -205,6 +206,19 @@ Tool versions are pinned in `tools.go` using the Go tools pattern. Install with 
 ### Feature Planning
 
 Plan features using phases. Record plans as GitHub issues before execution using `gh issue create`.
+
+### Dispatching Plans to Agents
+
+After drafting a plan as a GitHub issue, dispatch it to a Claude Code agent
+in a new worktree:
+
+    scripts/dispatch <issue-number>
+
+This creates a git worktree at ../holos-console-<N>, opens a new tmux window
+named i<N>, and starts a Claude Code agent that reads the issue and implements
+the plan. The script returns immediately so the main agent can continue planning.
+
+Prerequisite: must be run inside a tmux session.
 
 ### RED GREEN Implementation
 

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ dev: ## Start the Vite dev server for frontend development.
 rpc-version: ## Get server version via gRPC.
 	./scripts/rpc-version
 
+.PHONY: dispatch
+dispatch: ## Create worktree and spawn Claude Code agent for a GitHub issue.
+	./scripts/dispatch $(ISSUE)
+
 # Container image configuration
 DOCKER_REPO ?= ghcr.io/holos-run/holos-console
 GIT_SHA := $(shell git rev-parse --short HEAD)

--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Create a worktree and spawn a Claude Code agent in a tmux window for a GitHub issue.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+usage() {
+    echo "Usage: scripts/dispatch <issue-number>"
+    echo
+    echo "Create a git worktree for the issue, open a tmux window, and spawn"
+    echo "a Claude Code agent to implement the plan."
+    exit 1
+}
+
+# Validate argument
+if [[ $# -lt 1 ]] || ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    usage
+fi
+
+ISSUE="$1"
+
+# Validate prerequisites
+for tool in tmux gh claude; do
+    if ! command -v "$tool" &>/dev/null; then
+        echo "Error: $tool is not on PATH" >&2
+        exit 1
+    fi
+done
+
+if [[ -z "${TMUX:-}" ]]; then
+    echo "Error: not inside a tmux session" >&2
+    exit 1
+fi
+
+# Fetch issue title
+ISSUE_TITLE="$(gh issue view "$ISSUE" --json title --jq .title)" || {
+    echo "Error: failed to fetch issue #$ISSUE" >&2
+    exit 1
+}
+
+# Slugify title: lowercase, replace non-alphanumeric with hyphens, collapse, trim, truncate
+SLUG="$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-50)"
+BRANCH="feat/${SLUG}"
+
+# Worktree path
+WORKTREE_PATH="${PROJECT_ROOT}/../holos-console-${ISSUE}"
+
+# Create worktree if it doesn't exist
+if [[ -d "$WORKTREE_PATH" ]]; then
+    echo "Reusing existing worktree: $WORKTREE_PATH"
+else
+    echo "Creating worktree at $WORKTREE_PATH"
+    if ! git -C "$PROJECT_ROOT" worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null; then
+        # Branch may already exist, try without -b
+        git -C "$PROJECT_ROOT" worktree add "$WORKTREE_PATH" "$BRANCH"
+    fi
+fi
+
+# Resolve to absolute path for display
+WORKTREE_PATH="$(cd "$WORKTREE_PATH" && pwd)"
+
+# Create tmux window
+WINDOW_NAME="i${ISSUE}"
+tmux new-window -n "$WINDOW_NAME" -c "$WORKTREE_PATH"
+
+# Send claude command to the new window
+tmux send-keys -t "$WINDOW_NAME" "claude \"execute the plan in issue holos-console-${ISSUE}\"" Enter
+
+echo "Dispatched issue #$ISSUE"
+echo "  Worktree: $WORKTREE_PATH"
+echo "  Window:   $WINDOW_NAME"


### PR DESCRIPTION
## Summary
- Add `scripts/dispatch <issue-number>` that automates creating a git worktree, opening a tmux window, and spawning a Claude Code agent to implement a plan issue
- Add `make dispatch ISSUE=N` Makefile target
- Document the dispatch workflow in AGENTS.md

Closes: #102

## Test plan
- [ ] `scripts/dispatch 99` from the main worktree inside tmux — creates worktree, opens tmux window, starts claude
- [ ] `scripts/dispatch 99` again — detects existing worktree, reuses it, opens new tmux window
- [ ] Run outside tmux — errors with helpful message
- [ ] Run without arguments — prints usage and exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)