### PR TITLE
feat(deployments): add port to backend handler, storage, and CUE template

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"strconv"
 
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
@@ -232,7 +233,7 @@ func (h *Handler) CreateDeployment(
 		description = *req.Msg.Description
 	}
 
-	_, err = h.k8s.CreateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.Template, displayName, description, req.Msg.Command, req.Msg.Args, envInputs)
+	_, err = h.k8s.CreateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.Template, displayName, description, req.Msg.Command, req.Msg.Args, envInputs, req.Msg.Port)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -249,6 +250,7 @@ func (h *Handler) CreateDeployment(
 			Command:   req.Msg.Command,
 			Args:      req.Msg.Args,
 			Env:       envInputs,
+			Port:      req.Msg.Port,
 		}
 		resources, renderErr := h.renderer.Render(ctx, cueSource, input)
 		if renderErr != nil {
@@ -311,7 +313,7 @@ func (h *Handler) UpdateDeployment(
 		return nil, err
 	}
 
-	updated, err := h.k8s.UpdateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.DisplayName, req.Msg.Description, req.Msg.Command, req.Msg.Args, envInputs)
+	updated, err := h.k8s.UpdateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.DisplayName, req.Msg.Description, req.Msg.Command, req.Msg.Args, envInputs, req.Msg.Port)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -346,6 +348,7 @@ func (h *Handler) UpdateDeployment(
 			Command:   commandFromConfigMap(updated),
 			Args:      argsFromConfigMap(updated),
 			Env:       envFromConfigMapAsInputs(updated),
+			Port:      portFromConfigMap(updated),
 		}
 		resources, renderErr := h.renderer.Render(ctx, cueSource, input)
 		if renderErr != nil {
@@ -550,7 +553,7 @@ func validateDeploymentName(name string) error {
 
 // configMapToDeployment converts a Kubernetes ConfigMap to a Deployment protobuf message.
 func configMapToDeployment(cm *corev1.ConfigMap, project string) *consolev1.Deployment {
-	return &consolev1.Deployment{
+	dep := &consolev1.Deployment{
 		Name:        cm.Name,
 		Project:     project,
 		Image:       cm.Data[ImageKey],
@@ -562,6 +565,12 @@ func configMapToDeployment(cm *corev1.ConfigMap, project string) *consolev1.Depl
 		Args:        argsFromConfigMap(cm),
 		Env:         envFromConfigMap(cm),
 	}
+	if raw, ok := cm.Data[PortKey]; ok && raw != "" {
+		if p, err := strconv.ParseInt(raw, 10, 32); err == nil {
+			dep.Port = int32(p)
+		}
+	}
+	return dep
 }
 
 // commandFromConfigMap reads the JSON-encoded command slice from a ConfigMap.
@@ -654,6 +663,19 @@ func validateEnvVars(envVars []*consolev1.EnvVar) ([]EnvVarInput, error) {
 		result = append(result, protoToEnvVarInput(e))
 	}
 	return result, nil
+}
+
+// portFromConfigMap reads the port integer from a ConfigMap data key.
+func portFromConfigMap(cm *corev1.ConfigMap) int32 {
+	raw, ok := cm.Data[PortKey]
+	if !ok || raw == "" {
+		return 0
+	}
+	p, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return int32(p)
 }
 
 // stringSliceFromConfigMap decodes a JSON string slice from the given ConfigMap data key.

--- a/console/deployments/k8s.go
+++ b/console/deployments/k8s.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/holos-run/holos-console/console/resolver"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ const (
 	CommandKey  = "command"
 	ArgsKey     = "args"
 	EnvKey      = "env"
+	PortKey     = "port"
 )
 
 // K8sClient wraps Kubernetes client operations for deployments.
@@ -70,7 +72,7 @@ func (k *K8sClient) GetDeployment(ctx context.Context, project, name string) (*c
 }
 
 // CreateDeployment creates a new deployment ConfigMap.
-func (k *K8sClient) CreateDeployment(ctx context.Context, project, name, image, tag, tmpl, displayName, description string, command, args []string, env []EnvVarInput) (*corev1.ConfigMap, error) {
+func (k *K8sClient) CreateDeployment(ctx context.Context, project, name, image, tag, tmpl, displayName, description string, command, args []string, env []EnvVarInput, port int32) (*corev1.ConfigMap, error) {
 	ns := k.Resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "creating deployment in kubernetes",
 		slog.String("project", project),
@@ -108,13 +110,17 @@ func (k *K8sClient) CreateDeployment(ctx context.Context, project, name, image, 
 		b, _ := json.Marshal(env)
 		cm.Data[EnvKey] = string(b)
 	}
+	if port > 0 {
+		cm.Data[PortKey] = strconv.Itoa(int(port))
+	}
 	return k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 }
 
 // UpdateDeployment updates an existing deployment ConfigMap.
 // Only non-nil scalar fields are updated. Non-empty command/args slices replace stored values.
 // A non-nil env slice (even if empty) replaces the stored env vars.
-func (k *K8sClient) UpdateDeployment(ctx context.Context, project, name string, image, tag, displayName, description *string, command, args []string, env []EnvVarInput) (*corev1.ConfigMap, error) {
+// A non-nil port pointer updates the stored port value.
+func (k *K8sClient) UpdateDeployment(ctx context.Context, project, name string, image, tag, displayName, description *string, command, args []string, env []EnvVarInput, port *int32) (*corev1.ConfigMap, error) {
 	ns := k.Resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "updating deployment in kubernetes",
 		slog.String("project", project),
@@ -154,6 +160,13 @@ func (k *K8sClient) UpdateDeployment(ctx context.Context, project, name string, 
 	if env != nil {
 		b, _ := json.Marshal(env)
 		cm.Data[EnvKey] = string(b)
+	}
+	if port != nil {
+		if *port > 0 {
+			cm.Data[PortKey] = strconv.Itoa(int(*port))
+		} else {
+			delete(cm.Data, PortKey)
+		}
 	}
 	return k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
 }

--- a/console/deployments/k8s_test.go
+++ b/console/deployments/k8s_test.go
@@ -145,7 +145,7 @@ func TestCreateDeployment(t *testing.T) {
 		fakeClient := fake.NewClientset(ns)
 		k8s := NewK8sClient(fakeClient, testResolver())
 
-		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "Web App", "A web app", nil, nil, nil)
+		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "Web App", "A web app", nil, nil, nil, 0)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -182,7 +182,7 @@ func TestCreateDeployment(t *testing.T) {
 
 		cmd := []string{"myapp"}
 		args := []string{"--port", "8080"}
-		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", cmd, args, nil)
+		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", cmd, args, nil, 0)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -199,7 +199,7 @@ func TestCreateDeployment(t *testing.T) {
 		fakeClient := fake.NewClientset(ns)
 		k8s := NewK8sClient(fakeClient, testResolver())
 
-		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, nil)
+		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, nil, 0)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -221,7 +221,7 @@ func TestUpdateDeployment(t *testing.T) {
 
 		newTag := "1.26"
 		newDesc := "updated desc"
-		updated, err := k8s.UpdateDeployment(context.Background(), "my-project", "web-app", nil, &newTag, nil, &newDesc, nil, nil, nil)
+		updated, err := k8s.UpdateDeployment(context.Background(), "my-project", "web-app", nil, &newTag, nil, &newDesc, nil, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -245,7 +245,7 @@ func TestUpdateDeployment(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 
 		newTag := "1.26"
-		_, err := k8s.UpdateDeployment(context.Background(), "my-project", "does-not-exist", nil, &newTag, nil, nil, nil, nil, nil)
+		_, err := k8s.UpdateDeployment(context.Background(), "my-project", "does-not-exist", nil, &newTag, nil, nil, nil, nil, nil, nil)
 		if err == nil {
 			t.Fatal("expected error for non-existent deployment")
 		}
@@ -263,7 +263,7 @@ func TestCreateDeployment_Env(t *testing.T) {
 			{Name: "FROM_SECRET", SecretKeyRef: &KeyRefInput{Name: "mysecret", Key: "mykey"}},
 			{Name: "FROM_CM", ConfigMapKeyRef: &KeyRefInput{Name: "mycm", Key: "mykey"}},
 		}
-		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, env)
+		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, env, 0)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -294,7 +294,7 @@ func TestCreateDeployment_Env(t *testing.T) {
 		fakeClient := fake.NewClientset(ns)
 		k8s := NewK8sClient(fakeClient, testResolver())
 
-		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, nil)
+		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, nil, 0)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -314,7 +314,7 @@ func TestUpdateDeployment_Env(t *testing.T) {
 		env := []EnvVarInput{
 			{Name: "PORT", Value: "8080"},
 		}
-		updated, err := k8s.UpdateDeployment(context.Background(), "my-project", "web-app", nil, nil, nil, nil, nil, nil, env)
+		updated, err := k8s.UpdateDeployment(context.Background(), "my-project", "web-app", nil, nil, nil, nil, nil, nil, env, nil)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -328,6 +328,90 @@ func TestUpdateDeployment_Env(t *testing.T) {
 		}
 		if len(got) != 1 || got[0].Name != "PORT" || got[0].Value != "8080" {
 			t.Errorf("unexpected env vars: %+v", got)
+		}
+	})
+}
+
+func TestCreateDeployment_Port(t *testing.T) {
+	t.Run("stores port as string in ConfigMap", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, nil, 9090)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cm.Data[PortKey] != "9090" {
+			t.Errorf("expected port %q, got %q", "9090", cm.Data[PortKey])
+		}
+	})
+
+	t.Run("omits port key when zero", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		cm, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, nil, 0)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if _, ok := cm.Data[PortKey]; ok {
+			t.Error("expected port key to be absent when zero")
+		}
+	})
+
+	t.Run("round-trip: create with port then get returns same port", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		_, err := k8s.CreateDeployment(context.Background(), "my-project", "web-app", "nginx", "1.25", "default", "", "", nil, nil, nil, 3000)
+		if err != nil {
+			t.Fatalf("expected no error creating deployment, got %v", err)
+		}
+
+		got, err := k8s.GetDeployment(context.Background(), "my-project", "web-app")
+		if err != nil {
+			t.Fatalf("expected no error getting deployment, got %v", err)
+		}
+		dep := configMapToDeployment(got, "my-project")
+		if dep.Port != 3000 {
+			t.Errorf("expected port 3000, got %d", dep.Port)
+		}
+	})
+}
+
+func TestUpdateDeployment_Port(t *testing.T) {
+	t.Run("updates port in ConfigMap", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "", "")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		newPort := int32(8081)
+		updated, err := k8s.UpdateDeployment(context.Background(), "my-project", "web-app", nil, nil, nil, nil, nil, nil, nil, &newPort)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if updated.Data[PortKey] != "8081" {
+			t.Errorf("expected port %q, got %q", "8081", updated.Data[PortKey])
+		}
+	})
+
+	t.Run("does not update port when nil", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "", "")
+		cm.Data[PortKey] = "9090"
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		updated, err := k8s.UpdateDeployment(context.Background(), "my-project", "web-app", nil, nil, nil, nil, nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if updated.Data[PortKey] != "9090" {
+			t.Errorf("expected port unchanged %q, got %q", "9090", updated.Data[PortKey])
 		}
 	})
 }

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -51,6 +51,7 @@ type DeploymentInput struct {
 	Command   []string      `json:"command,omitempty"`
 	Args      []string      `json:"args,omitempty"`
 	Env       []EnvVarInput `json:"env,omitempty"`
+	Port      int32         `json:"port,omitempty"`
 }
 
 // CueRenderer evaluates CUE templates with deployment parameters.

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -586,6 +586,156 @@ func TestCueRenderer_CommandArgs(t *testing.T) {
 	})
 }
 
