### PR TITLE
Prevent unauthenticated RPC calls on deep link navigation

### DIFF
--- a/frontend/src/lib/transport.test.ts
+++ b/frontend/src/lib/transport.test.ts
@@ -1,4 +1,4 @@
-import { tokenRef } from './transport'
+import { tokenRef, readStoredToken } from './transport'
 
 // We can't easily test the interceptor as it's not exported, but we can
 // test the tokenRef which is the shared mutable state for auth tokens.
@@ -20,5 +20,46 @@ describe('tokenRef', () => {
     tokenRef.current = 'test-token-123'
     tokenRef.current = null
     expect(tokenRef.current).toBeNull()
+  })
+})
+
+describe('readStoredToken', () => {
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('returns null when sessionStorage is empty', () => {
+    expect(readStoredToken()).toBeNull()
+  })
+
+  it('returns the access_token from a valid oidc.user entry', () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600
+    sessionStorage.setItem(
+      'oidc.user:https://localhost:8443/dex:holos-console',
+      JSON.stringify({ access_token: 'valid-token-abc', expires_at: futureExp }),
+    )
+    expect(readStoredToken()).toBe('valid-token-abc')
+  })
+
+  it('returns null when the stored token is expired', () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 60
+    sessionStorage.setItem(
+      'oidc.user:https://localhost:8443/dex:holos-console',
+      JSON.stringify({ access_token: 'expired-token', expires_at: pastExp }),
+    )
+    expect(readStoredToken()).toBeNull()
+  })
+
+  it('returns null when access_token is missing from the stored entry', () => {
+    sessionStorage.setItem(
+      'oidc.user:https://localhost:8443/dex:holos-console',
+      JSON.stringify({ expires_at: Math.floor(Date.now() / 1000) + 3600 }),
+    )
+    expect(readStoredToken()).toBeNull()
+  })
+
+  it('returns null when the stored JSON is malformed', () => {
+    sessionStorage.setItem('oidc.user:https://localhost:8443/dex:holos-console', 'not-json')
+    expect(readStoredToken()).toBeNull()
   })
 })

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -1,9 +1,33 @@
 import { createConnectTransport } from '@connectrpc/connect-web'
 import type { Interceptor } from '@connectrpc/connect'
 
+// readStoredToken reads the access token from sessionStorage synchronously at
+// module load time. oidc-client-ts stores the user object under a key matching
+// "oidc.user:<authority>:<client_id>". Reading it here ensures tokenRef is
+// populated before any React effect runs, eliminating the timing race where
+// child query hooks fire before AuthProvider's useEffect sets the token.
+export function readStoredToken(): string | null {
+  try {
+    const key = Object.keys(sessionStorage).find((k) => k.startsWith('oidc.user:'))
+    if (!key) return null
+    const raw = sessionStorage.getItem(key)
+    if (!raw) return null
+    const data = JSON.parse(raw) as { access_token?: string; expires_at?: number }
+    if (!data?.access_token) return null
+    // Treat expired tokens as absent; silent renew in AuthProvider will fix them.
+    if (data.expires_at && data.expires_at * 1000 < Date.now()) return null
+    return data.access_token
+  } catch {
+    return null
+  }
+}
+
 // Shared mutable ref for the current access token.
