### PR TITLE
fix(sharing-panel): default expiration to midnight UTC

### DIFF
--- a/frontend/src/components/sharing-panel.test.tsx
+++ b/frontend/src/components/sharing-panel.test.tsx
@@ -356,6 +356,100 @@ describe('SharingPanel', () => {
     })
   })
 
+  describe('expiration UTC behavior', () => {
+    it('stores midnight UTC when a date is selected for user exp', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      const { container } = render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.VIEWER)]}
+          roleGrants={[]}
+          isOwner={true}
+          onSave={onSave}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      // datetime-local inputs in order: user nbf (0), user exp (1)
+      const datetimeInputs = container.querySelectorAll('input[type="datetime-local"]')
+      const expInput = datetimeInputs[1]
+      fireEvent.change(expInput, { target: { value: '2026-04-15T14:30' } })
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+      await waitFor(() => {
+        const savedUsers = onSave.mock.calls[0][0]
+        const expectedTs = BigInt(Math.floor(new Date('2026-04-15T00:00:00Z').getTime() / 1000))
+        expect(savedUsers[0].exp).toBe(expectedTs)
+      })
+    })
+
+    it('pre-populates exp with non-empty default on focus when unset', () => {
+      const { container } = render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.VIEWER)]}
+          roleGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      const datetimeInputs = container.querySelectorAll('input[type="datetime-local"]')
+      const expInput = datetimeInputs[1]
+      expect(expInput).toHaveValue('')
+      fireEvent.focus(expInput)
+      expect(expInput).not.toHaveValue('')
+    })
+
+    it('displays UTC midnight timestamp correctly in exp field', () => {
+      const exp = BigInt(Math.floor(new Date('2026-01-01T00:00:00Z').getTime() / 1000))
+      const { container } = render(
+        <SharingPanel
+          userGrants={[grant('alice@example.com', Role.VIEWER, undefined, exp)]}
+          roleGrants={[]}
+          isOwner={true}
+          onSave={vi.fn()}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      const datetimeInputs = container.querySelectorAll('input[type="datetime-local"]')
+      const expInput = datetimeInputs[1]
+      expect(expInput).toHaveValue('2026-01-01T00:00')
+    })
+
+    it('stores midnight UTC when a date is selected for role exp', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      const { container } = render(
+        <SharingPanel
+          userGrants={[]}
+          roleGrants={[grant('dev-team', Role.EDITOR)]}
+          isOwner={true}
+          onSave={onSave}
+          isSaving={false}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+
+      const datetimeInputs = container.querySelectorAll('input[type="datetime-local"]')
+      const expInput = datetimeInputs[1]
+      fireEvent.change(expInput, { target: { value: '2026-06-30T09:15' } })
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+      await waitFor(() => {
+        const savedRoles = onSave.mock.calls[0][1]
+        const expectedTs = BigInt(Math.floor(new Date('2026-06-30T00:00:00Z').getTime() / 1000))
+        expect(savedRoles[0].exp).toBe(expectedTs)
+      })
+    })
+  })
+
   describe('cancel', () => {
     it('reverts changes on cancel', () => {
       render(

--- a/frontend/src/components/sharing-panel.tsx
+++ b/frontend/src/components/sharing-panel.tsx
@@ -52,19 +52,25 @@ function grantSecondary(role: Role, nbf?: bigint, exp?: bigint): string {
 function timestampToDatetimeLocal(ts?: bigint): string {
   if (ts == null) return ''
   const d = new Date(Number(ts) * 1000)
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  const hours = String(d.getHours()).padStart(2, '0')
-  const minutes = String(d.getMinutes()).padStart(2, '0')
-  return `${year}-${month}-${day}T${hours}:${minutes}`
+  const year = d.getUTCFullYear()
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(d.getUTCDate()).padStart(2, '0')
+  return `${year}-${month}-${day}T00:00`
 }
 
 function datetimeLocalToTimestamp(value: string): bigint | undefined {
   if (!value) return undefined
-  const d = new Date(value)
+  const datePart = value.split('T')[0]
+  const d = new Date(datePart + 'T00:00:00Z')
   if (isNaN(d.getTime())) return undefined
   return BigInt(Math.floor(d.getTime() / 1000))
+}
+
+function defaultExpirationUTC(): bigint {
+  const now = new Date()
+  const firstOfMonthAfterNext = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 2, 1))
+  const lastDayOfNextMonth = new Date(firstOfMonthAfterNext.getTime() - 24 * 60 * 60 * 1000)
+  return BigInt(Math.floor(lastDayOfNextMonth.getTime() / 1000))
 }
 
 export function SharingPanel({ userGrants, roleGrants, isOwner, onSave, isSaving }: SharingPanelProps) {
@@ -201,6 +207,7 @@ export function SharingPanel({ userGrants, roleGrants, isOwner, onSave, isSaving
                 <Input
                   type="datetime-local"
                   value={timestampToDatetimeLocal(g.exp)}
+                  onFocus={() => { if (g.exp == null) handleUserChange(i, 'exp', defaultExpirationUTC()) }}
                   onChange={(e) => handleUserChange(i, 'exp', datetimeLocalToTimestamp(e.target.value))}
                 />
               </div>
@@ -254,6 +261,7 @@ export function SharingPanel({ userGrants, roleGrants, isOwner, onSave, isSaving
                 <Input
                   type="datetime-local"
                   value={timestampToDatetimeLocal(g.exp)}
+                  onFocus={() => { if (g.exp == null) handleRoleChange(i, 'exp', defaultExpirationUTC()) }}
                   onChange={(e) => handleRoleChange(i, 'exp', datetimeLocalToTimestamp(e.target.value))}
                 />
               </div>


### PR DESCRIPTION
## Summary
- Fix `timestampToDatetimeLocal` to format timestamps using UTC date parts, ensuring stored midnight UTC values always display as `YYYY-MM-DDT00:00`
- Fix `datetimeLocalToTimestamp` to parse only the date portion and construct `00:00:00 UTC`, so any date selection stores midnight UTC regardless of local timezone or time component
- Add `defaultExpirationUTC()` helper returning the last day of next month at midnight UTC
- Add `onFocus` handlers on exp inputs to pre-populate with the default when the field is unset

Closes: #179

## Test plan
- [x] Selecting a date stores midnight UTC on that date (user and role grants)
- [x] Focusing an empty exp field pre-populates with last day of next month at midnight UTC
- [x] UTC midnight timestamps display correctly as `YYYY-MM-DDT00:00`
- [x] All 23 `sharing-panel.test.tsx` tests pass
- [x] `make generate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)