### PR TITLE
feat(templates): populate rendered_json in RenderDeploymentTemplate handler

### DIFF
--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -33,9 +34,11 @@ type RenderInput struct {
 	Name, Image, Tag, Project, Namespace string
 }
 
-// RenderResource is a single rendered resource with its YAML representation.
+// RenderResource is a single rendered resource with its YAML representation
+// and its raw object data for JSON serialization.
 type RenderResource struct {
-	YAML string
+	YAML   string
+	Object map[string]interface{}
 }
 
 // Renderer evaluates a CUE template with deployment inputs and returns
@@ -308,15 +311,25 @@ func (h *Handler) RenderDeploymentTemplate(
 	}
 
 	var buf strings.Builder
+	objects := make([]map[string]interface{}, 0, len(resources))
 	for i, r := range resources {
 		if i > 0 {
 			buf.WriteString("---\n")
 		}
 		buf.WriteString(r.YAML)
+		if r.Object != nil {
+			objects = append(objects, r.Object)
+		}
+	}
+
+	jsonBytes, err := json.MarshalIndent(objects, "", "  ")
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to marshal rendered resources to JSON: %w", err))
 	}
 
 	return connect.NewResponse(&consolev1.RenderDeploymentTemplateResponse{
 		RenderedYaml: buf.String(),
+		RenderedJson: string(jsonBytes),
 	}), nil
 }
 

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -502,8 +503,14 @@ func TestHandler_RenderDeploymentTemplate(t *testing.T) {
 		pr := &stubProjectResolver{users: map[string]string{"viewer@example.com": "viewer"}}
 		stub := &stubRenderer{
 			resources: []RenderResource{
-				{YAML: "apiVersion: v1\nkind: ServiceAccount\n"},
-				{YAML: "apiVersion: apps/v1\nkind: Deployment\n"},
+				{
+					YAML:   "apiVersion: v1\nkind: ServiceAccount\n",
+					Object: map[string]interface{}{"apiVersion": "v1", "kind": "ServiceAccount"},
+				},
+				{
+					YAML:   "apiVersion: apps/v1\nkind: Deployment\n",
+					Object: map[string]interface{}{"apiVersion": "apps/v1", "kind": "Deployment"},
+				},
 			},
 		}
 		handler := NewHandler(k8s, pr, stub)
@@ -528,6 +535,102 @@ func TestHandler_RenderDeploymentTemplate(t *testing.T) {
 		}
 		if !strings.Contains(resp.Msg.RenderedYaml, "---\n") {
 			t.Error("expected YAML to contain document separator")
+		}
+	})
+
+	t.Run("rendered_json is a pretty-printed JSON array of all resource objects", func(t *testing.T) {
+		fakeClient := fake.NewClientset(projectNS("my-project"))
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"viewer@example.com": "viewer"}}
+		stub := &stubRenderer{
+			resources: []RenderResource{
+				{
+					YAML:   "apiVersion: v1\nkind: ServiceAccount\n",
+					Object: map[string]interface{}{"apiVersion": "v1", "kind": "ServiceAccount"},
+				},
+				{
+					YAML:   "apiVersion: apps/v1\nkind: Deployment\n",
+					Object: map[string]interface{}{"apiVersion": "apps/v1", "kind": "Deployment"},
+				},
+			},
+		}
+		handler := NewHandler(k8s, pr, stub)
+
+		ctx := authedCtx("viewer@example.com", nil)
+		req := connect.NewRequest(&consolev1.RenderDeploymentTemplateRequest{
+			Project:     "my-project",
+			CueTemplate: validCueSrc,
+		})
+		resp, err := handler.RenderDeploymentTemplate(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// rendered_json must be non-empty.
+		if resp.Msg.RenderedJson == "" {
+			t.Fatal("expected non-empty rendered_json")
+		}
+
+		// rendered_json must be pretty-printed (contains newlines).
+		if !strings.Contains(resp.Msg.RenderedJson, "\n") {
+			t.Error("expected rendered_json to be pretty-printed with newlines")
+		}
+
+		// rendered_json must be valid JSON and parse as a JSON array.
+		var resources []map[string]interface{}
+		if err := json.Unmarshal([]byte(resp.Msg.RenderedJson), &resources); err != nil {
+			t.Fatalf("rendered_json is not valid JSON: %v", err)
+		}
+
+		// Must contain both resources.
+		if len(resources) != 2 {
+			t.Fatalf("expected 2 elements in rendered_json array, got %d", len(resources))
+		}
+
+		// Verify resource kinds are present.
+		kinds := make(map[string]bool)
+		for _, r := range resources {
+			if k, ok := r["kind"].(string); ok {
+				kinds[k] = true
+			}
+		}
+		if !kinds["ServiceAccount"] {
+			t.Error("expected rendered_json to contain ServiceAccount")
+		}
+		if !kinds["Deployment"] {
+			t.Error("expected rendered_json to contain Deployment")
+		}
+	})
+
+	t.Run("rendered_json is empty array when renderer returns no objects", func(t *testing.T) {
+		fakeClient := fake.NewClientset(projectNS("my-project"))
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"viewer@example.com": "viewer"}}
+		// Resources with no Object set (legacy path).
+		stub := &stubRenderer{
+			resources: []RenderResource{
+				{YAML: "apiVersion: v1\nkind: ServiceAccount\n"},
+			},
+		}
+		handler := NewHandler(k8s, pr, stub)
+
+		ctx := authedCtx("viewer@example.com", nil)
+		req := connect.NewRequest(&consolev1.RenderDeploymentTemplateRequest{
+			Project:     "my-project",
+			CueTemplate: validCueSrc,
+		})
+		resp, err := handler.RenderDeploymentTemplate(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// rendered_json should be a valid JSON empty array.
+		var resources []map[string]interface{}
+		if err := json.Unmarshal([]byte(resp.Msg.RenderedJson), &resources); err != nil {
+			t.Fatalf("rendered_json is not valid JSON: %v", err)
+		}
+		if len(resources) != 0 {
+			t.Errorf("expected 0 elements in rendered_json when no objects provided, got %d", len(resources))
 		}
 	})
 