-// Set by AuthProvider whenever the user changes.
-export const tokenRef: { current: string | null } = { current: null }
+// Initialized synchronously from sessionStorage so that the very first RPC
+// request (before any React effect runs) already carries the correct token for
+// returning authenticated users. AuthProvider keeps this current on
+// login/logout/token refresh via a useEffect.
+export const tokenRef: { current: string | null } = { current: readStoredToken() }
 
 const authInterceptor: Interceptor = (next) => async (req) => {
   if (tokenRef.current) {

--- a/frontend/src/queries/organizations.ts
+++ b/frontend/src/queries/organizations.ts
@@ -5,18 +5,23 @@ import {
   OrganizationService,
 } from '@/gen/holos/console/v1/organizations_pb.js'
 import type { ListOrganizationsResponse, Organization } from '@/gen/holos/console/v1/organizations_pb.js'
+import { useAuth } from '@/lib/auth'
 
 export function useListOrganizations() {
+  const { isAuthenticated } = useAuth()
   return useQuery(
     OrganizationService.method.listOrganizations,
     {},
+    { enabled: isAuthenticated },
   )
 }
 
 export function useGetOrganization(name: string) {
+  const { isAuthenticated } = useAuth()
   return useQuery(
     OrganizationService.method.getOrganization,
     { name },
+    { enabled: isAuthenticated && !!name },
   )
 }
 

--- a/frontend/src/queries/projects.ts
+++ b/frontend/src/queries/projects.ts
@@ -7,18 +7,23 @@ import {
   ProjectService,
 } from '@/gen/holos/console/v1/projects_pb.js'
 import type { ListProjectsResponse, Project } from '@/gen/holos/console/v1/projects_pb.js'
+import { useAuth } from '@/lib/auth'
 
 export function useListProjects(organization: string) {
+  const { isAuthenticated } = useAuth()
   return useQuery(
     ProjectService.method.listProjects,
     create(ListProjectsRequestSchema, { organization }),
+    { enabled: isAuthenticated && !!organization },
   )
 }
 
 export function useGetProject(name: string) {
+  const { isAuthenticated } = useAuth()
   return useQuery(
     ProjectService.method.getProject,
     { name },
+    { enabled: isAuthenticated && !!name },
   )
 }
 

--- a/frontend/src/queries/secrets.ts
+++ b/frontend/src/queries/secrets.ts
@@ -4,12 +4,14 @@ import { useTransport } from '@connectrpc/connect-query'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { SecretsService } from '@/gen/holos/console/v1/secrets_pb.js'
 import type { SecretMetadata } from '@/gen/holos/console/v1/secrets_pb.js'
+import { useAuth } from '@/lib/auth'
 
 function listSecretsKey(project: string) {
   return ['secrets', 'list', project] as const
 }
 
 export function useListSecrets(project: string) {
+  const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
   return useQuery({
@@ -18,11 +20,12 @@ export function useListSecrets(project: string) {
       const response = await client.listSecrets({ project })
       return response.secrets
     },
-    enabled: !!project,
+    enabled: isAuthenticated && !!project,
   })
 }
 
 export function useGetSecret(project: string, name: string) {
+  const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
   return useQuery({
@@ -31,7 +34,7 @@ export function useGetSecret(project: string, name: string) {
       const response = await client.getSecret({ name, project })
       return response.data as Record<string, Uint8Array>
     },
-    enabled: !!project && !!name,
+    enabled: isAuthenticated && !!project && !!name,
   })
 }
 
@@ -40,6 +43,7 @@ export function useGetSecret(project: string, name: string) {
 // listSecrets cache. Uses the same query key as useListSecrets so TanStack Query
 // deduplicates the request when both hooks are active on the same page.
 export function useGetSecretMetadata(project: string, name: string) {
+  const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
   return useQuery({
@@ -48,7 +52,7 @@ export function useGetSecretMetadata(project: string, name: string) {
       const response = await client.listSecrets({ project })
       return response.secrets
     },
-    enabled: !!project && !!name,
+    enabled: isAuthenticated && !!project && !!name,
     select: (secrets) => secrets.find((s: SecretMetadata) => s.name === name) ?? null,
   })
 }

--- a/frontend/src/routes/_authenticated/organizations/$organizationName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$organizationName.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
@@ -16,7 +16,6 @@ import {
 } from '@/components/ui/dialog'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Check, Pencil, X } from 'lucide-react'
-import { useAuth } from '@/lib/auth'
 import { useOrg } from '@/lib/org-context'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { RawView } from '@/components/raw-view'
@@ -32,7 +31,6 @@ function OrganizationPage() {
   const { organizationName: name } = Route.useParams()
   const navigate = useNavigate()
   const { setSelectedOrg } = useOrg()
-  const { isAuthenticated, isLoading: authLoading, login } = useAuth()
   const transport = useTransport()
 
   const { data, isLoading, error } = useGetOrganization(name)
@@ -59,12 +57,6 @@ function OrganizationPage() {
   const [localDisplayName, setLocalDisplayName] = useState<string | null>(null)
   const [localDescription, setLocalDescription] = useState<string | null>(null)
   const [localOrganization, setLocalOrganization] = useState<typeof organization | null>(null)
-
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      login(`/organizations/${name}`)
-    }
-  }, [authLoading, isAuthenticated, login, name])
 
   const effectiveOrg = localOrganization ?? organization
   const displayName = localDisplayName ?? effectiveOrg?.displayName
@@ -118,7 +110,7 @@ function OrganizationPage() {
     } catch { /* error via mutation */ }
   }
 
