### PR TITLE
Fix review issues from PR #165

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -2,7 +2,6 @@ import { Link, useRouter } from '@tanstack/react-router'
 import {
   Building2,
   FolderKanban,
-  Home,
   Info,
   User,
   ChevronsUpDown,
@@ -30,7 +29,6 @@ import { useOrg } from '@/lib/org-context'
 import { useVersion } from '@/queries/version'
 
 const navItems = [
-  { label: 'Home', to: '/profile' as const, icon: Home },
   { label: 'Organizations', to: '/organizations' as const, icon: Building2 },
   { label: 'Projects', to: '/projects' as const, icon: FolderKanban },
 ]
@@ -66,7 +64,7 @@ export function AppSidebar() {
             <SidebarMenu>
               {navItems.map((item) => (
                 <SidebarMenuItem key={item.label}>
-                  <SidebarMenuButton asChild isActive={pathname.startsWith(item.to === '/profile' ? '/profile' : item.to)}>
+                  <SidebarMenuButton asChild isActive={pathname.startsWith(item.to)}>
                     <Link to={item.to}>
                       <item.icon className="h-4 w-4" />
                       <span>{item.label}</span>

--- a/frontend/src/routes/_authenticated/organizations/$organizationName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$organizationName.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
@@ -60,9 +60,11 @@ function OrganizationPage() {
   const [localDescription, setLocalDescription] = useState<string | null>(null)
   const [localOrganization, setLocalOrganization] = useState<typeof organization | null>(null)
 
-  if (!authLoading && !isAuthenticated) {
-    login(`/organizations/${name}`)
-  }
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      login(`/organizations/${name}`)
+    }
+  }, [authLoading, isAuthenticated, login, name])
 
   const effectiveOrg = localOrganization ?? organization
   const displayName = localDisplayName ?? effectiveOrg?.displayName

--- a/frontend/src/routes/_authenticated/projects/$projectName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { createFileRoute, Link, useNavigate, Outlet, useMatchRoute } from '@tanstack/react-router'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
@@ -62,9 +62,11 @@ function ProjectPage() {
   const matchRoute = useMatchRoute()
   const isChildRoute = !matchRoute({ to: '/projects/$projectName', params: { projectName: name } })
 
-  if (!authLoading && !isAuthenticated) {
-    login(`/projects/${name}`)
-  }
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      login(`/projects/${name}`)
+    }
+  }, [authLoading, isAuthenticated, login, name])
 
   // If we're on a child route, just render the outlet
   if (isChildRoute) {

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/$name.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/$name.tsx
@@ -21,7 +21,7 @@ import { SecretDataViewer } from '@/components/secret-data-viewer'
 import { RawView } from '@/components/raw-view'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { isSafeUrl } from '@/lib/utils'
-import { useGetSecret, useGetSecretMetadata, useUpdateSecret, useUpdateSecretSharing } from '@/queries/secrets'
+import { useGetSecret, useGetSecretMetadata, useUpdateSecret, useUpdateSecretSharing, useDeleteSecret } from '@/queries/secrets'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { SecretsService } from '@/gen/holos/console/v1/secrets_pb.js'
 import type { ShareGrant } from '@/gen/holos/console/v1/secrets_pb.js'
@@ -51,6 +51,7 @@ function SecretPage() {
 
   const updateMutation = useUpdateSecret(projectName)
   const updateSharingMutation = useUpdateSecretSharing(projectName)
+  const deleteMutation = useDeleteSecret(projectName)
 
   const secretsClient = useMemo(() => createClient(SecretsService, transport), [transport])
 
@@ -75,8 +76,6 @@ function SecretPage() {
 
   // Delete
   const [deleteOpen, setDeleteOpen] = useState(false)
-  const [isDeleting, setIsDeleting] = useState(false)
-  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   // Save
   const [saveError, setSaveError] = useState<string | null>(null)
@@ -165,17 +164,11 @@ function SecretPage() {
   }
 
   const handleDelete = async () => {
-    setIsDeleting(true)
-    setDeleteError(null)
     try {
-      await secretsClient.deleteSecret({ name, project: projectName })
+      await deleteMutation.mutateAsync(name)
       setDeleteOpen(false)
       navigate({ to: '/projects/$projectName/secrets', params: { projectName } })
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setIsDeleting(false)
-    }
+    } catch { /* error via mutation */ }
   }
 
   const isLoading = dataLoading || metaLoading
@@ -336,13 +329,13 @@ function SecretPage() {
               Are you sure you want to delete secret &quot;{name}&quot;? This action cannot be undone.
             </DialogDescription>
           </DialogHeader>
-          {deleteError && (
-            <Alert variant="destructive"><AlertDescription>{deleteError}</AlertDescription></Alert>
+          {deleteMutation.error && (
+            <Alert variant="destructive"><AlertDescription>{deleteMutation.error.message}</AlertDescription></Alert>
           )}
           <DialogFooter>
             <Button variant="ghost" onClick={() => setDeleteOpen(false)}>Cancel</Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
-              {isDeleting ? 'Deleting...' : 'Delete'}
+            <Button variant="destructive" onClick={handleDelete} disabled={deleteMutation.isPending}>
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
@@ -136,44 +136,49 @@ function SecretsListPage() {
             <ul className="divide-y">
               {secrets.map((secret) => (
                 <li key={secret.name} className="flex items-center gap-2 py-2">
-                  {secret.accessible ? (
-                    <Link
-                      to="/projects/$projectName/secrets/$name"
-                      params={{ projectName, name: secret.name }}
-                      className="flex-1 min-w-0 hover:underline"
-                    >
-                      <div className="font-medium truncate">{secret.name}</div>
-                      <div className="text-sm text-muted-foreground truncate">
-                        {secret.description || sharingSummary(secret.userGrants.length, secret.roleGrants.length) || secret.name}
-                      </div>
-                    </Link>
-                  ) : (
-                    <div className="flex-1 min-w-0 opacity-50">
-                      <div className="font-medium truncate">{secret.name}</div>
-                      <div className="text-sm text-muted-foreground truncate">
-                        {secret.description || secret.name}
-                      </div>
-                    </div>
-                  )}
-                  {secret.url && isSafeUrl(secret.url) && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`open ${secret.name} url`}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        e.preventDefault()
-                        window.open(secret.url, '_blank', 'noopener,noreferrer')
-                      }}
-                    >
-                      <ExternalLink className="h-4 w-4" />
-                    </Button>
-                  )}
-                  {secret.description && sharingSummary(secret.userGrants.length, secret.roleGrants.length) && (
-                    <Badge variant="outline" className="shrink-0">
-                      {sharingSummary(secret.userGrants.length, secret.roleGrants.length)}
-                    </Badge>
-                  )}
+                  {(() => {
+                    const summary = sharingSummary(secret.userGrants.length, secret.roleGrants.length)
+                    return (
+                      <>
+                        {secret.accessible ? (
+                          <Link
+                            to="/projects/$projectName/secrets/$name"
+                            params={{ projectName, name: secret.name }}
+                            className="flex-1 min-w-0 hover:underline"
+                          >
+                            <div className="font-medium truncate">{secret.name}</div>
+                            <div className="text-sm text-muted-foreground truncate">
+                              {secret.description || summary || secret.name}
+                            </div>
+                          </Link>
+                        ) : (
+                          <div className="flex-1 min-w-0 opacity-50">
+                            <div className="font-medium truncate">{secret.name}</div>
+                            <div className="text-sm text-muted-foreground truncate">
+                              {secret.description || secret.name}
+                            </div>
+                          </div>
+                        )}
+                        {secret.url && isSafeUrl(secret.url) && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            aria-label={`open ${secret.name} url`}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              e.preventDefault()
+                              window.open(secret.url, '_blank', 'noopener,noreferrer')
+                            }}
+                          >
+                            <ExternalLink className="h-4 w-4" />
+                          </Button>
+                        )}
+                        {secret.description && summary && (
+                          <Badge variant="outline" className="shrink-0">{summary}</Badge>
+                        )}
+                      </>
+                    )
+                  })()}
                   {!secret.accessible ? (
                     <TooltipProvider>
                       <Tooltip>


### PR DESCRIPTION
## Summary

Addresses all issues raised in the post-merge review comment on PR #165:

- **Remove duplicate Home sidebar nav item** (`app-sidebar.tsx`): `navItems` had `{ label: 'Home', to: '/profile' }` alongside `bottomItems` `{ label: 'Profile', to: '/profile' }`. Both highlighted simultaneously on `/profile`. Removed the duplicate Home entry and the unused `Home` lucide import; simplified the `isActive` expression.

- **Move `login()` out of render body** (`$organizationName.tsx`, `$projectName.tsx`): Both pages called `login()` directly in the render function body, an anti-pattern that causes issues in React StrictMode. Wrapped each in a `useEffect` matching the pattern already used in `_authenticated.tsx`.

- **Use `useDeleteSecret` on SecretPage** (`$projectName/secrets/$name.tsx`): `handleDelete` was calling `secretsClient.deleteSecret()` directly with manual `isDeleting`/`deleteError` state, bypassing the mutation hook. Switched to `useDeleteSecret` so the secrets list cache is invalidated on delete and mutation state is consistent.

- **Precompute `sharingSummary()` in secrets list** (`secrets/index.tsx`): The function was called up to three times per row iteration. Now computed once per row.

Note: The `staleTime` concern for the version query was already addressed — `useVersion()` in `frontend/src/queries/version.ts` already sets `staleTime: Infinity, gcTime: Infinity`.

## Test plan

- [ ] `make generate` passes (TypeScript type checks clean)
- [ ] Sidebar shows Organizations and Projects (no duplicate Home entry)
- [ ] Profile page link in sidebar footer highlights correctly
- [ ] Navigating to an org/project page while unauthenticated redirects to login
- [ ] Deleting a secret from the detail page navigates back and the list no longer shows the deleted secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)