### PR TITLE
feat: CUE template rendering and K8s resource application

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -270,7 +270,15 @@ func (s *Server) Serve(ctx context.Context) error {
 
 		// Deployment service with project grant fallback
 		deploymentsK8s := deployments.NewK8sClient(k8sClientset, nsResolver)
-		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templatesK8s, nil)
+		dynamicClient, err := deployments.NewDynamicClient()
+		if err != nil {
+			return fmt.Errorf("failed to create dynamic kubernetes client: %w", err)
+		}
+		var deploymentsApplier deployments.ResourceApplier
+		if dynamicClient != nil {
+			deploymentsApplier = deployments.NewApplier(dynamicClient)
+		}
+		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templatesK8s, &deployments.CueRenderer{}, deploymentsApplier)
 		deploymentsPath, deploymentsHTTPHandler := consolev1connect.NewDeploymentServiceHandler(deploymentsHandler, protectedInterceptors)
 		mux.Handle(deploymentsPath, deploymentsHTTPHandler)
 	} else {

--- a/console/deployments/apply.go
+++ b/console/deployments/apply.go
@@ -1,0 +1,130 @@
+package deployments
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	// OwnershipLabel tracks which deployment owns a resource.
+	OwnershipLabel = "console.holos.run/deployment"
+	// fieldManager is used for server-side apply.
+	fieldManager = "console.holos.run"
+)
+
+// allowedKinds maps Kind → GVR for the resource kinds that may be rendered.
+// This mirrors allowedKindSet in render.go.
+var allowedKinds = map[string]schema.GroupVersionResource{
+	"Deployment":     {Group: "apps", Version: "v1", Resource: "deployments"},
+	"Service":        {Group: "", Version: "v1", Resource: "services"},
+	"ServiceAccount": {Group: "", Version: "v1", Resource: "serviceaccounts"},
+	"Role":           {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
+	"RoleBinding":    {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
+	"HTTPRoute":      {Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"},
+	"ConfigMap":      {Group: "", Version: "v1", Resource: "configmaps"},
+	"Secret":         {Group: "", Version: "v1", Resource: "secrets"},
+}
+
+// Applier creates/updates/deletes K8s resources produced by CUE templates.
+type Applier struct {
+	client dynamic.Interface
+}
+
+// NewApplier creates an Applier using the given dynamic client.
+func NewApplier(client dynamic.Interface) *Applier {
+	return &Applier{client: client}
+}
+
+// Apply performs server-side apply of the rendered manifests, adding the
+// ownership label so resources can be cleaned up when the deployment is deleted.
+func (a *Applier) Apply(ctx context.Context, namespace, deploymentName string, resources []unstructured.Unstructured) error {
+	for i := range resources {
+		r := resources[i].DeepCopy()
+
+		// Inject ownership label.
+		labels := r.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[OwnershipLabel] = deploymentName
+		r.SetLabels(labels)
+
+		kind := r.GetKind()
+		gvr, ok := allowedKinds[kind]
+		if !ok {
+			return fmt.Errorf("unsupported kind %q for resource %s/%s", kind, namespace, r.GetName())
+		}
+
+		data, err := json.Marshal(r.Object)
+		if err != nil {
+			return fmt.Errorf("marshaling resource %s/%s: %w", kind, r.GetName(), err)
+		}
+
+		slog.DebugContext(ctx, "applying resource",
+			slog.String("kind", kind),
+			slog.String("name", r.GetName()),
+			slog.String("namespace", namespace),
+			slog.String("deployment", deploymentName),
+		)
+
+		_, err = a.client.Resource(gvr).Namespace(namespace).Patch(
+			ctx,
+			r.GetName(),
+			types.ApplyPatchType,
+			data,
+			metav1.PatchOptions{
+				FieldManager: fieldManager,
+				Force:        boolPtr(true),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("applying %s/%s: %w", kind, r.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// Cleanup deletes all K8s resources that carry the deployment ownership label.
+func (a *Applier) Cleanup(ctx context.Context, namespace, deploymentName string) error {
+	labelSelector := fmt.Sprintf("%s=%s", OwnershipLabel, deploymentName)
+
+	for kind, gvr := range allowedKinds {
+		list, err := a.client.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			// Some GVRs may not exist in the cluster; log and continue.
+			slog.DebugContext(ctx, "cleanup: list error (resource type may not exist)",
+				slog.String("kind", kind),
+				slog.String("namespace", namespace),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		for _, item := range list.Items {
+			slog.InfoContext(ctx, "cleanup: deleting owned resource",
+				slog.String("kind", kind),
+				slog.String("name", item.GetName()),
+				slog.String("namespace", namespace),
+				slog.String("deployment", deploymentName),
+			)
+			if err := a.client.Resource(gvr).Namespace(namespace).Delete(
+				ctx, item.GetName(), metav1.DeleteOptions{}); err != nil {
+				return fmt.Errorf("deleting %s/%s: %w", kind, item.GetName(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// boolPtr returns a pointer to the given bool value.
+func boolPtr(b bool) *bool { return &b }

--- a/console/deployments/apply_test.go
+++ b/console/deployments/apply_test.go
@@ -1,0 +1,257 @@
+package deployments
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	testing2 "k8s.io/client-go/testing"
+)
+
+// allTestGVRs lists every GVR that the fake scheme must know about,
+// including the gateway.networking.k8s.io group for HTTPRoute.
+var allTestGVRs = []struct {
+	gvr  schema.GroupVersionResource
+	kind string
+}{
+	{schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, "Deployment"},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, "Service"},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, "ServiceAccount"},
+	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}, "Role"},
+	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}, "RoleBinding"},
+	{schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}, "HTTPRoute"},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, "ConfigMap"},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, "Secret"},
+}
+
+// fakeDynamicScheme builds a scheme with all types used in tests.
+func fakeDynamicScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	for _, entry := range allTestGVRs {
+		gvk := schema.GroupVersionKind{Group: entry.gvr.Group, Version: entry.gvr.Version, Kind: entry.kind}
+		listGVK := schema.GroupVersionKind{Group: entry.gvr.Group, Version: entry.gvr.Version, Kind: entry.kind + "List"}
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+	}
+	return scheme
+}
+
+// newFakeApplier creates an Applier backed by a fake dynamic client.
+// A custom reactor is added so that PATCH (server-side apply) succeeds
+// even when the resource does not already exist.
+func newFakeApplier() (*Applier, *dynamicfake.FakeDynamicClient) {
+	fakeClient := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme())
+
+	// Server-side apply creates-or-updates; the fake client only patches
+	// existing objects. Prepend a reactor that accepts all patch calls.
+	fakeClient.PrependReactor("patch", "*", func(action testing2.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.Unstructured{}, nil
+	})
+
+	applier := NewApplier(fakeClient)
+	return applier, fakeClient
+}
+
+// makeDeploymentResource creates a minimal Deployment resource for tests.
+func makeDeploymentResource(name, namespace string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("apps/v1")
+	u.SetKind("Deployment")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(map[string]string{
+		"app.kubernetes.io/managed-by": "console.holos.run",
+	})
+	_ = unstructured.SetNestedField(u.Object, map[string]interface{}{}, "spec")
+	return u
+}
+
+// makeServiceResource creates a minimal Service resource for tests.
+func makeServiceResource(name, namespace string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("Service")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(map[string]string{
+		"app.kubernetes.io/managed-by": "console.holos.run",
+	})
+	_ = unstructured.SetNestedField(u.Object, map[string]interface{}{}, "spec")
+	return u
+}
+
+func TestApplier_Apply(t *testing.T) {
+	namespace := "prj-my-project"
+	deploymentName := "web-app"
+
+	t.Run("apply issues patch action for each resource", func(t *testing.T) {
+		applier, fakeClient := newFakeApplier()
+		resources := []unstructured.Unstructured{
+			makeDeploymentResource("web-app", namespace),
+		}
+
+		err := applier.Apply(context.Background(), namespace, deploymentName, resources)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		var patchActions []testing2.PatchAction
+		for _, a := range fakeClient.Actions() {
+			if pa, ok := a.(testing2.PatchAction); ok {
+				patchActions = append(patchActions, pa)
+			}
+		}
+		if len(patchActions) == 0 {
+			t.Fatal("expected at least one patch action for server-side apply")
+		}
+	})
+
+	t.Run("re-apply is idempotent", func(t *testing.T) {
+		applier, _ := newFakeApplier()
+		resources := []unstructured.Unstructured{
+			makeDeploymentResource("web-app", namespace),
+		}
+
+		if err := applier.Apply(context.Background(), namespace, deploymentName, resources); err != nil {
+			t.Fatalf("first apply failed: %v", err)
+		}
+		if err := applier.Apply(context.Background(), namespace, deploymentName, resources); err != nil {
+			t.Fatalf("second apply failed: %v", err)
+		}
+	})
+
+	t.Run("ownership label is injected into patch payload", func(t *testing.T) {
+		applier, fakeClient := newFakeApplier()
+		resources := []unstructured.Unstructured{
+			makeDeploymentResource("web-app", namespace),
+		}
+
+		if err := applier.Apply(context.Background(), namespace, deploymentName, resources); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		found := false
+		for _, a := range fakeClient.Actions() {
+			if pa, ok := a.(testing2.PatchAction); ok {
+				patch := string(pa.GetPatch())
+				if containsStr(patch, OwnershipLabel) {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Errorf("expected ownership label %q in patch payload", OwnershipLabel)
+		}
+	})
+
+	t.Run("multiple resources each get a patch action", func(t *testing.T) {
+		applier, fakeClient := newFakeApplier()
+		resources := []unstructured.Unstructured{
+			makeDeploymentResource("web-app", namespace),
+			makeServiceResource("web-app", namespace),
+		}
+
+		if err := applier.Apply(context.Background(), namespace, deploymentName, resources); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		var patchCount int
+		for _, a := range fakeClient.Actions() {
+			if _, ok := a.(testing2.PatchAction); ok {
+				patchCount++
+			}
+		}
+		if patchCount < 2 {
+			t.Errorf("expected at least 2 patch actions, got %d", patchCount)
+		}
+	})
+}
+
+func TestApplier_Cleanup(t *testing.T) {
+	namespace := "prj-my-project"
+	deploymentName := "web-app"
+	depGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	t.Run("cleanup deletes resources with ownership label", func(t *testing.T) {
+		applier, fakeClient := newFakeApplier()
+
+		// Pre-create a Deployment with the ownership label.
+		dep := makeDeploymentResource("web-app", namespace)
+		dep.SetLabels(map[string]string{
+			"app.kubernetes.io/managed-by": "console.holos.run",
+			OwnershipLabel:                 deploymentName,
+		})
+		_, err := fakeClient.Resource(depGVR).Namespace(namespace).Create(
+			context.Background(), &dep, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("pre-create failed: %v", err)
+		}
+
+		if err := applier.Cleanup(context.Background(), namespace, deploymentName); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Verify a delete action occurred.
+		deleted := false
+		for _, a := range fakeClient.Actions() {
+			if a.GetVerb() == "delete" {
+				deleted = true
+				break
+			}
+		}
+		if !deleted {
+			t.Error("expected at least one delete action during cleanup")
+		}
+	})
+
+	t.Run("cleanup with no owned resources is a no-op", func(t *testing.T) {
+		applier, _ := newFakeApplier()
+
+		if err := applier.Cleanup(context.Background(), namespace, deploymentName); err != nil {
+			t.Fatalf("expected no error for empty cleanup, got %v", err)
+		}
+	})
+
+	t.Run("cleanup does not delete resources owned by other deployments", func(t *testing.T) {
+		applier, fakeClient := newFakeApplier()
+
+		// Create a resource owned by "other-app".
+		dep := makeDeploymentResource("other-app", namespace)
+		dep.SetLabels(map[string]string{
+			"app.kubernetes.io/managed-by": "console.holos.run",
+			OwnershipLabel:                 "other-app",
+		})
+		_, err := fakeClient.Resource(depGVR).Namespace(namespace).Create(
+			context.Background(), &dep, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("pre-create failed: %v", err)
+		}
+
+		// Cleanup for "web-app" should not touch "other-app"'s resource.
+		if err := applier.Cleanup(context.Background(), namespace, deploymentName); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Verify no delete occurred.
+		for _, a := range fakeClient.Actions() {
+			if a.GetVerb() == "delete" {
+				t.Error("cleanup deleted a resource it does not own")
+			}
+		}
+	})
+}
+
+// containsStr checks whether s contains substr.
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/console/deployments/client.go
+++ b/console/deployments/client.go
@@ -1,0 +1,33 @@
+package deployments
+
+import (
+	"log/slog"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// NewDynamicClient creates a Kubernetes dynamic client using in-cluster config
+// or KUBECONFIG, mirroring the pattern used by secrets.NewClientset.
+// Returns nil (not an error) if no config is available.
+func NewDynamicClient() (dynamic.Interface, error) {
+	config, err := rest.InClusterConfig()
+	if err == nil {
+		slog.Debug("using in-cluster kubernetes config for dynamic client")
+		return dynamic.NewForConfig(config)
+	}
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	config, err = kubeConfig.ClientConfig()
+	if err != nil {
+		slog.Debug("no kubernetes config available for dynamic client", "error", err)
+		return nil, nil
+	}
+
+	slog.Debug("using kubeconfig for dynamic client", "host", config.Host)
+	return dynamic.NewForConfig(config)
+}

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
@@ -16,7 +17,12 @@ import (
 	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
 )
 
-const auditResourceType = "deployment"
+const (
+	auditResourceType = "deployment"
+	// cueTemplateKey is the ConfigMap data key holding the CUE template source.
+	// Mirrors templates.CueTemplateKey to avoid a cross-package import cycle.
+	cueTemplateKey = "template.cue"
+)
 
 // dnsLabelRe validates deployment names as DNS labels.
 var dnsLabelRe = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
@@ -31,9 +37,20 @@ type SettingsResolver interface {
 	GetSettings(ctx context.Context, project string) (*consolev1.ProjectSettings, error)
 }
 
-// TemplateResolver validates that a referenced template exists.
+// TemplateResolver validates that a referenced template exists and returns its CUE source.
 type TemplateResolver interface {
 	GetTemplate(ctx context.Context, project, name string) (*corev1.ConfigMap, error)
+}
+
+// Renderer evaluates CUE templates with deployment parameters.
+type Renderer interface {
+	Render(ctx context.Context, cueSource string, input DeploymentInput) ([]unstructured.Unstructured, error)
+}
+
+// ResourceApplier applies and cleans up K8s resources for a deployment.
+type ResourceApplier interface {
+	Apply(ctx context.Context, namespace, deploymentName string, resources []unstructured.Unstructured) error
+	Cleanup(ctx context.Context, namespace, deploymentName string) error
 }
 
 // Handler implements the DeploymentService.
@@ -43,16 +60,19 @@ type Handler struct {
 	projectResolver  ProjectResolver
 	settingsResolver SettingsResolver
 	templateResolver TemplateResolver
+	renderer         Renderer
+	applier          ResourceApplier
 }
 
 // NewHandler creates a DeploymentService handler.
-// renderer is reserved for Phase 5 and may be nil.
-func NewHandler(k8s *K8sClient, projectResolver ProjectResolver, settingsResolver SettingsResolver, templateResolver TemplateResolver, _ interface{}) *Handler {
+func NewHandler(k8s *K8sClient, projectResolver ProjectResolver, settingsResolver SettingsResolver, templateResolver TemplateResolver, renderer Renderer, applier ResourceApplier) *Handler {
 	return &Handler{
 		k8s:              k8s,
 		projectResolver:  projectResolver,
 		settingsResolver: settingsResolver,
 		templateResolver: templateResolver,
+		renderer:         renderer,
+		applier:          applier,
 	}
 }
 
@@ -186,11 +206,14 @@ func (h *Handler) CreateDeployment(
 		}
 	}
 
-	// Validate that the referenced template exists.
+	// Validate that the referenced template exists and get its CUE source.
+	var cueSource string
 	if h.templateResolver != nil {
-		if _, err := h.templateResolver.GetTemplate(ctx, project, req.Msg.Template); err != nil {
+		tmplCM, err := h.templateResolver.GetTemplate(ctx, project, req.Msg.Template)
+		if err != nil {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("template %q not found in project %q", req.Msg.Template, project))
 		}
+		cueSource = tmplCM.Data[cueTemplateKey]
 	}
 
 	displayName := ""
@@ -205,6 +228,35 @@ func (h *Handler) CreateDeployment(
 	_, err := h.k8s.CreateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.Template, displayName, description)
 	if err != nil {
 		return nil, mapK8sError(err)
+	}
+
+	// Render and apply the deployment resources.
+	if h.renderer != nil && h.applier != nil {
+		ns := h.k8s.Resolver.ProjectNamespace(project)
+		input := DeploymentInput{
+			Name:      name,
+			Image:     req.Msg.Image,
+			Tag:       req.Msg.Tag,
+			Project:   project,
+			Namespace: ns,
+		}
+		resources, renderErr := h.renderer.Render(ctx, cueSource, input)
+		if renderErr != nil {
+			slog.WarnContext(ctx, "render failed after creating deployment",
+				slog.String("project", project),
+				slog.String("name", name),
+				slog.Any("error", renderErr),
+			)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("rendering deployment resources: %w", renderErr))
+		}
+		if applyErr := h.applier.Apply(ctx, ns, name, resources); applyErr != nil {
+			slog.WarnContext(ctx, "apply failed after creating deployment",
+				slog.String("project", project),
+				slog.String("name", name),
+				slog.Any("error", applyErr),
+			)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("applying deployment resources: %w", applyErr))
+		}
 	}
 
 	slog.InfoContext(ctx, "deployment created",
@@ -244,9 +296,56 @@ func (h *Handler) UpdateDeployment(
 		return nil, err
 	}
 
-	_, err := h.k8s.UpdateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.DisplayName, req.Msg.Description)
+	updated, err := h.k8s.UpdateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.DisplayName, req.Msg.Description)
 	if err != nil {
 		return nil, mapK8sError(err)
+	}
+
+	// Re-render and re-apply deployment resources with updated parameters.
+	if h.renderer != nil && h.applier != nil && updated != nil {
+		templateName := updated.Data[TemplateKey]
+		image := updated.Data[ImageKey]
+		tag := updated.Data[TagKey]
+
+		var cueSource string
+		if h.templateResolver != nil && templateName != "" {
+			tmplCM, tmplErr := h.templateResolver.GetTemplate(ctx, project, templateName)
+			if tmplErr != nil {
+				slog.WarnContext(ctx, "template not found during update re-render",
+					slog.String("project", project),
+					slog.String("template", templateName),
+					slog.Any("error", tmplErr),
+				)
+			} else {
+				cueSource = tmplCM.Data[cueTemplateKey]
+			}
+		}
+
+		ns := h.k8s.Resolver.ProjectNamespace(project)
+		input := DeploymentInput{
+			Name:      name,
+			Image:     image,
+			Tag:       tag,
+			Project:   project,
+			Namespace: ns,
+		}
+		resources, renderErr := h.renderer.Render(ctx, cueSource, input)
+		if renderErr != nil {
+			slog.WarnContext(ctx, "render failed during deployment update",
+				slog.String("project", project),
+				slog.String("name", name),
+				slog.Any("error", renderErr),
+			)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("rendering deployment resources: %w", renderErr))
+		}
+		if applyErr := h.applier.Apply(ctx, ns, name, resources); applyErr != nil {
+			slog.WarnContext(ctx, "apply failed during deployment update",
+				slog.String("project", project),
+				slog.String("name", name),
+				slog.Any("error", applyErr),
+			)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("applying deployment resources: %w", applyErr))
+		}
 	}
 
 	slog.InfoContext(ctx, "deployment updated",
@@ -282,6 +381,19 @@ func (h *Handler) DeleteDeployment(
 
 	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsDelete); err != nil {
 		return nil, err
+	}
+
+	// Clean up all K8s resources owned by this deployment before removing the record.
+	if h.applier != nil {
+		ns := h.k8s.Resolver.ProjectNamespace(project)
+		if cleanupErr := h.applier.Cleanup(ctx, ns, name); cleanupErr != nil {
+			slog.WarnContext(ctx, "cleanup failed during deployment delete",
+				slog.String("project", project),
+				slog.String("name", name),
+				slog.Any("error", cleanupErr),
+			)
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("cleaning up deployment resources: %w", cleanupErr))
+		}
 	}
 
 	if err := h.k8s.DeleteDeployment(ctx, project, name); err != nil {

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/holos-run/holos-console/console/rpc"
@@ -72,12 +73,50 @@ func fakeTemplate(name string) *corev1.ConfigMap {
 			Name:      name,
 			Namespace: "prj-my-project",
 		},
+		Data: map[string]string{
+			"template.cue": `
+input: { name: string, image: string, tag: string, project: string, namespace: string }
+resources: []
+`,
+		},
 	}
+}
+
+// stubRenderer implements Renderer for tests.
+type stubRenderer struct {
+	resources []unstructured.Unstructured
+	err       error
+	called    bool
+	lastInput DeploymentInput
+}
+
+func (s *stubRenderer) Render(_ context.Context, _ string, input DeploymentInput) ([]unstructured.Unstructured, error) {
+	s.called = true
+	s.lastInput = input
+	return s.resources, s.err
+}
+
+// stubApplier implements Applier for tests.
+type stubApplier struct {
+	applyCalled   bool
+	cleanupCalled bool
+	applyErr      error
+	cleanupErr    error
+}
+
+func (s *stubApplier) Apply(_ context.Context, _, _ string, _ []unstructured.Unstructured) error {
+	s.applyCalled = true
+	return s.applyErr
+}
+
+func (s *stubApplier) Cleanup(_ context.Context, _, _ string) error {
+	s.cleanupCalled = true
+	return s.cleanupErr
 }
 
 func defaultHandler(fakeClient *fake.Clientset, pr *stubProjectResolver) *Handler {
 	k8s := NewK8sClient(fakeClient, testResolver())
-	return NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, nil)
+	return NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{})
 }
 
 // TestHandler_ListDeployments tests the ListDeployments RPC.
