### PR TITLE
chore: cleanup after org default sharing feature

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -85,6 +85,8 @@ Grants are stored as JSON annotations on Namespace and Secret resources:
 |---|---|---|
 | `console.holos.run/share-users` | `[{"principal":"email","role":"role","nbf":ts,"exp":ts}]` | Per-user grants |
 | `console.holos.run/share-roles` | `[{"principal":"role","role":"role","nbf":ts,"exp":ts}]` | Per-role grants |
+| `console.holos.run/default-share-users` | `[{"principal":"email","role":"role","nbf":ts,"exp":ts}]` | Default per-user grants applied to new projects in the org |
+| `console.holos.run/default-share-roles` | `[{"principal":"role","role":"role","nbf":ts,"exp":ts}]` | Default per-role grants applied to new projects in the org |
 
 Each grant is a JSON object with:
 
@@ -122,6 +124,10 @@ Parent grants do **not** implicitly grant full access to child resources:
 `PERMISSION_PROJECTS_CREATE` requires owner on **at least one existing project** or owner on the target organization (checked via a separate authorization path, not cascade).
 
 Organization creation is controlled by CLI flags (`--disable-org-creation`, `--org-creator-users`, `--org-creator-roles`), not by grant-based authorization.
+
+## Organization Default Sharing
+
+Organizations can define **default sharing grants** that are automatically applied to new projects created within the organization. These defaults are stored as annotations on the organization namespace (`console.holos.run/default-share-users` and `console.holos.run/default-share-roles`) and are copied to the project namespace at creation time. Changing the defaults does not retroactively update existing projects.
 
 ## Example: Organization with Project and Secrets
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -151,7 +151,7 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx` | Secrets list page: table, sorting, error/loading |
 | `src/routes/_authenticated/projects/$projectName/secrets/-$name.test.tsx` | Secret detail page: display, edit, delete |
 | `src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx` | Project settings page: display name, description, sharing, default secret sharing, delete |
-| `src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx` | Org settings page: display name, description, sharing, delete |
+| `src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx` | Org settings page: display name, description, sharing, default sharing, delete |
 | `src/routes/_authenticated/projects/-$projectName.test.tsx` | ProjectLayout: sets selected project from URL param |
 | `src/routes/_authenticated/orgs/$orgName/projects/-index.test.tsx` | Org projects page: list, navigate to project |
 | `src/routes/-_authenticated.test.tsx` | Auth layout: silent renewal, OIDC redirect |
@@ -160,7 +160,7 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/lib/project-context.test.tsx` | Project context: persistence, reset, filtering |
 | `src/lib/slug.test.ts` | Slug generation from display names |
 | `src/lib/transport.test.ts` | Token storage and transport setup |
-| `src/queries/-organizations.test.ts` | useListOrganizations and useCreateOrganization hooks |
+| `src/queries/-organizations.test.ts` | Organization query hooks: get, update, sharing, default sharing, delete |
 | `src/queries/-projects.test.ts` | useListProjects and useCreateProject hooks |
 | `src/components/create-org-dialog.test.tsx` | Create organization dialog: validation, submission |
 | `src/components/create-project-dialog.test.tsx` | Create project dialog: validation, submission |

--- a/frontend/src/queries/-organizations.test.ts
+++ b/frontend/src/queries/-organizations.test.ts
@@ -24,6 +24,7 @@ import {
   useGetOrganization,
   useUpdateOrganization,
   useUpdateOrganizationSharing,
+  useUpdateOrganizationDefaultSharing,
   useDeleteOrganization,
 } from './organizations'
 
@@ -167,6 +168,53 @@ describe('useUpdateOrganizationSharing', () => {
 
     await act(async () => {
       await result.current.mutateAsync({ name: 'my-org', userGrants: [], roleGrants: [] })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+  })
+})
+
+describe('useUpdateOrganizationDefaultSharing', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      updateOrganizationDefaultSharing: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+  })
+
+  it('calls updateOrganizationDefaultSharing RPC with correct params', async () => {
+    const { result } = renderHook(() => useUpdateOrganizationDefaultSharing(), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    const params = {
+      name: 'my-org',
+      defaultUserGrants: [{ principal: 'a@b.com', role: 3 }],
+      defaultRoleGrants: [],
+    }
+
+    await act(async () => {
+      await result.current.mutateAsync(params)
+    })
+
+    expect(mockClient.updateOrganizationDefaultSharing).toHaveBeenCalledWith(params)
+  })
+
+  it('invalidates connect-query cache on success', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useUpdateOrganizationDefaultSharing(), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'my-org', defaultUserGrants: [], defaultRoleGrants: [] })
     })
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })


### PR DESCRIPTION
## Summary
- Update `docs/rbac.md` with org default sharing annotations and behavior description
- Update `docs/testing.md` to reflect org default sharing test coverage in org settings and query hooks
- Add missing unit tests for `useUpdateOrganizationDefaultSharing` query hook
- Verified `make generate` produces no diff
- Verified `make test-go` and `make test-ui` pass (280 UI tests, all Go tests green)

Closes: #290
Closes: #286

## Test plan
- [x] `make generate` produces no diff
- [x] `make test-go` passes
- [x] `make test-ui` passes (280 tests)
- [x] New `useUpdateOrganizationDefaultSharing` hook tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1