### PR TITLE
docs: final cleanup for command/args feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ This is a Go HTTPS server that serves a web console UI and exposes ConnectRPC se
   - `secrets/` - SecretsService with K8s backend and annotation-based RBAC
   - `settings/` - ProjectSettingsService managing per-project feature flags (e.g. deployments toggle) stored as K8s ConfigMaps
   - `templates/` - DeploymentTemplateService managing CUE-based deployment templates stored as K8s ConfigMaps; embeds `default_template.cue`
-  - `deployments/` - DeploymentService managing Kubernetes Deployments: CRUD, status polling, log streaming, CUE render and apply, container env vars (literal values, SecretKeyRef, ConfigMapKeyRef), and listing project-namespace Secrets/ConfigMaps for env var references
+  - `deployments/` - DeploymentService managing Kubernetes Deployments: CRUD, status polling, log streaming, CUE render and apply, container command/args override, container env vars (literal values, SecretKeyRef, ConfigMapKeyRef), and listing project-namespace Secrets/ConfigMaps for env var references
   - `dist/` - Embedded static files served at `/` (build output from frontend, not source)
 - `proto/` - Protobuf source files
   - `holos/console/v1/organizations.proto` - OrganizationService

--- a/docs/rpc-service-definitions.md
+++ b/docs/rpc-service-definitions.md
@@ -20,7 +20,7 @@ proto/                          # Protobuf source files
     secrets.proto               # SecretsService
     project_settings.proto      # ProjectSettingsService
     deployment_templates.proto  # DeploymentTemplateService
-    deployments.proto           # DeploymentService (CRUD, status, logs, env vars, K8s resource listing)
+    deployments.proto           # DeploymentService (CRUD, status, logs, command/args override, env vars, K8s resource listing)
     rbac.proto                  # Role definitions
 
 gen/                            # Generated Go code (do not edit)


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` deployments package description to include container command/args override capability
- Update `docs/rpc-service-definitions.md` DeploymentService description to include command/args

Both files mentioned env vars but omitted the command/args override fields added in phases 1-4 (#322-#325).

Closes: #326

## Test plan
- [x] `make test` passes (396 UI tests, all Go tests)
- [x] `make generate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1