### PR TITLE
feat(backend): implement SystemTemplateService handler, ReferenceGrant kind support, and RBAC

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -40,6 +40,7 @@ import (
 	"github.com/holos-run/holos-console/console/rpc"
 	"github.com/holos-run/holos-console/console/secrets"
 	"github.com/holos-run/holos-console/console/settings"
+	system_templates "github.com/holos-run/holos-console/console/system_templates"
 	"github.com/holos-run/holos-console/console/templates"
 	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
 )
@@ -268,6 +269,12 @@ func (s *Server) Serve(ctx context.Context) error {
 		templatesPath, templatesHTTPHandler := consolev1connect.NewDeploymentTemplateServiceHandler(templatesHandler, protectedInterceptors)
 		mux.Handle(templatesPath, templatesHTTPHandler)
 
+		// System template service with org-level RBAC
+		sysTemplatesK8s := system_templates.NewK8sClient(k8sClientset, nsResolver)
+		sysTemplatesHandler := system_templates.NewHandler(sysTemplatesK8s, orgGrantResolver, system_templates.NewCueRendererAdapter())
+		sysTemplatesPath, sysTemplatesHTTPHandler := consolev1connect.NewSystemTemplateServiceHandler(sysTemplatesHandler, protectedInterceptors)
+		mux.Handle(sysTemplatesPath, sysTemplatesHTTPHandler)
+
 		// Deployment service with project grant fallback
 		deploymentsK8s := deployments.NewK8sClient(k8sClientset, nsResolver)
 		dynamicClient, err := deployments.NewDynamicClient()
@@ -301,6 +308,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		consolev1connect.OrganizationServiceName,
 		consolev1connect.ProjectSettingsServiceName,
 		consolev1connect.DeploymentTemplateServiceName,
+		consolev1connect.SystemTemplateServiceName,
 		consolev1connect.DeploymentServiceName,
 	)
 	reflectPath, reflectHandler := grpcreflect.NewHandlerV1(reflector)

--- a/console/deployments/apply.go
+++ b/console/deployments/apply.go
@@ -29,6 +29,7 @@ var allowedKinds = map[string]schema.GroupVersionResource{
 	"Role":           {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
 	"RoleBinding":    {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
 	"HTTPRoute":      {Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"},
+	"ReferenceGrant": {Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "referencegrants"},
 	"ConfigMap":      {Group: "", Version: "v1", Resource: "configmaps"},
 	"Secret":         {Group: "", Version: "v1", Resource: "secrets"},
 }

--- a/console/deployments/apply_test.go
+++ b/console/deployments/apply_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // allTestGVRs lists every GVR that the fake scheme must know about,
-// including the gateway.networking.k8s.io group for HTTPRoute.
+// including the gateway.networking.k8s.io group for HTTPRoute and ReferenceGrant.
 var allTestGVRs = []struct {
 	gvr  schema.GroupVersionResource
 	kind string
@@ -24,6 +24,7 @@ var allTestGVRs = []struct {
 	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}, "Role"},
 	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}, "RoleBinding"},
 	{schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}, "HTTPRoute"},
+	{schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "referencegrants"}, "ReferenceGrant"},
 	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, "ConfigMap"},
 	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, "Secret"},
 }

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -19,6 +19,7 @@ var allowedKindSet = map[string]bool{
 	"Role":           true,
 	"RoleBinding":    true,
 	"HTTPRoute":      true,
+	"ReferenceGrant": true,
 	"ConfigMap":      true,
 	"Secret":         true,
 }

--- a/console/rbac/rbac.go
+++ b/console/rbac/rbac.go
@@ -61,6 +61,10 @@ const (
 	PermissionProjectSettingsWrite = consolev1.Permission_PERMISSION_PROJECT_SETTINGS_WRITE
 
 	PermissionProjectDeploymentsEnable = consolev1.Permission_PERMISSION_PROJECT_DEPLOYMENTS_ENABLE
+
+	// PermissionSystemDeploymentsEdit allows creating, updating, and deleting
+	// system templates. Granted only to org-level OWNERs via OrgCascadeSystemTemplatePerms.
+	PermissionSystemDeploymentsEdit = consolev1.Permission_PERMISSION_SYSTEM_DEPLOYMENTS_EDIT
 )
 
 // rolePermissions defines which permissions each role has.
@@ -338,6 +342,16 @@ var ProjectCascadeTemplatePerms = CascadeTable{
 var OrgCascadeProjectSettingsPerms = CascadeTable{
 	RoleOwner: {
 		PermissionProjectDeploymentsEnable: true,
+	},
+}
+
+// OrgCascadeSystemTemplatePerms defines what system template permissions each
+// org role grants via cascade. Only org-level OWNERs can create, update, and
+// delete system templates — this permission is intentionally not inherited by
+// project-level OWNERs.
+var OrgCascadeSystemTemplatePerms = CascadeTable{
+	RoleOwner: {
+		PermissionSystemDeploymentsEdit: true,
 	},
 }
 

--- a/console/rbac/rbac_test.go
+++ b/console/rbac/rbac_test.go
@@ -639,3 +639,65 @@ func TestCheckAccessGrants(t *testing.T) {
 		}
 	})
 }
+
+func TestOrgCascadeSystemTemplatePerms(t *testing.T) {
+	t.Run("org OWNER has PERMISSION_SYSTEM_DEPLOYMENTS_EDIT", func(t *testing.T) {
+		if !HasCascadePermission(RoleOwner, PermissionSystemDeploymentsEdit, OrgCascadeSystemTemplatePerms) {
+			t.Error("org OWNER should have PERMISSION_SYSTEM_DEPLOYMENTS_EDIT via cascade")
+		}
+	})
+
+	t.Run("org EDITOR does not have PERMISSION_SYSTEM_DEPLOYMENTS_EDIT", func(t *testing.T) {
+		if HasCascadePermission(RoleEditor, PermissionSystemDeploymentsEdit, OrgCascadeSystemTemplatePerms) {
+			t.Error("org EDITOR should not have PERMISSION_SYSTEM_DEPLOYMENTS_EDIT")
+		}
+	})
+
+	t.Run("org VIEWER does not have PERMISSION_SYSTEM_DEPLOYMENTS_EDIT", func(t *testing.T) {
+		if HasCascadePermission(RoleViewer, PermissionSystemDeploymentsEdit, OrgCascadeSystemTemplatePerms) {
+			t.Error("org VIEWER should not have PERMISSION_SYSTEM_DEPLOYMENTS_EDIT")
+		}
+	})
+
+	t.Run("CheckCascadeAccess grants OWNER", func(t *testing.T) {
+		err := CheckCascadeAccess(
+			"owner@example.com",
+			nil,
+			map[string]string{"owner@example.com": "owner"},
+			nil,
+			PermissionSystemDeploymentsEdit,
+			OrgCascadeSystemTemplatePerms,
+		)
+		if err != nil {
+			t.Errorf("expected access granted for org OWNER, got %v", err)
+		}
+	})
+
+	t.Run("CheckCascadeAccess denies VIEWER", func(t *testing.T) {
+		err := CheckCascadeAccess(
+			"viewer@example.com",
+			nil,
+			map[string]string{"viewer@example.com": "viewer"},
+			nil,
+			PermissionSystemDeploymentsEdit,
+			OrgCascadeSystemTemplatePerms,
+		)
+		if err == nil {
+			t.Error("expected access denied for org VIEWER, got nil")
+		}
+	})
+
+	t.Run("CheckCascadeAccess denies EDITOR", func(t *testing.T) {
+		err := CheckCascadeAccess(
+			"editor@example.com",
+			nil,
+			map[string]string{"editor@example.com": "editor"},
+			nil,
+			PermissionSystemDeploymentsEdit,
+			OrgCascadeSystemTemplatePerms,
+		)
+		if err == nil {
+			t.Error("expected access denied for org EDITOR, got nil")
+		}
+	})
+}

