### PR TITLE
feat: migrate ProjectService to folder-aware parent pointer

### DIFF
--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -24,7 +24,7 @@ const auditResourceType = "organization"
 
 // ProjectLister checks for projects linked to an organization.
 type ProjectLister interface {
-	ListProjects(ctx context.Context, org string) ([]*corev1.Namespace, error)
+	ListProjects(ctx context.Context, org, parentNs string) ([]*corev1.Namespace, error)
 }
 
 // Handler implements the OrganizationService.
@@ -278,7 +278,7 @@ func (h *Handler) DeleteOrganization(
 	}
 
 	if h.projectLister != nil {
-		projects, err := h.projectLister.ListProjects(ctx, req.Msg.Name)
+		projects, err := h.projectLister.ListProjects(ctx, req.Msg.Name, "")
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("checking for linked projects: %w", err))
 		}

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -418,7 +418,7 @@ type mockProjectLister struct {
 	err      error
 }
 
-func (m *mockProjectLister) ListProjects(_ context.Context, _ string) ([]*corev1.Namespace, error) {
+func (m *mockProjectLister) ListProjects(_ context.Context, _, _ string) ([]*corev1.Namespace, error) {
 	return m.projects, m.err
 }
 

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -12,9 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/rbac"
-	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
 	"github.com/holos-run/holos-console/console/secrets"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
@@ -71,7 +70,17 @@ func (h *Handler) ListProjects(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	allProjects, err := h.k8s.ListProjects(ctx, req.Msg.Organization)
+	// Resolve parent namespace filter when parent_type+parent_name are set.
+	var parentNs string
+	if req.Msg.ParentType != consolev1.ParentType_PARENT_TYPE_UNSPECIFIED && req.Msg.ParentName != "" {
+		var err error
+		parentNs, err = h.resolveParentNS(req.Msg.ParentType, req.Msg.ParentName)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
+	}
+
+	allProjects, err := h.k8s.ListProjects(ctx, req.Msg.Organization, parentNs)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -177,9 +186,25 @@ func (h *Handler) CreateProject(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
+	// Resolve the immediate parent namespace.
+	// parent_name defaults to organization when unset (backwards-compatible).
+	parentName := req.Msg.ParentName
+	parentType := req.Msg.ParentType
+	if parentName == "" {
+		parentName = req.Msg.Organization
+		parentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	}
+	if parentType == consolev1.ParentType_PARENT_TYPE_UNSPECIFIED {
+		parentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	}
+	parentNs, err := h.resolveParentNS(parentType, parentName)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("resolving parent: %w", err))
+	}
+
 	// Check create access: user must be owner on at least one existing project
 	// or have owner grant on the organization
-	allProjects, err := h.k8s.ListProjects(ctx, "")
+	allProjects, err := h.k8s.ListProjects(ctx, "", "")
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -230,7 +255,7 @@ func (h *Handler) CreateProject(
 	// Ensure creator is included as owner
 	shareUsers = ensureCreatorOwner(shareUsers, claims.Email)
 
-	_, err = h.k8s.CreateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, req.Msg.Organization, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+	_, err = h.k8s.CreateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, req.Msg.Organization, parentNs, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -572,64 +597,78 @@ func (h *Handler) GetProjectRaw(
 }
 
 // buildProject creates a Project proto message from a namespace.
-func (h *Handler) buildProject(ns interface{ GetName() string }, shareUsers, shareRoles []secrets.AnnotationGrant, userRole rbac.Role) *consolev1.Project {
+func (h *Handler) buildProject(ns *corev1.Namespace, shareUsers, shareRoles []secrets.AnnotationGrant, userRole rbac.Role) *consolev1.Project {
 	p := &consolev1.Project{
 		UserGrants: annotationGrantsToProto(shareUsers),
 		RoleGrants: annotationGrantsToProto(shareRoles),
 		UserRole:   consolev1.Role(userRole),
 	}
 
-	// Type-assert to get annotations and labels for metadata
-	type annotated interface {
-		GetAnnotations() map[string]string
-	}
-	type labeled interface {
-		GetLabels() map[string]string
-	}
-	if a, ok := ns.(annotated); ok {
-		annotations := a.GetAnnotations()
-		if annotations != nil {
-			p.DisplayName = annotations[v1alpha1.AnnotationDisplayName]
-			p.Description = annotations[v1alpha1.AnnotationDescription]
-			p.CreatorEmail = annotations[v1alpha1.AnnotationCreatorEmail]
-		}
-		// Populate default sharing grants and creation timestamp from typed namespace
-		if nsTyped, ok := ns.(*corev1.Namespace); ok {
-			if defaultUsers, err := GetDefaultShareUsers(nsTyped); err == nil {
-				p.DefaultUserGrants = annotationGrantsToProto(defaultUsers)
+	if ns.Labels != nil {
+		p.Organization = ns.Labels[v1alpha2.LabelOrganization]
+		p.Name = ns.Labels[v1alpha2.LabelProject]
+
+		// Derive parent info from the parent label.
+		parentNs := ns.Labels[v1alpha2.AnnotationParent]
+		if parentNs != "" {
+			kind, name, err := h.k8s.Resolver.ResourceTypeFromNamespace(parentNs)
+			if err == nil {
+				p.ParentName = name
+				switch kind {
+				case v1alpha2.ResourceTypeOrganization:
+					p.ParentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+				case v1alpha2.ResourceTypeFolder:
+					p.ParentType = consolev1.ParentType_PARENT_TYPE_FOLDER
+				}
 			}
-			if defaultRoles, err := GetDefaultShareRoles(nsTyped); err == nil {
-				p.DefaultRoleGrants = annotationGrantsToProto(defaultRoles)
-			}
-			p.CreatedAt = nsTyped.CreationTimestamp.UTC().Format(time.RFC3339)
 		}
 	}
-	if l, ok := ns.(labeled); ok {
-		labels := l.GetLabels()
-		if labels != nil {
-			p.Organization = labels[resolver.OrganizationLabel]
-			p.Name = labels[resolver.ProjectLabel]
-		}
-	}
+
 	// Fallback: derive project name from namespace if label is missing (pre-label namespaces)
 	if p.Name == "" {
 		name, err := h.k8s.Resolver.ProjectFromNamespace(ns.GetName())
 		if err != nil {
 			slog.Warn("project namespace missing label and prefix mismatch",
 				slog.String("namespace", ns.GetName()),
-				slog.String("label", resolver.ProjectLabel),
+				slog.String("label", v1alpha2.LabelProject),
 				slog.Any("error", err),
 			)
 		} else {
 			p.Name = name
 			slog.Warn("project namespace missing label, falling back to namespace parsing",
 				slog.String("namespace", ns.GetName()),
-				slog.String("label", resolver.ProjectLabel),
+				slog.String("label", v1alpha2.LabelProject),
 			)
 		}
 	}
 
+	if ns.Annotations != nil {
+		p.DisplayName = ns.Annotations[v1alpha2.AnnotationDisplayName]
+		p.Description = ns.Annotations[v1alpha2.AnnotationDescription]
+		p.CreatorEmail = ns.Annotations[v1alpha2.AnnotationCreatorEmail]
+	}
+
+	if defaultUsers, err := GetDefaultShareUsers(ns); err == nil {
+		p.DefaultUserGrants = annotationGrantsToProto(defaultUsers)
+	}
+	if defaultRoles, err := GetDefaultShareRoles(ns); err == nil {
+		p.DefaultRoleGrants = annotationGrantsToProto(defaultRoles)
+	}
+	p.CreatedAt = ns.CreationTimestamp.UTC().Format(time.RFC3339)
+
 	return p
+}
+
+// resolveParentNS converts a ParentType+ParentName pair to a Kubernetes namespace name.
+func (h *Handler) resolveParentNS(parentType consolev1.ParentType, parentName string) (string, error) {
+	switch parentType {
+	case consolev1.ParentType_PARENT_TYPE_ORGANIZATION:
+		return h.k8s.Resolver.OrgNamespace(parentName), nil
+	case consolev1.ParentType_PARENT_TYPE_FOLDER:
+		return h.k8s.Resolver.FolderNamespace(parentName), nil
+	default:
+		return "", fmt.Errorf("unknown parent_type %v", parentType)
+	}
 }
 
 // resolveOrgGrants returns the active grant maps for the given organization.

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
-	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
 	"github.com/holos-run/holos-console/console/secrets"
@@ -81,15 +81,15 @@ func contextWithClaims(email string, groups ...string) context.Context {
 func managedNS(name string, shareUsersJSON string) *corev1.Namespace {
 	annotations := map[string]string{}
 	if shareUsersJSON != "" {
-		annotations[v1alpha1.AnnotationShareUsers] = shareUsersJSON
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
 	}
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-" + name,
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      name,
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      name,
 			},
 			Annotations: annotations,
 		},
@@ -97,7 +97,7 @@ func managedNS(name string, shareUsersJSON string) *corev1.Namespace {
 }
 
 func testResolver() *resolver.Resolver {
-	return &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", ProjectPrefix: "prj-"}
+	return &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 }
 
 func newHandler(namespaces ...*corev1.Namespace) (*Handler, *testLogHandler) {
@@ -196,8 +196,8 @@ func TestListProjects_ReturnsUnauthenticatedWithoutClaims(t *testing.T) {
 
 func TestGetProject_ReturnsProjectForAuthorizedUser(t *testing.T) {
 	ns := managedNS("my-project", `[{"principal":"alice@example.com","role":"viewer"}]`)
-	ns.Annotations[v1alpha1.AnnotationDisplayName] = "My Project"
-	ns.Annotations[v1alpha1.AnnotationDescription] = "A test project"
+	ns.Annotations[v1alpha2.AnnotationDisplayName] = "My Project"
+	ns.Annotations[v1alpha2.AnnotationDescription] = "A test project"
 
 	handler, logHandler := newHandler(ns)
 	ctx := contextWithClaims("alice@example.com")
@@ -566,17 +566,17 @@ func TestUpdateProjectSharing_ReturnsUnauthenticatedWithoutClaims(t *testing.T) 
 func TestBuildProject_FallbackProducesWrongNameWithPrefix(t *testing.T) {
 	// When the project label is missing and namespace-prefix is configured,
 	// ProjectFromNamespace produces the wrong name.
-	r := &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "o-", ProjectPrefix: "p-"}
+	r := &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "o-", FolderPrefix: "fld-", ProjectPrefix: "p-"}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-p-holos", // namespace-prefix "holos-" + project-prefix "p-" + name "holos"
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
 				// No ProjectLabel — forces fallback
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+				v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
 			},
 		},
 	}
@@ -598,17 +598,17 @@ func TestBuildProject_FallbackProducesWrongNameWithPrefix(t *testing.T) {
 }
 
 func TestBuildProject_LabelPreferredOverFallback(t *testing.T) {
-	r := &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "o-", ProjectPrefix: "p-"}
+	r := &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "o-", FolderPrefix: "fld-", ProjectPrefix: "p-"}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-p-holos",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "holos",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "holos",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+				v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
 			},
 		},
 	}
@@ -626,18 +626,18 @@ func TestBuildProject_LabelPreferredOverFallback(t *testing.T) {
 // ---- Namespace prefix tests ----
 
 func TestCreateProject_NamespacePrefixIncluded(t *testing.T) {
-	r := &resolver.Resolver{NamespacePrefix: "prod-", OrganizationPrefix: "org-", ProjectPrefix: "prj-"}
+	r := &resolver.Resolver{NamespacePrefix: "prod-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 	// Need an existing project with owner grant for create permission
 	existing := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prod-prj-existing",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "existing",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "existing",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+				v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
 			},
 		},
 	}
@@ -698,7 +698,7 @@ func assertPermissionDenied(t *testing.T, err error) {
 
 func TestGetProjectRaw_ReturnsNamespaceJSON(t *testing.T) {
 	ns := managedNS("my-project", `[{"principal":"alice@example.com","role":"viewer"}]`)
-	ns.Annotations[v1alpha1.AnnotationDisplayName] = "My Project"
+	ns.Annotations[v1alpha2.AnnotationDisplayName] = "My Project"
 	handler, _ := newHandler(ns)
 	ctx := contextWithClaims("alice@example.com")
 
@@ -722,11 +722,11 @@ func TestGetProjectRaw_ReturnsNamespaceJSON(t *testing.T) {
 		t.Errorf("expected metadata.name 'prj-my-project', got %v", metadata["name"])
 	}
 	labels := metadata["labels"].(map[string]interface{})
-	if labels[v1alpha1.LabelManagedBy] != v1alpha1.ManagedByValue {
-		t.Errorf("expected managed-by label, got %v", labels[v1alpha1.LabelManagedBy])
+	if labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		t.Errorf("expected managed-by label, got %v", labels[v1alpha2.LabelManagedBy])
 	}
-	if labels[resolver.ResourceTypeLabel] != resolver.ResourceTypeProject {
-		t.Errorf("expected resource-type label, got %v", labels[resolver.ResourceTypeLabel])
+	if labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeProject {
+		t.Errorf("expected resource-type label, got %v", labels[v1alpha2.LabelResourceType])
 	}
 }
 
@@ -764,7 +764,7 @@ func newHandlerWithOrg(orgResolver OrgResolver, namespaces ...*corev1.Namespace)
 // managedNSWithOrg creates a managed project namespace associated with an org.
 func managedNSWithOrg(name, org, shareUsersJSON string) *corev1.Namespace {
 	ns := managedNS(name, shareUsersJSON)
-	ns.Labels[resolver.OrganizationLabel] = org
+	ns.Labels[v1alpha2.LabelOrganization] = org
 	return ns
 }
 
@@ -901,13 +901,13 @@ func TestBuildProject_PopulatesDefaultGrants(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationDefaultShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
-				v1alpha1.AnnotationDefaultShareRoles: `[{"principal":"engineering","role":"editor"}]`,
+				v1alpha2.AnnotationDefaultShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+				v1alpha2.AnnotationDefaultShareRoles: `[{"principal":"engineering","role":"editor"}]`,
 			},
 		},
 	}

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/secrets"
 	corev1 "k8s.io/api/core/v1"
@@ -27,14 +27,16 @@ func NewK8sClient(client kubernetes.Interface, r *resolver.Resolver) *K8sClient 
 }
 
 // ListProjects returns all project namespaces. When org is non-empty, filters by organization.
