### PR TITLE
feat(folders): implement FolderService with hierarchy enforcement

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 
 	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/folders"
 	"github.com/holos-run/holos-console/console/oidc"
 	"github.com/holos-run/holos-console/console/organizations"
 	"github.com/holos-run/holos-console/console/projects"
@@ -251,6 +252,12 @@ func (s *Server) Serve(ctx context.Context) error {
 		orgsHandler := organizations.NewHandler(orgsK8s, projectsK8s, s.cfg.DisableOrgCreation, s.cfg.OrgCreatorUsers, s.cfg.OrgCreatorRoles)
 		orgsPath, orgsHTTPHandler := consolev1connect.NewOrganizationServiceHandler(orgsHandler, protectedInterceptors)
 		mux.Handle(orgsPath, orgsHTTPHandler)
+
+		// Folder service
+		foldersK8s := folders.NewK8sClient(k8sClientset, nsResolver)
+		foldersHandler := folders.NewHandler(foldersK8s)
+		foldersPath, foldersHTTPHandler := consolev1connect.NewFolderServiceHandler(foldersHandler, protectedInterceptors)
+		mux.Handle(foldersPath, foldersHTTPHandler)
 
 		// Create dynamic client early so it can be shared by both the deployment
 		// service and the mandatory template applier.

--- a/console/folders/authz.go
+++ b/console/folders/authz.go
@@ -1,0 +1,35 @@
+package folders
+
+import (
+	"github.com/holos-run/holos-console/console/rbac"
+)
+
+// CheckFolderListAccess verifies the user has list permission on the folder.
+func CheckFolderListAccess(email string, roles []string, shareUsers, shareRoles map[string]string) error {
+	return rbac.CheckAccessGrants(email, roles, shareUsers, shareRoles, rbac.PermissionFoldersList)
+}
+
+// CheckFolderReadAccess verifies the user has read permission on the folder.
+func CheckFolderReadAccess(email string, roles []string, shareUsers, shareRoles map[string]string) error {
+	return rbac.CheckAccessGrants(email, roles, shareUsers, shareRoles, rbac.PermissionFoldersRead)
+}
+
+// CheckFolderWriteAccess verifies the user has write permission on the folder.
+func CheckFolderWriteAccess(email string, roles []string, shareUsers, shareRoles map[string]string) error {
+	return rbac.CheckAccessGrants(email, roles, shareUsers, shareRoles, rbac.PermissionFoldersWrite)
+}
+
+// CheckFolderDeleteAccess verifies the user has delete permission on the folder.
+func CheckFolderDeleteAccess(email string, roles []string, shareUsers, shareRoles map[string]string) error {
+	return rbac.CheckAccessGrants(email, roles, shareUsers, shareRoles, rbac.PermissionFoldersDelete)
+}
+
+// CheckFolderAdminAccess verifies the user has admin permission on the folder.
+func CheckFolderAdminAccess(email string, roles []string, shareUsers, shareRoles map[string]string) error {
+	return rbac.CheckAccessGrants(email, roles, shareUsers, shareRoles, rbac.PermissionFoldersAdmin)
+}
+
+// CheckFolderCreateAccess verifies the user has create permission on the folder.
+func CheckFolderCreateAccess(email string, roles []string, shareUsers, shareRoles map[string]string) error {
+	return rbac.CheckAccessGrants(email, roles, shareUsers, shareRoles, rbac.PermissionFoldersCreate)
+}

--- a/console/folders/handler.go
+++ b/console/folders/handler.go
@@ -1,0 +1,776 @@
+package folders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rbac"
+	"github.com/holos-run/holos-console/console/rpc"
+	"github.com/holos-run/holos-console/console/secrets"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
+)
+
+const auditResourceType = "folder"
+
+// maxFolderDepth is the maximum number of folder levels between an org and a project.
+const maxFolderDepth = 3
+
+// Handler implements the FolderService.
+type Handler struct {
+	consolev1connect.UnimplementedFolderServiceHandler
+	k8s *K8sClient
+}
+
+// NewHandler creates a new FolderService handler.
+func NewHandler(k8s *K8sClient) *Handler {
+	return &Handler{k8s: k8s}
+}
+
+// ListFolders returns all folders the user has access to.
+func (h *Handler) ListFolders(
+	ctx context.Context,
+	req *connect.Request[consolev1.ListFoldersRequest],
+) (*connect.Response[consolev1.ListFoldersResponse], error) {
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	// Resolve parent namespace filter when parent_type+parent_name are set.
+	var parentNs string
+	if req.Msg.ParentType != consolev1.ParentType_PARENT_TYPE_UNSPECIFIED && req.Msg.ParentName != "" {
+		var err error
+		parentNs, err = h.resolveParentNS(req.Msg.ParentType, req.Msg.ParentName)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
+	}
+
+	allFolders, err := h.k8s.ListFolders(ctx, req.Msg.Organization, parentNs)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	now := time.Now()
+	var result []*consolev1.Folder
+	for _, ns := range allFolders {
+		shareUsers, _ := GetShareUsers(ns)
+		shareRoles, _ := GetShareRoles(ns)
+		activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+		activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+		if err := CheckFolderListAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+			continue
+		}
+
+		userRole := rbac.BestRoleFromGrants(claims.Email, claims.Roles, activeUsers, activeRoles)
+		result = append(result, buildFolder(h.k8s, ns, shareUsers, shareRoles, userRole))
+	}
+
+	slog.InfoContext(ctx, "folders listed",
+		slog.String("action", "folder_list"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+		slog.Int("total", len(result)),
+	)
+
+	return connect.NewResponse(&consolev1.ListFoldersResponse{
+		Folders: result,
+	}), nil
+}
+
+// GetFolder retrieves a folder by name.
+func (h *Handler) GetFolder(
+	ctx context.Context,
+	req *connect.Request[consolev1.GetFolderRequest],
+) (*connect.Response[consolev1.GetFolderResponse], error) {
+	if req.Msg.Name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("folder name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	ns, err := h.k8s.GetFolder(ctx, req.Msg.Name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	shareUsers, _ := GetShareUsers(ns)
+	shareRoles, _ := GetShareRoles(ns)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	if err := CheckFolderReadAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+		slog.WarnContext(ctx, "folder access denied",
+			slog.String("action", "folder_read_denied"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", req.Msg.Name),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return nil, err
+	}
+
+	userRole := rbac.BestRoleFromGrants(claims.Email, claims.Roles, activeUsers, activeRoles)
+
+	slog.InfoContext(ctx, "folder accessed",
+		slog.String("action", "folder_read"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", req.Msg.Name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.GetFolderResponse{
+		Folder: buildFolder(h.k8s, ns, shareUsers, shareRoles, userRole),
+	}), nil
+}
+
+// CreateFolder creates a new folder.
+func (h *Handler) CreateFolder(
+	ctx context.Context,
+	req *connect.Request[consolev1.CreateFolderRequest],
+) (*connect.Response[consolev1.CreateFolderResponse], error) {
+	if req.Msg.Name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("folder name is required"))
+	}
+	if req.Msg.Organization == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("organization is required"))
+	}
+	if req.Msg.ParentName == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parent_name is required"))
+	}
+	if req.Msg.ParentType == consolev1.ParentType_PARENT_TYPE_UNSPECIFIED {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parent_type is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	// Resolve parent namespace.
+	parentNs, err := h.resolveParentNS(req.Msg.ParentType, req.Msg.ParentName)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	// Fetch parent namespace to verify it exists and check access.
+	parentNamespace, err := h.k8s.GetNamespace(ctx, parentNs)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	// Check create access on the parent.
+	parentShareUsers, _ := GetShareUsers(parentNamespace)
+	parentShareRoles, _ := GetShareRoles(parentNamespace)
+	now := time.Now()
+	parentActiveUsers := secrets.ActiveGrantsMap(parentShareUsers, now)
+	parentActiveRoles := secrets.ActiveGrantsMap(parentShareRoles, now)
+
+	if err := CheckFolderCreateAccess(claims.Email, claims.Roles, parentActiveUsers, parentActiveRoles); err != nil {
+		slog.WarnContext(ctx, "folder create denied",
+			slog.String("action", "folder_create_denied"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", req.Msg.Name),
+			slog.String("parent", parentNs),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return nil, err
+	}
+
+	// Enforce max folder depth (3 folder levels between org and project).
+	depth, err := h.computeFolderDepth(ctx, parentNs)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("computing folder depth: %w", err))
+	}
+	if depth >= maxFolderDepth {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("cannot create folder: maximum folder depth of %d exceeded (current depth: %d)", maxFolderDepth, depth))
+	}
+
+	// Build initial grants from request, ensuring creator is owner.
+	shareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
+	shareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
+	shareUsers = ensureCreatorOwner(shareUsers, claims.Email)
+
+	// Merge default-share cascade from all ancestors into initial grants.
+	ancestorDefaults, err := h.collectAncestorDefaultShares(ctx, parentNs)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("collecting ancestor default shares: %w", err))
+	}
+	shareUsers = mergeGrants(ancestorDefaults.users, shareUsers)
+	shareRoles = mergeGrants(ancestorDefaults.roles, shareRoles)
+
+	if _, err := h.k8s.CreateFolder(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description,
+		req.Msg.Organization, parentNs, claims.Email, shareUsers, shareRoles); err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "folder created",
+		slog.String("action", "folder_create"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", req.Msg.Name),
+		slog.String("parent", parentNs),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.CreateFolderResponse{
+		Name: req.Msg.Name,
+	}), nil
+}
+
+// UpdateFolder updates folder metadata.
+func (h *Handler) UpdateFolder(
+	ctx context.Context,
+	req *connect.Request[consolev1.UpdateFolderRequest],
+) (*connect.Response[consolev1.UpdateFolderResponse], error) {
+	if req.Msg.Name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("folder name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	ns, err := h.k8s.GetFolder(ctx, req.Msg.Name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	shareUsers, _ := GetShareUsers(ns)
+	shareRoles, _ := GetShareRoles(ns)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	if err := CheckFolderWriteAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+		slog.WarnContext(ctx, "folder update denied",
+			slog.String("action", "folder_update_denied"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", req.Msg.Name),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return nil, err
+	}
+
+	if _, err := h.k8s.UpdateFolder(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "folder updated",
+		slog.String("action", "folder_update"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", req.Msg.Name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.UpdateFolderResponse{}), nil
+}
+
+// DeleteFolder deletes a folder.
+func (h *Handler) DeleteFolder(
+	ctx context.Context,
+	req *connect.Request[consolev1.DeleteFolderRequest],
+) (*connect.Response[consolev1.DeleteFolderResponse], error) {
+	if req.Msg.Name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("folder name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	ns, err := h.k8s.GetFolder(ctx, req.Msg.Name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	shareUsers, _ := GetShareUsers(ns)
+	shareRoles, _ := GetShareRoles(ns)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	if err := CheckFolderDeleteAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+		slog.WarnContext(ctx, "folder delete denied",
+			slog.String("action", "folder_delete_denied"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", req.Msg.Name),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return nil, err
+	}
+
+	// Check for child folders.
+	folderNsName := h.k8s.Resolver.FolderNamespace(req.Msg.Name)
+	childFolders, err := h.k8s.ListChildFolders(ctx, folderNsName)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("checking for child folders: %w", err))
+	}
+	if len(childFolders) > 0 {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("cannot delete folder %q: %d child folder(s) must be deleted first", req.Msg.Name, len(childFolders)))
+	}
+
+	// Check for child projects.
+	childProjects, err := h.k8s.ListChildProjects(ctx, folderNsName)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("checking for child projects: %w", err))
+	}
+	if len(childProjects) > 0 {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("cannot delete folder %q: %d child project(s) must be deleted first", req.Msg.Name, len(childProjects)))
+	}
+
+	if err := h.k8s.DeleteFolder(ctx, req.Msg.Name); err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "folder deleted",
+		slog.String("action", "folder_delete"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", req.Msg.Name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.DeleteFolderResponse{}), nil
+}
+
+// UpdateFolderSharing updates the sharing grants on a folder.
+func (h *Handler) UpdateFolderSharing(
+	ctx context.Context,
+	req *connect.Request[consolev1.UpdateFolderSharingRequest],
+) (*connect.Response[consolev1.UpdateFolderSharingResponse], error) {
+	if req.Msg.Name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("folder name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	ns, err := h.k8s.GetFolder(ctx, req.Msg.Name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	shareUsers, _ := GetShareUsers(ns)
+	shareRoles, _ := GetShareRoles(ns)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	if err := CheckFolderAdminAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+		slog.WarnContext(ctx, "folder sharing update denied",
+			slog.String("action", "folder_sharing_denied"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", req.Msg.Name),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return nil, err
+	}
+
+	newShareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
+	newShareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
+
+	updated, err := h.k8s.UpdateFolderSharing(ctx, req.Msg.Name, newShareUsers, newShareRoles)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "folder sharing updated",
+		slog.String("action", "folder_sharing_update"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", req.Msg.Name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	updatedUsers, _ := GetShareUsers(updated)
+	updatedRoles, _ := GetShareRoles(updated)
+	updatedActiveUsers := secrets.ActiveGrantsMap(updatedUsers, now)
+	updatedActiveGroups := secrets.ActiveGrantsMap(updatedRoles, now)
+	userRole := rbac.BestRoleFromGrants(claims.Email, claims.Roles, updatedActiveUsers, updatedActiveGroups)
+
+	return connect.NewResponse(&consolev1.UpdateFolderSharingResponse{
+		Folder: buildFolder(h.k8s, updated, updatedUsers, updatedRoles, userRole),
+	}), nil
+}
+
+// UpdateFolderDefaultSharing updates the default sharing grants on a folder.
+func (h *Handler) UpdateFolderDefaultSharing(
+	ctx context.Context,
+	req *connect.Request[consolev1.UpdateFolderDefaultSharingRequest],
+) (*connect.Response[consolev1.UpdateFolderDefaultSharingResponse], error) {
+	if req.Msg.Name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("folder name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	ns, err := h.k8s.GetFolder(ctx, req.Msg.Name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	shareUsers, _ := GetShareUsers(ns)
+	shareRoles, _ := GetShareRoles(ns)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	if err := CheckFolderAdminAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+		slog.WarnContext(ctx, "folder default sharing update denied",
+			slog.String("action", "folder_default_sharing_denied"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", req.Msg.Name),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return nil, err
+	}
+
+	newDefaultUsers := shareGrantsToAnnotations(req.Msg.DefaultUserGrants)
+	newDefaultRoles := shareGrantsToAnnotations(req.Msg.DefaultRoleGrants)
+
+	updated, err := h.k8s.UpdateFolderDefaultSharing(ctx, req.Msg.Name, newDefaultUsers, newDefaultRoles)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "folder default sharing updated",
+		slog.String("action", "folder_default_sharing_update"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", req.Msg.Name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	updatedShareUsers, _ := GetShareUsers(updated)
+	updatedShareRoles, _ := GetShareRoles(updated)
+	updatedActiveUsers := secrets.ActiveGrantsMap(updatedShareUsers, now)
+	updatedActiveRoles := secrets.ActiveGrantsMap(updatedShareRoles, now)
+	userRole := rbac.BestRoleFromGrants(claims.Email, claims.Roles, updatedActiveUsers, updatedActiveRoles)
+
+	return connect.NewResponse(&consolev1.UpdateFolderDefaultSharingResponse{
+		Folder: buildFolder(h.k8s, updated, updatedShareUsers, updatedShareRoles, userRole),
+	}), nil
+}
+
+// GetFolderRaw retrieves the full Kubernetes Namespace object as verbatim JSON.
+func (h *Handler) GetFolderRaw(
+	ctx context.Context,
+	req *connect.Request[consolev1.GetFolderRawRequest],
+) (*connect.Response[consolev1.GetFolderRawResponse], error) {
+	if req.Msg.Name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("folder name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	ns, err := h.k8s.GetFolder(ctx, req.Msg.Name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	shareUsers, _ := GetShareUsers(ns)
+	shareRoles, _ := GetShareRoles(ns)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	if err := CheckFolderReadAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+		slog.WarnContext(ctx, "folder raw access denied",
+			slog.String("action", "folder_raw_denied"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", req.Msg.Name),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return nil, err
+	}
+
+	slog.InfoContext(ctx, "folder raw accessed",
+		slog.String("action", "folder_raw"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", req.Msg.Name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	ns.APIVersion = "v1"
+	ns.Kind = "Namespace"
+
+	raw, err := json.Marshal(ns)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("marshaling namespace to JSON: %w", err))
+	}
+
+	return connect.NewResponse(&consolev1.GetFolderRawResponse{
+		Raw: string(raw),
+	}), nil
+}
+
+// resolveParentNS converts a ParentType+ParentName pair to a Kubernetes namespace name.
+func (h *Handler) resolveParentNS(parentType consolev1.ParentType, parentName string) (string, error) {
+	switch parentType {
+	case consolev1.ParentType_PARENT_TYPE_ORGANIZATION:
+		return h.k8s.Resolver.OrgNamespace(parentName), nil
+	case consolev1.ParentType_PARENT_TYPE_FOLDER:
+		return h.k8s.Resolver.FolderNamespace(parentName), nil
+	default:
+		return "", fmt.Errorf("unknown parent_type %v", parentType)
+	}
+}
+
+// computeFolderDepth counts how many folder levels are between the given parent
+// namespace and the root organization. Returns 0 when the parent is an org
+// namespace (the new folder would be at depth 1).
+func (h *Handler) computeFolderDepth(ctx context.Context, parentNs string) (int, error) {
+	depth := 0
+	current := parentNs
+	for i := 0; i <= maxFolderDepth; i++ {
+		ns, err := h.k8s.GetNamespace(ctx, current)
+		if err != nil {
+			return 0, fmt.Errorf("getting namespace %q: %w", current, err)
+		}
+		resourceType := ns.Labels[v1alpha2.LabelResourceType]
+		if resourceType == v1alpha2.ResourceTypeOrganization {
+			return depth, nil
+		}
+		if resourceType == v1alpha2.ResourceTypeFolder {
+			depth++
+			parent := ns.Labels[v1alpha2.AnnotationParent]
+			if parent == "" {
+				return 0, fmt.Errorf("folder namespace %q is missing parent label", current)
+			}
+			current = parent
+			continue
+		}
+		return 0, fmt.Errorf("unexpected resource type %q on namespace %q", resourceType, current)
+	}
+	return depth, nil
+}
+
+// ancestorDefaultShares holds merged default-share grants from ancestors.
+type ancestorDefaultShares struct {
+	users []secrets.AnnotationGrant
+	roles []secrets.AnnotationGrant
+}
+
+// collectAncestorDefaultShares walks from parentNs up to the org and collects
+// default-share-users and default-share-roles from each ancestor.
+func (h *Handler) collectAncestorDefaultShares(ctx context.Context, parentNs string) (ancestorDefaultShares, error) {
+	var result ancestorDefaultShares
+	current := parentNs
+	for i := 0; i <= maxFolderDepth+1; i++ {
+		ns, err := h.k8s.GetNamespace(ctx, current)
+		if err != nil {
+			return result, fmt.Errorf("getting namespace %q: %w", current, err)
+		}
+		defaultUsers, _ := GetDefaultShareUsers(ns)
+		defaultRoles, _ := GetDefaultShareRoles(ns)
+		result.users = mergeGrants(result.users, defaultUsers)
+		result.roles = mergeGrants(result.roles, defaultRoles)
+
+		resourceType := ns.Labels[v1alpha2.LabelResourceType]
+		if resourceType == v1alpha2.ResourceTypeOrganization {
+			break
+		}
+		parent := ns.Labels[v1alpha2.AnnotationParent]
+		if parent == "" {
+			break
+		}
+		current = parent
+	}
+	return result, nil
+}
+
+// mergeGrants merges base grants with override grants; override wins per principal.
+// Higher role wins when the same principal appears in both.
+func mergeGrants(base, override []secrets.AnnotationGrant) []secrets.AnnotationGrant {
+	merged := make(map[string]secrets.AnnotationGrant)
+	for _, g := range base {
+		merged[strings.ToLower(g.Principal)] = g
+	}
+	for _, g := range override {
+		key := strings.ToLower(g.Principal)
+		existing, ok := merged[key]
+		if !ok || rbac.RoleLevel(rbac.RoleFromString(g.Role)) > rbac.RoleLevel(rbac.RoleFromString(existing.Role)) {
+			merged[key] = g
+		}
+	}
+	result := make([]secrets.AnnotationGrant, 0, len(merged))
+	for _, g := range merged {
+		result = append(result, g)
+	}
+	return result
+}
+
+// buildFolder creates a Folder proto message from a namespace.
+func buildFolder(k8s *K8sClient, ns *corev1.Namespace, shareUsers, shareRoles []secrets.AnnotationGrant, userRole rbac.Role) *consolev1.Folder {
+	folder := &consolev1.Folder{
+		UserGrants: annotationGrantsToProto(shareUsers),
+		RoleGrants: annotationGrantsToProto(shareRoles),
+		UserRole:   consolev1.Role(userRole),
+	}
+
+	if ns.Labels != nil {
+		folder.Name = ns.Labels[v1alpha2.LabelFolder]
+		folder.Organization = ns.Labels[v1alpha2.LabelOrganization]
+
+		// Derive parent info from the parent label.
+		parentNs := ns.Labels[v1alpha2.AnnotationParent]
+		if parentNs != "" {
+			kind, name, err := k8s.Resolver.ResourceTypeFromNamespace(parentNs)
+			if err == nil {
+				folder.ParentName = name
+				switch kind {
+				case v1alpha2.ResourceTypeOrganization:
+					folder.ParentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+				case v1alpha2.ResourceTypeFolder:
+					folder.ParentType = consolev1.ParentType_PARENT_TYPE_FOLDER
+				}
+			}
+		}
+	}
+
+	if ns.Annotations != nil {
+		folder.DisplayName = ns.Annotations[v1alpha2.AnnotationDisplayName]
+		folder.Description = ns.Annotations[v1alpha2.AnnotationDescription]
+		folder.CreatorEmail = ns.Annotations[v1alpha2.AnnotationCreatorEmail]
+	}
+
+	if defaultUsers, err := GetDefaultShareUsers(ns); err == nil {
+		folder.DefaultUserGrants = annotationGrantsToProto(defaultUsers)
+	}
+	if defaultRoles, err := GetDefaultShareRoles(ns); err == nil {
+		folder.DefaultRoleGrants = annotationGrantsToProto(defaultRoles)
+	}
+	folder.CreatedAt = ns.CreationTimestamp.UTC().Format(time.RFC3339)
+
+	return folder
+}
+
+// shareGrantsToAnnotations converts proto ShareGrant slices to annotation grants.
+func shareGrantsToAnnotations(grants []*consolev1.ShareGrant) []secrets.AnnotationGrant {
+	result := make([]secrets.AnnotationGrant, 0, len(grants))
+	for _, g := range grants {
+		if g.Principal != "" {
+			ag := secrets.AnnotationGrant{
+				Principal: g.Principal,
+				Role:      strings.ToLower(g.Role.String()[len("ROLE_"):]),
+			}
+			if g.Nbf != nil {
+				nbf := *g.Nbf
+				ag.Nbf = &nbf
+			}
+			if g.Exp != nil {
+				exp := *g.Exp
+				ag.Exp = &exp
+			}
+			result = append(result, ag)
+		}
+	}
+	return secrets.DeduplicateGrants(result)
+}
+
+// annotationGrantsToProto converts annotation grants to proto ShareGrant slices.
+func annotationGrantsToProto(grants []secrets.AnnotationGrant) []*consolev1.ShareGrant {
+	result := make([]*consolev1.ShareGrant, 0, len(grants))
+	for _, g := range grants {
+		sg := &consolev1.ShareGrant{
+			Principal: g.Principal,
+			Role:      protoRoleFromString(g.Role),
+		}
+		if g.Nbf != nil {
+			nbf := *g.Nbf
+			sg.Nbf = &nbf
+		}
+		if g.Exp != nil {
+			exp := *g.Exp
+			sg.Exp = &exp
+		}
+		result = append(result, sg)
+	}
+	return result
+}
+
+func protoRoleFromString(s string) consolev1.Role {
+	switch strings.ToLower(s) {
+	case "viewer":
+		return consolev1.Role_ROLE_VIEWER
+	case "editor":
+		return consolev1.Role_ROLE_EDITOR
+	case "owner":
+		return consolev1.Role_ROLE_OWNER
+	default:
+		return consolev1.Role_ROLE_UNSPECIFIED
+	}
+}
+
+// ensureCreatorOwner ensures the creator email is in the share-users list as owner.
+func ensureCreatorOwner(shareUsers []secrets.AnnotationGrant, email string) []secrets.AnnotationGrant {
+	emailLower := strings.ToLower(email)
+	for _, g := range shareUsers {
+		if strings.ToLower(g.Principal) == emailLower && strings.ToLower(g.Role) == "owner" {
+			return shareUsers
+		}
+	}
+	return append(shareUsers, secrets.AnnotationGrant{Principal: email, Role: "owner"})
+}
+
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors.
+func mapK8sError(err error) error {
+	if errors.IsNotFound(err) {
+		return connect.NewError(connect.CodeNotFound, err)
+	}
+	if errors.IsAlreadyExists(err) {
+		return connect.NewError(connect.CodeAlreadyExists, err)
+	}
+	if errors.IsForbidden(err) {
+		return connect.NewError(connect.CodePermissionDenied, err)
+	}
+	if errors.IsUnauthorized(err) {
+		return connect.NewError(connect.CodeUnauthenticated, err)
+	}
+	if errors.IsBadRequest(err) {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if strings.Contains(err.Error(), "not managed by") || strings.Contains(err.Error(), "not a folder") {
+		return connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewError(connect.CodeInternal, err)
+}

--- a/console/folders/handler_test.go
+++ b/console/folders/handler_test.go
@@ -1,0 +1,675 @@
+package folders
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rpc"
+	secrpkg "github.com/holos-run/holos-console/console/secrets"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// contextWithClaims creates a context with OIDC claims.
+func contextWithClaims(email string, groups ...string) context.Context {
+	claims := &rpc.Claims{
+		Sub:           "sub-" + email,
+		Email:         email,
+		EmailVerified: true,
+		Name:          email,
+		Roles:         groups,
+	}
+	return rpc.ContextWithClaims(context.Background(), claims)
+}
+
+// newTestHandler creates a handler with a fake K8s client pre-populated with namespaces.
+func newTestHandler(namespaces ...*corev1.Namespace) *Handler {
+	objs := make([]runtime.Object, len(namespaces))
+	for i, ns := range namespaces {
+		objs[i] = ns
+	}
+	fakeClient := fake.NewClientset(objs...)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return NewHandler(k8s)
+}
+
+// folderNSWithGrants creates a folder namespace with share-users annotation.
+func folderNSWithGrants(name, org, parentNs, shareUsersJSON string) *corev1.Namespace {
+	annotations := map[string]string{}
+	if shareUsersJSON != "" {
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelFolder:       name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+func orgNSWithGrants(name, shareUsersJSON string) *corev1.Namespace {
+	annotations := map[string]string{}
+	if shareUsersJSON != "" {
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				v1alpha2.LabelOrganization: name,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// ---- ListFolders tests ----
+
+func TestListFolders_Unauthenticated(t *testing.T) {
+	handler := newTestHandler()
+	_, err := handler.ListFolders(context.Background(), connect.NewRequest(&consolev1.ListFoldersRequest{}))
+	assertUnauthenticated(t, err)
+}
+
+func TestListFolders_FiltersByAccess(t *testing.T) {
+	f1 := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	f2 := folderNSWithGrants("ops", "acme", "holos-org-acme", `[{"principal":"bob@example.com","role":"owner"}]`)
+	handler := newTestHandler(f1, f2)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.ListFolders(ctx, connect.NewRequest(&consolev1.ListFoldersRequest{Organization: "acme"}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resp.Msg.Folders) != 1 {
+		t.Errorf("expected 1 folder, got %d", len(resp.Msg.Folders))
+	}
+	if resp.Msg.Folders[0].Name != "eng" {
+		t.Errorf("expected 'eng', got %q", resp.Msg.Folders[0].Name)
+	}
+}
+
+// ---- GetFolder tests ----
+
+func TestGetFolder_Authorized(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	f.Annotations[v1alpha2.AnnotationDisplayName] = "Engineering"
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.GetFolder(ctx, connect.NewRequest(&consolev1.GetFolderRequest{Name: "eng"}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	folder := resp.Msg.Folder
+	if folder.Name != "eng" {
+		t.Errorf("expected name 'eng', got %q", folder.Name)
+	}
+	if folder.DisplayName != "Engineering" {
+		t.Errorf("expected display_name 'Engineering', got %q", folder.DisplayName)
+	}
+	if folder.UserRole != consolev1.Role_ROLE_VIEWER {
+		t.Errorf("expected ROLE_VIEWER, got %v", folder.UserRole)
+	}
+}
+
+func TestGetFolder_Denied(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"bob@example.com","role":"owner"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("nobody@example.com")
+
+	_, err := handler.GetFolder(ctx, connect.NewRequest(&consolev1.GetFolderRequest{Name: "eng"}))
+	assertPermissionDenied(t, err)
+}
+
+func TestGetFolder_EmptyNameRejects(t *testing.T) {
+	handler := newTestHandler()
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.GetFolder(ctx, connect.NewRequest(&consolev1.GetFolderRequest{Name: ""}))
+	assertInvalidArgument(t, err)
+}
+
+func TestGetFolder_Unauthenticated(t *testing.T) {
+	handler := newTestHandler()
+	_, err := handler.GetFolder(context.Background(), connect.NewRequest(&consolev1.GetFolderRequest{Name: "eng"}))
+	assertUnauthenticated(t, err)
+}
+
+// ---- CreateFolder tests ----
+
+func TestCreateFolder_UnderOrg_Depth1(t *testing.T) {
+	// org exists in fake K8s; alice has owner access on it
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(orgNs)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.CreateFolder(ctx, connect.NewRequest(&consolev1.CreateFolderRequest{
+		Name:         "eng",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_ORGANIZATION,
+		ParentName:   "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "eng" {
+		t.Errorf("expected name 'eng', got %q", resp.Msg.Name)
+	}
+}
+
+func TestCreateFolder_UnderFolder_Depth2(t *testing.T) {
+	// Folder "eng" exists under org "acme" (depth 1)
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	engFolder := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(orgNs, engFolder)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.CreateFolder(ctx, connect.NewRequest(&consolev1.CreateFolderRequest{
+		Name:         "backend",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_FOLDER,
+		ParentName:   "eng",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "backend" {
+		t.Errorf("expected name 'backend', got %q", resp.Msg.Name)
+	}
+}
+
+func TestCreateFolder_Depth3Allowed(t *testing.T) {
+	// Create a depth-3 folder: org -> f1 -> f2 -> f3
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	f1 := folderNSWithGrants("f1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	f2 := folderNSWithGrants("f2", "acme", "holos-fld-f1", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(orgNs, f1, f2)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.CreateFolder(ctx, connect.NewRequest(&consolev1.CreateFolderRequest{
+		Name:         "f3",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_FOLDER,
+		ParentName:   "f2",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error at depth 3, got %v", err)
+	}
+	if resp.Msg.Name != "f3" {
+		t.Errorf("expected name 'f3', got %q", resp.Msg.Name)
+	}
+}
+
+func TestCreateFolder_Depth4Rejected(t *testing.T) {
+	// Attempt to create a depth-4 folder: org -> f1 -> f2 -> f3 -> f4 (rejected)
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	f1 := folderNSWithGrants("f1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	f2 := folderNSWithGrants("f2", "acme", "holos-fld-f1", `[{"principal":"alice@example.com","role":"owner"}]`)
+	f3 := folderNSWithGrants("f3", "acme", "holos-fld-f2", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(orgNs, f1, f2, f3)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateFolder(ctx, connect.NewRequest(&consolev1.CreateFolderRequest{
+		Name:         "f4",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_FOLDER,
+		ParentName:   "f3",
+	}))
+	if err == nil {
+		t.Fatal("expected error for depth > 3, got nil")
+	}
+	assertInvalidArgument(t, err)
+}
+
+func TestCreateFolder_MissingName(t *testing.T) {
+	handler := newTestHandler()
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateFolder(ctx, connect.NewRequest(&consolev1.CreateFolderRequest{
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_ORGANIZATION,
+		ParentName:   "acme",
+	}))
+	assertInvalidArgument(t, err)
+}
+
+func TestCreateFolder_Unauthenticated(t *testing.T) {
+	handler := newTestHandler()
+	_, err := handler.CreateFolder(context.Background(), connect.NewRequest(&consolev1.CreateFolderRequest{
+		Name:         "eng",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_ORGANIZATION,
+		ParentName:   "acme",
+	}))
+	assertUnauthenticated(t, err)
+}
+
+func TestCreateFolder_CreatorIsAutoOwner(t *testing.T) {
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	fakeClient := fake.NewClientset(orgNs)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateFolder(ctx, connect.NewRequest(&consolev1.CreateFolderRequest{
+		Name:         "eng",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_ORGANIZATION,
+		ParentName:   "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify the created namespace has creator as owner.
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-fld-eng", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected namespace to exist, got %v", err)
+	}
+	users, err := GetShareUsers(ns)
+	if err != nil {
+		t.Fatalf("failed to parse share-users: %v", err)
+	}
+	found := false
+	for _, u := range users {
+		if u.Principal == "alice@example.com" && u.Role == "owner" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected creator as owner in share-users, got %v", users)
+	}
+}
+
+func TestCreateFolder_DefaultShareCascadeFromOrg(t *testing.T) {
+	// Org has default-share-users; folder should inherit them.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgNs.Annotations = map[string]string{
+		v1alpha2.AnnotationShareUsers:        `[{"principal":"alice@example.com","role":"owner"}]`,
+		v1alpha2.AnnotationDefaultShareUsers: `[{"principal":"bob@example.com","role":"editor"}]`,
+	}
+	fakeClient := fake.NewClientset(orgNs)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateFolder(ctx, connect.NewRequest(&consolev1.CreateFolderRequest{
+		Name:         "eng",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_ORGANIZATION,
+		ParentName:   "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-fld-eng", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected namespace to exist, got %v", err)
+	}
+	users, err := GetShareUsers(ns)
+	if err != nil {
+		t.Fatalf("failed to parse share-users: %v", err)
+	}
+	// Should include bob from default-share-users cascade
+	found := false
+	for _, u := range users {
+		if u.Principal == "bob@example.com" && u.Role == "editor" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected bob@example.com editor from default-share cascade, got %v", users)
+	}
+}
+
+// ---- UpdateFolder tests ----
+
+func TestUpdateFolder_EditorAllows(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	displayName := "Updated Engineering"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:        "eng",
+		DisplayName: &displayName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestUpdateFolder_ViewerDenies(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	displayName := "Updated"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:        "eng",
+		DisplayName: &displayName,
+	}))
+	assertPermissionDenied(t, err)
+}
+
+// ---- DeleteFolder tests ----
+
+func TestDeleteFolder_OwnerAllows(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.DeleteFolder(ctx, connect.NewRequest(&consolev1.DeleteFolderRequest{Name: "eng"}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestDeleteFolder_EditorDenies(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.DeleteFolder(ctx, connect.NewRequest(&consolev1.DeleteFolderRequest{Name: "eng"}))
+	assertPermissionDenied(t, err)
+}
+
+func TestDeleteFolder_FailsWithChildFolders(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	child := folderNSWithGrants("sub", "acme", "holos-fld-eng", `[]`)
+	handler := newTestHandler(f, child)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.DeleteFolder(ctx, connect.NewRequest(&consolev1.DeleteFolderRequest{Name: "eng"}))
+	assertFailedPrecondition(t, err)
+}
+
+func TestDeleteFolder_FailsWithChildProjects(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	prj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-api",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.AnnotationParent:  "holos-fld-eng",
+			},
+		},
+	}
+	handler := newTestHandler(f, prj)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.DeleteFolder(ctx, connect.NewRequest(&consolev1.DeleteFolderRequest{Name: "eng"}))
+	assertFailedPrecondition(t, err)
+}
+
+func TestDeleteFolder_SucceedsWithNoChildren(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.DeleteFolder(ctx, connect.NewRequest(&consolev1.DeleteFolderRequest{Name: "eng"}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// ---- UpdateFolderSharing tests ----
+
+func TestUpdateFolderSharing_OwnerAllows(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.UpdateFolderSharing(ctx, connect.NewRequest(&consolev1.UpdateFolderSharingRequest{
+		Name: "eng",
+		UserGrants: []*consolev1.ShareGrant{
+			{Principal: "alice@example.com", Role: consolev1.Role_ROLE_OWNER},
+			{Principal: "bob@example.com", Role: consolev1.Role_ROLE_EDITOR},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resp.Msg.Folder.UserGrants) != 2 {
+		t.Errorf("expected 2 user grants, got %d", len(resp.Msg.Folder.UserGrants))
+	}
+}
+
+func TestUpdateFolderSharing_NonOwnerDenies(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.UpdateFolderSharing(ctx, connect.NewRequest(&consolev1.UpdateFolderSharingRequest{
+		Name: "eng",
+	}))
+	assertPermissionDenied(t, err)
+}
+
+// ---- UpdateFolderDefaultSharing tests ----
+
+func TestUpdateFolderDefaultSharing_OwnerAllows(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.UpdateFolderDefaultSharing(ctx, connect.NewRequest(&consolev1.UpdateFolderDefaultSharingRequest{
+		Name: "eng",
+		DefaultUserGrants: []*consolev1.ShareGrant{
+			{Principal: "bob@example.com", Role: consolev1.Role_ROLE_EDITOR},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resp.Msg.Folder.DefaultUserGrants) != 1 {
+		t.Errorf("expected 1 default user grant, got %d", len(resp.Msg.Folder.DefaultUserGrants))
+	}
+}
+
+// ---- GetFolderRaw tests ----
+
+func TestGetFolderRaw_ReturnsNamespaceJSON(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.GetFolderRaw(ctx, connect.NewRequest(&consolev1.GetFolderRawRequest{Name: "eng"}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Raw == "" {
+		t.Error("expected non-empty raw JSON")
+	}
+}
+
+func TestGetFolderRaw_DeniesUnauthorized(t *testing.T) {
+	f := folderNSWithGrants("eng", "acme", "holos-org-acme", `[{"principal":"bob@example.com","role":"owner"}]`)
+	handler := newTestHandler(f)
+	ctx := contextWithClaims("nobody@example.com")
+
+	_, err := handler.GetFolderRaw(ctx, connect.NewRequest(&consolev1.GetFolderRawRequest{Name: "eng"}))
+	assertPermissionDenied(t, err)
+}
+
+// ---- buildFolder tests ----
+
+func TestBuildFolder_PopulatesParentInfo(t *testing.T) {
+	r := testResolver()
+	fakeClient := fake.NewClientset()
+	k8s := NewK8sClient(fakeClient, r)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-eng",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: "acme",
+				v1alpha2.LabelFolder:       "eng",
+				v1alpha2.AnnotationParent:  "holos-org-acme",
+			},
+		},
+	}
+
+	folder := buildFolder(k8s, ns, nil, nil, 0)
+	if folder.Name != "eng" {
+		t.Errorf("expected name 'eng', got %q", folder.Name)
+	}
+	if folder.Organization != "acme" {
+		t.Errorf("expected organization 'acme', got %q", folder.Organization)
+	}
+	if folder.ParentType != consolev1.ParentType_PARENT_TYPE_ORGANIZATION {
+		t.Errorf("expected PARENT_TYPE_ORGANIZATION, got %v", folder.ParentType)
+	}
+	if folder.ParentName != "acme" {
+		t.Errorf("expected parent_name 'acme', got %q", folder.ParentName)
+	}
+}
+
+func TestBuildFolder_FolderParentType(t *testing.T) {
+	r := testResolver()
+	fakeClient := fake.NewClientset()
+	k8s := NewK8sClient(fakeClient, r)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-sub",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: "acme",
+				v1alpha2.LabelFolder:       "sub",
+				v1alpha2.AnnotationParent:  "holos-fld-eng",
+			},
+		},
+	}
+
+	folder := buildFolder(k8s, ns, nil, nil, 0)
+	if folder.ParentType != consolev1.ParentType_PARENT_TYPE_FOLDER {
+		t.Errorf("expected PARENT_TYPE_FOLDER, got %v", folder.ParentType)
+	}
+	if folder.ParentName != "eng" {
+		t.Errorf("expected parent_name 'eng', got %q", folder.ParentName)
+	}
+}
+
+// ---- mergeGrants tests ----
+
+func TestMergeGrants_HigherRoleWins(t *testing.T) {
+	base := []annotationGrant{
+		{Principal: "alice@example.com", Role: "viewer"},
+	}
+	override := []annotationGrant{
+		{Principal: "alice@example.com", Role: "editor"},
+	}
+	result := mergeGrants(base, override)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(result))
+	}
+	if result[0].Role != "editor" {
+		t.Errorf("expected editor (override wins), got %q", result[0].Role)
+	}
+}
+
+func TestMergeGrants_PreservesBaseWhenOverrideIsLower(t *testing.T) {
+	base := []annotationGrant{
+		{Principal: "alice@example.com", Role: "owner"},
+	}
+	override := []annotationGrant{
+		{Principal: "alice@example.com", Role: "viewer"},
+	}
+	result := mergeGrants(base, override)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(result))
+	}
+	if result[0].Role != "owner" {
+		t.Errorf("expected owner (base wins when higher), got %q", result[0].Role)
+	}
+}
+
+// ---- helpers ----
+
+func assertUnauthenticated(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeUnauthenticated {
+		t.Errorf("expected CodeUnauthenticated, got %v", connectErr.Code())
+	}
+}
+
+func assertPermissionDenied(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodePermissionDenied {
+		t.Errorf("expected CodePermissionDenied, got %v", connectErr.Code())
+	}
+}
+
+func assertInvalidArgument(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeInvalidArgument {
+		t.Errorf("expected CodeInvalidArgument, got %v", connectErr.Code())
+	}
+}
+
+func assertFailedPrecondition(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeFailedPrecondition {
+		t.Errorf("expected CodeFailedPrecondition, got %v", connectErr.Code())
+	}
+}
+
+// annotationGrant is a local alias for merge tests, avoiding import naming conflicts.
+type annotationGrant = secrpkg.AnnotationGrant

--- a/console/folders/k8s.go
+++ b/console/folders/k8s.go
@@ -1,0 +1,323 @@
+package folders
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/secrets"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// K8sClient wraps Kubernetes client operations for folders (namespaces).
+type K8sClient struct {
+	client   kubernetes.Interface
+	Resolver *resolver.Resolver
+}
+
+// NewK8sClient creates a client for folder operations.
+func NewK8sClient(client kubernetes.Interface, r *resolver.Resolver) *K8sClient {
+	return &K8sClient{client: client, Resolver: r}
+}
+
+// ListFolders returns all folder namespaces. When org is non-empty, filters by
+// organization label. When parentNs is non-empty, filters to direct children of
+// that parent namespace.
+func (c *K8sClient) ListFolders(ctx context.Context, org, parentNs string) ([]*corev1.Namespace, error) {
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeFolder
+	if org != "" {
+		labelSelector += "," + v1alpha2.LabelOrganization + "=" + org
+	}
+	slog.DebugContext(ctx, "listing folders from kubernetes",
+		slog.String("labelSelector", labelSelector),
+	)
+	list, err := c.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*corev1.Namespace, 0, len(list.Items))
+	for i := range list.Items {
+		ns := &list.Items[i]
+		if ns.DeletionTimestamp != nil {
+			continue
+		}
+		if _, err := c.Resolver.FolderFromNamespace(ns.Name); err != nil {
+			var pme *resolver.PrefixMismatchError
+			if errors.As(err, &pme) {
+				slog.DebugContext(ctx, "filtering folder namespace with prefix mismatch",
+					slog.String("namespace", ns.Name),
+					slog.String("reason", err.Error()),
+				)
+				continue
+			}
+		}
+		// Filter by parent namespace when specified.
+		if parentNs != "" {
+			if ns.Labels[v1alpha2.AnnotationParent] != parentNs {
+				continue
+			}
+		}
+		result = append(result, ns)
+	}
+	return result, nil
+}
+
+// GetFolder retrieves a managed folder namespace by name.
+// The name is the user-facing folder name (not the Kubernetes namespace).
+func (c *K8sClient) GetFolder(ctx context.Context, name string) (*corev1.Namespace, error) {
+	nsName := c.Resolver.FolderNamespace(name)
+	slog.DebugContext(ctx, "getting folder from kubernetes",
+		slog.String("name", name),
+		slog.String("namespace", nsName),
+	)
+	ns, err := c.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if ns.Labels == nil || ns.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		return nil, fmt.Errorf("namespace %q is not managed by %s", nsName, v1alpha2.ManagedByValue)
+	}
+	if ns.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeFolder {
+		return nil, fmt.Errorf("namespace %q is not a folder", nsName)
+	}
+	return ns, nil
+}
+
+// GetNamespace retrieves any namespace by its full Kubernetes name.
+// Used for walking the parent chain during depth enforcement.
+func (c *K8sClient) GetNamespace(ctx context.Context, nsName string) (*corev1.Namespace, error) {
+	return c.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+}
+
+// CreateFolder creates a new namespace with folder labels and annotations.
+// parentNs is the Kubernetes namespace name of the immediate parent (org or folder).
+// org is the root organization name.
+func (c *K8sClient) CreateFolder(
+	ctx context.Context,
+	name, displayName, description, org, parentNs, creatorEmail string,
+	shareUsers, shareRoles []secrets.AnnotationGrant,
+) (*corev1.Namespace, error) {
+	nsName := c.Resolver.FolderNamespace(name)
+	slog.DebugContext(ctx, "creating folder in kubernetes",
+		slog.String("name", name),
+		slog.String("namespace", nsName),
+		slog.String("parent", parentNs),
+		slog.String("org", org),
+	)
+	usersJSON, err := json.Marshal(shareUsers)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling share-users: %w", err)
+	}
+	rolesJSON, err := json.Marshal(shareRoles)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling share-roles: %w", err)
+	}
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareUsers: string(usersJSON),
+		v1alpha2.AnnotationShareRoles: string(rolesJSON),
+	}
+	if displayName != "" {
+		annotations[v1alpha2.AnnotationDisplayName] = displayName
+	}
+	if description != "" {
+		annotations[v1alpha2.AnnotationDescription] = description
+	}
+	if creatorEmail != "" {
+		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelFolder:       name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+	return c.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+}
+
+// UpdateFolder updates display name and description annotations on a folder.
+func (c *K8sClient) UpdateFolder(ctx context.Context, name string, displayName, description *string) (*corev1.Namespace, error) {
+	slog.DebugContext(ctx, "updating folder in kubernetes",
+		slog.String("name", name),
+	)
+	ns, err := c.GetFolder(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	if displayName != nil {
+		if *displayName == "" {
+			delete(ns.Annotations, v1alpha2.AnnotationDisplayName)
+		} else {
+			ns.Annotations[v1alpha2.AnnotationDisplayName] = *displayName
+		}
+	}
+	if description != nil {
+		if *description == "" {
+			delete(ns.Annotations, v1alpha2.AnnotationDescription)
+		} else {
+			ns.Annotations[v1alpha2.AnnotationDescription] = *description
+		}
+	}
+	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+}
+
+// DeleteFolder deletes a managed folder namespace.
+func (c *K8sClient) DeleteFolder(ctx context.Context, name string) error {
+	slog.DebugContext(ctx, "deleting folder from kubernetes",
+		slog.String("name", name),
+	)
+	ns, err := c.GetFolder(ctx, name)
+	if err != nil {
+		return err
+	}
+	return c.client.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+}
+
+// UpdateFolderSharing updates the sharing annotations on a folder.
+func (c *K8sClient) UpdateFolderSharing(ctx context.Context, name string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	slog.DebugContext(ctx, "updating folder sharing in kubernetes",
+		slog.String("name", name),
+	)
+	ns, err := c.GetFolder(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	usersJSON, err := json.Marshal(shareUsers)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling share-users: %w", err)
+	}
+	rolesJSON, err := json.Marshal(shareRoles)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling share-roles: %w", err)
+	}
+	ns.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
+	ns.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
+	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+}
+
+// UpdateFolderDefaultSharing updates the default sharing annotations on a folder.
+func (c *K8sClient) UpdateFolderDefaultSharing(ctx context.Context, name string, defaultUsers, defaultRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	slog.DebugContext(ctx, "updating folder default sharing in kubernetes",
+		slog.String("name", name),
+	)
+	ns, err := c.GetFolder(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	usersJSON, err := json.Marshal(defaultUsers)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling default-share-users: %w", err)
+	}
+	rolesJSON, err := json.Marshal(defaultRoles)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling default-share-roles: %w", err)
+	}
+	ns.Annotations[v1alpha2.AnnotationDefaultShareUsers] = string(usersJSON)
+	ns.Annotations[v1alpha2.AnnotationDefaultShareRoles] = string(rolesJSON)
+	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+}
+
+// ListChildFolders returns all folder namespaces whose parent label equals the given namespace.
+func (c *K8sClient) ListChildFolders(ctx context.Context, parentNs string) ([]*corev1.Namespace, error) {
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeFolder
+	list, err := c.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var result []*corev1.Namespace
+	for i := range list.Items {
+		ns := &list.Items[i]
+		if ns.DeletionTimestamp != nil {
+			continue
+		}
+		if ns.Labels[v1alpha2.AnnotationParent] == parentNs {
+			result = append(result, ns)
+		}
+	}
+	return result, nil
+}
+
+// ListChildProjects returns all project namespaces whose parent label equals the given namespace.
+func (c *K8sClient) ListChildProjects(ctx context.Context, parentNs string) ([]*corev1.Namespace, error) {
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeProject
+	list, err := c.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var result []*corev1.Namespace
+	for i := range list.Items {
+		ns := &list.Items[i]
+		if ns.DeletionTimestamp != nil {
+			continue
+		}
+		if ns.Labels[v1alpha2.AnnotationParent] == parentNs {
+			result = append(result, ns)
+		}
+	}
+	return result, nil
+}
+
+// GetShareUsers parses the share-users annotation from a namespace.
+func GetShareUsers(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationShareUsers)
+}
+
+// GetShareRoles parses the share-roles annotation from a namespace.
+func GetShareRoles(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationShareRoles)
+}
+
+// GetDefaultShareUsers parses the default-share-users annotation from a namespace.
+func GetDefaultShareUsers(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationDefaultShareUsers)
+}
+
+// GetDefaultShareRoles parses the default-share-roles annotation from a namespace.
+func GetDefaultShareRoles(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationDefaultShareRoles)
+}
+
+func parseGrantAnnotation(ns *corev1.Namespace, key string) ([]secrets.AnnotationGrant, error) {
+	if ns.Annotations == nil {
+		return nil, nil
+	}
+	value, ok := ns.Annotations[key]
+	if !ok {
+		return nil, nil
+	}
+	var grants []secrets.AnnotationGrant
+	if err := json.Unmarshal([]byte(value), &grants); err != nil {
+		return nil, fmt.Errorf("invalid %s annotation: %w", key, err)
+	}
+	return grants, nil
+}

--- a/console/folders/k8s_test.go
+++ b/console/folders/k8s_test.go
@@ -1,0 +1,277 @@
+package folders
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/secrets"
+)
+
+func testResolver() *resolver.Resolver {
+	return &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+}
+
+func folderNS(name, org, parentNs string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelFolder:       name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+		},
+	}
+}
+
+func orgNS(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				v1alpha2.LabelOrganization: name,
+			},
+		},
+	}
+}
+
+func TestGetFolder_ReturnsFolder(t *testing.T) {
+	ns := folderNS("eng", "acme", "holos-org-acme")
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	result, err := k8s.GetFolder(context.Background(), "eng")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Name != "holos-fld-eng" {
+		t.Errorf("expected holos-fld-eng, got %s", result.Name)
+	}
+}
+
+func TestGetFolder_ReturnsNotFoundForMissing(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	_, err := k8s.GetFolder(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestGetFolder_RejectsNonFolder(t *testing.T) {
+	// Namespace with org label instead of folder label
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-fake",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	_, err := k8s.GetFolder(context.Background(), "fake")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestListFolders_ReturnsAllFoldersForOrg(t *testing.T) {
+	f1 := folderNS("eng", "acme", "holos-org-acme")
+	f2 := folderNS("ops", "acme", "holos-org-acme")
+	f3 := folderNS("other", "beta", "holos-org-beta")
+	fakeClient := fake.NewClientset(f1, f2, f3)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	results, err := k8s.ListFolders(context.Background(), "acme", "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 folders for acme, got %d", len(results))
+	}
+}
+
+func TestListFolders_FiltersByParent(t *testing.T) {
+	f1 := folderNS("eng", "acme", "holos-org-acme")
+	f2 := folderNS("sub", "acme", "holos-fld-eng") // child of eng
+	fakeClient := fake.NewClientset(f1, f2)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	results, err := k8s.ListFolders(context.Background(), "acme", "holos-fld-eng")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 folder, got %d", len(results))
+	}
+	if results[0].Name != "holos-fld-sub" {
+		t.Errorf("expected holos-fld-sub, got %s", results[0].Name)
+	}
+}
+
+func TestCreateFolder_CreatesNamespaceWithLabels(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	shareUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
+	result, err := k8s.CreateFolder(context.Background(), "eng", "Engineering", "Eng team", "acme", "holos-org-acme", "alice@example.com", shareUsers, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Name != "holos-fld-eng" {
+		t.Errorf("expected holos-fld-eng, got %s", result.Name)
+	}
+	if result.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeFolder {
+		t.Error("expected resource-type=folder label")
+	}
+	if result.Labels[v1alpha2.LabelOrganization] != "acme" {
+		t.Errorf("expected organization=acme, got %s", result.Labels[v1alpha2.LabelOrganization])
+	}
+	if result.Labels[v1alpha2.AnnotationParent] != "holos-org-acme" {
+		t.Errorf("expected parent=holos-org-acme, got %s", result.Labels[v1alpha2.AnnotationParent])
+	}
+	if result.Labels[v1alpha2.LabelFolder] != "eng" {
+		t.Errorf("expected folder=eng, got %s", result.Labels[v1alpha2.LabelFolder])
+	}
+	if result.Annotations[v1alpha2.AnnotationDisplayName] != "Engineering" {
+		t.Errorf("expected display name 'Engineering', got %s", result.Annotations[v1alpha2.AnnotationDisplayName])
+	}
+	if result.Annotations[v1alpha2.AnnotationCreatorEmail] != "alice@example.com" {
+		t.Errorf("expected creator email 'alice@example.com', got %s", result.Annotations[v1alpha2.AnnotationCreatorEmail])
+	}
+}
+
+func TestUpdateFolder_UpdatesAnnotations(t *testing.T) {
+	ns := folderNS("eng", "acme", "holos-org-acme")
+	ns.Annotations = map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+	}
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	displayName := "Engineering Updated"
+	result, err := k8s.UpdateFolder(context.Background(), "eng", &displayName, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Annotations[v1alpha2.AnnotationDisplayName] != "Engineering Updated" {
+		t.Errorf("expected 'Engineering Updated', got %q", result.Annotations[v1alpha2.AnnotationDisplayName])
+	}
+}
+
+func TestDeleteFolder_DeletesNamespace(t *testing.T) {
+	ns := folderNS("eng", "acme", "holos-org-acme")
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	err := k8s.DeleteFolder(context.Background(), "eng")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	_, err = fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-fld-eng", metav1.GetOptions{})
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected NotFound after delete, got %v", err)
+	}
+}
+
+func TestUpdateFolderSharing_UpdatesAnnotations(t *testing.T) {
+	ns := folderNS("eng", "acme", "holos-org-acme")
+	ns.Annotations = map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"old@example.com","role":"viewer"}]`,
+	}
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	newUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
+	result, err := k8s.UpdateFolderSharing(context.Background(), "eng", newUsers, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	users, err := GetShareUsers(result)
+	if err != nil {
+		t.Fatalf("failed to parse share-users: %v", err)
+	}
+	if len(users) != 1 || users[0].Principal != "alice@example.com" {
+		t.Errorf("expected alice@example.com, got %v", users)
+	}
+}
+
+func TestUpdateFolderDefaultSharing_UpdatesAnnotations(t *testing.T) {
+	ns := folderNS("eng", "acme", "holos-org-acme")
+	ns.Annotations = map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+	}
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	defaultUsers := []secrets.AnnotationGrant{{Principal: "bob@example.com", Role: "editor"}}
+	result, err := k8s.UpdateFolderDefaultSharing(context.Background(), "eng", defaultUsers, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	users, err := GetDefaultShareUsers(result)
+	if err != nil {
+		t.Fatalf("failed to parse default-share-users: %v", err)
+	}
+	if len(users) != 1 || users[0].Principal != "bob@example.com" {
+		t.Errorf("expected bob@example.com, got %v", users)
+	}
+}
+
+func TestListChildFolders_ReturnsChildren(t *testing.T) {
+	f1 := folderNS("eng", "acme", "holos-org-acme")
+	f2 := folderNS("sub", "acme", "holos-fld-eng")
+	f3 := folderNS("other", "acme", "holos-org-acme")
+	fakeClient := fake.NewClientset(f1, f2, f3)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	children, err := k8s.ListChildFolders(context.Background(), "holos-fld-eng")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(children) != 1 || children[0].Name != "holos-fld-sub" {
+		t.Errorf("expected [holos-fld-sub], got %v", children)
+	}
+}
+
+func TestListChildProjects_ReturnsChildren(t *testing.T) {
+	prj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-api",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelOrganization: "acme",
+				v1alpha2.AnnotationParent:  "holos-fld-eng",
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(prj)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	children, err := k8s.ListChildProjects(context.Background(), "holos-fld-eng")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(children) != 1 || children[0].Name != "holos-prj-api" {
+		t.Errorf("expected [holos-prj-api], got %v", children)
+	}
+}


### PR DESCRIPTION
## Summary
- Create `console/folders/` package with full FolderService implementation
- Enforce 3-folder depth limit at `CreateFolder` time (rejects depth ≥ 4 with `InvalidArgument`)
- Default-share cascade: merges ancestor `default-share-users`/`default-share-roles` into new folder's initial grants
- `DeleteFolder` guards against child folders and child projects (`FailedPrecondition`)
- Wire FolderService into `console/console.go`
- Full unit test coverage for all RPCs and depth scenarios

Closes: #628

## Test plan
- [x] `go test -count=1 ./console/folders/...` passes (k8s + handler tests)
- [x] `go test -count=1 ./console/... ./api/...` passes (all 15 packages)
- [x] Tests cover: depth 1/2/3 creation, depth 4 rejection, deletion with children, default-share cascade, creator auto-owner, sharing updates, parent type resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1