### PR TITLE
Fix Dockerfile: npm not found in Go build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN go mod download
 COPY . .
 # Copy built UI assets into the embed directory
 COPY --from=ui-build /src/console/dist/ console/dist/
-RUN CGO_ENABLED=0 make build
+RUN CGO_ENABLED=0 make build-binary
 
 # Runtime stage
 FROM gcr.io/distroless/static-debian13:nonroot

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ build: | console/dist ## Build executable.
 	@echo "GOPATH=${GOPATH}"
 	go build -trimpath -o bin/$(BIN_NAME) -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd
 
+.PHONY: build-binary
+build-binary: ## Build executable without UI prerequisites (for use in Dockerfile Go stage).
+	@echo "building ${BIN_NAME} ${VERSION}"
+	@echo "GOPATH=${GOPATH}"
+	go build -trimpath -o bin/$(BIN_NAME) -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd
+
 .PHONY: debug
 debug: | console/dist ## Build debug executable.
 	@echo "building ${BIN_NAME}-debug ${VERSION}"


### PR DESCRIPTION
## Summary

- Add `build-binary` Make target with no UI prerequisites for use in the Dockerfile Go stage
- Update Dockerfile to call `make build-binary` instead of `make build`

The root cause: `make build` has an order-only prerequisite on `console/dist → frontend/node_modules`, causing Make to invoke `npm install` in the `golang:1.25` image where npm is not present. The UI assets are already present via `COPY --from=ui-build`, so the prerequisite chain is unnecessary in that context.

Closes: #175

## Test plan
- [ ] `docker build .` completes successfully for `linux/amd64`
- [ ] `docker build . --platform linux/arm64` completes successfully
- [ ] The resulting binary starts and responds to `--version`
- [ ] Container workflow passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)