### PR TITLE
feat(backend): trigger mandatory system template apply on project creation

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -245,8 +245,26 @@ func (s *Server) Serve(ctx context.Context) error {
 		orgsPath, orgsHTTPHandler := consolev1connect.NewOrganizationServiceHandler(orgsHandler, protectedInterceptors)
 		mux.Handle(orgsPath, orgsHTTPHandler)
 
+		// Create dynamic client early so it can be shared by both the deployment
+		// service and the mandatory template applier.
+		dynamicClient, err := deployments.NewDynamicClient()
+		if err != nil {
+			return fmt.Errorf("failed to create dynamic kubernetes client: %w", err)
+		}
+
+		// System template applier for mandatory templates on project creation.
+		// Wired before the projects handler so it can be injected.
+		sysTemplatesApplierK8s := system_templates.NewK8sClient(k8sClientset, nsResolver)
+		var sysTmplApplier projects.MandatoryTemplateApplier
+		if dynamicClient != nil {
+			sysTmplApplier = system_templates.NewMandatoryTemplateApplier(sysTemplatesApplierK8s, &deployments.CueRenderer{}, deployments.NewApplier(dynamicClient))
+		}
+
 		// Project service with org grant fallback
 		projectsHandler := projects.NewHandler(projectsK8s, orgGrantResolver)
+		if sysTmplApplier != nil {
+			projectsHandler = projectsHandler.WithMandatoryTemplateApplier(sysTmplApplier)
+		}
 		projectsPath, projectsHTTPHandler := consolev1connect.NewProjectServiceHandler(projectsHandler, protectedInterceptors)
 		mux.Handle(projectsPath, projectsHTTPHandler)
 
@@ -277,10 +295,6 @@ func (s *Server) Serve(ctx context.Context) error {
 
 		// Deployment service with project grant fallback
 		deploymentsK8s := deployments.NewK8sClient(k8sClientset, nsResolver)
-		dynamicClient, err := deployments.NewDynamicClient()
-		if err != nil {
-			return fmt.Errorf("failed to create dynamic kubernetes client: %w", err)
-		}
 		var deploymentsApplier deployments.ResourceApplier
 		if dynamicClient != nil {
 			deploymentsApplier = deployments.NewApplier(dynamicClient)

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -34,16 +34,30 @@ type OrgDefaultShareResolver interface {
 	GetOrgDefaultGrants(ctx context.Context, org string) (defaultUsers, defaultRoles []secrets.AnnotationGrant, err error)
 }
 
+// MandatoryTemplateApplier renders and applies all mandatory system templates
+// into a newly created project namespace.
+type MandatoryTemplateApplier interface {
+	ApplyMandatorySystemTemplates(ctx context.Context, org, project, projectNamespace string, claims *rpc.Claims) error
+}
+
 // Handler implements the ProjectService.
 type Handler struct {
 	consolev1connect.UnimplementedProjectServiceHandler
-	k8s         *K8sClient
-	orgResolver OrgResolver
+	k8s                       *K8sClient
+	orgResolver               OrgResolver
+	mandatoryTemplateApplier  MandatoryTemplateApplier
 }
 
 // NewHandler creates a new ProjectService handler.
 func NewHandler(k8s *K8sClient, orgResolver OrgResolver) *Handler {
 	return &Handler{k8s: k8s, orgResolver: orgResolver}
+}
+
+// WithMandatoryTemplateApplier sets the MandatoryTemplateApplier for the handler.
+// When set, mandatory system templates are applied to new project namespaces at creation time.
+func (h *Handler) WithMandatoryTemplateApplier(applier MandatoryTemplateApplier) *Handler {
+	h.mandatoryTemplateApplier = applier
+	return h
 }
 
 // ListProjects returns all projects the user has access to.
@@ -218,6 +232,27 @@ func (h *Handler) CreateProject(
 	_, err = h.k8s.CreateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, req.Msg.Organization, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	if err != nil {
 		return nil, mapK8sError(err)
+	}
+
+	// Apply mandatory system templates into the new project namespace.
+	// On failure, attempt a best-effort cleanup of the project namespace to
+	// avoid leaving orphaned resources, then return the error.
+	if h.mandatoryTemplateApplier != nil && req.Msg.Organization != "" {
+		projectNamespace := h.k8s.Resolver.ProjectNamespace(req.Msg.Name)
+		if err := h.mandatoryTemplateApplier.ApplyMandatorySystemTemplates(ctx, req.Msg.Organization, req.Msg.Name, projectNamespace, claims); err != nil {
+			slog.ErrorContext(ctx, "mandatory system template apply failed, cleaning up project",
+				slog.String("project", req.Msg.Name),
+				slog.String("organization", req.Msg.Organization),
+				slog.Any("error", err),
+			)
+			if cleanupErr := h.k8s.DeleteProject(ctx, req.Msg.Name); cleanupErr != nil {
+				slog.WarnContext(ctx, "failed to clean up project after mandatory template apply failure",
+					slog.String("project", req.Msg.Name),
+					slog.Any("cleanup_error", cleanupErr),
+				)
+			}
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("applying mandatory system templates to project %q: %w", req.Msg.Name, err))
+		}
 	}
 
 	slog.InfoContext(ctx, "project created",

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -1181,5 +1182,98 @@ func assertInvalidArgument(t *testing.T, err error) {
 	}
 	if connectErr.Code() != connect.CodeInvalidArgument {
 		t.Errorf("expected CodeInvalidArgument, got %v", connectErr.Code())
+	}
+}
+
+// ---- CreateProject with mandatory system templates tests ----
+
+// stubMandatoryTemplateApplier implements MandatoryTemplateApplier for tests.
+type stubMandatoryTemplateApplier struct {
+	called  bool
+	org     string
+	project string
+	err     error
+}
+
+func (s *stubMandatoryTemplateApplier) ApplyMandatorySystemTemplates(_ context.Context, org, project, _ string, _ *rpc.Claims) error {
+	s.called = true
+	s.org = org
+	s.project = project
+	return s.err
+}
+
+func TestCreateProject_CallsMandatoryTemplateApplierOnSuccess(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler, _ := newHandler(existing)
+
+	applier := &stubMandatoryTemplateApplier{}
+	handler = handler.WithMandatoryTemplateApplier(applier)
+
+	ctx := contextWithClaims("alice@example.com")
+	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-project",
+		Organization: "my-org",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "new-project" {
+		t.Errorf("expected name 'new-project', got %q", resp.Msg.Name)
+	}
+	if !applier.called {
+		t.Error("expected mandatory template applier to be called")
+	}
+	if applier.org != "my-org" {
+		t.Errorf("expected org 'my-org', got %q", applier.org)
+	}
+	if applier.project != "new-project" {
+		t.Errorf("expected project 'new-project', got %q", applier.project)
+	}
+}
+
+func TestCreateProject_NotCalledWhenNoOrgSpecified(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler, _ := newHandler(existing)
+
+	applier := &stubMandatoryTemplateApplier{}
+	handler = handler.WithMandatoryTemplateApplier(applier)
+
+	ctx := contextWithClaims("alice@example.com")
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-project",
+		Organization: "", // no org
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if applier.called {
+		t.Error("expected mandatory template applier NOT to be called when org is empty")
+	}
+}
+
+func TestCreateProject_CleansUpNamespaceOnApplierFailure(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, nil)
+
+	applier := &stubMandatoryTemplateApplier{
+		err: fmt.Errorf("render failed"),
+	}
+	handler = handler.WithMandatoryTemplateApplier(applier)
+
+	ctx := contextWithClaims("alice@example.com")
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-project",
+		Organization: "my-org",
+	}))
+	if err == nil {
+		t.Fatal("expected error when mandatory template applier fails")
+	}
+
+	// Verify project namespace was cleaned up (deleted).
+	_, getErr := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-prj-new-project", metav1.GetOptions{})
+	if getErr == nil {
+		t.Error("expected project namespace to be deleted after applier failure")
 	}
 }

