### PR TITLE
docs: update AGENTS.md and docs after system templates implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ This is a Go HTTPS server that serves a web console UI and exposes ConnectRPC se
   - `secrets/` - SecretsService with K8s backend and annotation-based RBAC
   - `settings/` - ProjectSettingsService managing per-project feature flags (e.g. deployments toggle) stored as annotations on the project Namespace; deployments toggle requires org-level OWNER via `PERMISSION_PROJECT_DEPLOYMENTS_ENABLE`
   - `templates/` - DeploymentTemplateService managing CUE-based deployment templates stored as K8s ConfigMaps; embeds `default_template.cue`. Templates use the structured `namespaced`/`cluster` output format (see `docs/cue-template-guide.md`). Templates can carry `DeploymentDefaults` (image, tag, command, args, env, port) that pre-fill the Create Deployment form. The `RenderDeploymentTemplate` RPC returns rendered resources as both YAML (`rendered_yaml`) and JSON (`rendered_json`). The default template adds a `console.holos.run/deployer-email` annotation to all resources from `system.claims.email`.
+  - `system_templates/` - SystemTemplateService managing org-scoped CUE templates stored as K8s ConfigMaps in the org namespace. System templates differ from deployment templates in that they can be marked mandatory, causing them to be automatically applied to every project namespace at creation time. Includes `MandatoryTemplateApplier` which is called by the projects service after a project namespace is created. Embeds `default_referencegrant.cue` as the built-in mandatory template that creates a `ReferenceGrant` allowing HTTPRoute resources in project namespaces to reference the gateway. Edit access requires `PERMISSION_SYSTEM_DEPLOYMENTS_EDIT` (org-level OWNER only via `OrgCascadeSystemTemplatePerms`).
   - `deployments/` - DeploymentService managing Kubernetes Deployments: CRUD, status polling, log streaming, CUE render and apply (structured `namespaced`/`cluster` output), container command/args override, container env vars (literal values, SecretKeyRef, ConfigMapKeyRef), container port configuration, and listing project-namespace Secrets/ConfigMaps for env var references. CUE render uses split `SystemInput` (project, namespace, claims) and `UserInput` (name, image, tag, etc.) — see `docs/cue-template-guide.md`.
   - `dist/` - Embedded static files served at `/` (build output from frontend, not source)
 - `proto/` - Protobuf source files
@@ -158,6 +159,7 @@ This is a Go HTTPS server that serves a web console UI and exposes ConnectRPC se
   - `holos/console/v1/project_settings.proto` - ProjectSettingsService
   - `holos/console/v1/deployment_templates.proto` - DeploymentTemplateService
   - `holos/console/v1/deployments.proto` - DeploymentService
+  - `holos/console/v1/system_templates.proto` - SystemTemplateService
   - `holos/console/v1/rbac.proto` - Role definitions (VIEWER, EDITOR, OWNER)
   - `holos/console/v1/version.proto` - VersionService
 - `gen/` - Generated protobuf Go code (do not edit)
@@ -236,6 +238,8 @@ Organization creation is controlled by `--disable-org-creation`, `--org-creator-
 The `--roles-claim` flag (default `"groups"`) configures which OIDC token claim is used to extract role memberships. This allows integration with identity providers that use non-standard claim names (e.g., `realm_roles`).
 
 Roles: VIEWER (1), EDITOR (2), OWNER (3) defined in `proto/holos/console/v1/rbac.proto`
+
+`PERMISSION_SYSTEM_DEPLOYMENTS_EDIT` is required to create, update, or delete system templates. It is granted only to org-level OWNERs via the `OrgCascadeSystemTemplatePerms` cascade table in `console/rbac/rbac.go`.
 
 ### Code Generation
 

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -547,16 +547,17 @@ Cluster resources additionally require:
 
 Templates may only produce namespaced resources of these kinds:
 
-| Kind             | API Group                     |
-|------------------|-------------------------------|
-| `Deployment`     | `apps/v1`                     |
-| `Service`        | `v1`                          |
-| `ServiceAccount` | `v1`                          |
-| `Role`           | `rbac.authorization.k8s.io/v1`|
-| `RoleBinding`    | `rbac.authorization.k8s.io/v1`|
-| `HTTPRoute`      | `gateway.networking.k8s.io/v1`|
-| `ConfigMap`      | `v1`                          |
-| `Secret`         | `v1`                          |
+| Kind             | API Group                          |
+|------------------|------------------------------------|
+| `Deployment`     | `apps/v1`                          |
+| `Service`        | `v1`                               |
+| `ServiceAccount` | `v1`                               |
+| `Role`           | `rbac.authorization.k8s.io/v1`     |
+| `RoleBinding`    | `rbac.authorization.k8s.io/v1`     |
+| `HTTPRoute`      | `gateway.networking.k8s.io/v1`     |
+| `ReferenceGrant` | `gateway.networking.k8s.io/v1beta1`|
+| `ConfigMap`      | `v1`                               |
+| `Secret`         | `v1`                               |
 
 The cluster allowlist is initially empty. Cluster-scoped kind support will be
 added incrementally.
@@ -593,6 +594,7 @@ codebase. Use it for advanced troubleshooting or when developing new features.
 |------|---------|
 | `console/templates/default_template.cue` | Default CUE template with `#Input`, `#Claims`, and `#System` schema definitions, env var transformation, `_annotations` helper (stamps `system.claims.email`), `#Namespaced`/`#Cluster` constraints, and resource definitions. Embedded into the Go binary via `console/templates/embed.go`. |
 | `console/templates/embed.go` | `//go:embed` directive that loads `default_template.cue` as the fallback template. |