@@ -239,7 +278,7 @@ func TestHandler_CreateDeployment(t *testing.T) {
 		fakeClient := fake.NewClientset(projectNS("my-project"))
 		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
 		k8s := NewK8sClient(fakeClient, testResolver())
-		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: disabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, nil)
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: disabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{})
 
 		ctx := authedCtx("alice@example.com", nil)
 		req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
@@ -263,7 +302,7 @@ func TestHandler_CreateDeployment(t *testing.T) {
 		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
 		k8s := NewK8sClient(fakeClient, testResolver())
 		templateErr := connect.NewError(connect.CodeNotFound, nil)
-		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{err: templateErr}, nil)
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{err: templateErr}, &stubRenderer{}, &stubApplier{})
 
 		ctx := authedCtx("alice@example.com", nil)
 		req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
@@ -433,6 +472,100 @@ func TestHandler_DeleteDeployment(t *testing.T) {
 		}
 		if connect.CodeOf(err) != connect.CodePermissionDenied {
 			t.Errorf("expected CodePermissionDenied, got %v", connect.CodeOf(err))
+		}
+	})
+}
+
+// TestHandler_RenderAndApply tests that CreateDeployment and UpdateDeployment
+// trigger render+apply and DeleteDeployment triggers cleanup.
+func TestHandler_RenderAndApply(t *testing.T) {
+	t.Run("CreateDeployment calls renderer and applier", func(t *testing.T) {
+		fakeClient := fake.NewClientset(projectNS("my-project"))
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+		renderer := &stubRenderer{}
+		applier := &stubApplier{}
+		k8s := NewK8sClient(fakeClient, testResolver())
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, applier)
+
+		ctx := authedCtx("alice@example.com", nil)
+		req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+			Project:  "my-project",
+			Name:     "web-app",
+			Image:    "nginx",
+			Tag:      "1.25",
+			Template: "default",
+		})
+		_, err := handler.CreateDeployment(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !renderer.called {
+			t.Error("expected renderer to be called on CreateDeployment")
+		}
+		if !applier.applyCalled {
+			t.Error("expected applier.Apply to be called on CreateDeployment")
+		}
+		if renderer.lastInput.Name != "web-app" {
+			t.Errorf("expected input name 'web-app', got %q", renderer.lastInput.Name)
+		}
+		if renderer.lastInput.Image != "nginx" {
+			t.Errorf("expected input image 'nginx', got %q", renderer.lastInput.Image)
+		}
+		if renderer.lastInput.Tag != "1.25" {
+			t.Errorf("expected input tag '1.25', got %q", renderer.lastInput.Tag)
+		}
+	})
+
+	t.Run("UpdateDeployment calls renderer and applier", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc")
+		fakeClient := fake.NewClientset(ns, cm)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+		renderer := &stubRenderer{}
+		applier := &stubApplier{}
+		k8s := NewK8sClient(fakeClient, testResolver())
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, applier)
+
+		ctx := authedCtx("alice@example.com", nil)
+		newTag := "1.26"
+		req := connect.NewRequest(&consolev1.UpdateDeploymentRequest{
+			Project: "my-project",
+			Name:    "web-app",
+			Tag:     &newTag,
+		})
+		_, err := handler.UpdateDeployment(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !renderer.called {
+			t.Error("expected renderer to be called on UpdateDeployment")
+		}
+		if !applier.applyCalled {
+			t.Error("expected applier.Apply to be called on UpdateDeployment")
+		}
+	})
+
+	t.Run("DeleteDeployment calls applier cleanup", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "latest", "default", "", "")
+		fakeClient := fake.NewClientset(ns, cm)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "owner"}}
+		renderer := &stubRenderer{}
+		applier := &stubApplier{}
+		k8s := NewK8sClient(fakeClient, testResolver())
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, applier)
+
+		ctx := authedCtx("alice@example.com", nil)
+		req := connect.NewRequest(&consolev1.DeleteDeploymentRequest{
+			Project: "my-project",
+			Name:    "web-app",
+		})
+		_, err := handler.DeleteDeployment(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !applier.cleanupCalled {
+			t.Error("expected applier.Cleanup to be called on DeleteDeployment")
 		}
 	})
 }

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -1,0 +1,149 @@
+package deployments
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// allowedKindSet is the set of resource kinds that CUE templates may produce.
+var allowedKindSet = map[string]bool{
+	"Deployment":     true,
+	"Service":        true,
+	"ServiceAccount": true,
+	"Role":           true,
+	"RoleBinding":    true,
+	"HTTPRoute":      true,
+	"ConfigMap":      true,
+	"Secret":         true,
+}
+
+// renderTimeout is the maximum time allowed for CUE template evaluation.
+const renderTimeout = 5 * time.Second
+
+// DeploymentInput is the standard input passed to CUE templates.
+type DeploymentInput struct {
+	Name      string `json:"name"`
+	Image     string `json:"image"`
+	Tag       string `json:"tag"`
+	Project   string `json:"project"`
+	Namespace string `json:"namespace"`
+}
+
+// CueRenderer evaluates CUE templates with deployment parameters.
+type CueRenderer struct{}
+
+// Render evaluates the CUE template with the given input and returns a list of
+// K8s resource manifests as unstructured objects.
+func (r *CueRenderer) Render(ctx context.Context, cueSource string, input DeploymentInput) ([]unstructured.Unstructured, error) {
+	// Enforce evaluation timeout.
+	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
+	defer cancel()
+
+	// Run evaluation in a goroutine so we can respect context cancellation.
+	type result struct {
+		resources []unstructured.Unstructured
+		err       error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		resources, err := evaluate(cueSource, input)
+		ch <- result{resources, err}
+	}()
+
+	select {
+	case <-evalCtx.Done():
+		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
+	case res := <-ch:
+		return res.resources, res.err
+	}
+}
+
+// evaluate performs synchronous CUE template evaluation.
+func evaluate(cueSource string, input DeploymentInput) ([]unstructured.Unstructured, error) {
+	cueCtx := cuecontext.New()
+
+	// Compile the template source.
+	tmpl := cueCtx.CompileString(cueSource)
+	if err := tmpl.Err(); err != nil {
+		return nil, fmt.Errorf("invalid CUE template: %w", err)
+	}
+
+	// Encode input as JSON then compile to a CUE value.
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("encoding input: %w", err)
+	}
+	inputValue := cueCtx.CompileBytes(inputJSON)
+	if err := inputValue.Err(); err != nil {
+		return nil, fmt.Errorf("compiling input: %w", err)
+	}
+
+	// Unify template with the input field.
+	unified := tmpl.FillPath(cue.ParsePath("input"), inputValue)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("unifying template with input: %w", err)
+	}
+
+	// Extract the resources field.
+	resourcesValue := unified.LookupPath(cue.ParsePath("resources"))
+	if err := resourcesValue.Err(); err != nil {
+		return nil, fmt.Errorf("extracting resources field: %w", err)
+	}
+
+	// Decode the resources list.
+	var rawResources []map[string]interface{}
+	if err := resourcesValue.Decode(&rawResources); err != nil {
+		return nil, fmt.Errorf("decoding resources: %w", err)
+	}
+
+	return validateResources(rawResources, input.Namespace)
+}
+
+// validateResources validates each resource against safety constraints.
+func validateResources(rawResources []map[string]interface{}, expectedNamespace string) ([]unstructured.Unstructured, error) {
+	result := make([]unstructured.Unstructured, 0, len(rawResources))
+	for i, raw := range rawResources {
+		u := unstructured.Unstructured{Object: raw}
+
+		// Require apiVersion and kind.
+		if u.GetAPIVersion() == "" {
+			return nil, fmt.Errorf("resource[%d]: missing apiVersion", i)
+		}
+		kind := u.GetKind()
+		if kind == "" {
+			return nil, fmt.Errorf("resource[%d]: missing kind", i)
+		}
+		if u.GetName() == "" {
+			return nil, fmt.Errorf("resource[%d]: missing metadata.name", i)
+		}
+
+		// Enforce kind allowlist.
+		if !allowedKindSet[kind] {
+			return nil, fmt.Errorf("resource[%d] kind %q is not allowed; permitted kinds: Deployment, Service, ServiceAccount, Role, RoleBinding, HTTPRoute, ConfigMap, Secret", i, kind)
+		}
+
+		// Enforce namespace constraint.
+		ns := u.GetNamespace()
+		if ns == "" {
+			return nil, fmt.Errorf("resource[%d] %s/%s: missing metadata.namespace", i, kind, u.GetName())
+		}
+		if ns != expectedNamespace {
+			return nil, fmt.Errorf("resource[%d] %s/%s: namespace %q does not match project namespace %q", i, kind, u.GetName(), ns, expectedNamespace)
+		}
+
+		// Enforce managed-by label.
+		labels := u.GetLabels()
+		if labels["app.kubernetes.io/managed-by"] != "console.holos.run" {
+			return nil, fmt.Errorf("resource[%d] %s/%s: missing required label app.kubernetes.io/managed-by=console.holos.run", i, kind, u.GetName())
+		}
+
+		result = append(result, u)
+	}
+	return result, nil
+}

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -1,0 +1,228 @@
+package deployments
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// validTemplate produces a single Deployment resource.
+const validTemplate = `
+input: {
+	name:      string
+	image:     string
+	tag:        string
+	project:   string
+	namespace: string
+}
+
+resources: [
+	{
+		apiVersion: "apps/v1"
+		kind:       "Deployment"
+		metadata: {
+			name:      input.name
+			namespace: input.namespace
+			labels: {
+				"app.kubernetes.io/managed-by": "console.holos.run"
+				"app.kubernetes.io/name":       input.name
+			}
+		}
+		spec: {
+			selector: matchLabels: "app.kubernetes.io/name": input.name
+			template: {
+				metadata: labels: "app.kubernetes.io/name": input.name
+				spec: containers: [{
+					name:  input.name
+					image: input.image + ":" + input.tag
+				}]
+			}
+		}
+	},
+]
+`
+
+// crossNamespaceTemplate tries to write into a different namespace.
+const crossNamespaceTemplate = `
+input: {
+	name:      string
+	image:     string
+	tag:        string
+	project:   string
+	namespace: string
+}
+
+resources: [
+	{
+		apiVersion: "apps/v1"
+		kind:       "Deployment"
+		metadata: {
+			name:      input.name
+			namespace: "other-namespace"
+			labels: "app.kubernetes.io/managed-by": "console.holos.run"
+		}
+		spec: {}
+	},
+]
+`
+
+// disallowedKindTemplate uses a kind not in the allowlist.
+const disallowedKindTemplate = `
+input: {
+	name:      string
+	image:     string
+	tag:        string
+	project:   string
+	namespace: string
+}
+
+resources: [
+	{
+		apiVersion: "batch/v1"
+		kind:       "Job"
+		metadata: {
+			name:      input.name
+			namespace: input.namespace
+			labels: "app.kubernetes.io/managed-by": "console.holos.run"
+		}
+		spec: {}
+	},
+]
+`
+
+// missingManagedByTemplate is missing the required managed-by label.
+const missingManagedByTemplate = `
+input: {
+	name:      string
+	image:     string
+	tag:        string
+	project:   string
+	namespace: string
+}
+
+resources: [
+	{
+		apiVersion: "apps/v1"
+		kind:       "Deployment"
+		metadata: {
+			name:      input.name
+			namespace: input.namespace
+		}
+		spec: {}
+	},
+]
+`
+
+// invalidCUETemplate contains invalid CUE syntax.
+const invalidCUETemplate = `this is { not valid cue !!!`
+
+func defaultInput(namespace string) DeploymentInput {
+	return DeploymentInput{
+		Name:      "web-app",
+		Image:     "nginx",
+		Tag:       "1.25",
+		Project:   "my-project",
+		Namespace: namespace,
+	}
+}
+
+func TestCueRenderer_Render(t *testing.T) {
+	renderer := &CueRenderer{}
+	namespace := "prj-my-project"
+
+	t.Run("valid template produces expected resources", func(t *testing.T) {
+		resources, err := renderer.Render(context.Background(), validTemplate, defaultInput(namespace))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resources) != 1 {
+			t.Fatalf("expected 1 resource, got %d", len(resources))
+		}
+		r := resources[0]
+		if r.GetKind() != "Deployment" {
+			t.Errorf("expected kind 'Deployment', got %q", r.GetKind())
+		}
+		if r.GetName() != "web-app" {
+			t.Errorf("expected name 'web-app', got %q", r.GetName())
+		}
+		if r.GetNamespace() != namespace {
+			t.Errorf("expected namespace %q, got %q", namespace, r.GetNamespace())
+		}
+		labels := r.GetLabels()
+		if labels["app.kubernetes.io/managed-by"] != "console.holos.run" {
+			t.Errorf("expected managed-by label, got %v", labels)
+		}
+	})
+
+	t.Run("invalid CUE syntax returns error", func(t *testing.T) {
+		_, err := renderer.Render(context.Background(), invalidCUETemplate, defaultInput(namespace))
+		if err == nil {
+			t.Fatal("expected error for invalid CUE syntax")
+		}
+	})
+
+	t.Run("cross-namespace resource rejected", func(t *testing.T) {
+		_, err := renderer.Render(context.Background(), crossNamespaceTemplate, defaultInput(namespace))
+		if err == nil {
+			t.Fatal("expected error for cross-namespace resource")
+		}
+	})
+
+	t.Run("disallowed resource kind rejected", func(t *testing.T) {
+		_, err := renderer.Render(context.Background(), disallowedKindTemplate, defaultInput(namespace))
+		if err == nil {
+			t.Fatal("expected error for disallowed resource kind")
+		}
+	})
+
+	t.Run("missing managed-by label rejected", func(t *testing.T) {
+		_, err := renderer.Render(context.Background(), missingManagedByTemplate, defaultInput(namespace))
+		if err == nil {
+			t.Fatal("expected error for missing managed-by label")
+		}
+	})
+
+	t.Run("timeout enforced for slow evaluation", func(t *testing.T) {
+		// A valid template should not time out (5s limit, evaluation is fast).
+		ctx := context.Background()
+		_, err := renderer.Render(ctx, validTemplate, defaultInput(namespace))
+		if err != nil {
+			t.Fatalf("fast template should not time out: %v", err)
+		}
+	})
+
+	t.Run("input values are available in template", func(t *testing.T) {
+		resources, err := renderer.Render(context.Background(), validTemplate, DeploymentInput{
+			Name:      "my-app",
+			Image:     "myrepo/myapp",
+			Tag:       "v2.0.0",
+			Project:   "my-project",
+			Namespace: namespace,
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resources) != 1 {
+			t.Fatalf("expected 1 resource, got %d", len(resources))
+		}
+		r := resources[0]
+		// Verify name was substituted
+		if r.GetName() != "my-app" {
+			t.Errorf("expected name 'my-app', got %q", r.GetName())
+		}
+		// Verify image:tag was set
+		containers, _, _ := unstructured.NestedSlice(r.Object, "spec", "template", "spec", "containers")
+		if len(containers) != 1 {
+			t.Fatalf("expected 1 container, got %d", len(containers))
+		}
+		c, ok := containers[0].(map[string]interface{})
+		if !ok {
+			t.Fatal("container is not a map")
+		}
+		wantImage := "myrepo/myapp:v2.0.0"
+		if c["image"] != wantImage {
+			t.Errorf("expected image %q, got %q", wantImage, c["image"])
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/emicklei/proto v1.14.3 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -112,6 +113,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
@@ -121,12 +123,14 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/petermattis/goid v0.0.0-20251121121749-a11dd1a45f9a // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/protocolbuffers/txtpbfmt v0.0.0-20260217160748-a481f6a22f94 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.58.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect


### PR DESCRIPTION
## Summary
- Add `CueRenderer` that evaluates CUE templates with `DeploymentInput` parameters, validates rendered resources (namespace isolation, kind allowlist, managed-by label), and enforces a 5-second evaluation timeout
- Add `Applier` that performs server-side apply via the dynamic client with field manager `console.holos.run`, injects ownership labels for cleanup tracking, and deletes owned resources on `Cleanup`
- Wire render+apply into `CreateDeployment` and `UpdateDeployment`; wire cleanup into `DeleteDeployment` before removing the ConfigMap
- Add `NewDynamicClient` factory using the same in-cluster/kubeconfig pattern as other K8s clients

Closes: #303

## Test plan
- [x] `make test-go` passes (all packages, with race detector)
- [x] `make generate` passes (TypeScript type check + UI build)
- [x] `TestCueRenderer_Render` covers valid templates, invalid CUE syntax, cross-namespace rejection, disallowed kinds, missing managed-by label, and input substitution
- [x] `TestApplier_Apply` covers patch action emission, idempotency, ownership label injection, and multi-resource batches
- [x] `TestApplier_Cleanup` covers deletion of owned resources, no-op when empty, and non-deletion of resources owned by other deployments
- [x] `TestHandler_RenderAndApply` verifies CreateDeployment/UpdateDeployment call renderer+applier and DeleteDeployment calls cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)