### PR TITLE
refactor(templates): replace interface{} with any

### DIFF
--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -38,7 +38,7 @@ type RenderInput struct {
 // and its raw object data for JSON serialization.
 type RenderResource struct {
 	YAML   string
-	Object map[string]interface{}
+	Object map[string]any
 }
 
 // Renderer evaluates a CUE template with deployment inputs and returns
@@ -311,7 +311,7 @@ func (h *Handler) RenderDeploymentTemplate(
 	}
 
 	var buf strings.Builder
-	objects := make([]map[string]interface{}, 0, len(resources))
+	objects := make([]map[string]any, 0, len(resources))
 	for i, r := range resources {
 		if i > 0 {
 			buf.WriteString("---\n")

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -505,11 +505,11 @@ func TestHandler_RenderDeploymentTemplate(t *testing.T) {
 			resources: []RenderResource{
 				{
 					YAML:   "apiVersion: v1\nkind: ServiceAccount\n",
-					Object: map[string]interface{}{"apiVersion": "v1", "kind": "ServiceAccount"},
+					Object: map[string]any{"apiVersion": "v1", "kind": "ServiceAccount"},
 				},
 				{
 					YAML:   "apiVersion: apps/v1\nkind: Deployment\n",
-					Object: map[string]interface{}{"apiVersion": "apps/v1", "kind": "Deployment"},
+					Object: map[string]any{"apiVersion": "apps/v1", "kind": "Deployment"},
 				},
 			},
 		}
@@ -546,11 +546,11 @@ func TestHandler_RenderDeploymentTemplate(t *testing.T) {
 			resources: []RenderResource{
 				{
 					YAML:   "apiVersion: v1\nkind: ServiceAccount\n",
-					Object: map[string]interface{}{"apiVersion": "v1", "kind": "ServiceAccount"},
+					Object: map[string]any{"apiVersion": "v1", "kind": "ServiceAccount"},
 				},
 				{
 					YAML:   "apiVersion: apps/v1\nkind: Deployment\n",
-					Object: map[string]interface{}{"apiVersion": "apps/v1", "kind": "Deployment"},
+					Object: map[string]any{"apiVersion": "apps/v1", "kind": "Deployment"},
 				},
 			},
 		}
@@ -577,7 +577,7 @@ func TestHandler_RenderDeploymentTemplate(t *testing.T) {
 		}
 
 		// rendered_json must be valid JSON and parse as a JSON array.
-		var resources []map[string]interface{}
+		var resources []map[string]any
 		if err := json.Unmarshal([]byte(resp.Msg.RenderedJson), &resources); err != nil {
 			t.Fatalf("rendered_json is not valid JSON: %v", err)
 		}
@@ -625,7 +625,7 @@ func TestHandler_RenderDeploymentTemplate(t *testing.T) {
 		}
 
 		// rendered_json should be a valid JSON empty array.
-		var resources []map[string]interface{}
+		var resources []map[string]any
 		if err := json.Unmarshal([]byte(resp.Msg.RenderedJson), &resources); err != nil {
 			t.Fatalf("rendered_json is not valid JSON: %v", err)
 		}


### PR DESCRIPTION
## Summary
- Replace `interface{}` with `any` in `handler.go` and `handler_test.go`

These were flagged as lint suggestions after #377 was merged.

## Test plan
- [x] `go test ./console/templates/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)