### PR TITLE
docs: cleanup pass after cue-template-guide rewrite and guardrail addition

### DIFF
--- a/docs/adrs/013-separate-system-user-template-input.md
+++ b/docs/adrs/013-separate-system-user-template-input.md
@@ -162,7 +162,7 @@ The `system` field is filled before CUE evaluation using the same
 - **Foundation for platform input.** The two-field pattern (`system`, `input`)
   establishes the convention for a future third field (`platform: #PlatformInput`)
   for platform-mandated configuration, consistent with the direction indicated in
-  ADR 012 and the planned extensions section of the CUE template guide.
+  ADR 012.
 
 ### Negative
 


### PR DESCRIPTION
## Summary

- Remove stale cross-reference to the "Planned Extensions" section of `docs/cue-template-guide.md` from ADR 013. That section was removed during the guide rewrite in PR #464, leaving a dangling reference in the ADR's Consequences section.
- All other cross-references to `docs/cue-template-guide.md` in `AGENTS.md` (lines 151, 152, 270, 274, 279, 281, 326) and `docs/adrs/012-structured-resource-output.md` were reviewed and remain accurate — they reference the guide generally or sections that still exist.

Closes: #466

## Test plan
- [x] `make test` passes with no errors
- [x] Verified no remaining references to removed guide sections ("Planned Extensions", "Minimal Template", "Implemented: System / User Input Split") across the repo
- [x] Verified all cross-references to `docs/cue-template-guide.md` in `AGENTS.md` and other `docs/` files still accurately describe the guide's content

🤖 Generated with [Claude Code](https://claude.com/claude-code)