+// portTemplate renders a containerPort using input.port (structured output).
+const portTemplate = `
+package deployment
+
+input: {
+	name:      string
+	image:     string
+	tag:       string
+	project:   string
+	namespace: string
+	port:      int & >0 & <=65535 | *8080
+}
+
+namespaced: (input.namespace): {
+	Deployment: (input.name): {
+		apiVersion: "apps/v1"
+		kind:       "Deployment"
+		metadata: {
+			name:      input.name
+			namespace: input.namespace
+			labels: {
+				"app.kubernetes.io/managed-by": "console.holos.run"
+				"app.kubernetes.io/name":       input.name
+			}
+		}
+		spec: {
+			selector: matchLabels: "app.kubernetes.io/name": input.name
+			template: {
+				metadata: labels: "app.kubernetes.io/name": input.name
+				spec: containers: [{
+					name:  input.name
+					image: input.image + ":" + input.tag
+					ports: [{containerPort: input.port, name: "http"}]
+				}]
+			}
+		}
+	}
+	Service: (input.name): {
+		apiVersion: "v1"
+		kind:       "Service"
+		metadata: {
+			name:      input.name
+			namespace: input.namespace
+			labels: {
+				"app.kubernetes.io/managed-by": "console.holos.run"
+				"app.kubernetes.io/name":       input.name
+			}
+		}
+		spec: {
+			selector: "app.kubernetes.io/name": input.name
+			ports: [{port: 80, targetPort: "http", name: "http"}]
+		}
+	}
+}
+
+cluster: {}
+`
+
+func TestCueRenderer_Port(t *testing.T) {
+	renderer := &CueRenderer{}
+	namespace := "prj-my-project"
+
+	t.Run("explicit port is used in containerPort", func(t *testing.T) {
+		resources, err := renderer.Render(context.Background(), portTemplate, DeploymentInput{
+			Name:      "my-app",
+			Image:     "myrepo/myapp",
+			Tag:       "v1.0.0",
+			Project:   "my-project",
+			Namespace: namespace,
+			Port:      9090,
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		var deployment unstructured.Unstructured
+		for _, r := range resources {
+			if r.GetKind() == "Deployment" {
+				deployment = r
+				break
+			}
+		}
+		containers, _, _ := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		if len(containers) == 0 {
+			t.Fatal("expected at least 1 container")
+		}
+		c, ok := containers[0].(map[string]any)
+		if !ok {
+			t.Fatal("container is not a map")
+		}
+		ports, _, _ := unstructured.NestedSlice(map[string]any{"c": c}, "c", "ports")
+		if len(ports) != 1 {
+			t.Fatalf("expected 1 port, got %d", len(ports))
+		}
+		port, ok := ports[0].(map[string]any)
+		if !ok {
+			t.Fatal("port is not a map")
+		}
+		// CUE decodes integers as int64 in Go.
+		gotPort, _, _ := unstructured.NestedFieldNoCopy(map[string]any{"p": port}, "p", "containerPort")
+		if gotPort != int64(9090) {
+			t.Errorf("expected containerPort 9090, got %v (%T)", gotPort, gotPort)
+		}
+		if port["name"] != "http" {
+			t.Errorf("expected port name 'http', got %v", port["name"])
+		}
+	})
+
+	t.Run("zero port uses CUE default 8080", func(t *testing.T) {
+		// When Port is 0 (omitempty), the JSON omits the field and CUE applies default 8080.
+		resources, err := renderer.Render(context.Background(), portTemplate, DeploymentInput{
+			Name:      "my-app",
+			Image:     "myrepo/myapp",
+			Tag:       "v1.0.0",
+			Project:   "my-project",
+			Namespace: namespace,
+			Port:      0, // zero → omitempty → CUE default applies
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		var deployment unstructured.Unstructured
+		for _, r := range resources {
+			if r.GetKind() == "Deployment" {
+				deployment = r
+				break
+			}
+		}
+		containers, _, _ := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		if len(containers) == 0 {
+			t.Fatal("expected at least 1 container")
+		}
+		c, ok := containers[0].(map[string]any)
+		if !ok {
+			t.Fatal("container is not a map")
+		}
+		ports, _, _ := unstructured.NestedSlice(map[string]any{"c": c}, "c", "ports")
+		if len(ports) != 1 {
+			t.Fatalf("expected 1 port, got %d", len(ports))
+		}
+		port, ok := ports[0].(map[string]any)
+		if !ok {
+			t.Fatal("port is not a map")
+		}
+		gotPort, _, _ := unstructured.NestedFieldNoCopy(map[string]any{"p": port}, "p", "containerPort")
+		if gotPort != int64(8080) {
+			t.Errorf("expected default containerPort 8080, got %v (%T)", gotPort, gotPort)
+		}
+	})
+}
+
 // structuredDuplicateTemplate tries to define the same Kind/name twice.
 // CUE struct semantics naturally enforce uniqueness — setting the same path
 // twice merges values or produces a conflict error if they are incompatible.

--- a/console/templates/default_template.cue
+++ b/console/templates/default_template.cue
@@ -27,7 +27,8 @@ package deployment
 	namespace: string
 	command?: [...string]
 	args?: [...string]
-	env: [...#EnvVar] | *[]
+	env:  [...#EnvVar] | *[]
+	port: int & >0 & <=65535 | *8080
 }
 
 input: #Input
@@ -122,7 +123,7 @@ namespaced: #Namespaced & {
 							if len(_envSpec) > 0 {
 								env: _envSpec
 							}
-							ports: [{containerPort: 8443, name: "https"}]
+							ports: [{containerPort: input.port, name: "http"}]
 							if input.command != _|_ {
 								command: input.command
 							}
@@ -135,7 +136,7 @@ namespaced: #Namespaced & {
 			}
 		}
 
-		// Service exposes port 443 → container port 8443.
+		// Service exposes port 80 → container port input.port (named "http").
 		Service: (input.name): {
 			apiVersion: "v1"
 			kind:       "Service"
@@ -146,7 +147,7 @@ namespaced: #Namespaced & {
 			}
 			spec: {
 				selector: "app.kubernetes.io/name": input.name
-				ports: [{port: 443, targetPort: "https", name: "https"}]
+				ports: [{port: 80, targetPort: "http", name: "http"}]
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `Port int32` to `DeploymentInput` with `json:"port,omitempty"` so CUE templates receive the configured port; zero port lets the CUE default (8080) apply
- Add `PortKey = "port"` constant; store port as string in ConfigMap data in `CreateDeployment` and `UpdateDeployment` (nil pointer = no update, zero pointer = remove key)
- Update `configMapToDeployment` to parse port from ConfigMap and populate proto `Deployment.Port`
- Handler passes `req.Msg.Port` in Create; reads `portFromConfigMap` for re-render during Update
- Update `default_template.cue`: `#Input` gains `port: int & >0 & <=65535 | *8080`; containerPort uses `input.port` named `"http"`; Service exposes port 80 → targetPort `"http"`

Closes: #424

## Test plan
- [x] `make test-go` passes
- [x] Port storage round-trip test (create with port → get returns same port)
- [x] Render tests verify containerPort matches input port value
- [x] Render test verifies default port (8080) when port is omitted from input

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1