-func (c *K8sClient) ListProjects(ctx context.Context, org string) ([]*corev1.Namespace, error) {
-	labelSelector := v1alpha1.LabelManagedBy + "=" + v1alpha1.ManagedByValue + "," +
-		v1alpha1.LabelResourceType + "=" + v1alpha1.ResourceTypeProject
+// When parentNs is non-empty, additionally filters to direct children of that parent namespace.
+func (c *K8sClient) ListProjects(ctx context.Context, org, parentNs string) ([]*corev1.Namespace, error) {
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeProject
 	if org != "" {
-		labelSelector += "," + v1alpha1.LabelOrganization + "=" + org
+		labelSelector += "," + v1alpha2.LabelOrganization + "=" + org
 	}
 	slog.DebugContext(ctx, "listing projects from kubernetes",
 		slog.String("labelSelector", labelSelector),
+		slog.String("parentNs", parentNs),
 	)
 	list, err := c.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
@@ -57,6 +59,10 @@ func (c *K8sClient) ListProjects(ctx context.Context, org string) ([]*corev1.Nam
 				continue
 			}
 		}
+		// Filter by parent namespace when specified.
+		if parentNs != "" && list.Items[i].Labels[v1alpha2.AnnotationParent] != parentNs {
+			continue
+		}
 		result = append(result, &list.Items[i])
 	}
 	return result, nil
