### PR TITLE
chore: remove stale comments and dead code after settings pages

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -149,6 +149,15 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/routes/_authenticated/-about.test.tsx` | About page: Server Version card, license card |
 | `src/routes/_authenticated/-profile.test.tsx` | Profile page: token claims, raw JSON view |
 | `src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx` | Secrets list page: table, sorting, error/loading |
+| `src/routes/_authenticated/projects/$projectName/secrets/-$name.test.tsx` | Secret detail page: display, edit, delete |
+| `src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx` | Project settings page: display name, description, sharing, delete |
+| `src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx` | Org settings page: display name, description, sharing, delete |
+| `src/routes/_authenticated/projects/-$projectName.test.tsx` | ProjectLayout: sets selected project from URL param |
+| `src/routes/_authenticated/orgs/$orgName/projects/-index.test.tsx` | Org projects page: list, navigate to project |
 | `src/routes/-_authenticated.test.tsx` | Auth layout: silent renewal, OIDC redirect |
 | `src/lib/isOwner.test.ts` | RBAC owner check logic |
+| `src/lib/org-context.test.tsx` | Org context: persistence, reset, filtering |
+| `src/lib/project-context.test.tsx` | Project context: persistence, reset, filtering |
 | `src/lib/transport.test.ts` | Token storage and transport setup |
+| `src/queries/-organizations.test.ts` | useListOrganizations and useCreateOrganization hooks |
+| `src/queries/-projects.test.ts` | useListProjects and useCreateProject hooks |

--- a/frontend/src/lib/isOwner.ts
+++ b/frontend/src/lib/isOwner.ts
@@ -1,6 +1,6 @@
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 
-// isOwner returns true if the user has the owner role on a secret.
+// isOwner returns true if the user has the owner role on a resource.
 // It checks both direct user grants (by email) and role grants (by group membership).
 export function isOwner(
   email: string | undefined,


### PR DESCRIPTION
## Summary
- Fix stale comment in `isOwner.ts` that described the function as secret-only; it is now used for org, project, and secret resources
- Add missing test file entries to `docs/testing.md` for settings pages, project layout, org projects list, context hooks, and query hooks introduced by #239

Closes: #246

## Test plan
- [x] `make test-ui` passes with zero failures (261 tests)
- [x] `make generate` passes with no TypeScript errors
- [x] No comments in the codebase describe Settings as redirecting to secrets
- [x] No unused imports in files touched by #239

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-0