### PR TITLE
Convert make run to a script that accepts extra flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ certs: ## Generate TLS certificates using mkcert.
 	./scripts/certs
 
 .PHONY: run
-run: build ## Run the server with generated certificates.
-	./bin/$(BIN_NAME) --enable-insecure-dex --cert certs/tls.crt --key certs/tls.key --ca-cert "$$(mkcert -CAROOT)/rootCA.pem"
+run: ## Build and run the server with generated certificates.
+	./scripts/run
 
 .PHONY: dev
 dev: ## Start the Vite dev server for frontend development.

--- a/scripts/run
+++ b/scripts/run
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Build and run the dev server with generated certificates.
+# Extra arguments are appended to the server flags, e.g.:
+#   scripts/run --listen :9443
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+make build
+
+exec ./bin/holos-console \
+    --enable-insecure-dex \
+    --cert certs/tls.crt \
+    --key certs/tls.key \
+    --ca-cert "$(mkcert -CAROOT)/rootCA.pem" \
+    "$@"


### PR DESCRIPTION
## Summary
- Extract `make run` into `scripts/run` so extra CLI flags (e.g. `--listen :9443`) can be appended
- `make run` still works identically via the new script
- Enables running multiple local instances on different ports: `scripts/run --listen :9443`

## Test plan
- [ ] `make run` starts the server on the default port (:8443)
- [ ] `scripts/run --listen :9443` starts the server on port 9443

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-2