--- a/console/system_templates/default_referencegrant.cue
+++ b/console/system_templates/default_referencegrant.cue
@@ -1,0 +1,95 @@
+// package system_template is the required CUE package declaration.
+package system_template
+
+// #Claims carries the OIDC ID token claims of the authenticated user.
+// These values are set by the console backend from the verified JWT and are
+// never supplied directly by the user.
+#Claims: {
+	iss:            string
+	sub:            string
+	exp:            int
+	iat:            int
+	email:          string
+	email_verified: bool
+	name?:          string
+	groups?: [...string]
+	... // allow provider-specific claims
+}
+
+// #System defines the trusted system-provided fields set by the console backend.
+// These values are derived from authenticated context (project namespace resolution
+// and OIDC token claims) and are never supplied by the user.
+#System: {
+	project:   string
+	namespace: string
+	claims:    #Claims
+}
+
+// #Input defines template-specific user or system-configured inputs.
+#Input: {
+	// gatewayNamespace is the Kubernetes namespace that contains the Gateway
+	// resource. HTTPRoute resources in this namespace will be granted
+	// permission to reference Services in the project namespace.
+	// Defaults to "istio-ingress" per Istio's recommended Helm install
+	// convention (https://istio.io/latest/docs/setup/additional-setup/gateway/).
+	gatewayNamespace: string | *"istio-ingress"
+}
+
+system: #System
+input:  #Input
+
+// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+// Structure: namespaced.<namespace>.<Kind>.<name>
+#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+	kind: Kind
+	metadata: {
+		name:      Name
+		namespace: Namespace
+		...
+	}
+	...
+}
+
+// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+#Cluster: [Kind=string]: [Name=string]: {
+	kind: Kind
+	metadata: {
+		name: Name
+		...
+	}
+	...
+}
+
+// namespaced organizes resources that live within a Kubernetes namespace.
+namespaced: #Namespaced & {
+	(system.namespace): {
+		// ReferenceGrant allows HTTPRoute resources in the gateway namespace to
+		// reference Service resources in the project namespace.
+		// See: https://gateway-api.sigs.k8s.io/api-types/referencegrant/
+		ReferenceGrant: "allow-gateway-httproute": {
+			apiVersion: "gateway.networking.k8s.io/v1beta1"
+			kind:       "ReferenceGrant"
+			metadata: {
+				name:      "allow-gateway-httproute"
+				namespace: system.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+				}
+			}
+			spec: {
+				from: [{
+					group:     "gateway.networking.k8s.io"
+					kind:      "HTTPRoute"
+					namespace: input.gatewayNamespace
+				}]
+				to: [{
+					group: ""
+					kind:  "Service"
+				}]
+			}
+		}
+	}
+}
+
+// cluster organizes cluster-scoped resources (none for this template).
+cluster: #Cluster & {}

--- a/console/system_templates/embed.go
+++ b/console/system_templates/embed.go
@@ -1,0 +1,10 @@
+package system_templates
+
+import _ "embed"
+
+// DefaultReferenceGrantTemplate is the built-in CUE system template that
+// produces a ReferenceGrant allowing HTTPRoute resources in the gateway
+// namespace to reference Service resources in the project namespace.
+//
+//go:embed default_referencegrant.cue
+var DefaultReferenceGrantTemplate string

