### PR TITLE
docs: add Template Doc Completeness Guardrail to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,22 @@ See `docs/rpc-service-definitions.md` for detailed examples. See `docs/permissio
 
 This ensures template authors always see new fields in the preview and that the CUE schema stays in sync with the proto interface. See `docs/cue-template-guide.md` for the full template interface.
 
+### Template Doc Completeness Guardrail
+
+**When making any of the following changes**, verify that the "Writing a Custom Template" section of `docs/cue-template-guide.md` remains end-to-end complete for a product engineer trying to deploy a web service:
+
+Triggers:
+1. Adding or removing kinds from the allowed kinds list in `console/deployments/render.go` or `apply.go`.
+2. Modifying `console/templates/default_template.cue` (the default resource set).
+3. Editing any section of `docs/cue-template-guide.md`.
+
+After any of the above, confirm the "Writing a Custom Template" section still includes:
+- A complete working template with `ServiceAccount`, `Deployment`, and `Service`.
+- An explanation of the port flow: `input.port` → container `containerPort` → Service `targetPort` → HTTPRoute (optional).
+- Guidance on `HTTPRoute`: when to add one (external access) versus relying on the Service ClusterIP (cluster-internal), with a minimal CUE example.
+
+If any of the above is missing or stale after your changes, update the doc as part of the same commit.
+
 ### Testing Patterns
 
 **Preference: unit tests first, E2E only for full-stack behaviours.**  


### PR DESCRIPTION
## Summary
- Add a new `### Template Doc Completeness Guardrail` section to `AGENTS.md` immediately after the existing `### Template Field Guardrail` section
- The guardrail specifies three triggers: modifying allowed kinds in render.go/apply.go, modifying default_template.cue, or editing docs/cue-template-guide.md
- The guardrail specifies three things to verify remain present in the "Writing a Custom Template" section: complete ServiceAccount + Deployment + Service template, port flow explanation, and HTTPRoute guidance

Closes: #465

## Test plan
- [ ] `AGENTS.md` contains the new `### Template Doc Completeness Guardrail` section
- [ ] The existing `### Template Field Guardrail` section is unchanged
- [ ] No Go, proto, or frontend code is changed

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1