### PR TITLE
chore: cleanup after CUE preview debounce implementation

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -24,6 +24,10 @@ vi.mock('@/queries/deployment-templates', () => ({
   useRenderDeploymentTemplate: vi.fn(),
 }))
 
+vi.mock('@/hooks/use-debounced-value', () => ({
+  useDebouncedValue: vi.fn((value: unknown) => value),
+}))
+
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { useCreateDeploymentTemplate, useRenderDeploymentTemplate } from '@/queries/deployment-templates'

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useCreateDeploymentTemplate, useRenderDeploymentTemplate } from '@/queries/deployment-templates'
+import { useDebouncedValue } from '@/hooks/use-debounced-value'
 
 const DEFAULT_CUE_TEMPLATE = `// package deployment is the required CUE package declaration.
 package deployment
@@ -131,8 +132,9 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
 \tnamespace: "holos-prj-${projectName}"
 }`
 
+  const debouncedCueTemplate = useDebouncedValue(cueTemplate, 500)
   const renderQuery = useRenderDeploymentTemplate(
-    cueTemplate,
+    debouncedCueTemplate,
     previewCueInput,
     previewOpen,
   )


### PR DESCRIPTION
## Summary
- Apply `useDebouncedValue` to the Create Template page's preview toggle for consistency with the template detail preview tab added in #432
- Add identity mock for `useDebouncedValue` in the new template page test so existing tests are unaffected
- No unused imports, no stale comments, no outdated documentation in `docs/` referencing non-debounced behavior

Closes: #433

## Test plan
- [ ] `make test` passes (470 tests)
- [ ] Typing in the Create Template CUE editor no longer fires the render RPC on every keystroke

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1