--- a/console/templates/render_adapter.go
+++ b/console/templates/render_adapter.go
@@ -35,7 +35,7 @@ func (a *CueRendererAdapter) Render(ctx context.Context, cueSource string, in Re
 		if err != nil {
 			return nil, err
 		}
-		out[i] = RenderResource{YAML: string(b)}
+		out[i] = RenderResource{YAML: string(b), Object: u.Object}
 	}
 	return out, nil
 }

--- a/console/templates/render_adapter_test.go
+++ b/console/templates/render_adapter_test.go
@@ -204,6 +204,32 @@ func TestCueRendererAdapter_Render(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("each resource has non-nil Object for JSON serialization", func(t *testing.T) {
+		resources, err := adapter.Render(context.Background(), adapterStructuredTemplate, RenderInput{
+			Name:      "web-app",
+			Image:     "nginx",
+			Tag:       "1.25",
+			Project:   "my-project",
+			Namespace: namespace,
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		for i, r := range resources {
+			if r.Object == nil {
+				t.Errorf("resource %d: expected non-nil Object for JSON serialization", i)
+			}
+			// Verify Object contains expected fields.
+			if _, ok := r.Object["apiVersion"]; !ok {
+				t.Errorf("resource %d: Object missing apiVersion field", i)
+			}
+			if _, ok := r.Object["kind"]; !ok {
+				t.Errorf("resource %d: Object missing kind field", i)
+			}
+		}
+	})
 }
 
 // TestCueRendererAdapter_WithDefaultTemplate verifies the adapter works end-to-end


### PR DESCRIPTION
## Summary
- Add `Object map[string]interface{}` field to `RenderResource` to carry raw K8s object data alongside YAML
- Update `CueRendererAdapter.Render` to populate `Object` from `unstructured.Unstructured` for each resource
- Update `RenderDeploymentTemplate` handler to serialize resources as a pretty-printed JSON array in `RenderedJson`
- Add Go unit tests verifying JSON output is valid, pretty-printed, and contains expected resource kinds

Closes: #369

## Test plan
- [x] `make test-go` passes
- [x] `make generate` succeeds (TypeScript type checking)
- [ ] `rendered_json` in response is a valid pretty-printed JSON array of K8s resource objects
- [ ] `rendered_yaml` continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1