### PR TITLE
feat(templates): store/retrieve deployment defaults and populate rendered_json

### DIFF
--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -169,7 +169,7 @@ func (h *Handler) CreateDeploymentTemplate(
 		return nil, err
 	}
 
-	_, err := h.k8s.CreateTemplate(ctx, project, name, req.Msg.DisplayName, req.Msg.Description, req.Msg.CueTemplate)
+	_, err := h.k8s.CreateTemplate(ctx, project, name, req.Msg.DisplayName, req.Msg.Description, req.Msg.CueTemplate, req.Msg.Defaults)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -218,7 +218,7 @@ func (h *Handler) UpdateDeploymentTemplate(
 		return nil, err
 	}
 
-	_, err := h.k8s.UpdateTemplate(ctx, project, name, req.Msg.DisplayName, req.Msg.Description, req.Msg.CueTemplate)
+	_, err := h.k8s.UpdateTemplate(ctx, project, name, req.Msg.DisplayName, req.Msg.Description, req.Msg.CueTemplate, req.Msg.Defaults, false)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -373,14 +373,29 @@ func validateCueSyntax(source string) error {
 }
 
 // configMapToTemplate converts a Kubernetes ConfigMap to a DeploymentTemplate protobuf message.
+// If the ConfigMap data contains a DefaultsKey entry, it is deserialized into the Defaults field.
+// Missing or empty DefaultsKey leaves the Defaults field nil.
 func configMapToTemplate(cm *corev1.ConfigMap, project string) *consolev1.DeploymentTemplate {
-	return &consolev1.DeploymentTemplate{
+	tmpl := &consolev1.DeploymentTemplate{
 		Name:        cm.Name,
 		Project:     project,
 		DisplayName: cm.Annotations[DisplayNameAnnotation],
 		Description: cm.Annotations[DescriptionAnnotation],
 		CueTemplate: cm.Data[CueTemplateKey],
 	}
+	if rawJSON, ok := cm.Data[DefaultsKey]; ok && rawJSON != "" {
+		var defaults consolev1.DeploymentDefaults
+		if err := json.Unmarshal([]byte(rawJSON), &defaults); err == nil {
+			tmpl.Defaults = &defaults
+		} else {
+			slog.Warn("failed to deserialize deployment defaults from ConfigMap",
+				slog.String("name", cm.Name),
+				slog.String("namespace", cm.Namespace),
+				slog.Any("error", err),
+			)
+		}
+	}
+	return tmpl
 }
 
 // mapK8sError converts Kubernetes API errors to ConnectRPC errors.

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -50,6 +51,149 @@ const validCue = `package deployment
 	name: string
 }
 `
+
+// templateConfigMapWithDefaults builds a ConfigMap that includes a defaults.json key.
+func templateConfigMapWithDefaults(project, name, displayName, description, cueTemplate string, defaultsJSON string) *corev1.ConfigMap {
+	cm := templateConfigMap(project, name, displayName, description, cueTemplate)
+	if defaultsJSON != "" {
+		cm.Data[DefaultsKey] = defaultsJSON
+	}
+	return cm
+}
+
+func TestHandler_DefaultsRoundTrip(t *testing.T) {
+	t.Run("create with defaults then get returns defaults", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		createReq := connect.NewRequest(&consolev1.CreateDeploymentTemplateRequest{
+			Project:     "my-project",
+			Name:        "web-app",
+			DisplayName: "Web App",
+			CueTemplate: validCue,
+			Defaults: &consolev1.DeploymentDefaults{
+				Image: "ghcr.io/mccutchen/go-httpbin",
+				Tag:   "2.21",
+			},
+		})
+		_, err := handler.CreateDeploymentTemplate(ctx, createReq)
+		if err != nil {
+			t.Fatalf("create: expected no error, got %v", err)
+		}
+
+		getReq := connect.NewRequest(&consolev1.GetDeploymentTemplateRequest{Project: "my-project", Name: "web-app"})
+		getResp, err := handler.GetDeploymentTemplate(ctx, getReq)
+		if err != nil {
+			t.Fatalf("get: expected no error, got %v", err)
+		}
+		tmpl := getResp.Msg.Template
+		if tmpl.Defaults == nil {
+			t.Fatal("expected non-nil defaults after create with defaults")
+		}
+		if tmpl.Defaults.Image != "ghcr.io/mccutchen/go-httpbin" {
+			t.Errorf("expected image 'ghcr.io/mccutchen/go-httpbin', got %q", tmpl.Defaults.Image)
+		}
+		if tmpl.Defaults.Tag != "2.21" {
+			t.Errorf("expected tag '2.21', got %q", tmpl.Defaults.Tag)
+		}
+	})
+
+	t.Run("create without defaults then get returns nil defaults", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		createReq := connect.NewRequest(&consolev1.CreateDeploymentTemplateRequest{
+			Project:     "my-project",
+			Name:        "web-app",
+			DisplayName: "Web App",
+			CueTemplate: validCue,
+		})
+		_, err := handler.CreateDeploymentTemplate(ctx, createReq)
+		if err != nil {
+			t.Fatalf("create: expected no error, got %v", err)
+		}
+
+		getReq := connect.NewRequest(&consolev1.GetDeploymentTemplateRequest{Project: "my-project", Name: "web-app"})
+		getResp, err := handler.GetDeploymentTemplate(ctx, getReq)
+		if err != nil {
+			t.Fatalf("get: expected no error, got %v", err)
+		}
+		if getResp.Msg.Template.Defaults != nil {
+			t.Error("expected nil defaults when template created without defaults")
+		}
+	})
+
+	t.Run("update to add defaults then get returns defaults", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "A web app", validCue)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		updateReq := connect.NewRequest(&consolev1.UpdateDeploymentTemplateRequest{
+			Project: "my-project",
+			Name:    "web-app",
+			Defaults: &consolev1.DeploymentDefaults{
+				Image: "ghcr.io/example/app",
+				Tag:   "v2.0",
+			},
+		})
+		_, err := handler.UpdateDeploymentTemplate(ctx, updateReq)
+		if err != nil {
+			t.Fatalf("update: expected no error, got %v", err)
+		}
+
+		getReq := connect.NewRequest(&consolev1.GetDeploymentTemplateRequest{Project: "my-project", Name: "web-app"})
+		getResp, err := handler.GetDeploymentTemplate(ctx, getReq)
+		if err != nil {
+			t.Fatalf("get: expected no error, got %v", err)
+		}
+		tmpl := getResp.Msg.Template
+		if tmpl.Defaults == nil {
+			t.Fatal("expected non-nil defaults after update with defaults")
+		}
+		if tmpl.Defaults.Image != "ghcr.io/example/app" {
+			t.Errorf("expected image 'ghcr.io/example/app', got %q", tmpl.Defaults.Image)
+		}
+	})
+
+	t.Run("list returns defaults on each template", func(t *testing.T) {
+		ns := projectNS("my-project")
+		defaultsJSON := `{"image":"ghcr.io/example/app","tag":"v1.0"}`
+		cm := templateConfigMapWithDefaults("my-project", "web-app", "Web App", "A web app", validCue, defaultsJSON)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"viewer@example.com": "viewer"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("viewer@example.com", nil)
+		listReq := connect.NewRequest(&consolev1.ListDeploymentTemplatesRequest{Project: "my-project"})
+		listResp, err := handler.ListDeploymentTemplates(ctx, listReq)
+		if err != nil {
+			t.Fatalf("list: expected no error, got %v", err)
+		}
+		if len(listResp.Msg.Templates) != 1 {
+			t.Fatalf("expected 1 template, got %d", len(listResp.Msg.Templates))
+		}
+		tmpl := listResp.Msg.Templates[0]
+		if tmpl.Defaults == nil {
+			t.Fatal("expected non-nil defaults in list response")
+		}
+		if tmpl.Defaults.Image != "ghcr.io/example/app" {
+			t.Errorf("expected image 'ghcr.io/example/app', got %q", tmpl.Defaults.Image)
+		}
+	})
+}
 
 func TestHandler_ListDeploymentTemplates(t *testing.T) {
 	t.Run("viewer can list templates", func(t *testing.T) {

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -2,10 +2,12 @@ package templates
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
 	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -19,6 +21,8 @@ const (
 	DisplayNameAnnotation = "console.holos.run/display-name"
 	DescriptionAnnotation = "console.holos.run/description"
 	CueTemplateKey        = "template.cue"
+	// DefaultsKey is the ConfigMap data key that stores DeploymentDefaults as JSON.
+	DefaultsKey = "defaults.json"
 )
 
 // K8sClient wraps Kubernetes client operations for deployment templates.
@@ -62,13 +66,24 @@ func (k *K8sClient) GetTemplate(ctx context.Context, project, name string) (*cor
 }
 
 // CreateTemplate creates a new deployment template ConfigMap.
-func (k *K8sClient) CreateTemplate(ctx context.Context, project, name, displayName, description, cueTemplate string) (*corev1.ConfigMap, error) {
+// If defaults is non-nil, it is serialized to JSON and stored under DefaultsKey.
+func (k *K8sClient) CreateTemplate(ctx context.Context, project, name, displayName, description, cueTemplate string, defaults *consolev1.DeploymentDefaults) (*corev1.ConfigMap, error) {
 	ns := k.Resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "creating deployment template in kubernetes",
 		slog.String("project", project),
 		slog.String("namespace", ns),
 		slog.String("name", name),
 	)
+	data := map[string]string{
+		CueTemplateKey: cueTemplate,
+	}
+	if defaults != nil {
+		b, err := json.Marshal(defaults)
+		if err != nil {
+			return nil, fmt.Errorf("serializing deployment defaults: %w", err)
+		}
+		data[DefaultsKey] = string(b)
+	}
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -82,16 +97,16 @@ func (k *K8sClient) CreateTemplate(ctx context.Context, project, name, displayNa
 				DescriptionAnnotation: description,
 			},
 		},
-		Data: map[string]string{
-			CueTemplateKey: cueTemplate,
-		},
+		Data: data,
 	}
 	return k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 }
 
 // UpdateTemplate updates an existing deployment template ConfigMap.
-// Only non-nil fields are updated.
-func (k *K8sClient) UpdateTemplate(ctx context.Context, project, name string, displayName, description, cueTemplate *string) (*corev1.ConfigMap, error) {
+// Only non-nil fields are updated. If defaults is non-nil, it is serialized to
+// JSON and stored under DefaultsKey. If clearDefaults is true, the DefaultsKey
+// is removed from the ConfigMap data regardless of the defaults parameter.
+func (k *K8sClient) UpdateTemplate(ctx context.Context, project, name string, displayName, description, cueTemplate *string, defaults *consolev1.DeploymentDefaults, clearDefaults bool) (*corev1.ConfigMap, error) {
 	ns := k.Resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "updating deployment template in kubernetes",
 		slog.String("project", project),
@@ -111,11 +126,20 @@ func (k *K8sClient) UpdateTemplate(ctx context.Context, project, name string, di
 	if description != nil {
 		cm.Annotations[DescriptionAnnotation] = *description
 	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
 	if cueTemplate != nil {
-		if cm.Data == nil {
-			cm.Data = make(map[string]string)
-		}
 		cm.Data[CueTemplateKey] = *cueTemplate
+	}
+	if clearDefaults {
+		delete(cm.Data, DefaultsKey)
+	} else if defaults != nil {
+		b, err := json.Marshal(defaults)
+		if err != nil {
+			return nil, fmt.Errorf("serializing deployment defaults: %w", err)
+		}
+		cm.Data[DefaultsKey] = string(b)
 	}
 	return k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
 }

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -9,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
 
 func testResolver() *resolver.Resolver {
@@ -119,7 +121,7 @@ func TestCreateTemplate(t *testing.T) {
 		fakeClient := fake.NewClientset(ns)
 		k8s := NewK8sClient(fakeClient, testResolver())
 
-		cm, err := k8s.CreateTemplate(context.Background(), "my-project", "web-app", "Web App", "A web app", "package deployment\n")
+		cm, err := k8s.CreateTemplate(context.Background(), "my-project", "web-app", "Web App", "A web app", "package deployment\n", nil)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -148,6 +150,50 @@ func TestCreateTemplate(t *testing.T) {
 			t.Errorf("expected persisted cue template, got %q", got.Data[CueTemplateKey])
 		}
 	})
+
+	t.Run("creates template with defaults stored as JSON", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		defaults := &consolev1.DeploymentDefaults{
+			Image: "ghcr.io/mccutchen/go-httpbin",
+			Tag:   "2.21",
+		}
+		cm, err := k8s.CreateTemplate(context.Background(), "my-project", "web-app", "Web App", "A web app", "package deployment\n", defaults)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// Verify defaults.json key was written
+		rawJSON, ok := cm.Data[DefaultsKey]
+		if !ok {
+			t.Fatalf("expected %q key in ConfigMap data", DefaultsKey)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(rawJSON), &got); err != nil {
+			t.Fatalf("defaults.json is not valid JSON: %v", err)
+		}
+		if got["image"] != "ghcr.io/mccutchen/go-httpbin" {
+			t.Errorf("expected image 'ghcr.io/mccutchen/go-httpbin', got %v", got["image"])
+		}
+		if got["tag"] != "2.21" {
+			t.Errorf("expected tag '2.21', got %v", got["tag"])
+		}
+	})
+
+	t.Run("creates template without defaults omits defaults.json key", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		cm, err := k8s.CreateTemplate(context.Background(), "my-project", "web-app", "Web App", "A web app", "package deployment\n", nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if _, ok := cm.Data[DefaultsKey]; ok {
+			t.Errorf("expected no %q key in ConfigMap data when defaults is nil", DefaultsKey)
+		}
+	})
 }
 
 func TestUpdateTemplate(t *testing.T) {
@@ -158,7 +204,7 @@ func TestUpdateTemplate(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 
 		newName := "Updated Web App"
-		updated, err := k8s.UpdateTemplate(context.Background(), "my-project", "web-app", &newName, nil, nil)
+		updated, err := k8s.UpdateTemplate(context.Background(), "my-project", "web-app", &newName, nil, nil, nil, false)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -178,12 +224,74 @@ func TestUpdateTemplate(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 
 		newTemplate := "package deployment\n\n#Input: { name: string }\n"
-		updated, err := k8s.UpdateTemplate(context.Background(), "my-project", "web-app", nil, nil, &newTemplate)
+		updated, err := k8s.UpdateTemplate(context.Background(), "my-project", "web-app", nil, nil, &newTemplate, nil, false)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 		if updated.Data[CueTemplateKey] != newTemplate {
 			t.Errorf("expected updated template, got %q", updated.Data[CueTemplateKey])
+		}
+	})
+
+	t.Run("adds defaults on update", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "A web app", "package deployment\n")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		defaults := &consolev1.DeploymentDefaults{Image: "ghcr.io/example/app", Tag: "v1.0"}
+		updated, err := k8s.UpdateTemplate(context.Background(), "my-project", "web-app", nil, nil, nil, defaults, false)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		rawJSON, ok := updated.Data[DefaultsKey]
+		if !ok {
+			t.Fatalf("expected %q key after update with defaults", DefaultsKey)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(rawJSON), &got); err != nil {
+			t.Fatalf("defaults.json is not valid JSON: %v", err)
+		}
+		if got["image"] != "ghcr.io/example/app" {
+			t.Errorf("expected image 'ghcr.io/example/app', got %v", got["image"])
+		}
+	})
+
+	t.Run("clears defaults on update when clearDefaults is true", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "A web app", "package deployment\n")
+		// Pre-populate defaults.json
+		cm.Data[DefaultsKey] = `{"image":"old","tag":"old"}`
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		updated, err := k8s.UpdateTemplate(context.Background(), "my-project", "web-app", nil, nil, nil, nil, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if _, ok := updated.Data[DefaultsKey]; ok {
+			t.Errorf("expected %q key to be removed after clearDefaults=true", DefaultsKey)
+		}
+	})
+
+	t.Run("preserves existing defaults when not updating them", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "A web app", "package deployment\n")
+		cm.Data[DefaultsKey] = `{"image":"preserved","tag":"v1"}`
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		newName := "New Display Name"
+		updated, err := k8s.UpdateTemplate(context.Background(), "my-project", "web-app", &newName, nil, nil, nil, false)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		rawJSON, ok := updated.Data[DefaultsKey]
+		if !ok {
+			t.Fatalf("expected %q key to be preserved when not updating defaults", DefaultsKey)
+		}
+		if rawJSON != `{"image":"preserved","tag":"v1"}` {
+			t.Errorf("expected defaults to be preserved, got %q", rawJSON)
 		}
 	})
 