@@ -74,21 +80,24 @@ func (c *K8sClient) GetProject(ctx context.Context, name string) (*corev1.Namesp
 	if err != nil {
 		return nil, err
 	}
-	if ns.Labels == nil || ns.Labels[v1alpha1.LabelManagedBy] != v1alpha1.ManagedByValue {
-		return nil, fmt.Errorf("namespace %q is not managed by %s", nsName, v1alpha1.ManagedByValue)
+	if ns.Labels == nil || ns.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		return nil, fmt.Errorf("namespace %q is not managed by %s", nsName, v1alpha2.ManagedByValue)
 	}
-	if ns.Labels[v1alpha1.LabelResourceType] != v1alpha1.ResourceTypeProject {
+	if ns.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeProject {
 		return nil, fmt.Errorf("namespace %q is not a project", nsName)
 	}
 	return ns, nil
 }
 
 // CreateProject creates a new namespace with managed-by and resource-type labels.
-func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+// parentNs is the Kubernetes namespace name of the immediate parent (org or folder namespace).
+// When non-empty, it is stored in the v1alpha2.AnnotationParent label for hierarchy traversal.
+func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	nsName := c.Resolver.ProjectNamespace(name)
 	slog.DebugContext(ctx, "creating project in kubernetes",
 		slog.String("name", name),
 		slog.String("namespace", nsName),
+		slog.String("parent", parentNs),
 	)
 	usersJSON, err := json.Marshal(shareUsers)
 	if err != nil {
@@ -99,39 +108,42 @@ func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, descri
 		return nil, fmt.Errorf("marshaling share-roles: %w", err)
 	}
 	annotations := map[string]string{
-		v1alpha1.AnnotationShareUsers: string(usersJSON),
-		v1alpha1.AnnotationShareRoles: string(rolesJSON),
+		v1alpha2.AnnotationShareUsers: string(usersJSON),
+		v1alpha2.AnnotationShareRoles: string(rolesJSON),
 	}
 	if len(defaultShareUsers) > 0 {
 		defaultUsersJSON, err := json.Marshal(defaultShareUsers)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling default-share-users: %w", err)
 		}
-		annotations[v1alpha1.AnnotationDefaultShareUsers] = string(defaultUsersJSON)
+		annotations[v1alpha2.AnnotationDefaultShareUsers] = string(defaultUsersJSON)
 	}
 	if len(defaultShareRoles) > 0 {
 		defaultRolesJSON, err := json.Marshal(defaultShareRoles)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling default-share-roles: %w", err)
 		}
