### PR TITLE
chore: cleanup stale code and docs after template defaults and preview feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ This is a Go HTTPS server that serves a web console UI and exposes ConnectRPC se
   - `resolver/` - Namespace prefix resolver translating user-facing names to K8s namespace names (`{namespace-prefix}{organization-prefix}{name}` for orgs, `{namespace-prefix}{project-prefix}{name}` for projects)
   - `secrets/` - SecretsService with K8s backend and annotation-based RBAC
   - `settings/` - ProjectSettingsService managing per-project feature flags (e.g. deployments toggle) stored as K8s ConfigMaps
-  - `templates/` - DeploymentTemplateService managing CUE-based deployment templates stored as K8s ConfigMaps; embeds `default_template.cue`. Templates use the structured `namespaced`/`cluster` output format (see `docs/cue-template-guide.md`)
+  - `templates/` - DeploymentTemplateService managing CUE-based deployment templates stored as K8s ConfigMaps; embeds `default_template.cue`. Templates use the structured `namespaced`/`cluster` output format (see `docs/cue-template-guide.md`). Templates can carry `DeploymentDefaults` (image, tag, command, args, env) that pre-fill the Create Deployment form. The `RenderDeploymentTemplate` RPC returns rendered resources as both YAML (`rendered_yaml`) and JSON (`rendered_json`).
   - `deployments/` - DeploymentService managing Kubernetes Deployments: CRUD, status polling, log streaming, CUE render and apply (structured `namespaced`/`cluster` output), container command/args override, container env vars (literal values, SecretKeyRef, ConfigMapKeyRef), and listing project-namespace Secrets/ConfigMaps for env var references
   - `dist/` - Embedded static files served at `/` (build output from frontend, not source)
 - `proto/` - Protobuf source files

--- a/frontend/src/gen/holos/console/v1/deployment_templates_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/deployment_templates_pb.d.ts
@@ -335,7 +335,8 @@ export declare const DeleteDeploymentTemplateResponseSchema: GenMessage<DeleteDe
 
 /**
  * RenderDeploymentTemplateRequest evaluates a CUE template with example inputs
- * and returns the rendered Kubernetes resource manifests as multi-document YAML.
+ * and returns the rendered Kubernetes resource manifests as multi-document YAML
+ * and as a pretty-printed JSON array.
  * The cue_template field is rendered directly (supports unsaved/draft templates).
  *
  * @generated from message holos.console.v1.RenderDeploymentTemplateRequest
@@ -384,7 +385,7 @@ export declare type RenderDeploymentTemplateRequest = Message<"holos.console.v1.
 export declare const RenderDeploymentTemplateRequestSchema: GenMessage<RenderDeploymentTemplateRequest>;
 
 /**
- * RenderDeploymentTemplateResponse contains the rendered YAML output.
+ * RenderDeploymentTemplateResponse contains the rendered output in both YAML and JSON formats.
  *
  * @generated from message holos.console.v1.RenderDeploymentTemplateResponse
  */

--- a/gen/holos/console/v1/deployment_templates.pb.go
+++ b/gen/holos/console/v1/deployment_templates.pb.go
@@ -720,7 +720,8 @@ func (*DeleteDeploymentTemplateResponse) Descriptor() ([]byte, []int) {
 }
 
 // RenderDeploymentTemplateRequest evaluates a CUE template with example inputs
-// and returns the rendered Kubernetes resource manifests as multi-document YAML.
+// and returns the rendered Kubernetes resource manifests as multi-document YAML
+// and as a pretty-printed JSON array.
 // The cue_template field is rendered directly (supports unsaved/draft templates).
 type RenderDeploymentTemplateRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -798,7 +799,7 @@ func (x *RenderDeploymentTemplateRequest) GetExampleTag() string {
 	return ""
 }
 
-// RenderDeploymentTemplateResponse contains the rendered YAML output.
+// RenderDeploymentTemplateResponse contains the rendered output in both YAML and JSON formats.
 type RenderDeploymentTemplateResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// rendered_yaml is the concatenated multi-document YAML of all rendered

--- a/proto/holos/console/v1/deployment_templates.proto
+++ b/proto/holos/console/v1/deployment_templates.proto
@@ -98,7 +98,8 @@ message DeleteDeploymentTemplateRequest {
 message DeleteDeploymentTemplateResponse {}
 
 // RenderDeploymentTemplateRequest evaluates a CUE template with example inputs
-// and returns the rendered Kubernetes resource manifests as multi-document YAML.
+// and returns the rendered Kubernetes resource manifests as multi-document YAML
+// and as a pretty-printed JSON array.
 // The cue_template field is rendered directly (supports unsaved/draft templates).
 message RenderDeploymentTemplateRequest {
   string project      = 1; // owning project (used to resolve namespace)
@@ -108,7 +109,7 @@ message RenderDeploymentTemplateRequest {
   string example_tag   = 5; // example tag (e.g. "latest")
 }
 
-// RenderDeploymentTemplateResponse contains the rendered YAML output.
+// RenderDeploymentTemplateResponse contains the rendered output in both YAML and JSON formats.
 message RenderDeploymentTemplateResponse {
   // rendered_yaml is the concatenated multi-document YAML of all rendered
   // resources, separated by "---\n".


### PR DESCRIPTION
## Summary
- Fix stale proto comment on `RenderDeploymentTemplateRequest`: the response returns both YAML and JSON, not just YAML
- Fix stale proto comment on `RenderDeploymentTemplateResponse`: was "contains the rendered YAML output"; now accurately describes both formats
- Update `AGENTS.md` templates/ description to mention `DeploymentDefaults` (image, tag, command, args, env pre-fill) and the dual render output (`rendered_yaml` and `rendered_json`) introduced by #381/#382/#383

All issues from #367 sub-tree (#368, #369, #370, #371) are already closed. Issues from parent issue #380 sub-tree (#381, #382, #383) are also merged.

Closes: #384

## Test plan
- [x] `make generate` succeeds
- [x] `make test` passes (33 test files, 420 tests)
- [x] No frontend changes (this is docs/comments only + generated code regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1