### PR TITLE
chore: final cleanup for environment variables feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ This is a Go HTTPS server that serves a web console UI and exposes ConnectRPC se
   - `secrets/` - SecretsService with K8s backend and annotation-based RBAC
   - `settings/` - ProjectSettingsService managing per-project feature flags (e.g. deployments toggle) stored as K8s ConfigMaps
   - `templates/` - DeploymentTemplateService managing CUE-based deployment templates stored as K8s ConfigMaps; embeds `default_template.cue`
-  - `deployments/` - DeploymentService managing Kubernetes Deployments: CRUD, status polling, log streaming, CUE render, and apply
+  - `deployments/` - DeploymentService managing Kubernetes Deployments: CRUD, status polling, log streaming, CUE render and apply, container env vars (literal values, SecretKeyRef, ConfigMapKeyRef), and listing project-namespace Secrets/ConfigMaps for env var references
   - `dist/` - Embedded static files served at `/` (build output from frontend, not source)
 - `proto/` - Protobuf source files
   - `holos/console/v1/organizations.proto` - OrganizationService

--- a/docs/rpc-service-definitions.md
+++ b/docs/rpc-service-definitions.md
@@ -20,7 +20,7 @@ proto/                          # Protobuf source files
     secrets.proto               # SecretsService
     project_settings.proto      # ProjectSettingsService
     deployment_templates.proto  # DeploymentTemplateService
-    deployments.proto           # DeploymentService
+    deployments.proto           # DeploymentService (CRUD, status, logs, env vars, K8s resource listing)
     rbac.proto                  # Role definitions
 
 gen/                            # Generated Go code (do not edit)

--- a/frontend/src/components/env-var-editor.tsx
+++ b/frontend/src/components/env-var-editor.tsx
@@ -19,6 +19,18 @@ interface EnvVarEditorProps {
   onChange: (value: EnvVar[]) => void
 }
 
+// filterEnvVars removes incomplete rows before submitting to the API.
+// A row is valid if the name is non-empty and the source is fully specified.
+export function filterEnvVars(envVars: EnvVar[]): EnvVar[] {
+  return envVars.filter((ev) => {
+    if (!ev.name.trim()) return false
+    if (ev.source.case === 'value') return true
+    if (ev.source.case === 'secretKeyRef') return !!(ev.source.value.name && ev.source.value.key)
+    if (ev.source.case === 'configMapKeyRef') return !!(ev.source.value.name && ev.source.value.key)
+    return false
+  })
+}
+
 // EnvVarEditor renders a dynamic list of environment variable rows.
 // Each row has a name, a source type selector (Value / Secret / ConfigMap),
 // and source-specific fields.

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { StringListInput } from '@/components/string-list-input'
-import { EnvVarEditor } from '@/components/env-var-editor'
+import { EnvVarEditor, filterEnvVars } from '@/components/env-var-editor'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -39,17 +39,6 @@ import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import type { EnvVar } from '@/gen/holos/console/v1/deployments_pb'
 import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useUpdateDeployment, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
-
-// filterEnvVars removes incomplete rows before submit.
-function filterEnvVars(envVars: EnvVar[]): EnvVar[] {
-  return envVars.filter((ev) => {
-    if (!ev.name.trim()) return false
-    if (ev.source.case === 'value') return true
-    if (ev.source.case === 'secretKeyRef') return !!(ev.source.value.name && ev.source.value.key)
-    if (ev.source.case === 'configMapKeyRef') return !!(ev.source.value.name && ev.source.value.key)
-    return false
-  })
-}
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/deployments/$deploymentName')({
   component: DeploymentDetailRoute,

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { CreateTemplateModal } from '@/components/create-template-modal'
 import { StringListInput } from '@/components/string-list-input'
-import { EnvVarEditor } from '@/components/env-var-editor'
+import { EnvVarEditor, filterEnvVars } from '@/components/env-var-editor'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -41,18 +41,6 @@ import type { EnvVar } from '@/gen/holos/console/v1/deployments_pb'
 import { useListDeployments, useCreateDeployment, useDeleteDeployment } from '@/queries/deployments'
 import { useListDeploymentTemplates } from '@/queries/deployment-templates'
 import { useGetProject } from '@/queries/projects'
-
-// filterEnvVars removes incomplete rows before submit.
-// A row is valid if the name is non-empty and the source is complete.
-function filterEnvVars(envVars: EnvVar[]): EnvVar[] {
-  return envVars.filter((ev) => {
-    if (!ev.name.trim()) return false
-    if (ev.source.case === 'value') return true
-    if (ev.source.case === 'secretKeyRef') return !!(ev.source.value.name && ev.source.value.key)
-    if (ev.source.case === 'configMapKeyRef') return !!(ev.source.value.name && ev.source.value.key)
-    return false
-  })
-}
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/deployments/')({
   component: DeploymentsRoute,


### PR DESCRIPTION
## Summary
- Extract duplicated `filterEnvVars` helper from two deployment route files into `env-var-editor.tsx` (its logical home) and export it so both routes share one implementation
- Update `AGENTS.md` `deployments/` package description to cover env var support and the new `ListNamespaceSecrets`/`ListNamespaceConfigMaps` RPCs
- Update `docs/rpc-service-definitions.md` to note the expanded `DeploymentService` capabilities

Closes: #333

## Test plan
- [x] `make generate` succeeds (TypeScript type checking passes)
- [x] `make test` passes (396 UI tests + all Go tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1