-		annotations[v1alpha1.AnnotationDefaultShareRoles] = string(defaultRolesJSON)
+		annotations[v1alpha2.AnnotationDefaultShareRoles] = string(defaultRolesJSON)
 	}
 	if displayName != "" {
-		annotations[v1alpha1.AnnotationDisplayName] = displayName
+		annotations[v1alpha2.AnnotationDisplayName] = displayName
 	}
 	if description != "" {
-		annotations[v1alpha1.AnnotationDescription] = description
+		annotations[v1alpha2.AnnotationDescription] = description
 	}
 	if creatorEmail != "" {
-		annotations[v1alpha1.AnnotationCreatorEmail] = creatorEmail
+		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
 	}
 	labels := map[string]string{
-		v1alpha1.LabelManagedBy:    v1alpha1.ManagedByValue,
-		v1alpha1.LabelResourceType: v1alpha1.ResourceTypeProject,
-		v1alpha1.LabelProject:      name,
+		v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+		v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+		v1alpha2.LabelProject:      name,
 	}
 	if org != "" {
-		labels[v1alpha1.LabelOrganization] = org
+		labels[v1alpha2.LabelOrganization] = org
+	}
+	if parentNs != "" {
+		labels[v1alpha2.AnnotationParent] = parentNs
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -158,16 +170,16 @@ func (c *K8sClient) UpdateProject(ctx context.Context, name string, displayName,
 	}
 	if displayName != nil {
 		if *displayName == "" {
-			delete(ns.Annotations, v1alpha1.AnnotationDisplayName)
+			delete(ns.Annotations, v1alpha2.AnnotationDisplayName)
 		} else {
-			ns.Annotations[v1alpha1.AnnotationDisplayName] = *displayName
+			ns.Annotations[v1alpha2.AnnotationDisplayName] = *displayName
 		}
 	}
 	if description != nil {
 		if *description == "" {
-			delete(ns.Annotations, v1alpha1.AnnotationDescription)
+			delete(ns.Annotations, v1alpha2.AnnotationDescription)
 		} else {
-			ns.Annotations[v1alpha1.AnnotationDescription] = *description
+			ns.Annotations[v1alpha2.AnnotationDescription] = *description
 		}
 	}
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
@@ -207,8 +219,8 @@ func (c *K8sClient) UpdateProjectSharing(ctx context.Context, name string, share
 	if err != nil {
 		return nil, fmt.Errorf("marshaling share-roles: %w", err)
 	}
-	ns.Annotations[v1alpha1.AnnotationShareUsers] = string(usersJSON)
-	ns.Annotations[v1alpha1.AnnotationShareRoles] = string(rolesJSON)
+	ns.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
+	ns.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 
@@ -217,7 +229,7 @@ func GetOrganization(ns *corev1.Namespace) string {
 	if ns.Labels == nil {
 		return ""
 	}
-	return ns.Labels[v1alpha1.LabelOrganization]
+	return ns.Labels[v1alpha2.LabelOrganization]
 }
 
 // GetProjectOrg returns the organization name for the given project.
@@ -235,7 +247,7 @@ func GetDisplayName(ns *corev1.Namespace) string {
 	if ns.Annotations == nil {
 		return ""
 	}
-	return ns.Annotations[v1alpha1.AnnotationDisplayName]
+	return ns.Annotations[v1alpha2.AnnotationDisplayName]
 }
 
 // GetDescription returns the description annotation value from a namespace.
@@ -243,30 +255,30 @@ func GetDescription(ns *corev1.Namespace) string {
 	if ns.Annotations == nil {
 		return ""
 	}
-	return ns.Annotations[v1alpha1.AnnotationDescription]
+	return ns.Annotations[v1alpha2.AnnotationDescription]
 }
 
 // GetShareUsers parses the share-users annotation from a namespace.
 func GetShareUsers(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
-	return parseGrantAnnotation(ns, v1alpha1.AnnotationShareUsers)
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationShareUsers)
 }
 
 // GetShareRoles parses the share-roles annotation from a namespace.
 // Returns nil if the annotation is absent.
 func GetShareRoles(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
-	return parseGrantAnnotation(ns, v1alpha1.AnnotationShareRoles)
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationShareRoles)
 }
 
 // GetDefaultShareUsers parses the default-share-users annotation from a namespace.
 // Returns nil if the annotation is absent.
 func GetDefaultShareUsers(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
-	return parseGrantAnnotation(ns, v1alpha1.AnnotationDefaultShareUsers)
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationDefaultShareUsers)
 }
 
 // GetDefaultShareRoles parses the default-share-roles annotation from a namespace.
 // Returns nil if the annotation is absent.
 func GetDefaultShareRoles(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
-	return parseGrantAnnotation(ns, v1alpha1.AnnotationDefaultShareRoles)
+	return parseGrantAnnotation(ns, v1alpha2.AnnotationDefaultShareRoles)
 }
 
 // UpdateProjectDefaultSharing updates the default sharing annotations on a managed namespace.