+| `console/system_templates/default_referencegrant.cue` | Built-in mandatory system template that produces a `ReferenceGrant` allowing HTTPRoute resources in project namespaces to reference the org's gateway. Embedded via `console/system_templates/embed.go` and seeded into the org namespace ConfigMap on first `ListSystemTemplates` access. |
 
 ### Go Rendering Pipeline
 
@@ -615,6 +617,14 @@ Two render paths exist — one for the deployment service and one for the templa
 | `console/templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `deployment-template` resource-type label. |
 | `console/templates/render_adapter.go` | `CueRendererAdapter` — wraps `deployments.CueRenderer` to produce YAML and structured object data for the template preview RPC. |
 
+### System Template Service
+
+| File | Purpose |
+|------|---------|
+| `console/system_templates/handler.go` | `SystemTemplateService` handler — CRUD and render for org-scoped system templates stored as ConfigMaps. Edit access requires `PERMISSION_SYSTEM_DEPLOYMENTS_EDIT`. |
+| `console/system_templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `system-template` resource-type label, `mandatory` and `gateway-namespace` annotations. Seeds `default_referencegrant.cue` on first `ListSystemTemplates`. |
+| `console/system_templates/apply.go` | `MandatoryTemplateApplier.ApplyMandatorySystemTemplates()` — called by the projects service after project namespace creation to apply all mandatory system templates into the new project namespace. |
+
 ### Deployment Service
 
 | File | Purpose |
@@ -629,6 +639,7 @@ Two render paths exist — one for the deployment service and one for the templa
 |------|---------|
 | `proto/holos/console/v1/deployments.proto` | `Deployment`, `EnvVar`, `SecretKeyRef`, `ConfigMapKeyRef` messages; `DeploymentService` RPCs. |
 | `proto/holos/console/v1/deployment_templates.proto` | `DeploymentTemplate` message; `DeploymentTemplateService` RPCs including `RenderDeploymentTemplate`. |
+| `proto/holos/console/v1/system_templates.proto` | `SystemTemplate` message; `SystemTemplateService` RPCs including `RenderSystemTemplate`. |
 
 ### Generated Code
 

--- a/docs/permissions-guide.md
+++ b/docs/permissions-guide.md
@@ -34,6 +34,18 @@ var OrgCascadeProjectSettingsPerms = rbac.CascadeTable{
 }
 ```
 
+A second cascade table controls system template write access:
+
+```go
+var OrgCascadeSystemTemplatePerms = rbac.CascadeTable{
+    rbac.RoleOwner: {
+        rbac.PermissionSystemDeploymentsEdit: true,
+    },
+}
+```
+
+`PermissionSystemDeploymentsEdit` (`PERMISSION_SYSTEM_DEPLOYMENTS_EDIT`) grants the ability to create, update, and delete org-scoped system templates. It is intentionally restricted to org-level OWNERs because system templates are applied automatically to every new project namespace — a misconfigured template can affect all projects in the org. Narrowing the grant to OWNERs prevents editors from inadvertently breaking project creation.
+
 To check access: resolve the user's best role from grants at the parent scope, then look up permissions in the cascade table.
 
 ```go


### PR DESCRIPTION
## Summary

- Added `console/system_templates/` package description to AGENTS.md Architecture section
- Added `holos/console/v1/system_templates.proto` to the proto files list in AGENTS.md
- Added `PERMISSION_SYSTEM_DEPLOYMENTS_EDIT` description to the RBAC section of AGENTS.md
- Added `ReferenceGrant` (`gateway.networking.k8s.io/v1beta1`) to the allowed kinds table in `docs/cue-template-guide.md`
- Added System Template Service section to the Source Code Reference appendix in `docs/cue-template-guide.md`
- Added `OrgCascadeSystemTemplatePerms` cascade table entry with rationale to `docs/permissions-guide.md`

Closes: #473

## Test plan

- [x] `make test-go` passes (all packages green, no code changes)
- [x] No frontend changes — no screenshots required

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1