### PR TITLE
Accept risk of unauthenticated gRPC reflection endpoints

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -261,7 +261,11 @@ func (s *Server) Serve(ctx context.Context) error {
 		mux.Handle(secretsPath, secretsHTTPHandler)
 	}
 
-	// Register gRPC reflection for introspection (grpcurl, etc.)
+	// Register gRPC reflection for introspection (grpcurl, etc.).
+	// These endpoints are intentionally unauthenticated. The API surface they
+	// expose (service names, method signatures, message schemas) is public
+	// information available in the proto/ source files and UI bundle.
+	// See ADR 009 (docs/adrs/009-grpc-reflection-unauthenticated.md).
 	reflector := grpcreflect.NewStaticReflector(
 		consolev1connect.VersionServiceName,
 		consolev1connect.SecretsServiceName,

--- a/docs/adrs/009-grpc-reflection-unauthenticated.md
+++ b/docs/adrs/009-grpc-reflection-unauthenticated.md
@@ -1,0 +1,47 @@
+# ADR 009: Accept unauthenticated gRPC reflection endpoints
+
+## Status
+
+Accepted
+
+## Context
+
+The application security review (FINDING-03 in #134) identified that gRPC
+reflection services (`grpc.reflection.v1` and `grpc.reflection.v1alpha`) are
+registered without authentication interceptors. This allows unauthenticated
+clients to enumerate all available RPC services, methods, and message schemas
+via tools like `grpcurl`.
+
+The finding is rated Low severity because the information disclosed is limited
+to the API surface definition, which does not include any user data, secrets, or
+internal state.
+
+## Decision
+
+Accept the risk. gRPC reflection endpoints remain unauthenticated.
+
+Rationale:
+
+1. **The API surface is already public.** Proto source files are checked into
+   the `proto/` directory of this repository and generated TypeScript types are
+   shipped in the UI bundle. Reflection does not expose information beyond what
+   is already available to anyone with read access to the repository or the
+   browser developer tools.
+
+2. **Reflection aids developer and operator tooling.** Tools such as `grpcurl`
+   and `grpcui` rely on reflection for service discovery. Requiring
+   authentication would degrade the developer experience without a meaningful
+   security benefit.
+
+3. **No sensitive data is exposed.** Reflection returns only service names,
+   method signatures, and message schemas. It does not return request/response
+   payloads, user data, or server configuration.
+
+## Consequences
+
+- Unauthenticated clients can discover the full list of RPC services and their
+  request/response message schemas.
+- This is acceptable because the same information is publicly available in the
+  source repository and client bundles.
+- If the API surface becomes sensitive in the future (e.g., internal-only
+  services are added), this decision should be revisited.


### PR DESCRIPTION
## Summary
- Add ADR 007 documenting the decision to accept unauthenticated gRPC reflection as a known, low-severity risk
- Update the code comment at the reflection registration site to reference the ADR and explain the rationale
- The API surface exposed by reflection (service names, method signatures, message schemas) is already public in `proto/` and the UI bundle

Closes: #139

## Test plan
- [x] `make generate` succeeds
- [ ] Review ADR 007 at `docs/adrs/007-grpc-reflection-unauthenticated.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)