@@ -289,8 +301,8 @@ func (c *K8sClient) UpdateProjectDefaultSharing(ctx context.Context, name string
 	if err != nil {
 		return nil, fmt.Errorf("marshaling default-share-roles: %w", err)
 	}
-	ns.Annotations[v1alpha1.AnnotationDefaultShareUsers] = string(usersJSON)
-	ns.Annotations[v1alpha1.AnnotationDefaultShareRoles] = string(rolesJSON)
+	ns.Annotations[v1alpha2.AnnotationDefaultShareUsers] = string(usersJSON)
+	ns.Annotations[v1alpha2.AnnotationDefaultShareRoles] = string(rolesJSON)
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 

--- a/console/projects/k8s_test.go
+++ b/console/projects/k8s_test.go
@@ -9,8 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
-	"github.com/holos-run/holos-console/console/resolver"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/secrets"
 )
 
@@ -19,10 +18,10 @@ func TestListProjects_ReturnsOnlyProjectNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-project-a",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "project-a",
-				resolver.OrganizationLabel: "acme",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "project-a",
+				v1alpha2.LabelOrganization: "acme",
 			},
 		},
 	}
@@ -30,10 +29,10 @@ func TestListProjects_ReturnsOnlyProjectNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-project-b",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "project-b",
-				resolver.OrganizationLabel: "acme",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "project-b",
+				v1alpha2.LabelOrganization: "acme",
 			},
 		},
 	}
