### PR TITLE
fix(frontend): add 401 interceptor with serialized silent renewal

### DIFF
--- a/frontend/src/lib/transport.test.ts
+++ b/frontend/src/lib/transport.test.ts
@@ -1,7 +1,27 @@
-import { tokenRef, readStoredToken } from './transport'
+import { ConnectError, Code } from '@connectrpc/connect'
+import type { UnaryRequest, UnaryResponse } from '@connectrpc/connect'
+import { tokenRef, readStoredToken, createAuthInterceptor } from './transport'
 
-// We can't easily test the interceptor as it's not exported, but we can
-// test the tokenRef which is the shared mutable state for auth tokens.
+// Mock getUserManager so tests don't need a real OIDC provider.
+vi.mock('@/lib/auth/userManager', () => ({
+  getUserManager: vi.fn(),
+}))
+
+import { getUserManager } from '@/lib/auth/userManager'
+
+// Minimal stub types for ConnectRPC interceptor testing.
+type MockRequest = UnaryRequest & { header: Headers }
+type MockResponse = UnaryResponse
+
+function makeMockRequest(headers?: Record<string, string>): MockRequest {
+  const h = new Headers(headers)
+  return { header: h } as unknown as MockRequest
+}
+
+function makeMockResponse(token?: string): MockResponse {
+  return {} as unknown as MockResponse
+}
+
 describe('tokenRef', () => {
   afterEach(() => {
     tokenRef.current = null
@@ -61,5 +81,158 @@ describe('readStoredToken', () => {
   it('returns null when the stored JSON is malformed', () => {
     sessionStorage.setItem('oidc.user:https://localhost:8443/dex:holos-console', 'not-json')
     expect(readStoredToken()).toBeNull()
+  })
+})
+
+describe('createAuthInterceptor', () => {
+  beforeEach(() => {
+    tokenRef.current = null
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    tokenRef.current = null
+  })
+
+  it('sets Authorization header when tokenRef has a token', async () => {
+    tokenRef.current = 'initial-token'
+    const interceptor = createAuthInterceptor()
+    const req = makeMockRequest()
+    const next = vi.fn().mockResolvedValue(makeMockResponse())
+
+    await interceptor(next)(req)
+
+    expect(req.header.get('Authorization')).toBe('Bearer initial-token')
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not set Authorization header when tokenRef is null', async () => {
+    tokenRef.current = null
+    const interceptor = createAuthInterceptor()
+    const req = makeMockRequest()
+    const next = vi.fn().mockResolvedValue(makeMockResponse())
+
+    await interceptor(next)(req)
+
+    expect(req.header.get('Authorization')).toBeNull()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries request after successful signinSilent on 401', async () => {
+    tokenRef.current = 'old-token'
+    const freshToken = 'fresh-token'
+    const mockSigninSilent = vi.fn().mockResolvedValue({ access_token: freshToken })
+    vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
+
+    const interceptor = createAuthInterceptor()
+    const req = makeMockRequest()
+    const response = makeMockResponse()
+
+    // First call throws 401, second call succeeds.
+    const next = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('unauthenticated', Code.Unauthenticated))
+      .mockResolvedValueOnce(response)
+
+    const result = await interceptor(next)(req)
+
+    expect(mockSigninSilent).toHaveBeenCalledTimes(1)
+    expect(next).toHaveBeenCalledTimes(2)
+    expect(result).toBe(response)
+    // tokenRef must be updated with the fresh token.
+    expect(tokenRef.current).toBe(freshToken)
+    // The retried request must carry the fresh token.
+    expect(req.header.get('Authorization')).toBe(`Bearer ${freshToken}`)
+  })
+
+  it('propagates renewal error when signinSilent fails', async () => {
+    tokenRef.current = 'old-token'
+    const renewalError = new Error('renewal failed')
+    const mockSigninSilent = vi.fn().mockRejectedValue(renewalError)
+    vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
+
+    const interceptor = createAuthInterceptor()
+    const req = makeMockRequest()
+
+    const next = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('unauthenticated', Code.Unauthenticated))
+
+    await expect(interceptor(next)(req)).rejects.toBe(renewalError)
+    expect(mockSigninSilent).toHaveBeenCalledTimes(1)
+    // Should not retry after failed renewal.
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry a second 401 (prevents retry loops)', async () => {
+    tokenRef.current = 'old-token'
+    const freshToken = 'fresh-token'
+    const mockSigninSilent = vi.fn().mockResolvedValue({ access_token: freshToken })
+    vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
+
+    const interceptor = createAuthInterceptor()
+    const req = makeMockRequest()
+
+    // Both calls throw 401 — the retry itself returns 401.
+    const next = vi
+      .fn()
+      .mockRejectedValue(new ConnectError('unauthenticated', Code.Unauthenticated))
+
+    await expect(interceptor(next)(req)).rejects.toBeInstanceOf(ConnectError)
+    // signinSilent called once, next called twice (original + one retry), then gives up.
+    expect(mockSigninSilent).toHaveBeenCalledTimes(1)
+    expect(next).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes through non-401 errors without attempting renewal', async () => {
+    tokenRef.current = 'some-token'
+    const mockSigninSilent = vi.fn()
+    vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
+
+    const interceptor = createAuthInterceptor()
+    const req = makeMockRequest()
+    const permissionError = new ConnectError('permission denied', Code.PermissionDenied)
+
+    const next = vi.fn().mockRejectedValue(permissionError)
+
+    await expect(interceptor(next)(req)).rejects.toBe(permissionError)
+    expect(mockSigninSilent).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces concurrent 401s into a single signinSilent call', async () => {
+    tokenRef.current = 'old-token'
+    const freshToken = 'fresh-token'
+
+    // signinSilent returns a promise that resolves after a tick so concurrent
+    // calls overlap.
+    const mockSigninSilent = vi.fn().mockImplementation(
+      () => new Promise<{ access_token: string }>((resolve) => setTimeout(() => resolve({ access_token: freshToken }), 0))
+    )
+    vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
+
+    const interceptor = createAuthInterceptor()
+    const req1 = makeMockRequest()
+    const req2 = makeMockRequest()
+    const response1 = makeMockResponse()
+    const response2 = makeMockResponse()
+
+    // Both requests fail with 401 on first call, succeed on second.
+    const next1 = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('unauthenticated', Code.Unauthenticated))
+      .mockResolvedValueOnce(response1)
+    const next2 = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('unauthenticated', Code.Unauthenticated))
+      .mockResolvedValueOnce(response2)
+
+    // Fire both requests concurrently.
+    const [r1, r2] = await Promise.all([interceptor(next1)(req1), interceptor(next2)(req2)])
+
+    expect(r1).toBe(response1)
+    expect(r2).toBe(response2)
+    // Despite two concurrent 401s, signinSilent must only be called once.
+    expect(mockSigninSilent).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -1,5 +1,6 @@
 import { createConnectTransport } from '@connectrpc/connect-web'
-import type { Interceptor } from '@connectrpc/connect'
+import { ConnectError, Code, type Interceptor } from '@connectrpc/connect'
+import { getUserManager } from '@/lib/auth/userManager'
 
 // readStoredToken reads the access token from sessionStorage synchronously at
 // module load time. oidc-client-ts stores the user object under a key matching
@@ -29,14 +30,69 @@ export function readStoredToken(): string | null {
 // login/logout/token refresh via a useEffect.
 export const tokenRef: { current: string | null } = { current: readStoredToken() }
 
-const authInterceptor: Interceptor = (next) => async (req) => {
-  if (tokenRef.current) {
-    req.header.set('Authorization', `Bearer ${tokenRef.current}`)
+// Shared promise for in-flight silent token renewal. When multiple concurrent
+// requests all receive a 401, they coalesce onto this single promise so only
+// one signinSilent() OIDC flow is initiated.
+let renewalPromise: Promise<string> | null = null
+
+// renewToken performs a single serialized silent token renewal via
+// oidc-client-ts. Concurrent callers all share the same promise, ensuring only
+// one OIDC silent-renew flow runs at a time.
+async function renewToken(): Promise<string> {
+  if (renewalPromise) return renewalPromise
+  renewalPromise = (async () => {
+    const userManager = getUserManager()
+    const user = await userManager.signinSilent()
+    if (!user?.access_token) {
+      throw new Error('signinSilent returned no access token')
+    }
+    tokenRef.current = user.access_token
+    return user.access_token
+  })()
+  try {
+    return await renewalPromise
+  } finally {
+    renewalPromise = null
   }
-  return next(req)
+}
+
+// createAuthInterceptor returns a ConnectRPC interceptor that:
+//   1. Attaches the current Bearer token to every outgoing request.
+//   2. On a 401/Unauthenticated response, performs a single serialized silent
+//      token renewal via oidc-client-ts and retries the request once.
+//   3. Coalesces concurrent 401s so only one signinSilent() call is made.
+//   4. Does not retry a second 401 to prevent infinite loops.
+export function createAuthInterceptor(): Interceptor {
+  return (next) => async (req) => {
+    // Attach current token.
+    if (tokenRef.current) {
+      req.header.set('Authorization', `Bearer ${tokenRef.current}`)
+    }
+
+    let isRetry = false
+
+    try {
+      return await next(req)
+    } catch (err) {
+      // Only handle Unauthenticated errors on first attempt.
+      if (
+        !isRetry &&
+        err instanceof ConnectError &&
+        err.code === Code.Unauthenticated
+      ) {
+        isRetry = true
+        // Renew token (coalesced with other concurrent 401s).
+        const freshToken = await renewToken()
+        // Update the request header with the fresh token for the retry.
+        req.header.set('Authorization', `Bearer ${freshToken}`)
+        return await next(req)
+      }
+      throw err
+    }
+  }
 }
 
 export const transport = createConnectTransport({
   baseUrl: '/',
-  interceptors: [authInterceptor],
+  interceptors: [createAuthInterceptor()],
 })


### PR DESCRIPTION
## Summary

- Export `createAuthInterceptor()` from `frontend/src/lib/transport.ts` replacing the inline unexported `authInterceptor`
- On `Code.Unauthenticated` (HTTP 401), the interceptor calls `signinSilent()` via `getUserManager()` and retries the request once with the fresh token
- Concurrent 401s are coalesced via a module-level `renewalPromise` so only one `signinSilent()` OIDC flow runs regardless of how many requests fail simultaneously
- `tokenRef.current` is updated with the fresh `access_token` immediately after successful renewal so subsequent requests use it
- A request is only retried once — a second 401 on the retried request propagates as-is to prevent infinite loops
- Non-401 errors pass through without triggering renewal
- Full unit test coverage: successful 401→renew→retry, failed renewal propagation, no double-retry, non-401 passthrough, and concurrent 401 coalescing

Closes: #391

## Test plan

- [x] `make test-ui` passes (431 tests)
- [x] `make generate` succeeds (TypeScript type-checks and builds)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1