--- a/console/system_templates/handler.go
+++ b/console/system_templates/handler.go
@@ -1,0 +1,403 @@
+// Package system_templates implements the SystemTemplateService RPC handler.
+// System templates are org-scoped CUE templates stored in org namespace ConfigMaps.
+// They differ from deployment templates in that they can be marked mandatory,
+// causing them to be automatically applied to project namespaces at creation time.
+package system_templates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"connectrpc.com/connect"
+	"cuelang.org/go/cue/parser"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/holos-run/holos-console/console/rbac"
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
+)
+
+const auditResourceType = "system-template"
+
+// dnsLabelRe validates template names as DNS labels.
+var dnsLabelRe = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
+
+// OrgResolver resolves organization-level grants for access checks.
+type OrgResolver interface {
+	GetOrgGrants(ctx context.Context, org string) (users, roles map[string]string, err error)
+}
+
+// RenderResource is a single rendered resource with its YAML representation
+// and its raw object data for JSON serialization.
+type RenderResource struct {
+	YAML   string
+	Object map[string]any
+}
+
+// Renderer evaluates a CUE template unified with system and user CUE input strings
+// and returns a list of rendered Kubernetes manifests.
+type Renderer interface {
+	Render(ctx context.Context, cueTemplate string, cueSystemInput string, cueInput string) ([]RenderResource, error)
+}
+
+// Handler implements the SystemTemplateService.
+type Handler struct {
+	consolev1connect.UnimplementedSystemTemplateServiceHandler
+	k8s         *K8sClient
+	orgResolver OrgResolver
+	renderer    Renderer
+}
+
+// NewHandler creates a SystemTemplateService handler.
+func NewHandler(k8s *K8sClient, orgResolver OrgResolver, renderer Renderer) *Handler {
+	return &Handler{k8s: k8s, orgResolver: orgResolver, renderer: renderer}
+}
+
+// ListSystemTemplates returns all system templates in an org, seeding defaults on first access.
+func (h *Handler) ListSystemTemplates(
+	ctx context.Context,
+	req *connect.Request[consolev1.ListSystemTemplatesRequest],
+) (*connect.Response[consolev1.ListSystemTemplatesResponse], error) {
+	org := req.Msg.Org
+	if org == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("org is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkOrgReadAccess(ctx, claims, org); err != nil {
+		return nil, err
+	}
+
+	cms, err := h.k8s.ListSystemTemplates(ctx, org)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	// Seed built-in templates on first access (no existing templates found).
+	if len(cms) == 0 {
+		if seedErr := h.k8s.SeedDefaultTemplates(ctx, org); seedErr != nil {
+			// Log but don't fail: seeding is best-effort; the org namespace may not exist yet.
+			slog.WarnContext(ctx, "failed to seed default system templates",
+				slog.String("org", org),
+				slog.Any("error", seedErr),
+			)
+		} else {
+			// Re-list after seeding.
+			cms, err = h.k8s.ListSystemTemplates(ctx, org)
+			if err != nil {
+				return nil, mapK8sError(err)
+			}
+		}
+	}
+
+	templates := make([]*consolev1.SystemTemplate, 0, len(cms))
+	for _, cm := range cms {
+		templates = append(templates, configMapToSystemTemplate(&cm, org))
+	}
+
+	slog.InfoContext(ctx, "system templates listed",
+		slog.String("action", "system_templates_list"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("org", org),
+		slog.String("sub", claims.Sub),
+		slog.Int("count", len(templates)),
+	)
+
+	return connect.NewResponse(&consolev1.ListSystemTemplatesResponse{
+		Templates: templates,
+	}), nil
+}
+
+// GetSystemTemplate returns a single system template by name.
+func (h *Handler) GetSystemTemplate(
+	ctx context.Context,
+	req *connect.Request[consolev1.GetSystemTemplateRequest],
+) (*connect.Response[consolev1.GetSystemTemplateResponse], error) {
+	org := req.Msg.Org
+	name := req.Msg.Name
+	if org == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("org is required"))
+	}
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkOrgReadAccess(ctx, claims, org); err != nil {
+		return nil, err
+	}
+
+	cm, err := h.k8s.GetSystemTemplate(ctx, org, name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "system template read",
+		slog.String("action", "system_template_read"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("org", org),
+		slog.String("name", name),
+		slog.String("sub", claims.Sub),
+	)
+
+	return connect.NewResponse(&consolev1.GetSystemTemplateResponse{
+		Template: configMapToSystemTemplate(cm, org),
+	}), nil
+}
+
+// CreateSystemTemplate creates a new system template.
+func (h *Handler) CreateSystemTemplate(
+	ctx context.Context,
+	req *connect.Request[consolev1.CreateSystemTemplateRequest],
+) (*connect.Response[consolev1.CreateSystemTemplateResponse], error) {
+	org := req.Msg.Org
+	name := req.Msg.Name
+	if org == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("org is required"))
+	}
+	if err := validateTemplateName(name); err != nil {
+		return nil, err
+	}
+	if err := validateCueSyntax(req.Msg.CueTemplate); err != nil {
+		return nil, err
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkOrgEditAccess(ctx, claims, org); err != nil {
+		return nil, err
+	}
+
+	_, err := h.k8s.CreateSystemTemplate(ctx, org, name, req.Msg.DisplayName, req.Msg.Description, req.Msg.CueTemplate, req.Msg.Mandatory, req.Msg.GatewayNamespace)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "system template created",
+		slog.String("action", "system_template_create"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("org", org),
+		slog.String("name", name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.CreateSystemTemplateResponse{
+		Name: name,
+	}), nil
+}
+
+// UpdateSystemTemplate updates an existing system template.
+func (h *Handler) UpdateSystemTemplate(
+	ctx context.Context,
+	req *connect.Request[consolev1.UpdateSystemTemplateRequest],
+) (*connect.Response[consolev1.UpdateSystemTemplateResponse], error) {
+	org := req.Msg.Org
+	name := req.Msg.Name
+	if org == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("org is required"))
+	}
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+
+	// Validate CUE syntax if a new template is provided.
+	if req.Msg.CueTemplate != nil {
+		if err := validateCueSyntax(*req.Msg.CueTemplate); err != nil {
+			return nil, err
+		}
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkOrgEditAccess(ctx, claims, org); err != nil {
+		return nil, err
+	}
+
+	_, err := h.k8s.UpdateSystemTemplate(ctx, org, name, req.Msg.DisplayName, req.Msg.Description, req.Msg.CueTemplate, req.Msg.Mandatory, req.Msg.GatewayNamespace)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "system template updated",
+		slog.String("action", "system_template_update"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("org", org),
+		slog.String("name", name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.UpdateSystemTemplateResponse{}), nil
+}
+
+// DeleteSystemTemplate deletes a system template.
+func (h *Handler) DeleteSystemTemplate(
+	ctx context.Context,
+	req *connect.Request[consolev1.DeleteSystemTemplateRequest],
+) (*connect.Response[consolev1.DeleteSystemTemplateResponse], error) {
+	org := req.Msg.Org
+	name := req.Msg.Name
+	if org == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("org is required"))
+	}
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkOrgEditAccess(ctx, claims, org); err != nil {
+		return nil, err
+	}
+
+	if err := h.k8s.DeleteSystemTemplate(ctx, org, name); err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "system template deleted",
+		slog.String("action", "system_template_delete"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("org", org),
+		slog.String("name", name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.DeleteSystemTemplateResponse{}), nil
+}
+
+// RenderSystemTemplate evaluates a CUE system template and returns rendered manifests.
+func (h *Handler) RenderSystemTemplate(
+	ctx context.Context,
+	req *connect.Request[consolev1.RenderSystemTemplateRequest],
+) (*connect.Response[consolev1.RenderSystemTemplateResponse], error) {
+	if req.Msg.CueTemplate == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("cue_template is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	resources, err := h.renderer.Render(ctx, req.Msg.CueTemplate, req.Msg.CueSystemInput, req.Msg.CueInput)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
+	}
+
+	var buf strings.Builder
+	objects := make([]map[string]any, 0, len(resources))
+	for i, r := range resources {
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		buf.WriteString(r.YAML)
+		if r.Object != nil {
+			objects = append(objects, r.Object)
+		}
+	}
+
+	jsonBytes, err := json.MarshalIndent(objects, "", "  ")
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to marshal rendered resources to JSON: %w", err))
+	}
+
+	return connect.NewResponse(&consolev1.RenderSystemTemplateResponse{
+		RenderedYaml: buf.String(),
+		RenderedJson: string(jsonBytes),
+	}), nil
+}
+
+// checkOrgReadAccess verifies the user can read system templates in the org.
+// Requires org-level grants (VIEWER or above).
+func (h *Handler) checkOrgReadAccess(ctx context.Context, claims *rpc.Claims, org string) error {
+	if h.orgResolver == nil {
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	users, roles, err := h.orgResolver.GetOrgGrants(ctx, org)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve org grants",
+			slog.String("org", org),
+			slog.Any("error", err),
+		)
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	return rbac.CheckAccessGrants(claims.Email, claims.Roles, users, roles, rbac.PermissionOrganizationsRead)
+}
+
+// checkOrgEditAccess verifies the user has PERMISSION_SYSTEM_DEPLOYMENTS_EDIT
+// at the org level via the OrgCascadeSystemTemplatePerms cascade table.
+func (h *Handler) checkOrgEditAccess(ctx context.Context, claims *rpc.Claims, org string) error {
+	if h.orgResolver == nil {
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	users, roles, err := h.orgResolver.GetOrgGrants(ctx, org)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve org grants",
+			slog.String("org", org),
+			slog.Any("error", err),
+		)
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	return rbac.CheckCascadeAccess(claims.Email, claims.Roles, users, roles, rbac.PermissionSystemDeploymentsEdit, rbac.OrgCascadeSystemTemplatePerms)
+}
+
+// validateTemplateName checks that the name is a valid DNS label.
+func validateTemplateName(name string) error {
+	if name == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+	if len(name) > 63 {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name must be at most 63 characters"))
+	}
+	if !dnsLabelRe.MatchString(name) {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name must be a valid DNS label (lowercase alphanumeric and hyphens, starting with a letter)"))
+	}
+	return nil
+}
+
+// validateCueSyntax parses the CUE source to verify it is syntactically valid.
+func validateCueSyntax(source string) error {
+	_, err := parser.ParseFile("template.cue", source)
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid CUE syntax: %w", err))
+	}
+	return nil
+}
+
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors.
+func mapK8sError(err error) error {
+	if errors.IsNotFound(err) {
+		return connect.NewError(connect.CodeNotFound, err)
+	}
+	if errors.IsAlreadyExists(err) {
+		return connect.NewError(connect.CodeAlreadyExists, err)
+	}
+	if errors.IsForbidden(err) {
+		return connect.NewError(connect.CodePermissionDenied, err)
+	}
+	return connect.NewError(connect.CodeInternal, err)
+}