@@ -41,8 +40,8 @@ func TestListProjects_ReturnsOnlyProjectNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-org-acme",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeOrganization,
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
 			},
 		},
 	}
@@ -54,7 +53,7 @@ func TestListProjects_ReturnsOnlyProjectNamespaces(t *testing.T) {
 	fakeClient := fake.NewClientset(managed1, managed2, orgNS, unmanaged)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	projects, err := k8s.ListProjects(context.Background(), "")
+	projects, err := k8s.ListProjects(context.Background(), "", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -72,7 +71,7 @@ func TestListProjects_ReturnsEmptyListWhenNoManagedNamespaces(t *testing.T) {
 	fakeClient := fake.NewClientset(unmanaged)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	projects, err := k8s.ListProjects(context.Background(), "")
+	projects, err := k8s.ListProjects(context.Background(), "", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -90,9 +89,9 @@ func TestListProjects_ExcludesTerminatingNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-active",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "active",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "active",
 			},
 		},
 	}
@@ -100,9 +99,9 @@ func TestListProjects_ExcludesTerminatingNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-terminating",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "terminating",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "terminating",
 			},
 			DeletionTimestamp: &now,
 		},
@@ -110,7 +109,7 @@ func TestListProjects_ExcludesTerminatingNamespaces(t *testing.T) {
 	fakeClient := fake.NewClientset(active, terminating)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	projects, err := k8s.ListProjects(context.Background(), "")
+	projects, err := k8s.ListProjects(context.Background(), "", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -127,10 +126,10 @@ func TestListProjects_FilterByOrg(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-foo",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "foo",
-				resolver.OrganizationLabel: "acme",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "foo",
+				v1alpha2.LabelOrganization: "acme",
 			},
 		},
 	}
@@ -138,10 +137,10 @@ func TestListProjects_FilterByOrg(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-bar",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "bar",
-				resolver.OrganizationLabel: "acme",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "bar",
+				v1alpha2.LabelOrganization: "acme",
 			},
 		},
 	}
@@ -149,17 +148,17 @@ func TestListProjects_FilterByOrg(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-baz",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "baz",
-				resolver.OrganizationLabel: "beta",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "baz",
+				v1alpha2.LabelOrganization: "beta",
 			},
 		},
 	}
 	fakeClient := fake.NewClientset(prj1, prj2, prj3)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	projects, err := k8s.ListProjects(context.Background(), "acme")
+	projects, err := k8s.ListProjects(context.Background(), "acme", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -173,14 +172,14 @@ func TestGetProject_ReturnsByDerivedNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
-				resolver.OrganizationLabel: "acme",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
+				v1alpha2.LabelOrganization: "acme",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationDisplayName:         "My Project",
-				v1alpha1.AnnotationDescription: "Test project",
+				v1alpha2.AnnotationDisplayName:         "My Project",
+				v1alpha2.AnnotationDescription: "Test project",
 			},
 		},
 	}
