### PR TITLE
fix(frontend): suppress TanStack Query retries for authentication errors

### DIFF
--- a/frontend/src/lib/-query-client.test.ts
+++ b/frontend/src/lib/-query-client.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { ConnectError, Code } from '@connectrpc/connect'
+import { shouldRetry } from '@/lib/query-client'
+
+describe('shouldRetry', () => {
+  it('returns false for ConnectError with Unauthenticated code', () => {
+    const err = new ConnectError('unauthenticated', Code.Unauthenticated)
+    expect(shouldRetry(0, err)).toBe(false)
+    expect(shouldRetry(1, err)).toBe(false)
+    expect(shouldRetry(2, err)).toBe(false)
+  })
+
+  it('returns true for ConnectError with non-auth codes when failureCount < 3', () => {
+    const err = new ConnectError('internal error', Code.Internal)
+    expect(shouldRetry(0, err)).toBe(true)
+    expect(shouldRetry(1, err)).toBe(true)
+    expect(shouldRetry(2, err)).toBe(true)
+  })
+
+  it('returns false for ConnectError with non-auth codes when failureCount >= 3', () => {
+    const err = new ConnectError('internal error', Code.Internal)
+    expect(shouldRetry(3, err)).toBe(false)
+  })
+
+  it('returns true for regular Error when failureCount < 3', () => {
+    const err = new Error('network error')
+    expect(shouldRetry(0, err)).toBe(true)
+    expect(shouldRetry(1, err)).toBe(true)
+    expect(shouldRetry(2, err)).toBe(true)
+  })
+
+  it('returns false for regular Error when failureCount >= 3', () => {
+    const err = new Error('network error')
+    expect(shouldRetry(3, err)).toBe(false)
+  })
+})

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -1,9 +1,23 @@
 import { QueryClient } from '@tanstack/react-query'
+import { ConnectError, Code } from '@connectrpc/connect'
+
+// shouldRetry returns false for ConnectRPC Unauthenticated errors so that
+// TanStack Query does not amplify the 401 burst with its default 3-retry
+// backoff. The transport-level interceptor handles token renewal; once it
+// exhausts its single retry the error should propagate immediately.
+// All other errors use the default TanStack Query retry limit of 3.
+export function shouldRetry(failureCount: number, error: unknown): boolean {
+  if (error instanceof ConnectError && error.code === Code.Unauthenticated) {
+    return false
+  }
+  return failureCount < 3
+}
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      retry: shouldRetry,
     },
   },
 })


### PR DESCRIPTION
## Summary

- Export `shouldRetry` function from `frontend/src/lib/query-client.ts` that returns `false` for `ConnectError` with `Code.Unauthenticated`, preventing TanStack Query from amplifying 401 bursts with its default 3-retry backoff
- Wire `shouldRetry` into `QueryClient` `defaultOptions.queries.retry`
- Add unit tests covering all four cases: Unauthenticated errors, other ConnectRPC errors (< 3 and >= 3 failures), and plain Errors (< 3 and >= 3 failures)

Closes: #392

## Test plan

- [x] `shouldRetry(_, ConnectError(Unauthenticated))` returns `false`
- [x] `shouldRetry(n < 3, ConnectError(Internal))` returns `true`
- [x] `shouldRetry(3, ConnectError(Internal))` returns `false`
- [x] `shouldRetry(n < 3, Error)` returns `true`
- [x] `shouldRetry(3, Error)` returns `false`
- [x] `make test` passes (436 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1