--- a/console/system_templates/apply.go
+++ b/console/system_templates/apply.go
@@ -1,0 +1,132 @@
+package system_templates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/rpc"
+)
+
+// ResourceApplier applies K8s resources to a namespace.
+type ResourceApplier interface {
+	Apply(ctx context.Context, namespace, deploymentName string, resources []unstructured.Unstructured) error
+}
+
+// MandatoryTemplateApplier renders and applies all mandatory system templates
+// for an org into a project namespace.
+type MandatoryTemplateApplier struct {
+	k8s      *K8sClient
+	renderer *deployments.CueRenderer
+	applier  ResourceApplier
+}
+
+// NewMandatoryTemplateApplier creates a MandatoryTemplateApplier.
+func NewMandatoryTemplateApplier(k8s *K8sClient, renderer *deployments.CueRenderer, applier ResourceApplier) *MandatoryTemplateApplier {
+	return &MandatoryTemplateApplier{k8s: k8s, renderer: renderer, applier: applier}
+}
+
+// ApplyMandatorySystemTemplates lists all mandatory system templates for the
+// org, renders each one using SystemInput derived from the project and caller
+// claims, and applies the rendered resources to the project namespace.
+//
+// If any template render or apply fails, an error is returned describing which
+// template failed. The caller (CreateProject) is responsible for cleanup.
+func (a *MandatoryTemplateApplier) ApplyMandatorySystemTemplates(ctx context.Context, org, project, projectNamespace string, claims *rpc.Claims) error {
+	templates, err := a.k8s.ListSystemTemplates(ctx, org)
+	if err != nil {
+		return fmt.Errorf("listing system templates for org %q: %w", org, err)
+	}
+
+	for _, cm := range templates {
+		// Only apply mandatory templates.
+		tmpl := configMapToSystemTemplate(&cm, org)
+		if !tmpl.Mandatory {
+			continue
+		}
+
+		slog.InfoContext(ctx, "applying mandatory system template",
+			slog.String("org", org),
+			slog.String("project", project),
+			slog.String("namespace", projectNamespace),
+			slog.String("template", tmpl.Name),
+		)
+
+		// Build SystemInput for the render.
+		systemInput := deployments.SystemInput{
+			Project:   project,
+			Namespace: projectNamespace,
+		}
+		if claims != nil {
+			systemInput.Claims = deployments.ClaimsInput{
+				Iss:           claims.Iss,
+				Sub:           claims.Sub,
+				Exp:           claims.Exp,
+				Iat:           claims.Iat,
+				Email:         claims.Email,
+				EmailVerified: claims.EmailVerified,
+				Name:          claims.Name,
+				Groups:        claims.Roles,
+			}
+		}
+
+		// Build UserInput with gateway_namespace from the template.
+		userInput := systemTemplateUserInput{
+			GatewayNamespace: tmpl.GatewayNamespace,
+		}
+		if userInput.GatewayNamespace == "" {
+			userInput.GatewayNamespace = DefaultGatewayNamespace
+		}
+
+		// Encode both inputs as a combined CUE value.
+		systemJSON, err := json.Marshal(systemInput)
+		if err != nil {
+			return fmt.Errorf("encoding system input for template %q: %w", tmpl.Name, err)
+		}
+		userJSON, err := json.Marshal(userInput)
+		if err != nil {
+			return fmt.Errorf("encoding user input for template %q: %w", tmpl.Name, err)
+		}
+
+		// Combine as CUE source: system: {...}, input: {...}
+		combinedCUE := fmt.Sprintf("system: %s\ninput: %s", string(systemJSON), string(userJSON))
+
+		resources, err := a.renderer.RenderWithCueInput(ctx, tmpl.CueTemplate, combinedCUE)
+		if err != nil {
+			return fmt.Errorf("rendering mandatory system template %q for project %q: %w", tmpl.Name, project, err)
+		}
+
+		if a.applier == nil {
+			slog.WarnContext(ctx, "no resource applier configured, skipping mandatory system template apply",
+				slog.String("template", tmpl.Name),
+				slog.String("project", project),
+			)
+			continue
+		}
+
+		// Use the template name as the "deployment name" for the ownership label.
+		if err := a.applier.Apply(ctx, projectNamespace, tmpl.Name, resources); err != nil {
+			return fmt.Errorf("applying mandatory system template %q to project %q: %w", tmpl.Name, project, err)
+		}
+
+		slog.InfoContext(ctx, "mandatory system template applied",
+			slog.String("org", org),
+			slog.String("project", project),
+			slog.String("namespace", projectNamespace),
+			slog.String("template", tmpl.Name),
+			slog.Int("resources", len(resources)),
+		)
+	}
+
+	return nil
+}
+
+// systemTemplateUserInput carries the user-configurable input for system templates.
+// The field name must match the CUE #Input struct field name in the template.
+type systemTemplateUserInput struct {
+	GatewayNamespace string `json:"gatewayNamespace"`
+}