@@ -194,8 +193,8 @@ func TestGetProject_ReturnsByDerivedNamespace(t *testing.T) {
 	if result.Name != "holos-prj-my-project" {
 		t.Errorf("expected namespace 'holos-prj-my-project', got %q", result.Name)
 	}
-	if result.Annotations[v1alpha1.AnnotationDisplayName] != "My Project" {
-		t.Errorf("expected display-name 'My Project', got %q", result.Annotations[v1alpha1.AnnotationDisplayName])
+	if result.Annotations[v1alpha2.AnnotationDisplayName] != "My Project" {
+		t.Errorf("expected display-name 'My Project', got %q", result.Annotations[v1alpha2.AnnotationDisplayName])
 	}
 }
 
@@ -204,10 +203,10 @@ func TestGetProject_ReturnsOrganization(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
-				resolver.OrganizationLabel: "acme",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
+				v1alpha2.LabelOrganization: "acme",
 			},
 		},
 	}
@@ -258,24 +257,24 @@ func TestCreateProject_UsesPrefixNamespace(t *testing.T) {
 	shareUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
 	shareRoles := []secrets.AnnotationGrant{{Principal: "engineering", Role: "editor"}}
 
-	result, err := k8s.CreateProject(context.Background(), "new-project", "New Project", "A test project", "acme", "", shareUsers, shareRoles, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "new-project", "New Project", "A test project", "acme", "", "", shareUsers, shareRoles, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if result.Name != "holos-prj-new-project" {
 		t.Errorf("expected namespace 'holos-prj-new-project', got %q", result.Name)
 	}
-	if result.Labels[v1alpha1.LabelManagedBy] != v1alpha1.ManagedByValue {
+	if result.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
 		t.Errorf("expected managed-by label, got %v", result.Labels)
 	}
-	if result.Labels[resolver.ResourceTypeLabel] != resolver.ResourceTypeProject {
+	if result.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeProject {
 		t.Error("expected resource-type=project label")
 	}
-	if result.Labels[resolver.ProjectLabel] != "new-project" {
-		t.Errorf("expected project label 'new-project', got %q", result.Labels[resolver.ProjectLabel])
+	if result.Labels[v1alpha2.LabelProject] != "new-project" {
+		t.Errorf("expected project label 'new-project', got %q", result.Labels[v1alpha2.LabelProject])
 	}
-	if result.Annotations[v1alpha1.AnnotationDisplayName] != "New Project" {
-		t.Errorf("expected display-name 'New Project', got %q", result.Annotations[v1alpha1.AnnotationDisplayName])
+	if result.Annotations[v1alpha2.AnnotationDisplayName] != "New Project" {
+		t.Errorf("expected display-name 'New Project', got %q", result.Annotations[v1alpha2.AnnotationDisplayName])
 	}
 }
 
@@ -283,12 +282,12 @@ func TestCreateProject_SetsOrgLabelWhenProvided(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "acme", "", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "acme", "", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if result.Labels[resolver.OrganizationLabel] != "acme" {
-		t.Errorf("expected organization label 'acme', got %q", result.Labels[resolver.OrganizationLabel])
+	if result.Labels[v1alpha2.LabelOrganization] != "acme" {
+		t.Errorf("expected organization label 'acme', got %q", result.Labels[v1alpha2.LabelOrganization])
 	}
 }
 
@@ -296,11 +295,11 @@ func TestCreateProject_OmitsOrgLabelWhenEmpty(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "", "", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "", "", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if _, ok := result.Labels[resolver.OrganizationLabel]; ok {
+	if _, ok := result.Labels[v1alpha2.LabelOrganization]; ok {
 		t.Error("expected no organization label when org is empty")
 	}
 }
@@ -310,16 +309,16 @@ func TestCreateProject_ReturnsAlreadyExistsForDuplicateName(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-existing",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "existing",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "existing",
 			},
 		},
 	}
 	fakeClient := fake.NewClientset(existing)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	_, err := k8s.CreateProject(context.Background(), "existing", "", "", "", "", nil, nil, nil, nil)
+	_, err := k8s.CreateProject(context.Background(), "existing", "", "", "", "", "", nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -333,12 +332,12 @@ func TestUpdateProject_UpdatesDescriptionAndDisplayName(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+				v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
 			},
 		},
 	}
@@ -378,9 +377,9 @@ func TestDeleteProject_DeletesManagedNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 		},
 	}
@@ -415,9 +414,9 @@ func TestListProjects_FiltersPrefixMismatchNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-project-a",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "project-a",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "project-a",
 			},
 		},
 	}