-  if (authLoading || (isAuthenticated && isLoading)) {
+  if (isLoading) {
     return (
       <Card>
         <CardContent className="pt-6">

--- a/frontend/src/routes/_authenticated/projects/$projectName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { createFileRoute, Link, useNavigate, Outlet, useMatchRoute } from '@tanstack/react-router'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
@@ -16,7 +16,6 @@ import {
 } from '@/components/ui/dialog'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Check, Pencil, X } from 'lucide-react'
-import { useAuth } from '@/lib/auth'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { RawView } from '@/components/raw-view'
 import { useGetProject, useDeleteProject, useUpdateProject, useUpdateProjectSharing } from '@/queries/projects'
@@ -30,7 +29,6 @@ export const Route = createFileRoute('/_authenticated/projects/$projectName')({
 function ProjectPage() {
   const { projectName: name } = Route.useParams()
   const navigate = useNavigate()
-  const { isAuthenticated, isLoading: authLoading, login } = useAuth()
   const transport = useTransport()
 
   const { data, isLoading, error } = useGetProject(name)
@@ -61,12 +59,6 @@ function ProjectPage() {
   // Check if we're rendering a child route (secrets)
   const matchRoute = useMatchRoute()
   const isChildRoute = !matchRoute({ to: '/projects/$projectName', params: { projectName: name } })
-
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      login(`/projects/${name}`)
-    }
-  }, [authLoading, isAuthenticated, login, name])
 
   // If we're on a child route, just render the outlet
   if (isChildRoute) {
@@ -125,7 +117,7 @@ function ProjectPage() {
     } catch { /* dialog stays open; deleteMutation.error is shown in the dialog */ }
   }
 
-  if (authLoading || (isAuthenticated && isLoading)) {
+  if (isLoading) {
     return (
       <Card>
         <CardContent className="pt-6">


### PR DESCRIPTION
## Summary

- **`transport.ts`**: Export `readStoredToken()` that reads the oidc-client-ts session from `sessionStorage` synchronously at module load time. Initialize `tokenRef.current` with it, so the very first RPC request carries the correct Bearer token before any React effect runs.
- **Query hooks**: Add `enabled: isAuthenticated` to `useListOrganizations`, `useGetOrganization`, `useListProjects`, `useGetProject`, `useListSecrets`, `useGetSecret`, and `useGetSecretMetadata`. Queries now stay dormant until auth is confirmed.
- **Page components**: Remove redundant per-page auth redirect `useEffect` from `$organizationName.tsx` and `$projectName.tsx`. The `_authenticated.tsx` layout already handles auth redirects; these were defensive duplicates.

Closes: #180

## Test plan
- [ ] Navigate directly to `/projects/garage/secrets/local-dev-secrets` while unauthenticated: zero RPC calls in Network tab before redirect to OIDC
- [ ] Navigate directly to `/projects/garage/secrets/local-dev-secrets` with a valid session: all RPC calls carry `Authorization: Bearer <token>` on first attempt, no 401s
- [ ] Login flow completes and data loads correctly
- [ ] Logout clears `tokenRef.current` and subsequent navigation does not carry stale token
- [ ] `make generate` passes ✅
- [ ] `make test-ui` passes (71 tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)