### PR TITLE
Fix: role group with owner permission can now modify sharing

### DIFF
--- a/frontend/src/lib/isOwner.test.ts
+++ b/frontend/src/lib/isOwner.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { isOwner } from './isOwner'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+
+describe('isOwner', () => {
+  describe('user grants', () => {
+    it('returns true when email matches a user grant with owner role', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          [],
+          [{ principal: 'alice@example.com', role: Role.OWNER }],
+          [],
+        ),
+      ).toBe(true)
+    })
+
+    it('returns false when email matches a user grant with non-owner role', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          [],
+          [{ principal: 'alice@example.com', role: Role.EDITOR }],
+          [],
+        ),
+      ).toBe(false)
+    })
+
+    it('returns false when email does not match any user grant', () => {
+      expect(
+        isOwner(
+          'bob@example.com',
+          [],
+          [{ principal: 'alice@example.com', role: Role.OWNER }],
+          [],
+        ),
+      ).toBe(false)
+    })
+
+    it('returns false when email is undefined', () => {
+      expect(
+        isOwner(
+          undefined,
+          [],
+          [{ principal: 'alice@example.com', role: Role.OWNER }],
+          [],
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('role grants (the bug: groups with owner permission)', () => {
+    it('returns true when user group matches a role grant with owner role', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          ['platform-owner'],
+          [],
+          [{ principal: 'platform-owner', role: Role.OWNER }],
+        ),
+      ).toBe(true)
+    })
+
+    it('returns false when user group matches a role grant with non-owner role', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          ['platform-owner'],
+          [],
+          [{ principal: 'platform-owner', role: Role.EDITOR }],
+        ),
+      ).toBe(false)
+    })
+
+    it('returns false when user has no groups matching any role grant', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          ['dev-team'],
+          [],
+          [{ principal: 'platform-owner', role: Role.OWNER }],
+        ),
+      ).toBe(false)
+    })
+
+    it('returns true when one of multiple user groups matches owner role grant', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          ['dev-team', 'platform-owner'],
+          [],
+          [{ principal: 'platform-owner', role: Role.OWNER }],
+        ),
+      ).toBe(true)
+    })
+
+    it('returns false when groups array is empty', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          [],
+          [],
+          [{ principal: 'platform-owner', role: Role.OWNER }],
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('combined user and role grants', () => {
+    it('returns true when email matches owner user grant even without matching role grant', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          ['dev-team'],
+          [{ principal: 'alice@example.com', role: Role.OWNER }],
+          [{ principal: 'platform-owner', role: Role.OWNER }],
+        ),
+      ).toBe(true)
+    })
+
+    it('returns true when group matches owner role grant even without matching user grant', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          ['platform-owner'],
+          [{ principal: 'bob@example.com', role: Role.OWNER }],
+          [{ principal: 'platform-owner', role: Role.OWNER }],
+        ),
+      ).toBe(true)
+    })
+
+    it('returns false when no email or group match owner role', () => {
+      expect(
+        isOwner(
+          'alice@example.com',
+          ['dev-team'],
+          [{ principal: 'bob@example.com', role: Role.OWNER }],
+          [{ principal: 'platform-owner', role: Role.OWNER }],
+        ),
+      ).toBe(false)
+    })
+  })
+})

--- a/frontend/src/lib/isOwner.ts
+++ b/frontend/src/lib/isOwner.ts
@@ -1,0 +1,15 @@
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+
+// isOwner returns true if the user has the owner role on a secret.
+// It checks both direct user grants (by email) and role grants (by group membership).
+export function isOwner(
+  email: string | undefined,
+  groups: string[],
+  userGrants: { principal: string; role: Role }[],
+  roleGrants: { principal: string; role: Role }[],
+): boolean {
+  if (email != null && userGrants.some((g) => g.principal === email && g.role === Role.OWNER)) {
+    return true
+  }
+  return roleGrants.some((g) => groups.includes(g.principal) && g.role === Role.OWNER)
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/$name.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/$name.tsx
@@ -22,9 +22,9 @@ import { RawView } from '@/components/raw-view'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { isSafeUrl } from '@/lib/utils'
 import { useGetSecret, useGetSecretMetadata, useUpdateSecret, useUpdateSecretSharing, useDeleteSecret } from '@/queries/secrets'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { SecretsService } from '@/gen/holos/console/v1/secrets_pb.js'
 import type { ShareGrant } from '@/gen/holos/console/v1/secrets_pb.js'
+import { isOwner as computeIsOwner } from '@/lib/isOwner'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/secrets/$name')({
   component: SecretPage,
@@ -116,9 +116,10 @@ function SecretPage() {
      effectiveUrl !== (originalUrl ?? ''))
 
   const userEmail = user?.profile?.email as string | undefined
-  const isOwner =
-    userEmail != null &&
-    effectiveUserGrants.some((g) => g.principal === userEmail && g.role === Role.OWNER)
+  const userGroups = Array.isArray((user?.profile as Record<string, unknown> | undefined)?.groups)
+    ? ((user!.profile as Record<string, unknown>).groups as string[])
+    : []
+  const isOwner = computeIsOwner(userEmail, userGroups, effectiveUserGrants, effectiveRoleGrants)
 
   const handleSaveSharing = async (newUserGrants: Grant[], newRoleGrants: Grant[]) => {
     const response = await updateSharingMutation.mutateAsync({


### PR DESCRIPTION
## Summary
- Extract `isOwner` helper (`frontend/src/lib/isOwner.ts`) that checks both direct user grants (by email) and role grants (by group membership)
- Fix `$name.tsx` to pass the user's OIDC groups when computing `isOwner`, so the sharing Edit button appears when the user holds owner via a role grant (e.g. `platform-owner`) rather than only when explicitly named by email
- Add 12 unit tests covering both user-grant and role-grant paths, including the bug scenario

Closes: #168

## Root cause
`isOwner` in `$name.tsx` only scanned `effectiveUserGrants` for the user's email. The backend already evaluates both user and role grants via `CheckAccessGrants`/`BestRoleFromGrants`, but the frontend did not mirror this logic.

## Test plan
- [ ] `make test-ui` passes (87 tests)
- [ ] `make generate` succeeds (TypeScript build clean)
- [ ] User in `platform-owner` group with owner role grant sees the Edit button on the sharing panel
- [ ] User with direct email owner grant still sees the Edit button (no regression)
- [ ] User with only editor/viewer role does not see the Edit button

🤖 Generated with [Claude Code](https://claude.com/claude-code)