@@ -425,16 +424,16 @@ func TestListProjects_FiltersPrefixMismatchNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "other-prj-project-b",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "project-b",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "project-b",
 			},
 		},
 	}
 	fakeClient := fake.NewClientset(matching, mismatched)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	projects, err := k8s.ListProjects(context.Background(), "")
+	projects, err := k8s.ListProjects(context.Background(), "", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -451,12 +450,12 @@ func TestGetDefaultShareUsers_ParsesAnnotation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationDefaultShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+				v1alpha2.AnnotationDefaultShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
 			},
 		},
 	}
@@ -477,9 +476,9 @@ func TestGetDefaultShareUsers_ReturnsNilWhenAbsent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 		},
 	}
@@ -497,12 +496,12 @@ func TestGetDefaultShareRoles_ParsesAnnotation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationDefaultShareRoles: `[{"principal":"engineering","role":"editor"}]`,
+				v1alpha2.AnnotationDefaultShareRoles: `[{"principal":"engineering","role":"editor"}]`,
 			},
 		},
 	}
@@ -523,9 +522,9 @@ func TestUpdateProjectDefaultSharing_PersistsAnnotations(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 		},
 	}
@@ -573,13 +572,13 @@ func TestUpdateProjectSharing_UpdatesShareAnnotations(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationShareUsers: `[{"principal":"old@example.com","role":"viewer"}]`,
-				v1alpha1.AnnotationShareRoles: `[]`,
+				v1alpha2.AnnotationShareUsers: `[{"principal":"old@example.com","role":"viewer"}]`,
+				v1alpha2.AnnotationShareRoles: `[]`,
 			},
 		},
 	}
@@ -611,12 +610,12 @@ func TestCreateProject_StoresCreatorEmailAnnotation(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "creator@example.com", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", "creator@example.com", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if result.Annotations[v1alpha1.AnnotationCreatorEmail] != "creator@example.com" {
-		t.Errorf("expected creator-email annotation %q, got %q", "creator@example.com", result.Annotations[v1alpha1.AnnotationCreatorEmail])
+	if result.Annotations[v1alpha2.AnnotationCreatorEmail] != "creator@example.com" {
+		t.Errorf("expected creator-email annotation %q, got %q", "creator@example.com", result.Annotations[v1alpha2.AnnotationCreatorEmail])
 	}
 }
 
@@ -624,11 +623,11 @@ func TestCreateProject_EmptyCreatorEmail_NoAnnotation(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if _, ok := result.Annotations[v1alpha1.AnnotationCreatorEmail]; ok {
+	if _, ok := result.Annotations[v1alpha2.AnnotationCreatorEmail]; ok {
 		t.Error("expected no creator-email annotation when email is empty")
 	}
 }
@@ -640,15 +639,15 @@ func TestBuildProject_PopulatesCreatorEmailAndCreatedAt(t *testing.T) {
 			Name:              "holos-prj-my-project",
 			CreationTimestamp: now,
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
-				resolver.OrganizationLabel: "acme",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
+				v1alpha2.LabelOrganization: "acme",
 			},
 			Annotations: map[string]string{
-				v1alpha1.AnnotationCreatorEmail:       "creator@example.com",
-				v1alpha1.AnnotationShareUsers: `[{"principal":"creator@example.com","role":"owner"}]`,
-				v1alpha1.AnnotationShareRoles: `[]`,
+				v1alpha2.AnnotationCreatorEmail:       "creator@example.com",
+				v1alpha2.AnnotationShareUsers: `[{"principal":"creator@example.com","role":"owner"}]`,
+				v1alpha2.AnnotationShareRoles: `[]`,
 			},
 		},
 	}
@@ -676,9 +675,9 @@ func TestBuildProject_NoAnnotation_EmptyCreatorEmail(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-my-project",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:     v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "my-project",
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "my-project",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Add `parentNs` parameter to `K8sClient.CreateProject` and `K8sClient.ListProjects` so projects can be nested under a folder namespace
- `Handler.resolveParentNS` converts `ParentType+ParentName` to a Kubernetes namespace name (mirrors the same helper in FolderService)
- `buildProject` now populates `ParentType` and `ParentName` on the proto using `Resolver.ResourceTypeFromNamespace`
- Migrate all `v1alpha1.*` and `resolver.*` constant references to `v1alpha2.*` in handler and k8s layers
- Update `organizations.ProjectLister` interface to include `parentNs` argument (caller passes `""`)

Closes: #629

## Test plan
- [x] `go test ./console/projects/... ./console/organizations/... ./console/folders/...` passes
- [x] `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1