### PR TITLE
chore: cleanup stale code and docs after creator/creation-time feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,8 @@ Three-tier access control model evaluated in order (highest role wins):
 
 Grant annotations: `console.holos.run/share-users`, `console.holos.run/share-roles`
 
+Metadata annotations on org/project namespaces: `console.holos.run/display-name`, `console.holos.run/creator-email` (email of the user who created the resource, written at creation time from the OIDC email claim)
+
 Namespace prefix scheme (three-part naming: `{namespace-prefix}{type-prefix}{name}`):
 - Organizations: `{namespace-prefix}{organization-prefix}{name}` (resource-type label: `organization`)
 - Projects: `{namespace-prefix}{project-prefix}{name}` (resource-type label: `project`, optional organization label for IAM inheritance, project label stores project name)

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -77,6 +77,17 @@ Cascade behavior is defined by explicit permission tables per scope (`CascadeTab
 
 Organization grants have no cascade tables — they never cascade to projects or secrets ([ADR 007](adrs/007-org-grants-no-cascade.md)).
 
+## Metadata Annotations
+
+Metadata annotations are stored on organization and project Namespace resources:
+
+| Annotation | Resource | Description |
+|---|---|---|
+| `console.holos.run/display-name` | Organization, Project | Human-readable display name |
+| `console.holos.run/creator-email` | Organization, Project | Email address of the user who created the resource |
+
+The `creator-email` annotation is written at creation time from the authenticated user's OIDC email claim. It is read-only after creation and surfaced in the settings UI.
+
 ## Grant Annotations
 
 Grants are stored as JSON annotations on Namespace and Secret resources:
@@ -142,6 +153,7 @@ metadata:
     console.holos.run/resource-type: organization
   annotations:
     console.holos.run/display-name: "My Organization"
+    console.holos.run/creator-email: "alice@example.com"
     console.holos.run/share-users: '[{"principal":"alice@example.com","role":"owner"}]'
     console.holos.run/share-roles: '[{"principal":"dev-team","role":"editor"}]'
 ---
@@ -157,6 +169,7 @@ metadata:
     console.holos.run/project: my-project
   annotations:
     console.holos.run/display-name: "My Project"
+    console.holos.run/creator-email: "bob@example.com"
     console.holos.run/description: "Production secrets"
     console.holos.run/share-users: '[{"principal":"bob@example.com","role":"viewer","exp":1735689600}]'
 ---


### PR DESCRIPTION
## Summary

- Add a **Metadata Annotations** section to `docs/rbac.md` documenting `console.holos.run/display-name` and `console.holos.run/creator-email` annotations on organization and project namespaces
- Update the example YAML in `docs/rbac.md` to include `creator-email` on both the org and project namespaces
- Update `AGENTS.md` RBAC section to mention metadata annotations alongside grant annotations

No dead code, unused imports, or stale TODO/FIXME comments were found in the scanned files. The only gap was the missing annotation documentation.

Closes: #358

## Test plan

- [x] `make test-go` passes (all Go tests green)
- [x] `make test-ui` passes (all 406 UI tests green)
- [x] `docs/rbac.md` now documents `console.holos.run/creator-email`
- [x] `AGENTS.md` RBAC section references the new metadata annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1