### PR TITLE
chore: final cleanup for structured resource output refactoring

### DIFF
--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// structuredTemplate uses the new namespaced/cluster output format.
+// structuredTemplate uses the namespaced/cluster structured output format.
 const structuredTemplate = `
 package deployment
 
@@ -627,7 +627,7 @@ namespaced: (input.namespace): {
 cluster: {}
 `
 
-// TestCueRenderer_StructuredOutput tests the new namespaced/cluster output format.
+// TestCueRenderer_StructuredOutput tests the namespaced/cluster structured output format.
 func TestCueRenderer_StructuredOutput(t *testing.T) {
 	renderer := &CueRenderer{}
 	namespace := "prj-my-project"

--- a/console/templates/render_adapter_test.go
+++ b/console/templates/render_adapter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// adapterStructuredTemplate uses the structured namespaced/cluster output format.
+// adapterStructuredTemplate uses the namespaced/cluster structured output format.
 const adapterStructuredTemplate = `
 package deployment
 


### PR DESCRIPTION
## Summary

- Scanned the entire repository for dead, deprecated, or outdated information introduced or made stale by the structured resource output refactoring (phases 1-4, issues #342–#345)
- Found and removed stale "new" qualifiers from test comments in `render_test.go` and `render_adapter_test.go` that described the namespaced/cluster format as "new" — now that the old flat `resources` list is removed, there is no contrast to draw and the temporal language will become confusing
- Verified all documentation (ADR 012, CUE template guide, AGENTS.md) correctly describes the structured output format with no stale references to the old flat list
- Confirmed no remaining references to `validateResources`, `evaluateList`, or the old `resources: [...]` flat list format anywhere in production code

Closes: #346
Closes: #341

## Test plan
- [x] `make test-go` passes (all 15 packages)
- [x] `make test-ui` passes (396 tests)
- [x] `make vet` passes
- [x] No references to old flat resources format in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1