### PR TITLE
Fix tab title from 'frontend' to 'Holos Console'

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Holos Console</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/index.test.ts
+++ b/frontend/src/index.test.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('index.html', () => {
+  it('has correct tab title', () => {
+    const html = readFileSync(resolve(__dirname, '../index.html'), 'utf-8')
+    expect(html).toContain('<title>Holos Console</title>')
+  })
+})


### PR DESCRIPTION
## Summary
- Fix `<title>` in `frontend/index.html` from `frontend` to `Holos Console`
- Add `frontend/src/index.test.ts` to assert the title stays correct

## Test plan
- [x] `npm test -- src/index.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)