### PR TITLE
chore: cleanup stale code after template preview feature

### DIFF
--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -42,7 +42,7 @@ type RenderResource struct {
 }
 
 // Renderer evaluates a CUE template with deployment inputs and returns
-// a list of rendered Kubernetes manifests as YAML strings.
+// a list of rendered Kubernetes manifests with both YAML and structured object data.
 type Renderer interface {
 	Render(ctx context.Context, cueSource string, input RenderInput) ([]RenderResource, error)
 }

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -314,7 +314,9 @@ cluster: #Cluster & {}
 
 Use the `RenderDeploymentTemplate` RPC to preview a template without creating a
 deployment. This accepts raw CUE source and example inputs, returning the
-rendered YAML. Useful for validating templates during authoring.
+rendered resources as multi-document YAML (`rendered_yaml`) and as a
+pretty-printed JSON array (`rendered_json`). Useful for validating templates
+during authoring.
 
 ## Planned Extensions
 
@@ -370,7 +372,7 @@ codebase. Use it for advanced troubleshooting or when developing new features.
 |------|---------|
 | `console/templates/handler.go` | `DeploymentTemplateService` handler — CRUD for templates stored as ConfigMaps. |
 | `console/templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `deployment-template` resource-type label. |
-| `console/templates/render_adapter.go` | `CueRendererAdapter` — wraps `deployments.CueRenderer` to produce YAML strings for the template preview RPC. |
+| `console/templates/render_adapter.go` | `CueRendererAdapter` — wraps `deployments.CueRenderer` to produce YAML and structured object data for the template preview RPC. |
 
 ### Deployment Service
 


### PR DESCRIPTION
## Summary
- Update `Renderer` interface doc comment in `console/templates/handler.go` to reflect that it returns both YAML and structured object data (not just YAML strings)
- Update `docs/cue-template-guide.md` "Previewing Templates" section to document both `rendered_yaml` and `rendered_json` response fields
- Update `docs/cue-template-guide.md` source code reference table entry for `render_adapter.go` to mention structured object data alongside YAML

Closes: #371

## Test plan
- [x] `make test-go` passes
- [x] `make test-ui` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1