### PR TITLE
docs: MVP PaaS phase 9 final cleanup scan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,19 @@ This is a Go HTTPS server that serves a web console UI and exposes ConnectRPC se
   - `projects/` - ProjectService with K8s Namespace backend and annotation-based grants
   - `resolver/` - Namespace prefix resolver translating user-facing names to K8s namespace names (`{namespace-prefix}{organization-prefix}{name}` for orgs, `{namespace-prefix}{project-prefix}{name}` for projects)
   - `secrets/` - SecretsService with K8s backend and annotation-based RBAC
+  - `settings/` - ProjectSettingsService managing per-project feature flags (e.g. deployments toggle) stored as K8s ConfigMaps
+  - `templates/` - DeploymentTemplateService managing CUE-based deployment templates stored as K8s ConfigMaps; embeds `default_template.cue`
+  - `deployments/` - DeploymentService managing Kubernetes Deployments: CRUD, status polling, log streaming, CUE render, and apply
   - `dist/` - Embedded static files served at `/` (build output from frontend, not source)
 - `proto/` - Protobuf source files
+  - `holos/console/v1/organizations.proto` - OrganizationService
+  - `holos/console/v1/projects.proto` - ProjectService
+  - `holos/console/v1/secrets.proto` - SecretsService
+  - `holos/console/v1/project_settings.proto` - ProjectSettingsService
+  - `holos/console/v1/deployment_templates.proto` - DeploymentTemplateService
+  - `holos/console/v1/deployments.proto` - DeploymentService
+  - `holos/console/v1/rbac.proto` - Role definitions (VIEWER, EDITOR, OWNER)
+  - `holos/console/v1/version.proto` - VersionService
 - `gen/` - Generated protobuf Go code (do not edit)
 - `frontend/` - React frontend source (see UI Architecture below)
 
@@ -257,6 +268,8 @@ gh workflow run container.yaml --ref main -f git_ref=refs/tags/v1.2.3
 ### Tool Dependencies
 
 Tool versions are pinned in `tools.go` using the Go tools pattern. Install with `make tools`. Currently pins: buf.
+
+CUE is used at runtime (not as a pinned tool) by the `console/templates/` package to parse and validate deployment template source. The `cuelang.org/go` module is a regular Go dependency listed in `go.mod`.
 
 ## Planning and Execution
 

--- a/docs/rpc-service-definitions.md
+++ b/docs/rpc-service-definitions.md
@@ -14,16 +14,25 @@ The project uses:
 ```
 proto/                          # Protobuf source files
   holos/console/v1/
-    version.proto               # Service and message definitions
+    version.proto               # VersionService
+    organizations.proto         # OrganizationService
+    projects.proto              # ProjectService
+    secrets.proto               # SecretsService
+    project_settings.proto      # ProjectSettingsService
+    deployment_templates.proto  # DeploymentTemplateService
+    deployments.proto           # DeploymentService
+    rbac.proto                  # Role definitions
 
 gen/                            # Generated Go code (do not edit)
   holos/console/v1/
-    version.pb.go               # Go structs for messages
+    *.pb.go                     # Go structs for messages
     consolev1connect/
-      version.connect.go        # ConnectRPC client and server bindings
+      *.connect.go              # ConnectRPC client and server bindings
 
-console/rpc/                    # Hand-written RPC handlers
+console/rpc/                    # Hand-written RPC handlers (thin wrappers)
   version.go                    # VersionService implementation
+  # Service handlers delegate to console/{organizations,projects,secrets,
+  # settings,templates,deployments}/ packages for business logic
 ```
 
 ## Configuration Files

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -151,6 +151,11 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx` | Secrets list page: table, sorting, error/loading |
 | `src/routes/_authenticated/projects/$projectName/secrets/-$name.test.tsx` | Secret detail page: display, edit, delete |
 | `src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx` | Project settings page: display name, description, sharing, default secret sharing, delete |
+| `src/routes/_authenticated/projects/$projectName/settings/-settings-deployments.test.tsx` | Project settings — Features section: deployments toggle, RBAC (owner/editor/viewer) |
+| `src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx` | Deployment templates list: template names, create/delete buttons, RBAC, empty/error state |
+| `src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx` | Deployment template detail: CUE editor, save/delete, RBAC, skeleton, error state |
+| `src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx` | Deployments list: names, image/tag, status badges, create/delete, RBAC, empty/error state |
+| `src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx` | Deployment detail: image/tag, replicas, conditions, logs, re-deploy/delete, RBAC |
 | `src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx` | Org settings page: display name, description, sharing, default sharing, delete |
 | `src/routes/_authenticated/projects/-$projectName.test.tsx` | ProjectLayout: sets selected project from URL param |
 | `src/routes/_authenticated/orgs/$orgName/projects/-index.test.tsx` | Org projects page: list, navigate to project |


### PR DESCRIPTION
## Summary

- Added `console/settings/`, `console/templates/`, and `console/deployments/` packages to the AGENTS.md architecture section with descriptions of each package's role
- Documented all seven proto files in the package structure section
- Added CUE runtime dependency note (used by `console/templates/` for CUE parsing/validation)
- Added five missing test files to the `docs/testing.md` table (settings-deployments, templates index/detail, deployments index/detail)
- Updated `docs/rpc-service-definitions.md` directory structure to reflect all seven services instead of just `version.proto`

**Verification:**
- No TODO/FIXME comments found in new implementation code
- gRPC reflection already registers all new services (verified in `console/console.go`)
- `make generate && make test && make build` all pass
- `go vet ./...` clean

Closes: #307

## Test plan
- [x] `make generate` passes (clean output)
- [x] `make test` passes (357 tests, 31 test files)
- [x] `make build` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)