### PR TITLE
feat: project nav heading and label improvements

### DIFF
--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -147,7 +147,7 @@ describe('AppSidebar', () => {
   it('does not render project nav links when no project is selected', () => {
     render(<AppSidebar />)
     expect(screen.queryByText('Secrets')).toBeNull()
-    expect(screen.queryByText('Settings')).toBeNull()
+    expect(screen.queryByText('Project Settings')).toBeNull()
   })
 })
 
@@ -303,20 +303,27 @@ describe('AppSidebar — project selected', () => {
     expect(screen.getByText('Secrets')).toBeInTheDocument()
   })
 
-  it('renders project Settings nav link when a project is selected', () => {
+  it('renders project Settings nav link labeled "Project Settings" when a project is selected', () => {
     render(<AppSidebar />)
-    // Org nav shows "Org Settings"; project nav shows "Settings".
-    expect(screen.getByRole('link', { name: /^settings$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^project settings$/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /^org settings$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^settings$/i })).toBeNull()
   })
 
   it('project Settings link points to /projects/$projectName/settings', () => {
     render(<AppSidebar />)
-    const links = screen.getAllByRole('link', { name: /settings/i })
+    const links = screen.getAllByRole('link', { name: /project settings/i })
     const projectSettingsLink = links.find((l) =>
       l.getAttribute('href')?.startsWith('/projects/'),
     )
     expect(projectSettingsLink?.getAttribute('href')).toBe('/projects/my-project/settings/')
+  })
+
+  it('renders project display name as group label in project nav section', () => {
+    render(<AppSidebar />)
+    const labels = screen.getAllByTestId('sidebar-group-label')
+    const labelTexts = labels.map((l) => l.textContent)
+    expect(labelTexts).toContain('My Project')
   })
 
   it('org nav group is also visible when a project is selected', () => {

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -46,13 +46,18 @@ export function AppSidebar() {
   const { data: versionData } = useVersion()
   const router = useRouter()
   const pathname = router.state.location.pathname
-  const { selectedProject } = useProject()
+  const { projects, selectedProject } = useProject()
   const { selectedOrg, organizations } = useOrg()
 
   const selectedOrgObj = organizations.find((o) => o.name === selectedOrg)
   const orgDisplayName = selectedOrgObj
     ? (selectedOrgObj.displayName || selectedOrgObj.name)
     : selectedOrg ?? ''
+
+  const selectedProjectObj = projects.find((p) => p.name === selectedProject)
+  const projectDisplayName = selectedProjectObj
+    ? (selectedProjectObj.displayName || selectedProjectObj.name)
+    : selectedProject ?? ''
 
   const orgNavItems: Array<{
     label: string
@@ -90,7 +95,7 @@ export function AppSidebar() {
           icon: KeyRound,
         },
         {
-          label: 'Settings',
+          label: 'Project Settings',
           to: '/projects/$projectName/settings/' as const,
           params: { projectName: selectedProject },
           icon: Settings,
@@ -141,6 +146,7 @@ export function AppSidebar() {
         )}
         {projectNavItems.length > 0 && (
           <SidebarGroup>
+            <SidebarGroupLabel>{projectDisplayName}</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 {projectNavItems.map((item) => {


### PR DESCRIPTION
## Summary
- Add `SidebarGroupLabel` to project nav section showing the selected project's display name (mirrors the org nav pattern)
- Rename project nav "Settings" label to "Project Settings" for clarity
- Resolve `selectedProjectObj` / `projectDisplayName` in `AppSidebar`, mirroring the existing `selectedOrgObj` / `orgDisplayName` pattern
- Update unit tests to assert new "Project Settings" label and project display name as a group heading

Closes: #255

## Test plan
- [x] `make test-ui` passes (23 tests)
- [x] `make generate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1