### PR TITLE
feat(templates): implement clone RPCs for system and deployment templates

### DIFF
--- a/console/system_templates/handler_test.go
+++ b/console/system_templates/handler_test.go
@@ -508,6 +508,30 @@ func TestCloneSystemTemplateHandler(t *testing.T) {
 			t.Errorf("expected CodeNotFound, got %v", err)
 		}
 	})
+
+	t.Run("returns error when target name already exists", func(t *testing.T) {
+		email := "owner@example.com"
+		source := sysTemplateConfigMap("my-org", "ref-grant", "ReferenceGrant", "desc", validCue, true, false)
+		target := sysTemplateConfigMap("my-org", "ref-grant-copy", "ReferenceGrant Copy", "desc", validCue, false, false)
+		ns := orgNS("my-org")
+		fakeClient := fake.NewClientset(ns, source, target)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		h := NewHandler(k8s, ownerGrants(email), &stubRenderer{})
+
+		ctx := authedCtx(email, nil)
+		_, err := h.CloneSystemTemplate(ctx, connect.NewRequest(&consolev1.CloneSystemTemplateRequest{
+			SourceName:  "ref-grant",
+			Org:         "my-org",
+			Name:        "ref-grant-copy",
+			DisplayName: "ReferenceGrant Copy",
+		}))
+		if err == nil {
+			t.Fatal("expected error when target name already exists")
+		}
+		if connect.CodeOf(err) != connect.CodeAlreadyExists {
+			t.Errorf("expected CodeAlreadyExists, got %v", err)
+		}
+	})
 }
 
 func TestSeedDefaultTemplates(t *testing.T) {

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -560,6 +560,177 @@ func TestHandler_DeleteDeploymentTemplate(t *testing.T) {
 	})
 }
 
