### PR TITLE
chore: cleanup after RenderDeploymentTemplate gating fix

### DIFF
--- a/frontend/src/components/create-template-modal.test.tsx
+++ b/frontend/src/components/create-template-modal.test.tsx
@@ -263,4 +263,23 @@ describe('CreateTemplateModal', () => {
       expect(enabledCall).toBeDefined()
     })
   })
+
+  it('default CUE template uses structured namespaced/cluster output format', () => {
+    setupMocks()
+    render(
+      <CreateTemplateModal
+        projectName="test-project"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    )
+    const textarea = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
+    // Verify the default template uses the structured output format required by the backend
+    expect(textarea.value).toContain('package deployment')
+    expect(textarea.value).toContain('namespaced:')
+    expect(textarea.value).toContain('cluster:')
+    expect(textarea.value).toContain('#Input')
+    expect(textarea.value).toContain('input: #Input')
+    expect(textarea.value).toContain('"app.kubernetes.io/managed-by": "console.holos.run"')
+  })
 })

--- a/frontend/src/components/create-template-modal.tsx
+++ b/frontend/src/components/create-template-modal.tsx
@@ -14,16 +14,90 @@ import {
 } from '@/components/ui/dialog'
 import { useCreateDeploymentTemplate, useRenderDeploymentTemplate } from '@/queries/deployment-templates'
 
-const DEFAULT_CUE_TEMPLATE = `// deployment.cue — default deployment template
-package holos
+const DEFAULT_CUE_TEMPLATE = `// package deployment is the required CUE package declaration.
+package deployment
 
-// #Deployment defines the shape of a deployment.
-#Deployment: {
-  name:      string
-  namespace: string
-  image:     string
-  replicas?: int & >=1 | *1
+// #KeyRef identifies a key within a Kubernetes Secret or ConfigMap.
+#KeyRef: {
+  name: string
+  key:  string
 }
+
+// #EnvVar represents a container environment variable.
+#EnvVar: {
+  name:               string
+  value?:             string
+  secretKeyRef?:      #KeyRef
+  configMapKeyRef?:   #KeyRef
+}
+
+// #Input defines the fields the console fills in at render time.
+#Input: {
+  name:      string & =~"^[a-z][a-z0-9-]*$"
+  image:     string
+  tag:       string
+  project:   string
+  namespace: string
+  command?: [...string]
+  args?: [...string]
+  env: [...#EnvVar] | *[]
+}
+
+input: #Input
+
+// _labels are the standard labels required on every resource.
+_labels: {
+  "app.kubernetes.io/name":       input.name
+  "app.kubernetes.io/managed-by": "console.holos.run"
+}
+
+// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+  kind: Kind
+  metadata: {
+    name:      Name
+    namespace: Namespace
+    ...
+  }
+  ...
+}
+
+// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+#Cluster: [Kind=string]: [Name=string]: {
+  kind: Kind
+  metadata: {
+    name: Name
+    ...
+  }
+  ...
+}
+
+namespaced: #Namespaced & {
+  (input.namespace): {
+    Deployment: (input.name): {
+      apiVersion: "apps/v1"
+      kind:       "Deployment"
+      metadata: {
+        name:      input.name
+        namespace: input.namespace
+        labels:    _labels
+      }
+      spec: {
+        replicas: 1
+        selector: matchLabels: "app.kubernetes.io/name": input.name
+        template: {
+          metadata: labels: _labels
+          spec: containers: [{
+            name:  input.name
+            image: input.image + ":" + input.tag
+          }]
+        }
+      }
+    }
+  }
+}
+
+cluster: #Cluster & {}
 `
 
 const HTTPBIN_EXAMPLE_NAME = 'go-httpbin'


### PR DESCRIPTION
## Summary

- Update `DEFAULT_CUE_TEMPLATE` in `create-template-modal.tsx` to use the structured `namespaced`/`cluster` output format that the `RenderDeploymentTemplate` RPC requires
- The previous template defined a bare `#Deployment` struct with no valid output, causing the preview to fail when clicked
- Add a unit test asserting the default template contains the required structured output fields
- Verified `deployment-templates.ts` and the template detail page have no stale comments

Closes: #389

## Test plan

- [x] `make test-ui` passes (423 tests)
- [x] `make test-go` passes
- [x] New test verifies `DEFAULT_CUE_TEMPLATE` contains `package deployment`, `namespaced:`, `cluster:`, `#Input`, `input: #Input`, and the managed-by label

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1