--- a/console/system_templates/handler_test.go
+++ b/console/system_templates/handler_test.go
@@ -1,0 +1,425 @@
+package system_templates
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// stubOrgResolver implements OrgResolver for tests.
+type stubOrgResolver struct {
+	users map[string]string
+	roles map[string]string
+	err   error
+}
+
+func (s *stubOrgResolver) GetOrgGrants(_ context.Context, _ string) (map[string]string, map[string]string, error) {
+	return s.users, s.roles, s.err
+}
+
+// stubRenderer implements Renderer for tests.
+type stubRenderer struct {
+	resources []RenderResource
+	err       error
+}
+
+func (r *stubRenderer) Render(_ context.Context, _ string, _ string, _ string) ([]RenderResource, error) {
+	return r.resources, r.err
+}
+
+func authedCtx(email string, roles []string) context.Context {
+	return rpc.ContextWithClaims(context.Background(), &rpc.Claims{
+		Sub:   "user-123",
+		Email: email,
+		Roles: roles,
+	})
+}
+
+// ownerGrants returns grants giving the email OWNER access to the org.
+func ownerGrants(email string) *stubOrgResolver {
+	return &stubOrgResolver{
+		users: map[string]string{email: "owner"},
+	}
+}
+
+// viewerGrants returns grants giving the email VIEWER access to the org.
+func viewerGrants(email string) *stubOrgResolver {
+	return &stubOrgResolver{
+		users: map[string]string{email: "viewer"},
+	}
+}
+
+
+const validCue = `package system_template
+
+#Input: {
+	gatewayNamespace: string | *"istio-ingress"
+}
+`
+
+func TestListSystemTemplatesHandler(t *testing.T) {
+	t.Run("returns templates for org OWNER", func(t *testing.T) {
+		email := "owner@example.com"
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", true, "istio-ingress")
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		resp, err := h.ListSystemTemplates(ctx, connect.NewRequest(&consolev1.ListSystemTemplatesRequest{Org: "my-org"}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Msg.Templates) != 1 {
+			t.Errorf("expected 1 template, got %d", len(resp.Msg.Templates))
+		}
+	})
+
+	t.Run("seeds default templates when org has none", func(t *testing.T) {
+		email := "owner@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		resp, err := h.ListSystemTemplates(ctx, connect.NewRequest(&consolev1.ListSystemTemplatesRequest{Org: "my-org"}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// Should have seeded the default reference-grant template.
+		if len(resp.Msg.Templates) != 1 {
+			t.Errorf("expected 1 seeded template, got %d", len(resp.Msg.Templates))
+		}
+		if resp.Msg.Templates[0].Name != DefaultReferenceGrantName {
+			t.Errorf("expected seeded template name %q, got %q", DefaultReferenceGrantName, resp.Msg.Templates[0].Name)
+		}
+		if !resp.Msg.Templates[0].Mandatory {
+			t.Error("expected seeded template to be mandatory")
+		}
+	})
+
+	t.Run("returns error when org is missing", func(t *testing.T) {
+		email := "owner@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		_, err := h.ListSystemTemplates(ctx, connect.NewRequest(&consolev1.ListSystemTemplatesRequest{}))
+		if err == nil {
+			t.Fatal("expected error when org is empty")
+		}
+	})
+
+	t.Run("returns error when unauthenticated", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants("owner@example.com"), &stubRenderer{})
+
+		_, err := h.ListSystemTemplates(context.Background(), connect.NewRequest(&consolev1.ListSystemTemplatesRequest{Org: "my-org"}))
+		if err == nil {
+			t.Fatal("expected error for unauthenticated request")
+		}
+	})
+}
+
+func TestGetSystemTemplateHandler(t *testing.T) {
+	t.Run("returns template for org VIEWER", func(t *testing.T) {
+		email := "viewer@example.com"
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", true, "istio-ingress")
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, viewerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		resp, err := h.GetSystemTemplate(ctx, connect.NewRequest(&consolev1.GetSystemTemplateRequest{Org: "my-org", Name: "ref-grant"}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Template.Name != "ref-grant" {
+			t.Errorf("expected name 'ref-grant', got %q", resp.Msg.Template.Name)
+		}
+		if !resp.Msg.Template.Mandatory {
+			t.Error("expected mandatory=true")
+		}
+	})
+}
+
+func TestCreateSystemTemplateHandler(t *testing.T) {
+	t.Run("allows org OWNER to create", func(t *testing.T) {
+		email := "owner@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		resp, err := h.CreateSystemTemplate(ctx, connect.NewRequest(&consolev1.CreateSystemTemplateRequest{
+			Name:             "ref-grant",
+			Org:              "my-org",
+			DisplayName:      "ReferenceGrant",
+			Description:      "desc",
+			CueTemplate:      validCue,
+			Mandatory:        true,
+			GatewayNamespace: "istio-ingress",
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Name != "ref-grant" {
+			t.Errorf("expected name 'ref-grant', got %q", resp.Msg.Name)
+		}
+	})
+
+	t.Run("denies org VIEWER", func(t *testing.T) {
+		email := "viewer@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, viewerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		_, err := h.CreateSystemTemplate(ctx, connect.NewRequest(&consolev1.CreateSystemTemplateRequest{
+			Name:        "ref-grant",
+			Org:         "my-org",
+			CueTemplate: validCue,
+		}))
+		if err == nil {
+			t.Fatal("expected permission denied error for VIEWER")
+		}
+		if connect.CodeOf(err) != connect.CodePermissionDenied {
+			t.Errorf("expected CodePermissionDenied, got %v", err)
+		}
+	})
+
+	t.Run("rejects invalid CUE syntax", func(t *testing.T) {
+		email := "owner@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		_, err := h.CreateSystemTemplate(ctx, connect.NewRequest(&consolev1.CreateSystemTemplateRequest{
+			Name:        "ref-grant",
+			Org:         "my-org",
+			CueTemplate: "THIS IS NOT VALID CUE {{{{",
+		}))
+		if err == nil {
+			t.Fatal("expected error for invalid CUE syntax")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected CodeInvalidArgument, got %v", err)
+		}
+	})
+}
+
+func TestUpdateSystemTemplateHandler(t *testing.T) {
+	t.Run("allows org OWNER to update", func(t *testing.T) {
+		email := "owner@example.com"
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", validCue, true, "istio-ingress")
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		newGateway := "custom-gateway"
+		ctx := authedCtx(email, nil)
+		_, err := h.UpdateSystemTemplate(ctx, connect.NewRequest(&consolev1.UpdateSystemTemplateRequest{
+			Name:             "ref-grant",
+			Org:              "my-org",
+			GatewayNamespace: &newGateway,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("denies org VIEWER", func(t *testing.T) {
+		email := "viewer@example.com"
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", validCue, true, "istio-ingress")
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, viewerGrants(email), &stubRenderer{})
+
+		newGateway := "custom-gateway"
+		ctx := authedCtx(email, nil)
+		_, err := h.UpdateSystemTemplate(ctx, connect.NewRequest(&consolev1.UpdateSystemTemplateRequest{
+			Name:             "ref-grant",
+			Org:              "my-org",
+			GatewayNamespace: &newGateway,
+		}))
+		if err == nil {
+			t.Fatal("expected permission denied error for VIEWER")
+		}
+	})
+}
+
+func TestDeleteSystemTemplateHandler(t *testing.T) {
+	t.Run("allows org OWNER to delete", func(t *testing.T) {
+		email := "owner@example.com"
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", validCue, true, "istio-ingress")
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		_, err := h.DeleteSystemTemplate(ctx, connect.NewRequest(&consolev1.DeleteSystemTemplateRequest{
+			Name: "ref-grant",
+			Org:  "my-org",
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("denies org VIEWER", func(t *testing.T) {
+		email := "viewer@example.com"
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", validCue, true, "istio-ingress")
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, viewerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		_, err := h.DeleteSystemTemplate(ctx, connect.NewRequest(&consolev1.DeleteSystemTemplateRequest{
+			Name: "ref-grant",
+			Org:  "my-org",
+		}))
+		if err == nil {
+			t.Fatal("expected permission denied error for VIEWER")
+		}
+		if connect.CodeOf(err) != connect.CodePermissionDenied {
+			t.Errorf("expected CodePermissionDenied, got %v", err)
+		}
+	})
+}
+
+func TestRenderSystemTemplateHandler(t *testing.T) {
+	t.Run("renders template for authenticated user", func(t *testing.T) {
+		email := "owner@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		renderer := &stubRenderer{
+			resources: []RenderResource{
+				{YAML: "kind: ReferenceGrant\n", Object: map[string]any{"kind": "ReferenceGrant"}},
+			},
+		}
+		h := NewHandler(k8s, ownerGrants(email), renderer)
+
+		ctx := authedCtx(email, nil)
+		resp, err := h.RenderSystemTemplate(ctx, connect.NewRequest(&consolev1.RenderSystemTemplateRequest{
+			CueTemplate: validCue,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.RenderedYaml == "" {
+			t.Error("expected rendered YAML to be non-empty")
+		}
+		if resp.Msg.RenderedJson == "" {
+			t.Error("expected rendered JSON to be non-empty")
+		}
+	})
+
+	t.Run("returns error when cue_template is empty", func(t *testing.T) {
+		email := "owner@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		_, err := h.RenderSystemTemplate(ctx, connect.NewRequest(&consolev1.RenderSystemTemplateRequest{}))
+		if err == nil {
+			t.Fatal("expected error when cue_template is empty")
+		}
+	})
+
+	t.Run("renders default ReferenceGrant template", func(t *testing.T) {
+		email := "owner@example.com"
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), NewCueRendererAdapter())
+
+		ctx := authedCtx(email, nil)
+		systemInput := `system: {
+	project:   "my-project"
+	namespace: "prj-my-project"
+	claims: {
+		iss:            "https://example.com"
+		sub:            "user-123"
+		exp:            9999999999
+		iat:            1000000000
+		email:          "owner@example.com"
+		email_verified: true
+	}
+}`
+		userInput := `input: gatewayNamespace: "istio-ingress"`
+		resp, err := h.RenderSystemTemplate(ctx, connect.NewRequest(&consolev1.RenderSystemTemplateRequest{
+			CueTemplate:    DefaultReferenceGrantTemplate,
+			CueSystemInput: systemInput,
+			CueInput:       userInput,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error rendering default template, got %v", err)
+		}
+		if resp.Msg.RenderedYaml == "" {
+			t.Error("expected non-empty YAML for default ReferenceGrant template")
+		}
+		// Verify ReferenceGrant is in the output.
+		if !contains(resp.Msg.RenderedYaml, "ReferenceGrant") {
+			t.Errorf("expected 'ReferenceGrant' in rendered YAML, got: %s", resp.Msg.RenderedYaml)
+		}
+		if !contains(resp.Msg.RenderedYaml, "istio-ingress") {
+			t.Errorf("expected 'istio-ingress' in rendered YAML, got: %s", resp.Msg.RenderedYaml)
+		}
+	})
+}
+
+// contains checks if s contains substr.
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) >= len(substr) && (s[:len(substr)] == substr || contains(s[1:], substr)))
+}
+
+func TestSeedDefaultTemplates(t *testing.T) {
+	t.Run("seeds reference-grant template with mandatory=true", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		err := k8s.SeedDefaultTemplates(context.Background(), "my-org")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		cm, err := fakeClient.CoreV1().ConfigMaps("org-my-org").Get(context.Background(), DefaultReferenceGrantName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected seeded ConfigMap, got %v", err)
+		}
+		if cm.Annotations[MandatoryAnnotation] != "true" {
+			t.Errorf("expected mandatory annotation 'true', got %q", cm.Annotations[MandatoryAnnotation])
+		}
+		if cm.Annotations[GatewayNsAnnotation] != "istio-ingress" {
+			t.Errorf("expected gateway-namespace 'istio-ingress', got %q", cm.Annotations[GatewayNsAnnotation])
+		}
+		if cm.Data[CueTemplateKey] == "" {
+			t.Error("expected non-empty CUE template")
+		}
+	})
+}

--- a/console/system_templates/k8s.go
+++ b/console/system_templates/k8s.go
@@ -1,0 +1,194 @@
+package system_templates
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ManagedByLabel        = "app.kubernetes.io/managed-by"
+	ManagedByValue        = "console.holos.run"
+	ResourceTypeLabel     = "console.holos.run/resource-type"
+	ResourceTypeValue     = "system-template"
+	DisplayNameAnnotation = "console.holos.run/display-name"
+	DescriptionAnnotation = "console.holos.run/description"
+	MandatoryAnnotation   = "console.holos.run/mandatory"
+	GatewayNsAnnotation   = "console.holos.run/gateway-namespace"
+	CueTemplateKey        = "template.cue"
+
+	// DefaultGatewayNamespace is the default gateway namespace per Istio's
+	// recommended Helm install convention.
+	// See: https://istio.io/latest/docs/setup/additional-setup/gateway/
+	DefaultGatewayNamespace = "istio-ingress"
+
+	// DefaultReferenceGrantName is the name of the seeded built-in template.
+	DefaultReferenceGrantName = "reference-grant"
+)
+
+// K8sClient wraps Kubernetes client operations for system templates.
+type K8sClient struct {
+	client   kubernetes.Interface
+	Resolver *resolver.Resolver
+}
+
+// NewK8sClient creates a client for system template operations.
+func NewK8sClient(client kubernetes.Interface, r *resolver.Resolver) *K8sClient {
+	return &K8sClient{client: client, Resolver: r}
+}
+
+// ListSystemTemplates returns all system template ConfigMaps in the org namespace.
+func (k *K8sClient) ListSystemTemplates(ctx context.Context, org string) ([]corev1.ConfigMap, error) {
+	ns := k.Resolver.OrgNamespace(org)
+	labelSelector := ResourceTypeLabel + "=" + ResourceTypeValue
+	slog.DebugContext(ctx, "listing system templates from kubernetes",
+		slog.String("org", org),
+		slog.String("namespace", ns),
+		slog.String("labelSelector", labelSelector),
+	)
+	list, err := k.client.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing system templates: %w", err)
+	}
+	return list.Items, nil
+}
+
+// GetSystemTemplate retrieves a system template ConfigMap by name.
+func (k *K8sClient) GetSystemTemplate(ctx context.Context, org, name string) (*corev1.ConfigMap, error) {
+	ns := k.Resolver.OrgNamespace(org)
+	slog.DebugContext(ctx, "getting system template from kubernetes",
+		slog.String("org", org),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	return k.client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+}
+
+// CreateSystemTemplate creates a new system template ConfigMap in the org namespace.
+func (k *K8sClient) CreateSystemTemplate(ctx context.Context, org, name, displayName, description, cueTemplate string, mandatory bool, gatewayNamespace string) (*corev1.ConfigMap, error) {
+	ns := k.Resolver.OrgNamespace(org)
+	slog.DebugContext(ctx, "creating system template in kubernetes",
+		slog.String("org", org),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	if gatewayNamespace == "" {
+		gatewayNamespace = DefaultGatewayNamespace
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				ManagedByLabel:    ManagedByValue,
+				ResourceTypeLabel: ResourceTypeValue,
+			},
+			Annotations: map[string]string{
+				DisplayNameAnnotation: displayName,
+				DescriptionAnnotation: description,
+				MandatoryAnnotation:   strconv.FormatBool(mandatory),
+				GatewayNsAnnotation:   gatewayNamespace,
+			},
+		},
+		Data: map[string]string{
+			CueTemplateKey: cueTemplate,
+		},
+	}
+	return k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+}
+
+// UpdateSystemTemplate updates an existing system template ConfigMap.
+// Only non-nil pointer fields are updated.
+func (k *K8sClient) UpdateSystemTemplate(ctx context.Context, org, name string, displayName, description, cueTemplate *string, mandatory *bool, gatewayNamespace *string) (*corev1.ConfigMap, error) {
+	ns := k.Resolver.OrgNamespace(org)
+	slog.DebugContext(ctx, "updating system template in kubernetes",
+		slog.String("org", org),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	cm, err := k.client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting system template for update: %w", err)
+	}
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	if displayName != nil {
+		cm.Annotations[DisplayNameAnnotation] = *displayName
+	}
+	if description != nil {
+		cm.Annotations[DescriptionAnnotation] = *description
+	}
+	if mandatory != nil {
+		cm.Annotations[MandatoryAnnotation] = strconv.FormatBool(*mandatory)
+	}
+	if gatewayNamespace != nil {
+		gns := *gatewayNamespace
+		if gns == "" {
+			gns = DefaultGatewayNamespace
+		}
+		cm.Annotations[GatewayNsAnnotation] = gns
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	if cueTemplate != nil {
+		cm.Data[CueTemplateKey] = *cueTemplate
+	}
+	return k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+}
+
+// DeleteSystemTemplate deletes a system template ConfigMap.
+func (k *K8sClient) DeleteSystemTemplate(ctx context.Context, org, name string) error {
+	ns := k.Resolver.OrgNamespace(org)
+	slog.DebugContext(ctx, "deleting system template from kubernetes",
+		slog.String("org", org),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	return k.client.CoreV1().ConfigMaps(ns).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// SeedDefaultTemplates seeds the built-in ReferenceGrant system template into
+// the org namespace if no system templates exist. This is called on first List
+// to avoid a separate migration step.
+func (k *K8sClient) SeedDefaultTemplates(ctx context.Context, org string) error {
+	_, err := k.CreateSystemTemplate(
+		ctx,
+		org,
+		DefaultReferenceGrantName,
+		"ReferenceGrant",
+		"Allows HTTPRoute resources in the gateway namespace to reference Services in the project namespace.",
+		DefaultReferenceGrantTemplate,
+		true,  // mandatory
+		"istio-ingress",
+	)
+	return err
+}
+
+// configMapToSystemTemplate converts a Kubernetes ConfigMap to a SystemTemplate protobuf message.
+func configMapToSystemTemplate(cm *corev1.ConfigMap, org string) *consolev1.SystemTemplate {
+	mandatory, _ := strconv.ParseBool(cm.Annotations[MandatoryAnnotation])
+	gatewayNs := cm.Annotations[GatewayNsAnnotation]
+	if gatewayNs == "" {
+		gatewayNs = DefaultGatewayNamespace
+	}
+	return &consolev1.SystemTemplate{
+		Name:            cm.Name,
+		Org:             org,
+		DisplayName:     cm.Annotations[DisplayNameAnnotation],
+		Description:     cm.Annotations[DescriptionAnnotation],
+		CueTemplate:     cm.Data[CueTemplateKey],
+		Mandatory:       mandatory,
+		GatewayNamespace: gatewayNs,
+	}
+}

--- a/console/system_templates/k8s_test.go
+++ b/console/system_templates/k8s_test.go
@@ -1,0 +1,291 @@
+package system_templates
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/holos-run/holos-console/console/resolver"
+)
+
+func testResolver() *resolver.Resolver {
+	return &resolver.Resolver{OrganizationPrefix: "org-", ProjectPrefix: "prj-"}
+}
+
+func orgNS(org string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "org-" + org,
+			Labels: map[string]string{
+				ManagedByLabel:             ManagedByValue,
+				resolver.ResourceTypeLabel: resolver.ResourceTypeOrganization,
+			},
+		},
+	}
+}
+
+func sysTemplateConfigMap(org, name, displayName, description, cueTemplate string, mandatory bool, gatewayNs string) *corev1.ConfigMap {
+	if gatewayNs == "" {
+		gatewayNs = DefaultGatewayNamespace
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "org-" + org,
+			Labels: map[string]string{
+				ManagedByLabel:    ManagedByValue,
+				ResourceTypeLabel: ResourceTypeValue,
+			},
+			Annotations: map[string]string{
+				DisplayNameAnnotation: displayName,
+				DescriptionAnnotation: description,
+				MandatoryAnnotation:   boolToStr(mandatory),
+				GatewayNsAnnotation:   gatewayNs,
+			},
+		},
+		Data: map[string]string{
+			CueTemplateKey: cueTemplate,
+		},
+	}
+}
+
+func boolToStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func TestListSystemTemplates(t *testing.T) {
+	t.Run("returns empty list when no templates exist", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		cms, err := k8s.ListSystemTemplates(context.Background(), "my-org")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(cms) != 0 {
+			t.Errorf("expected 0 templates, got %d", len(cms))
+		}
+	})
+
+	t.Run("returns templates with correct label", func(t *testing.T) {
+		ns := orgNS("my-org")
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "A test template", "package system_template\n", true, "istio-ingress")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		cms, err := k8s.ListSystemTemplates(context.Background(), "my-org")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(cms) != 1 {
+			t.Fatalf("expected 1 template, got %d", len(cms))
+		}
+		if cms[0].Name != "ref-grant" {
+			t.Errorf("expected name 'ref-grant', got %q", cms[0].Name)
+		}
+	})
+}
+
+func TestGetSystemTemplate(t *testing.T) {
+	t.Run("returns existing template", func(t *testing.T) {
+		ns := orgNS("my-org")
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "A test template", "package system_template\n", true, "istio-ingress")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		result, err := k8s.GetSystemTemplate(context.Background(), "my-org", "ref-grant")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result.Name != "ref-grant" {
+			t.Errorf("expected name 'ref-grant', got %q", result.Name)
+		}
+		if result.Data[CueTemplateKey] != "package system_template\n" {
+			t.Errorf("expected cue template content, got %q", result.Data[CueTemplateKey])
+		}
+	})
+
+	t.Run("returns error for nonexistent template", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		_, err := k8s.GetSystemTemplate(context.Background(), "my-org", "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent template")
+		}
+	})
+}
+
+func TestCreateSystemTemplate(t *testing.T) {
+	t.Run("creates template with mandatory flag and gateway namespace", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		cm, err := k8s.CreateSystemTemplate(context.Background(), "my-org", "ref-grant", "ReferenceGrant", "A test template", "package system_template\n", true, "istio-ingress")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cm.Labels[ManagedByLabel] != ManagedByValue {
+			t.Error("expected managed-by label")
+		}
+		if cm.Labels[ResourceTypeLabel] != ResourceTypeValue {
+			t.Error("expected resource-type label")
+		}
+		if cm.Annotations[DisplayNameAnnotation] != "ReferenceGrant" {
+			t.Errorf("expected display name 'ReferenceGrant', got %q", cm.Annotations[DisplayNameAnnotation])
+		}
+		if cm.Annotations[MandatoryAnnotation] != "true" {
+			t.Errorf("expected mandatory annotation 'true', got %q", cm.Annotations[MandatoryAnnotation])
+		}
+		if cm.Annotations[GatewayNsAnnotation] != "istio-ingress" {
+			t.Errorf("expected gateway-namespace 'istio-ingress', got %q", cm.Annotations[GatewayNsAnnotation])
+		}
+		if cm.Data[CueTemplateKey] != "package system_template\n" {
+			t.Errorf("expected cue template content, got %q", cm.Data[CueTemplateKey])
+		}
+	})
+
+	t.Run("defaults gateway namespace to istio-ingress when empty", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		cm, err := k8s.CreateSystemTemplate(context.Background(), "my-org", "ref-grant", "ReferenceGrant", "A test template", "package system_template\n", false, "")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cm.Annotations[GatewayNsAnnotation] != DefaultGatewayNamespace {
+			t.Errorf("expected default gateway namespace %q, got %q", DefaultGatewayNamespace, cm.Annotations[GatewayNsAnnotation])
+		}
+	})
+
+	t.Run("stores in org namespace not project namespace", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		_, err := k8s.CreateSystemTemplate(context.Background(), "my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", true, "istio-ingress")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		got, err := fakeClient.CoreV1().ConfigMaps("org-my-org").Get(context.Background(), "ref-grant", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected ConfigMap in org namespace, got %v", err)
+		}
+		if got.Namespace != "org-my-org" {
+			t.Errorf("expected namespace 'org-my-org', got %q", got.Namespace)
+		}
+	})
+}
+
+func TestUpdateSystemTemplate(t *testing.T) {
+	t.Run("updates mandatory flag", func(t *testing.T) {
+		ns := orgNS("my-org")
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", false, "istio-ingress")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		mandatory := true
+		updated, err := k8s.UpdateSystemTemplate(context.Background(), "my-org", "ref-grant", nil, nil, nil, &mandatory, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if updated.Annotations[MandatoryAnnotation] != "true" {
+			t.Errorf("expected mandatory annotation 'true', got %q", updated.Annotations[MandatoryAnnotation])
+		}
+	})
+
+	t.Run("updates gateway namespace", func(t *testing.T) {
+		ns := orgNS("my-org")
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", true, "istio-ingress")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		newGatewayNs := "my-gateway"
+		updated, err := k8s.UpdateSystemTemplate(context.Background(), "my-org", "ref-grant", nil, nil, nil, nil, &newGatewayNs)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if updated.Annotations[GatewayNsAnnotation] != "my-gateway" {
+			t.Errorf("expected gateway-namespace 'my-gateway', got %q", updated.Annotations[GatewayNsAnnotation])
+		}
+	})
+
+	t.Run("returns error for nonexistent template", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		newName := "Updated"
+		_, err := k8s.UpdateSystemTemplate(context.Background(), "my-org", "nonexistent", &newName, nil, nil, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for nonexistent template")
+		}
+	})
+}
+
+func TestDeleteSystemTemplate(t *testing.T) {
+	t.Run("deletes existing template", func(t *testing.T) {
+		ns := orgNS("my-org")
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", true, "istio-ingress")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		err := k8s.DeleteSystemTemplate(context.Background(), "my-org", "ref-grant")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		_, err = fakeClient.CoreV1().ConfigMaps("org-my-org").Get(context.Background(), "ref-grant", metav1.GetOptions{})
+		if err == nil {
+			t.Fatal("expected ConfigMap to be deleted")
+		}
+	})
+
+	t.Run("returns error for nonexistent template", func(t *testing.T) {
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		err := k8s.DeleteSystemTemplate(context.Background(), "my-org", "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent template")
+		}
+	})
+}
+
+func TestConfigMapToSystemTemplate(t *testing.T) {
+	t.Run("reads mandatory flag correctly", func(t *testing.T) {
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", true, "istio-ingress")
+		tmpl := configMapToSystemTemplate(cm, "my-org")
+		if !tmpl.Mandatory {
+			t.Error("expected mandatory=true")
+		}
+		if tmpl.GatewayNamespace != "istio-ingress" {
+			t.Errorf("expected gateway_namespace 'istio-ingress', got %q", tmpl.GatewayNamespace)
+		}
+		if tmpl.Org != "my-org" {
+			t.Errorf("expected org 'my-org', got %q", tmpl.Org)
+		}
+	})
+
+	t.Run("defaults gateway namespace when annotation is empty", func(t *testing.T) {
+		cm := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", "package system_template\n", false, "")
+		// Explicitly remove the annotation to simulate missing annotation.
+		delete(cm.Annotations, GatewayNsAnnotation)
+		tmpl := configMapToSystemTemplate(cm, "my-org")
+		if tmpl.GatewayNamespace != DefaultGatewayNamespace {
+			t.Errorf("expected default gateway namespace %q, got %q", DefaultGatewayNamespace, tmpl.GatewayNamespace)
+		}
+	})
+}

