### PR TITLE
fix(deployments): replace deprecated CUE Iterator.Label and interface{}

### DIFF
--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -123,7 +123,7 @@ func evaluate(cueSource string, input DeploymentInput) ([]unstructured.Unstructu
 		return nil, fmt.Errorf("extracting resources field: %w", err)
 	}
 
-	var rawResources []map[string]interface{}
+	var rawResources []map[string]any
 	if err := resourcesValue.Decode(&rawResources); err != nil {
 		return nil, fmt.Errorf("decoding resources: %w", err)
 	}
@@ -147,20 +147,20 @@ func evaluateStructured(unified cue.Value, expectedNamespace string) ([]unstruct
 			return nil, fmt.Errorf("iterating namespaced keys: %w", err)
 		}
 		for nsIter.Next() {
-			nsKey := nsIter.Label()
+			nsKey := nsIter.Selector().Unquoted()
 			kindIter, err := nsIter.Value().Fields()
 			if err != nil {
 				return nil, fmt.Errorf("iterating Kind keys under namespace %q: %w", nsKey, err)
 			}
 			for kindIter.Next() {
-				kindKey := kindIter.Label()
+				kindKey := kindIter.Selector().Unquoted()
 				nameIter, err := kindIter.Value().Fields()
 				if err != nil {
 					return nil, fmt.Errorf("iterating name keys under %q/%q: %w", nsKey, kindKey, err)
 				}
 				for nameIter.Next() {
-					nameKey := nameIter.Label()
-					var raw map[string]interface{}
+					nameKey := nameIter.Selector().Unquoted()
+					var raw map[string]any
 					if err := nameIter.Value().Decode(&raw); err != nil {
 						return nil, fmt.Errorf("decoding namespaced/%s/%s/%s: %w", nsKey, kindKey, nameKey, err)
 					}
@@ -187,7 +187,7 @@ func evaluateStructured(unified cue.Value, expectedNamespace string) ([]unstruct
 					}
 
 					// Run common resource validations.
-					if err := validateResource(u, expectedNamespace); err != nil {
+					if err := validateResource(u); err != nil {
 						return nil, err
 					}
 
@@ -205,14 +205,14 @@ func evaluateStructured(unified cue.Value, expectedNamespace string) ([]unstruct
 			return nil, fmt.Errorf("iterating cluster Kind keys: %w", err)
 		}
 		for kindIter.Next() {
-			kindKey := kindIter.Label()
+			kindKey := kindIter.Selector().Unquoted()
 			nameIter, err := kindIter.Value().Fields()
 			if err != nil {
 				return nil, fmt.Errorf("iterating name keys under cluster/%q: %w", kindKey, err)
 			}
 			for nameIter.Next() {
-				nameKey := nameIter.Label()
-				var raw map[string]interface{}
+				nameKey := nameIter.Selector().Unquoted()
+				var raw map[string]any
 				if err := nameIter.Value().Decode(&raw); err != nil {
 					return nil, fmt.Errorf("decoding cluster/%s/%s: %w", kindKey, nameKey, err)
 				}
@@ -242,7 +242,7 @@ func evaluateStructured(unified cue.Value, expectedNamespace string) ([]unstruct
 }
 
 // validateResource runs common safety checks on a single resource.
-func validateResource(u unstructured.Unstructured, expectedNamespace string) error {
+func validateResource(u unstructured.Unstructured) error {
 	if u.GetAPIVersion() == "" {
 		return fmt.Errorf("resource %s/%s: missing apiVersion", u.GetKind(), u.GetName())
 	}
@@ -270,7 +270,7 @@ func validateResource(u unstructured.Unstructured, expectedNamespace string) err
 }
 
 // validateResources validates each resource against safety constraints.
-func validateResources(rawResources []map[string]interface{}, expectedNamespace string) ([]unstructured.Unstructured, error) {
+func validateResources(rawResources []map[string]any, expectedNamespace string) ([]unstructured.Unstructured, error) {
 	result := make([]unstructured.Unstructured, 0, len(rawResources))
 	for i, raw := range rawResources {
 		u := unstructured.Unstructured{Object: raw}

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -325,7 +325,7 @@ func TestCueRenderer_Render(t *testing.T) {
 		if len(containers) != 1 {
 			t.Fatalf("expected 1 container, got %d", len(containers))
 		}
-		c, ok := containers[0].(map[string]interface{})
+		c, ok := containers[0].(map[string]any)
 		if !ok {
 			t.Fatal("container is not a map")
 		}
@@ -445,15 +445,15 @@ func TestCueRenderer_Env(t *testing.T) {
 		if len(containers) == 0 {
 			t.Fatal("expected at least 1 container")
 		}
-		c, ok := containers[0].(map[string]interface{})
+		c, ok := containers[0].(map[string]any)
 		if !ok {
 			t.Fatal("container is not a map")
 		}
-		envList, _, _ := unstructured.NestedSlice(map[string]interface{}{"c": c}, "c", "env")
+		envList, _, _ := unstructured.NestedSlice(map[string]any{"c": c}, "c", "env")
 		if len(envList) != 1 {
 			t.Fatalf("expected 1 env var, got %d", len(envList))
 		}
-		envItem, ok := envList[0].(map[string]interface{})
+		envItem, ok := envList[0].(map[string]any)
 		if !ok {
 			t.Fatal("env item is not a map")
 		}
@@ -483,7 +483,7 @@ func TestCueRenderer_Env(t *testing.T) {
 		if len(containers) == 0 {
 			t.Fatal("expected at least 1 container")
 		}
-		c, ok := containers[0].(map[string]interface{})
+		c, ok := containers[0].(map[string]any)
 		if !ok {
 			t.Fatal("container is not a map")
 		}
@@ -517,15 +517,15 @@ func TestCueRenderer_CommandArgs(t *testing.T) {
 		if len(containers) == 0 {
 			t.Fatal("expected at least 1 container")
 		}
-		c, ok := containers[0].(map[string]interface{})
+		c, ok := containers[0].(map[string]any)
 		if !ok {
 			t.Fatal("container is not a map")
 		}
-		gotCommand, _, _ := unstructured.NestedStringSlice(map[string]interface{}{"c": c}, "c", "command")
+		gotCommand, _, _ := unstructured.NestedStringSlice(map[string]any{"c": c}, "c", "command")
 		if len(gotCommand) != 2 || gotCommand[0] != "/bin/sh" {
 			t.Errorf("expected command [/bin/sh -c], got %v", gotCommand)
 		}
-		gotArgs, _, _ := unstructured.NestedStringSlice(map[string]interface{}{"c": c}, "c", "args")
+		gotArgs, _, _ := unstructured.NestedStringSlice(map[string]any{"c": c}, "c", "args")
 		if len(gotArgs) != 1 || gotArgs[0] != "echo hello" {
 			t.Errorf("expected args [echo hello], got %v", gotArgs)
 		}
@@ -549,7 +549,7 @@ func TestCueRenderer_CommandArgs(t *testing.T) {
 		if len(containers) == 0 {
 			t.Fatal("expected at least 1 container")
 		}
-		c, ok := containers[0].(map[string]interface{})
+		c, ok := containers[0].(map[string]any)
 		if !ok {
 			t.Fatal("container is not a map")
 		}


### PR DESCRIPTION
## Summary
- Replace deprecated `Iterator.Label()` calls with `Selector().Unquoted()` in the CUE structured output walker
- Replace `interface{}` with `any` throughout render.go and render_test.go
- Remove unused `expectedNamespace` parameter from `validateResource`

These are cleanup fixes for diagnostics introduced by PR #348 (issue #342).

## Test plan
- [x] `go test ./console/deployments/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1