--- a/console/system_templates/apply_test.go
+++ b/console/system_templates/apply_test.go
@@ -1,0 +1,142 @@
+package system_templates
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/rpc"
+)
+
+// stubResourceApplier implements ResourceApplier for tests.
+type stubResourceApplier struct {
+	calls []applyCall
+	err   error
+}
+
+type applyCall struct {
+	namespace      string
+	deploymentName string
+	resourceCount  int
+}
+
+func (s *stubResourceApplier) Apply(_ context.Context, namespace, deploymentName string, resources []unstructured.Unstructured) error {
+	s.calls = append(s.calls, applyCall{
+		namespace:      namespace,
+		deploymentName: deploymentName,
+		resourceCount:  len(resources),
+	})
+	return s.err
+}
+
+func TestApplyMandatorySystemTemplates_AppliesMandatoryTemplates(t *testing.T) {
+	ns := orgNS("my-org")
+	cm := sysTemplateConfigMap("my-org", DefaultReferenceGrantName, "ReferenceGrant", "desc", DefaultReferenceGrantTemplate, true, "istio-ingress")
+	fakeClient := fake.NewClientset(ns, cm)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	applier := &stubResourceApplier{}
+	mta := NewMandatoryTemplateApplier(k8s, &deployments.CueRenderer{}, applier)
+
+	claims := &rpc.Claims{
+		Sub:   "user-123",
+		Email: "owner@example.com",
+		Iss:   "https://example.com",
+		Exp:   9999999999,
+		Iat:   1000000000,
+		EmailVerified: true,
+	}
+
+	err := mta.ApplyMandatorySystemTemplates(context.Background(), "my-org", "my-project", "prj-my-project", claims)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(applier.calls) != 1 {
+		t.Fatalf("expected 1 apply call, got %d", len(applier.calls))
+	}
+	if applier.calls[0].namespace != "prj-my-project" {
+		t.Errorf("expected namespace 'prj-my-project', got %q", applier.calls[0].namespace)
+	}
+	if applier.calls[0].deploymentName != DefaultReferenceGrantName {
+		t.Errorf("expected deployment name %q, got %q", DefaultReferenceGrantName, applier.calls[0].deploymentName)
+	}
+	if applier.calls[0].resourceCount < 1 {
+		t.Errorf("expected at least 1 resource applied, got %d", applier.calls[0].resourceCount)
+	}
+}
+
+func TestApplyMandatorySystemTemplates_SkipsNonMandatoryTemplates(t *testing.T) {
+	ns := orgNS("my-org")
+	// mandatory=false — should not be applied.
+	cm := sysTemplateConfigMap("my-org", "optional-template", "Optional", "desc", DefaultReferenceGrantTemplate, false, "istio-ingress")
+	fakeClient := fake.NewClientset(ns, cm)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	applier := &stubResourceApplier{}
+	mta := NewMandatoryTemplateApplier(k8s, &deployments.CueRenderer{}, applier)
+
+	claims := &rpc.Claims{Sub: "user-123", Email: "owner@example.com"}
+
+	err := mta.ApplyMandatorySystemTemplates(context.Background(), "my-org", "my-project", "prj-my-project", claims)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(applier.calls) != 0 {
+		t.Errorf("expected 0 apply calls for non-mandatory template, got %d", len(applier.calls))
+	}
+}
+
+func TestApplyMandatorySystemTemplates_NoTemplates(t *testing.T) {
+	ns := orgNS("my-org")
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	applier := &stubResourceApplier{}
+	mta := NewMandatoryTemplateApplier(k8s, &deployments.CueRenderer{}, applier)
+
+	claims := &rpc.Claims{Sub: "user-123", Email: "owner@example.com"}
+
+	err := mta.ApplyMandatorySystemTemplates(context.Background(), "my-org", "my-project", "prj-my-project", claims)
+	if err != nil {
+		t.Fatalf("expected no error when no templates exist, got %v", err)
+	}
+
+	if len(applier.calls) != 0 {
+		t.Errorf("expected 0 apply calls, got %d", len(applier.calls))
+	}
+}
+
+func TestApplyMandatorySystemTemplates_ApplierErrorPropagates(t *testing.T) {
+	ns := orgNS("my-org")
+	cm := sysTemplateConfigMap("my-org", DefaultReferenceGrantName, "ReferenceGrant", "desc", DefaultReferenceGrantTemplate, true, "istio-ingress")
+	fakeClient := fake.NewClientset(ns, cm)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	applier := &stubResourceApplier{err: fmt.Errorf("apply failed")}
+	mta := NewMandatoryTemplateApplier(k8s, &deployments.CueRenderer{}, applier)
+
+	claims := &rpc.Claims{Sub: "user-123", Email: "owner@example.com"}
+
+	err := mta.ApplyMandatorySystemTemplates(context.Background(), "my-org", "my-project", "prj-my-project", claims)
+	if err == nil {
+		t.Fatal("expected error when applier fails, got nil")
+	}
+}
+
+func TestApplyMandatorySystemTemplates_NilApplierSkips(t *testing.T) {
+	ns := orgNS("my-org")
+	cm := sysTemplateConfigMap("my-org", DefaultReferenceGrantName, "ReferenceGrant", "desc", DefaultReferenceGrantTemplate, true, "istio-ingress")
+	fakeClient := fake.NewClientset(ns, cm)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	// nil applier — should log a warning and skip without error.
+	mta := NewMandatoryTemplateApplier(k8s, &deployments.CueRenderer{}, nil)
+
+	claims := &rpc.Claims{Sub: "user-123", Email: "owner@example.com"}
+
+	err := mta.ApplyMandatorySystemTemplates(context.Background(), "my-org", "my-project", "prj-my-project", claims)
+	if err != nil {
+		t.Fatalf("expected no error with nil applier (should skip), got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `MandatoryTemplateApplier` interface and `WithMandatoryTemplateApplier()` method to `console/projects/handler.go`; `CreateProject` calls it after namespace creation, cleaning up on failure
- Add `console/system_templates/apply.go` with `MandatoryTemplateApplier` concrete implementation backed by K8s list + CUE render + dynamic apply
- Wire dynamic client creation earlier in `console.go` so it can be shared by both deployment service and mandatory template applier
- Table-driven unit tests for happy path, no-org skip, cleanup-on-failure, non-mandatory skip, nil applier

Closes: #471

## Test plan
- [x] `make test` passes (all Go packages and UI unit tests)
- [x] `TestCreateProject_CallsMandatoryTemplateApplierOnSuccess` — applier called with correct org/project
- [x] `TestCreateProject_CleansUpNamespaceOnApplierFailure` — namespace deleted when applier errors
- [x] `TestApplyMandatorySystemTemplates_AppliesMandatoryTemplates` — real CUE render + stub apply

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1