+func TestHandler_CloneDeploymentTemplate(t *testing.T) {
+	t.Run("editor can clone template", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "A web app", validCue)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		req := connect.NewRequest(&consolev1.CloneDeploymentTemplateRequest{
+			Project:     "my-project",
+			SourceName:  "web-app",
+			Name:        "web-app-copy",
+			DisplayName: "Web App Copy",
+		})
+		resp, err := handler.CloneDeploymentTemplate(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Name != "web-app-copy" {
+			t.Errorf("expected name 'web-app-copy', got %q", resp.Msg.Name)
+		}
+	})
+
+	t.Run("clone inherits CUE template and description from source", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "original description", validCue)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		req := connect.NewRequest(&consolev1.CloneDeploymentTemplateRequest{
+			Project:     "my-project",
+			SourceName:  "web-app",
+			Name:        "web-app-copy",
+			DisplayName: "Web App Copy",
+		})
+		_, err := handler.CloneDeploymentTemplate(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		clonedCM, err := fakeClient.CoreV1().ConfigMaps("prj-my-project").Get(context.Background(), "web-app-copy", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected cloned ConfigMap, got %v", err)
+		}
+		if clonedCM.Data[CueTemplateKey] != validCue {
+			t.Errorf("expected CUE template from source, got %q", clonedCM.Data[CueTemplateKey])
+		}
+		if clonedCM.Annotations[DescriptionAnnotation] != "original description" {
+			t.Errorf("expected description from source, got %q", clonedCM.Annotations[DescriptionAnnotation])
+		}
+		if clonedCM.Annotations[DisplayNameAnnotation] != "Web App Copy" {
+			t.Errorf("expected display name 'Web App Copy', got %q", clonedCM.Annotations[DisplayNameAnnotation])
+		}
+	})
+
+	t.Run("returns error when source does not exist", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		req := connect.NewRequest(&consolev1.CloneDeploymentTemplateRequest{
+			Project:     "my-project",
+			SourceName:  "nonexistent",
+			Name:        "copy",
+			DisplayName: "Copy",
+		})
+		_, err := handler.CloneDeploymentTemplate(ctx, req)
+		if err == nil {
+			t.Fatal("expected error when source does not exist")
+		}
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Errorf("expected CodeNotFound, got %v", err)
+		}
+	})
+
+	t.Run("returns error when target name already exists", func(t *testing.T) {
+		ns := projectNS("my-project")
+		source := templateConfigMap("my-project", "web-app", "Web App", "desc", validCue)
+		target := templateConfigMap("my-project", "web-app-copy", "Web App Copy", "desc", validCue)
+		fakeClient := fake.NewClientset(ns, source, target)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		req := connect.NewRequest(&consolev1.CloneDeploymentTemplateRequest{
+			Project:     "my-project",
+			SourceName:  "web-app",
+			Name:        "web-app-copy",
+			DisplayName: "Web App Copy",
+		})
+		_, err := handler.CloneDeploymentTemplate(ctx, req)
+		if err == nil {
+			t.Fatal("expected error when target name already exists")
+		}
+		if connect.CodeOf(err) != connect.CodeAlreadyExists {
+			t.Errorf("expected CodeAlreadyExists, got %v", err)
+		}
+	})
+
+	t.Run("viewer cannot clone template", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "desc", validCue)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"viewer@example.com": "viewer"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("viewer@example.com", nil)
+		req := connect.NewRequest(&consolev1.CloneDeploymentTemplateRequest{
+			Project:     "my-project",
+			SourceName:  "web-app",
+			Name:        "web-app-copy",
+			DisplayName: "Web App Copy",
+		})
+		_, err := handler.CloneDeploymentTemplate(ctx, req)
+		if err == nil {
+			t.Fatal("expected permission denied error for viewer")
+		}
+		if connect.CodeOf(err) != connect.CodePermissionDenied {
+			t.Errorf("expected CodePermissionDenied, got %v", err)
+		}
+	})
+
+	t.Run("clone inherits defaults from source", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := templateConfigMap("my-project", "web-app", "Web App", "desc", validCue)
+		cm.Data[DefaultsKey] = `{"image":"ghcr.io/example/app","tag":"v1.0"}`
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"editor@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, nil)
+
+		ctx := authedCtx("editor@example.com", nil)
+		req := connect.NewRequest(&consolev1.CloneDeploymentTemplateRequest{
+			Project:     "my-project",
+			SourceName:  "web-app",
+			Name:        "web-app-copy",
+			DisplayName: "Web App Copy",
+		})
+		_, err := handler.CloneDeploymentTemplate(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		clonedCM, err := fakeClient.CoreV1().ConfigMaps("prj-my-project").Get(context.Background(), "web-app-copy", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected cloned ConfigMap, got %v", err)
+		}
+		rawDefaults, ok := clonedCM.Data[DefaultsKey]
+		if !ok {
+			t.Fatalf("expected %q key in cloned ConfigMap", DefaultsKey)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(rawDefaults), &got); err != nil {
+			t.Fatalf("defaults.json is not valid JSON: %v", err)
+		}
+		if got["image"] != "ghcr.io/example/app" {
+			t.Errorf("expected image from source defaults, got %v", got["image"])
+		}
+	})
+}
+
 func TestHandler_RenderDeploymentTemplate(t *testing.T) {
 	const validCueSrc = `package deployment
 #Input: { name: string }


### PR DESCRIPTION
## Summary
- `CloneSystemTemplate` handler: copies CUE template, display name (with provided display name), description, and mandatory flag to a new template name; new clones start with `enabled=false`
- `CloneDeploymentTemplate` handler: copies CUE template, display name, description, and defaults to a new template name
- Both handlers return `CodeNotFound` if source template not found and `CodeAlreadyExists` if target name already exists
- RBAC enforced: org-level OWNER for system templates, EDITOR+ for deployment templates
- Table-driven Go tests added covering: successful clone, source not found, target exists, permission denied, defaults inheritance

Closes: #493

## Test plan
- [x] `make test` passes (Go + UI unit tests)
- [x] `TestCloneSystemTemplateHandler` covers all acceptance criteria cases
- [x] `TestHandler_CloneDeploymentTemplate` covers all acceptance criteria cases

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1