--- a/console/system_templates/render_adapter.go
+++ b/console/system_templates/render_adapter.go
@@ -1,0 +1,48 @@
+package system_templates
+
+import (
+	"context"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/holos-run/holos-console/console/deployments"
+)
+
+// CueRendererAdapter wraps deployments.CueRenderer to satisfy system_templates.Renderer.
+type CueRendererAdapter struct {
+	inner *deployments.CueRenderer
+}
+
+// NewCueRendererAdapter creates a Renderer backed by deployments.CueRenderer.
+func NewCueRendererAdapter() *CueRendererAdapter {
+	return &CueRendererAdapter{inner: &deployments.CueRenderer{}}
+}
+
+// Render evaluates cueTemplate unified with cueSystemInput and cueInput and
+// returns the rendered Kubernetes resource manifests. cueSystemInput carries
+// trusted backend values (org, namespace, claims); cueInput carries
+// user-provided or system-configured template parameters. Both must be valid
+// CUE source; cueSystemInput may be empty when not needed during preview.
+func (a *CueRendererAdapter) Render(ctx context.Context, cueTemplate string, cueSystemInput string, cueInput string) ([]RenderResource, error) {
+	// Combine cueSystemInput and cueInput into a single CUE document so that
+	// both "system" and "input" top-level fields are available to the template.
+	combined := cueSystemInput
+	if combined != "" && cueInput != "" {
+		combined = combined + "\n" + cueInput
+	} else if cueInput != "" {
+		combined = cueInput
+	}
+	resources, err := a.inner.RenderWithCueInput(ctx, cueTemplate, combined)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RenderResource, len(resources))
+	for i, u := range resources {
+		b, err := yaml.Marshal(u.Object)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = RenderResource{YAML: string(b), Object: u.Object}
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- Add `console/system_templates/` package with `SystemTemplateService` handler, K8s ConfigMap storage in org namespace, built-in ReferenceGrant CUE template, and CueRendererAdapter
- Add `PermissionSystemDeploymentsEdit` constant and `OrgCascadeSystemTemplatePerms` cascade table to `console/rbac/rbac.go`
- Add `ReferenceGrant` to `allowedKindSet` and `allowedKinds` GVR map in `console/deployments/render.go` and `apply.go`
- Register `SystemTemplateService` in `console/console.go` with org-level RBAC and gRPC reflection
- Table-driven unit tests for CRUD, RBAC cascade, seeding, and CUE render

Closes: #470

## Test plan
- [x] `make test` passes (all Go packages and UI unit tests)
- [x] `TestApplier_Cleanup` updated to include ReferenceGrant in fake scheme
- [x] `TestOrgCascadeSystemTemplatePerms` covers OWNER/EDITOR/VIEWER cascade paths
- [x] `TestRenderSystemTemplateHandler/renders_default_ReferenceGrant_template` renders the embedded CUE template end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1