### PR TITLE
fix(auth): skip silent renewal, redirect immediately through OIDC

### DIFF
--- a/frontend/src/routes/-_authenticated.test.tsx
+++ b/frontend/src/routes/-_authenticated.test.tsx
@@ -54,25 +54,12 @@ function setAuthState({
   })
 }
 
-describe('AuthenticatedLayout silent renewal', () => {
+describe('AuthenticatedLayout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('attempts silent renewal before redirecting when not authenticated', async () => {
-    mockRefreshTokens.mockResolvedValue(undefined)
-    setAuthState({ isAuthenticated: false, isLoading: false })
-
-    render(<AuthenticatedLayout />)
-
-    await waitFor(() => {
-      expect(mockRefreshTokens).toHaveBeenCalled()
-    })
-    expect(mockLogin).not.toHaveBeenCalled()
-  })
-
-  it('redirects through OIDC login when silent renewal fails', async () => {
-    mockRefreshTokens.mockRejectedValue(new Error('silent renew failed'))
+  it('calls login() immediately without refreshTokens() when not authenticated', async () => {
     mockLogin.mockResolvedValue(undefined)
     setAuthState({ isAuthenticated: false, isLoading: false })
 
@@ -81,6 +68,7 @@ describe('AuthenticatedLayout silent renewal', () => {
     await waitFor(() => {
       expect(mockLogin).toHaveBeenCalled()
     })
+    expect(mockRefreshTokens).not.toHaveBeenCalled()
   })
 
   it('does not attempt auth when still loading', async () => {

--- a/frontend/src/routes/_authenticated.tsx
+++ b/frontend/src/routes/_authenticated.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { useAuth } from '@/lib/auth'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect } from 'react'
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
 import { OrgProvider } from '@/lib/org-context'
@@ -12,26 +12,15 @@ export const Route = createFileRoute('/_authenticated')({
 })
 
 export function AuthenticatedLayout() {
-  const { isAuthenticated, isLoading, refreshTokens, login } = useAuth()
-  const silentRenewAttempted = useRef(false)
-  const [silentRenewPending, setSilentRenewPending] = useState(false)
+  const { isAuthenticated, isLoading, login } = useAuth()
 
-  // Attempt silent token renewal once. If it succeeds, isAuthenticated flips
-  // to true and we re-render with the sidebar. If it fails, redirect the user
-  // through the OIDC auth flow so they land back at the same URL after login.
   useEffect(() => {
-    if (!isLoading && !isAuthenticated && !silentRenewAttempted.current) {
-      silentRenewAttempted.current = true
-      setSilentRenewPending(true)
-      refreshTokens()
-        .catch(() => {
-          login(window.location.pathname + window.location.search).catch(() => {})
-        })
-        .finally(() => setSilentRenewPending(false))
+    if (!isLoading && !isAuthenticated) {
+      login(window.location.pathname + window.location.search).catch(() => {})
     }
-  }, [isLoading, isAuthenticated, refreshTokens, login])
+  }, [isLoading, isAuthenticated, login])
 
-  if (isLoading || silentRenewPending || !isAuthenticated) {
+  if (isLoading || !isAuthenticated) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />


### PR DESCRIPTION
## Summary
- Remove `silentRenewPending` state, `silentRenewAttempted` ref, and the `refreshTokens()` call from `AuthenticatedLayout`
- When `isLoading=false` and `isAuthenticated=false`, call `login()` directly — eliminates the up-to-10-second wait for `signinSilent()` iframe timeout
- Update tests: drop the old "attempts silent renewal" tests, add test asserting `login()` fires immediately and `refreshTokens()` is not called
- `refreshTokens`, `lastRefreshStatus`, `lastRefreshTime`, `lastRefreshError` are retained in `AuthContextValue` and `AuthProvider` — still used by the Profile page

Closes: #229

## Test plan
- [x] `make generate` passes (TypeScript type check + build)
- [x] `make test` passes (116/116 tests)
- [ ] Direct navigation to `/profile` or `/secrets` without a session redirects immediately to OIDC login (no spinner wait)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-4