### PR TITLE
feat(projects): apply org default sharing to new projects

### DIFF
--- a/console/organizations/resolver.go
+++ b/console/organizations/resolver.go
@@ -30,3 +30,16 @@ func (r *OrgGrantResolver) GetOrgGrants(ctx context.Context, org string) (map[st
 	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
 	return activeUsers, activeRoles, nil
 }
+
+// GetOrgDefaultGrants returns the default sharing grants for an organization.
+// These are applied to new projects created within the organization.
+// Implements projects.OrgDefaultShareResolver.
+func (r *OrgGrantResolver) GetOrgDefaultGrants(ctx context.Context, org string) ([]secrets.AnnotationGrant, []secrets.AnnotationGrant, error) {
+	ns, err := r.k8s.GetOrganization(ctx, org)
+	if err != nil {
+		return nil, nil, err
+	}
+	defaultUsers, _ := GetDefaultShareUsers(ns)
+	defaultRoles, _ := GetDefaultShareRoles(ns)
+	return defaultUsers, defaultRoles, nil
+}

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -27,6 +27,13 @@ type OrgResolver interface {
 	GetOrgGrants(ctx context.Context, org string) (users, roles map[string]string, err error)
 }
 
+// OrgDefaultShareResolver is an optional interface that an OrgResolver can also
+// implement to provide default sharing grants from the organization.  These
+// defaults are merged into new projects created within the organization.
+type OrgDefaultShareResolver interface {
+	GetOrgDefaultGrants(ctx context.Context, org string) (defaultUsers, defaultRoles []secrets.AnnotationGrant, err error)
+}
+
 // Handler implements the ProjectService.
 type Handler struct {
 	consolev1connect.UnimplementedProjectServiceHandler
@@ -181,10 +188,34 @@ func (h *Handler) CreateProject(
 	shareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
 	shareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
 
+	// Merge organization-level default sharing grants (if the resolver supports it).
+	// Request-supplied grants override defaults for the same principal via DeduplicateGrants
+	// (highest role wins, so explicit grants at a higher role shadow lower defaults).
+	// Also copy org defaults as the project's default sharing so new secrets inherit them.
+	var defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant
+	if req.Msg.Organization != "" {
+		if ds, ok := h.orgResolver.(OrgDefaultShareResolver); ok {
+			orgDefaultUsers, orgDefaultRoles, err := ds.GetOrgDefaultGrants(ctx, req.Msg.Organization)
+			if err != nil {
+				slog.WarnContext(ctx, "failed to resolve org default grants, proceeding without them",
+					slog.String("organization", req.Msg.Organization),
+					slog.Any("error", err),
+				)
+			} else {
+				// Concatenate: request grants first so they win over defaults for the same principal.
+				shareUsers = secrets.DeduplicateGrants(append(shareUsers, orgDefaultUsers...))
+				shareRoles = secrets.DeduplicateGrants(append(shareRoles, orgDefaultRoles...))
+				// Copy org defaults as project defaults so new secrets also inherit them.
+				defaultShareUsers = orgDefaultUsers
+				defaultShareRoles = orgDefaultRoles
+			}
+		}
+	}
+
 	// Ensure creator is included as owner
 	shareUsers = ensureCreatorOwner(shareUsers, claims.Email)
 
-	_, err = h.k8s.CreateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, req.Msg.Organization, shareUsers, shareRoles)
+	_, err = h.k8s.CreateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, req.Msg.Organization, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -935,6 +935,241 @@ func TestBuildProject_PopulatesDefaultGrants(t *testing.T) {
 	}
 }
 
+// ---- CreateProject with org default sharing tests ----
+
+// mockOrgDefaultShareResolver implements both OrgResolver and OrgDefaultShareResolver.
+type mockOrgDefaultShareResolver struct {
+	users         map[string]string
+	groups        map[string]string
+	defaultUsers  []secrets.AnnotationGrant
+	defaultRoles  []secrets.AnnotationGrant
+	defaultCalled bool
+}
+
+func (m *mockOrgDefaultShareResolver) GetOrgGrants(_ context.Context, _ string) (map[string]string, map[string]string, error) {
+	return m.users, m.groups, nil
+}
+
+func (m *mockOrgDefaultShareResolver) GetOrgDefaultGrants(_ context.Context, _ string) ([]secrets.AnnotationGrant, []secrets.AnnotationGrant, error) {
+	m.defaultCalled = true
+	return m.defaultUsers, m.defaultRoles, nil
+}
+
+func TestCreateProject_MergesOrgDefaultsIntoProjectGrants(t *testing.T) {
+	// Existing project so alice has create permission
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgResolver := &mockOrgDefaultShareResolver{
+		users:  map[string]string{"alice@example.com": "owner"},
+		groups: nil,
+		defaultUsers: []secrets.AnnotationGrant{
+			{Principal: "bob@example.com", Role: "viewer"},
+			{Principal: "carol@example.com", Role: "editor"},
+		},
+		defaultRoles: []secrets.AnnotationGrant{
+			{Principal: "engineering", Role: "viewer"},
+		},
+	}
+
+	objs := []runtime.Object{existing}
+	fakeClient := fake.NewClientset(objs...)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, orgResolver)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-project",
+		Organization: "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify the created namespace has merged grants
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-prj-new-project", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected namespace to exist, got %v", err)
+	}
+
+	users, err := GetShareUsers(ns)
+	if err != nil {
+		t.Fatalf("failed to parse share-users: %v", err)
+	}
+
+	// Should contain: alice (owner from ensureCreatorOwner), bob (viewer from org default), carol (editor from org default)
+	principalRoles := make(map[string]string)
+	for _, u := range users {
+		principalRoles[u.Principal] = u.Role
+	}
+	if principalRoles["alice@example.com"] != "owner" {
+		t.Errorf("expected alice as owner, got %q", principalRoles["alice@example.com"])
+	}
+	if principalRoles["bob@example.com"] != "viewer" {
+		t.Errorf("expected bob as viewer from org default, got %q", principalRoles["bob@example.com"])
+	}
+	if principalRoles["carol@example.com"] != "editor" {
+		t.Errorf("expected carol as editor from org default, got %q", principalRoles["carol@example.com"])
+	}
+
+	// Verify role grants merged
+	roles, err := GetShareRoles(ns)
+	if err != nil {
+		t.Fatalf("failed to parse share-roles: %v", err)
+	}
+	roleMap := make(map[string]string)
+	for _, r := range roles {
+		roleMap[r.Principal] = r.Role
+	}
+	if roleMap["engineering"] != "viewer" {
+		t.Errorf("expected engineering as viewer from org default, got %q", roleMap["engineering"])
+	}
+}
+
+func TestCreateProject_CopiesOrgDefaultsAsProjectDefaults(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgResolver := &mockOrgDefaultShareResolver{
+		users:  map[string]string{"alice@example.com": "owner"},
+		groups: nil,
+		defaultUsers: []secrets.AnnotationGrant{
+			{Principal: "bob@example.com", Role: "viewer"},
+		},
+		defaultRoles: []secrets.AnnotationGrant{
+			{Principal: "engineering", Role: "editor"},
+		},
+	}
+
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, orgResolver)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-project",
+		Organization: "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-prj-new-project", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected namespace to exist, got %v", err)
+	}
+
+	// Verify default sharing annotations were set
+	defaultUsers, err := GetDefaultShareUsers(ns)
+	if err != nil {
+		t.Fatalf("failed to parse default-share-users: %v", err)
+	}
+	if len(defaultUsers) != 1 || defaultUsers[0].Principal != "bob@example.com" || defaultUsers[0].Role != "viewer" {
+		t.Errorf("expected default-share-users [{bob@example.com viewer}], got %v", defaultUsers)
+	}
+
+	defaultRoles, err := GetDefaultShareRoles(ns)
+	if err != nil {
+		t.Fatalf("failed to parse default-share-roles: %v", err)
+	}
+	if len(defaultRoles) != 1 || defaultRoles[0].Principal != "engineering" || defaultRoles[0].Role != "editor" {
+		t.Errorf("expected default-share-roles [{engineering editor}], got %v", defaultRoles)
+	}
+}
+
+func TestCreateProject_RequestGrantsOverrideOrgDefaults(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgResolver := &mockOrgDefaultShareResolver{
+		users:  map[string]string{"alice@example.com": "owner"},
+		groups: nil,
+		defaultUsers: []secrets.AnnotationGrant{
+			{Principal: "bob@example.com", Role: "viewer"},
+		},
+	}
+
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, orgResolver)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	// Request grants bob as editor — should override the org default of viewer
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-project",
+		Organization: "acme",
+		UserGrants: []*consolev1.ShareGrant{
+			{Principal: "bob@example.com", Role: consolev1.Role_ROLE_EDITOR},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-prj-new-project", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected namespace to exist, got %v", err)
+	}
+	users, err := GetShareUsers(ns)
+	if err != nil {
+		t.Fatalf("failed to parse share-users: %v", err)
+	}
+	for _, u := range users {
+		if u.Principal == "bob@example.com" {
+			if u.Role != "editor" {
+				t.Errorf("expected bob as editor (request override), got %q", u.Role)
+			}
+			return
+		}
+	}
+	t.Error("expected bob@example.com in share-users")
+}
+
+func TestCreateProject_WithoutOrg_BehavesAsBeforeNoDefaults(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgResolver := &mockOrgDefaultShareResolver{
+		users: map[string]string{"alice@example.com": "owner"},
+		defaultUsers: []secrets.AnnotationGrant{
+			{Principal: "should-not-appear@example.com", Role: "viewer"},
+		},
+	}
+
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, orgResolver)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	// Create without organization — org defaults should NOT be applied
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name: "standalone-project",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if orgResolver.defaultCalled {
+		t.Error("expected org default resolver to NOT be called when no organization is specified")
+	}
+
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-prj-standalone-project", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected namespace to exist, got %v", err)
+	}
+
+	// Should only have creator as owner, no org defaults
+	users, err := GetShareUsers(ns)
+	if err != nil {
+		t.Fatalf("failed to parse share-users: %v", err)
+	}
+	if len(users) != 1 || users[0].Principal != "alice@example.com" {
+		t.Errorf("expected only creator alice, got %v", users)
+	}
+
+	// Should have no default sharing annotations
+	defaultUsers, _ := GetDefaultShareUsers(ns)
+	if len(defaultUsers) != 0 {
+		t.Errorf("expected no default-share-users, got %v", defaultUsers)
+	}
+}
+
 func assertInvalidArgument(t *testing.T, err error) {
 	t.Helper()
 	if err == nil {

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -92,7 +92,7 @@ func (c *K8sClient) GetProject(ctx context.Context, name string) (*corev1.Namesp
 }
 
 // CreateProject creates a new namespace with managed-by and resource-type labels.
-func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	nsName := c.Resolver.ProjectNamespace(name)
 	slog.DebugContext(ctx, "creating project in kubernetes",
 		slog.String("name", name),
@@ -109,6 +109,20 @@ func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, descri
 	annotations := map[string]string{
 		secrets.ShareUsersAnnotation: string(usersJSON),
 		secrets.ShareRolesAnnotation: string(rolesJSON),
+	}
+	if len(defaultShareUsers) > 0 {
+		defaultUsersJSON, err := json.Marshal(defaultShareUsers)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling default-share-users: %w", err)
+		}
+		annotations[DefaultShareUsersAnnotation] = string(defaultUsersJSON)
+	}
+	if len(defaultShareRoles) > 0 {
+		defaultRolesJSON, err := json.Marshal(defaultShareRoles)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling default-share-roles: %w", err)
+		}
+		annotations[DefaultShareRolesAnnotation] = string(defaultRolesJSON)
 	}
 	if displayName != "" {
 		annotations[DisplayNameAnnotation] = displayName

--- a/console/projects/k8s_test.go
+++ b/console/projects/k8s_test.go
@@ -256,7 +256,7 @@ func TestCreateProject_UsesPrefixNamespace(t *testing.T) {
 	shareUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
 	shareRoles := []secrets.AnnotationGrant{{Principal: "engineering", Role: "editor"}}
 
-	result, err := k8s.CreateProject(context.Background(), "new-project", "New Project", "A test project", "acme", shareUsers, shareRoles)
+	result, err := k8s.CreateProject(context.Background(), "new-project", "New Project", "A test project", "acme", shareUsers, shareRoles, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -281,7 +281,7 @@ func TestCreateProject_SetsOrgLabelWhenProvided(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "acme", nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "acme", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -294,7 +294,7 @@ func TestCreateProject_OmitsOrgLabelWhenEmpty(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "", nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -317,7 +317,7 @@ func TestCreateProject_ReturnsAlreadyExistsForDuplicateName(t *testing.T) {
 	fakeClient := fake.NewClientset(existing)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	_, err := k8s.CreateProject(context.Background(), "existing", "", "", "", nil, nil)
+	_, err := k8s.CreateProject(context.Background(), "existing", "", "", "", nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
## Summary
- Add `OrgDefaultShareResolver` interface in projects package for resolving org-level default sharing grants
- Implement `GetOrgDefaultGrants` on `organizations.OrgGrantResolver` to read default sharing annotations from org namespaces
- Modify `CreateProject` handler to merge org default sharing grants into project direct grants when an organization is specified
- Copy org default sharing as project default sharing so new secrets also inherit the defaults
- Extend `K8sClient.CreateProject` to accept default sharing parameters in a single create call

Closes: #288

## Test plan
- [x] `TestCreateProject_MergesOrgDefaultsIntoProjectGrants` — org defaults merge into project grants
- [x] `TestCreateProject_CopiesOrgDefaultsAsProjectDefaults` — org defaults copied as project default sharing
- [x] `TestCreateProject_RequestGrantsOverrideOrgDefaults` — request-supplied grants override org defaults for same principal
- [x] `TestCreateProject_WithoutOrg_BehavesAsBeforeNoDefaults` — no org means no defaults applied
- [x] All existing tests pass (`go test ./console/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1