### PR TITLE
fix(frontend): gate RenderDeploymentTemplate query on modal and preview visibility

### DIFF
--- a/frontend/src/components/create-template-modal.test.tsx
+++ b/frontend/src/components/create-template-modal.test.tsx
@@ -212,4 +212,55 @@ describe('CreateTemplateModal', () => {
       expect(screen.getByText(/CUE render error/i)).toBeInTheDocument()
     })
   })
+
+  it('does not call useRenderDeploymentTemplate with enabled=true when modal is closed', () => {
+    setupMocks()
+    render(
+      <CreateTemplateModal
+        projectName="test-project"
+        open={false}
+        onOpenChange={vi.fn()}
+      />,
+    )
+    // The hook is always called (rules of hooks), but enabled should be false
+    const calls = (useRenderDeploymentTemplate as Mock).mock.calls
+    expect(calls.length).toBeGreaterThan(0)
+    // enabled argument should be false (open=false)
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall[5]).toBe(false)
+  })
+
+  it('does not pass enabled=true when modal is open but preview is closed', () => {
+    setupMocks()
+    render(
+      <CreateTemplateModal
+        projectName="test-project"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    )
+    // Preview is not open by default, so enabled should be false
+    const calls = (useRenderDeploymentTemplate as Mock).mock.calls
+    expect(calls.length).toBeGreaterThan(0)
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall[5]).toBe(false)
+  })
+
+  it('passes enabled=true when modal is open and preview is open', async () => {
+    setupMocks()
+    render(
+      <CreateTemplateModal
+        projectName="test-project"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /preview/i }))
+    await waitFor(() => {
+      const calls = (useRenderDeploymentTemplate as Mock).mock.calls
+      // Find the last call where enabled is true
+      const enabledCall = calls.find((c) => c[5] === true)
+      expect(enabledCall).toBeDefined()
+    })
+  })
 })

--- a/frontend/src/components/create-template-modal.tsx
+++ b/frontend/src/components/create-template-modal.tsx
@@ -53,6 +53,7 @@ export function CreateTemplateModal({ projectName, open, onOpenChange, onCreated
     HTTPBIN_EXAMPLE_NAME,
     HTTPBIN_EXAMPLE_IMAGE,
     HTTPBIN_EXAMPLE_TAG,
+    open && previewOpen,
   )
 
   const slugify = (val: string) =>

--- a/frontend/src/queries/deployment-templates.ts
+++ b/frontend/src/queries/deployment-templates.ts
@@ -87,6 +87,7 @@ export function useRenderDeploymentTemplate(
   exampleName = 'holos-console',
   exampleImage = 'ghcr.io/holos-run/holos-console',
   exampleTag = 'latest',
+  enabled = true,
 ) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
@@ -103,7 +104,7 @@ export function useRenderDeploymentTemplate(
       })
       return { renderedYaml: response.renderedYaml, renderedJson: response.renderedJson }
     },
-    enabled: isAuthenticated && !!project && !!cueTemplate,
+    enabled: isAuthenticated && !!project && !!cueTemplate && enabled,
     retry: false,
   })
 }


### PR DESCRIPTION
## Summary
- Add optional `enabled` parameter to `useRenderDeploymentTemplate` so callers can gate the query with additional conditions
- Pass `open && previewOpen` from `CreateTemplateModal` so the render RPC fires only when the modal is visible AND the user has opened the preview panel
- Add three new unit tests verifying the gating behavior: modal closed, modal open but preview closed, and both open

Closes: #388

## Test plan
- [x] `make test` passes (423 tests)
- [x] `make generate` succeeds (TypeScript compiles cleanly)
- [x] New tests verify query is disabled when modal is closed
- [x] New tests verify query is disabled when modal is open but preview is closed
- [x] New tests verify query is enabled when both modal and preview are open
- [x] Template detail page (`$templateName.tsx`) unaffected — it uses default `enabled=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1