@@ -193,7 +301,7 @@ func TestUpdateTemplate(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 
 		newName := "Updated"
-		_, err := k8s.UpdateTemplate(context.Background(), "my-project", "nonexistent", &newName, nil, nil)
+		_, err := k8s.UpdateTemplate(context.Background(), "my-project", "nonexistent", &newName, nil, nil, nil, false)
 		if err == nil {
 			t.Fatal("expected error for nonexistent template")
 		}


### PR DESCRIPTION
## Summary

- Add `DefaultsKey = "defaults.json"` constant to `console/templates/k8s.go`
- Update `CreateTemplate` to accept `*consolev1.DeploymentDefaults` and serialize to JSON under `defaults.json` when non-nil
- Update `UpdateTemplate` to accept `defaults` and `clearDefaults bool`, updating or removing the `defaults.json` key accordingly
- Update `configMapToTemplate` in `handler.go` to deserialize `defaults.json` back into the `Defaults` field on each read
- Pass `req.Msg.Defaults` through in `CreateDeploymentTemplate` and `UpdateDeploymentTemplate` handlers
- Add comprehensive table-driven tests: defaults round-trip (create→get→verify), update to add/clear defaults, list returns defaults, nil defaults returns nil field

The `rendered_json` field was already implemented in a prior commit and all tests for it pass.

Closes: #382

## Test plan
- [x] `make test-go` passes (all packages)
- [x] `make generate` completes without errors
- [x] Defaults round-trip: create with defaults → get → verify defaults match
- [x] Create without defaults → get → verify nil defaults (backwards compatible)
- [x] Update to add defaults → get → verify defaults updated
- [x] List returns defaults on each template
- [x] `rendered_json` valid JSON array with expected resource kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1