### PR TITLE
feat: migrate SecretsService to v1alpha2 with ancestor default-share cascade

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -282,9 +282,10 @@ func (s *Server) Serve(ctx context.Context) error {
 		projectsPath, projectsHTTPHandler := consolev1connect.NewProjectServiceHandler(projectsHandler, protectedInterceptors)
 		mux.Handle(projectsPath, projectsHTTPHandler)
 
-		// Secrets service with project grant fallback
+		// Secrets service with project grant fallback and ancestor default-share cascade.
 		secretsK8s := secrets.NewK8sClient(k8sClientset, nsResolver)
-		projectResolver := projects.NewProjectGrantResolver(projectsK8s)
+		nsWalker := &resolver.Walker{Client: k8sClientset, Resolver: nsResolver}
+		projectResolver := projects.NewProjectGrantResolver(projectsK8s).WithWalker(nsWalker)
 		secretsHandler := secrets.NewProjectScopedHandler(secretsK8s, projectResolver)
 		secretsPath, secretsHTTPHandler := consolev1connect.NewSecretsServiceHandler(secretsHandler, protectedInterceptors)
 		mux.Handle(secretsPath, secretsHTTPHandler)

--- a/console/projects/resolver.go
+++ b/console/projects/resolver.go
@@ -2,20 +2,38 @@ package projects
 
 import (
 	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rbac"
+	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/secrets"
 )
 
 // ProjectGrantResolver implements secrets.ProjectResolver by looking up
 // namespace annotations for project-level grants.
 type ProjectGrantResolver struct {
-	k8s *K8sClient
+	k8s    *K8sClient
+	walker *resolver.Walker // optional; enables ancestor default-share cascade
 }
 
 // NewProjectGrantResolver creates a resolver that reads grants from project namespaces.
 func NewProjectGrantResolver(k8s *K8sClient) *ProjectGrantResolver {
 	return &ProjectGrantResolver{k8s: k8s}
+}
+
+// WithWalker attaches a hierarchy walker to the resolver. When set,
+// GetDefaultGrants walks the full ancestor chain (project → folders → org)
+// and merges default-share grants from all levels (highest role wins per
+// principal). Without a walker, GetDefaultGrants only reads project-level defaults.
+func (r *ProjectGrantResolver) WithWalker(w *resolver.Walker) *ProjectGrantResolver {
+	r.walker = w
+	return r
 }
 
 // GetProjectGrants returns the active user and role grant maps for a project.
@@ -45,13 +63,95 @@ func (r *ProjectGrantResolver) GetProjectOrganization(ctx context.Context, proje
 
 // GetDefaultGrants returns the default sharing grants for a project.
 // These are applied to new secrets created in the project.
+// When a Walker is configured (see WithWalker), it walks the full ancestor
+// chain (project → folders → org) and merges default-share grants from all
+// levels; highest role wins per principal. Without a walker, only project-level
+// defaults are returned.
 // Implements secrets.DefaultShareResolver.
 func (r *ProjectGrantResolver) GetDefaultGrants(ctx context.Context, project string) ([]secrets.AnnotationGrant, []secrets.AnnotationGrant, error) {
-	ns, err := r.k8s.GetProject(ctx, project)
-	if err != nil {
-		return nil, nil, err
+	if r.walker == nil {
+		// Fallback: project-level defaults only.
+		ns, err := r.k8s.GetProject(ctx, project)
+		if err != nil {
+			return nil, nil, err
+		}
+		defaultUsers, _ := GetDefaultShareUsers(ns)
+		defaultRoles, _ := GetDefaultShareRoles(ns)
+		return defaultUsers, defaultRoles, nil
 	}
-	defaultUsers, _ := GetDefaultShareUsers(ns)
-	defaultRoles, _ := GetDefaultShareRoles(ns)
-	return defaultUsers, defaultRoles, nil
+
+	// Walk the full ancestor chain (project → folders → org) and merge defaults.
+	projectNs := r.k8s.Resolver.ProjectNamespace(project)
+	ancestors, err := r.walker.WalkAncestors(ctx, projectNs)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to walk ancestor chain for default grants, falling back to project-level only",
+			slog.String("project", project),
+			slog.String("namespace", projectNs),
+			slog.Any("error", err),
+		)
+		// Graceful degradation: fall back to project-level defaults only.
+		ns, err := r.k8s.GetProject(ctx, project)
+		if err != nil {
+			return nil, nil, err
+		}
+		defaultUsers, _ := GetDefaultShareUsers(ns)
+		defaultRoles, _ := GetDefaultShareRoles(ns)
+		return defaultUsers, defaultRoles, nil
+	}
+
+	// Merge defaults from all ancestors. Walk order is child → parent (project
+	// first, org last). We accumulate into the result, with highest-role-wins
+	// per principal so that an explicit project default beats a broader org default.
+	var mergedUsers, mergedRoles []secrets.AnnotationGrant
+	for _, ns := range ancestors {
+		nsDefaultUsers := parseNamespaceDefaultGrants(ns, v1alpha2.AnnotationDefaultShareUsers)
+		nsDefaultRoles := parseNamespaceDefaultGrants(ns, v1alpha2.AnnotationDefaultShareRoles)
+		mergedUsers = mergeAnnotationGrants(mergedUsers, nsDefaultUsers)
+		mergedRoles = mergeAnnotationGrants(mergedRoles, nsDefaultRoles)
+	}
+
+	return mergedUsers, mergedRoles, nil
+}
+
+// parseNamespaceDefaultGrants parses a JSON annotation from a namespace into
+// a slice of AnnotationGrant. Returns nil when the annotation is absent or empty.
+func parseNamespaceDefaultGrants(ns *corev1.Namespace, key string) []secrets.AnnotationGrant {
+	if ns.Annotations == nil {
+		return nil
+	}
+	value, ok := ns.Annotations[key]
+	if !ok || value == "" {
+		return nil
+	}
+	var grants []secrets.AnnotationGrant
+	if err := json.Unmarshal([]byte(value), &grants); err != nil {
+		slog.Warn("failed to parse default grants annotation",
+			slog.String("namespace", ns.Name),
+			slog.String("annotation", key),
+			slog.Any("error", err),
+		)
+		return nil
+	}
+	return grants
+}
+
+// mergeAnnotationGrants merges base and override grant slices. Highest role
+// wins per principal; override wins when roles are equal.
+func mergeAnnotationGrants(base, override []secrets.AnnotationGrant) []secrets.AnnotationGrant {
+	merged := make(map[string]secrets.AnnotationGrant)
+	for _, g := range base {
+		merged[strings.ToLower(g.Principal)] = g
+	}
+	for _, g := range override {
+		key := strings.ToLower(g.Principal)
+		existing, ok := merged[key]
+		if !ok || rbac.RoleLevel(rbac.RoleFromString(g.Role)) >= rbac.RoleLevel(rbac.RoleFromString(existing.Role)) {
+			merged[key] = g
+		}
+	}
+	result := make([]secrets.AnnotationGrant, 0, len(merged))
+	for _, g := range merged {
+		result = append(result, g)
+	}
+	return result
 }

--- a/console/projects/resolver_test.go
+++ b/console/projects/resolver_test.go
@@ -1,0 +1,265 @@
+package projects
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/secrets"
+)
+
+// resolverTestResolver returns a Resolver with the full prefix set.
+func resolverTestResolver() *resolver.Resolver {
+	return &resolver.Resolver{
+		NamespacePrefix:    "holos-",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
+}
+
+// grantsJSON marshals a slice of grants to JSON for use in annotations.
+func grantsJSON(t *testing.T, grants []secrets.AnnotationGrant) string {
+	t.Helper()
+	b, err := json.Marshal(grants)
+	if err != nil {
+		t.Fatalf("marshaling grants: %v", err)
+	}
+	return string(b)
+}
+
+// managedProjectNS returns a project namespace fixture with the parent label set.
+func managedProjectNS(name, org, parentNs string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      name,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+		},
+	}
+}
+
+// orgNSWithDefaults returns an org namespace fixture with default share annotations.
+func orgNSWithDefaults(name string, defaultUsers, defaultRoles []secrets.AnnotationGrant, t *testing.T) *corev1.Namespace {
+	t.Helper()
+	annotations := map[string]string{}
+	if len(defaultUsers) > 0 {
+		annotations[v1alpha2.AnnotationDefaultShareUsers] = grantsJSON(t, defaultUsers)
+	}
+	if len(defaultRoles) > 0 {
+		annotations[v1alpha2.AnnotationDefaultShareRoles] = grantsJSON(t, defaultRoles)
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				v1alpha2.LabelOrganization: name,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// folderNSWithDefaults returns a folder namespace fixture with default share annotations.
+func folderNSWithDefaults(name, org, parentNs string, defaultUsers, defaultRoles []secrets.AnnotationGrant, t *testing.T) *corev1.Namespace {
+	t.Helper()
+	annotations := map[string]string{}
+	if len(defaultUsers) > 0 {
+		annotations[v1alpha2.AnnotationDefaultShareUsers] = grantsJSON(t, defaultUsers)
+	}
+	if len(defaultRoles) > 0 {
+		annotations[v1alpha2.AnnotationDefaultShareRoles] = grantsJSON(t, defaultRoles)
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelFolder:       name,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+func TestGetDefaultGrants_NoWalker_ReturnsProjectDefaultsOnly(t *testing.T) {
+	r := resolverTestResolver()
+	projectNs := managedProjectNS("myproject", "acme", "holos-org-acme")
+	projectNs.Annotations = map[string]string{
+		v1alpha2.AnnotationDefaultShareUsers: grantsJSON(t, []secrets.AnnotationGrant{
+			{Principal: "alice@example.com", Role: "viewer"},
+		}),
+	}
+	projectNs.Labels[v1alpha2.AnnotationShareUsers] = grantsJSON(t, []secrets.AnnotationGrant{
+		{Principal: "alice@example.com", Role: "owner"},
+	})
+	fakeClient := fake.NewClientset(projectNs)
+	k8s := NewK8sClient(fakeClient, r)
+	resolver := NewProjectGrantResolver(k8s) // no Walker
+
+	users, roles, err := resolver.GetDefaultGrants(context.Background(), "myproject")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(users) != 1 || users[0].Principal != "alice@example.com" {
+		t.Errorf("expected 1 user grant from project, got %v", users)
+	}
+	if len(roles) != 0 {
+		t.Errorf("expected 0 role grants, got %v", roles)
+	}
+}
+
+func TestGetDefaultGrants_WithWalker_ProjectUnderOrg_MergesOrgDefaults(t *testing.T) {
+	r := resolverTestResolver()
+	orgNs := orgNSWithDefaults("acme", []secrets.AnnotationGrant{
+		{Principal: "bob@example.com", Role: "viewer"},
+	}, nil, t)
+	projectNs := managedProjectNS("myproject", "acme", "holos-org-acme")
+	projectNs.Annotations = map[string]string{
+		v1alpha2.AnnotationShareUsers: grantsJSON(t, []secrets.AnnotationGrant{
+			{Principal: "alice@example.com", Role: "owner"},
+		}),
+	}
+	fakeClient := fake.NewClientset(orgNs, projectNs)
+	k8s := NewK8sClient(fakeClient, r)
+	w := &resolver.Walker{Client: fakeClient, Resolver: r}
+	pr := NewProjectGrantResolver(k8s).WithWalker(w)
+
+	users, roles, err := pr.GetDefaultGrants(context.Background(), "myproject")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	// Should include bob from org defaults
+	found := false
+	for _, u := range users {
+		if u.Principal == "bob@example.com" && u.Role == "viewer" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected bob@example.com viewer from org defaults, got %v", users)
+	}
+	if len(roles) != 0 {
+		t.Errorf("expected 0 role grants, got %v", roles)
+	}
+}
+
+func TestGetDefaultGrants_WithWalker_ProjectUnderFolder_MergesOrgAndFolderDefaults(t *testing.T) {
+	r := resolverTestResolver()
+	orgNs := orgNSWithDefaults("acme", []secrets.AnnotationGrant{
+		{Principal: "org-user@example.com", Role: "viewer"},
+	}, nil, t)
+	folderNs := folderNSWithDefaults("eng", "acme", "holos-org-acme", []secrets.AnnotationGrant{
+		{Principal: "folder-user@example.com", Role: "editor"},
+	}, nil, t)
+	projectNs := managedProjectNS("myproject", "acme", "holos-fld-eng")
+	fakeClient := fake.NewClientset(orgNs, folderNs, projectNs)
+	k8s := NewK8sClient(fakeClient, r)
+	w := &resolver.Walker{Client: fakeClient, Resolver: r}
+	pr := NewProjectGrantResolver(k8s).WithWalker(w)
+
+	users, _, err := pr.GetDefaultGrants(context.Background(), "myproject")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	principalRoles := make(map[string]string)
+	for _, u := range users {
+		principalRoles[u.Principal] = u.Role
+	}
+	if principalRoles["org-user@example.com"] != "viewer" {
+		t.Errorf("expected org-user as viewer, got %q", principalRoles["org-user@example.com"])
+	}
+	if principalRoles["folder-user@example.com"] != "editor" {
+		t.Errorf("expected folder-user as editor, got %q", principalRoles["folder-user@example.com"])
+	}
+}
+
+func TestGetDefaultGrants_WithWalker_NestedFolders_MergesAllLevels(t *testing.T) {
+	r := resolverTestResolver()
+	orgNs := orgNSWithDefaults("acme", []secrets.AnnotationGrant{
+		{Principal: "org-user@example.com", Role: "viewer"},
+	}, nil, t)
+	parentFolder := folderNSWithDefaults("eng", "acme", "holos-org-acme", []secrets.AnnotationGrant{
+		{Principal: "parent-user@example.com", Role: "viewer"},
+	}, nil, t)
+	childFolder := folderNSWithDefaults("frontend", "acme", "holos-fld-eng", []secrets.AnnotationGrant{
+		{Principal: "child-user@example.com", Role: "editor"},
+	}, nil, t)
+	projectNs := managedProjectNS("myproject", "acme", "holos-fld-frontend")
+	fakeClient := fake.NewClientset(orgNs, parentFolder, childFolder, projectNs)
+	k8s := NewK8sClient(fakeClient, r)
+	w := &resolver.Walker{Client: fakeClient, Resolver: r}
+	pr := NewProjectGrantResolver(k8s).WithWalker(w)
+
+	users, _, err := pr.GetDefaultGrants(context.Background(), "myproject")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	principalRoles := make(map[string]string)
+	for _, u := range users {
+		principalRoles[u.Principal] = u.Role
+	}
+	if principalRoles["org-user@example.com"] != "viewer" {
+		t.Errorf("expected org-user as viewer, got %q", principalRoles["org-user@example.com"])
+	}
+	if principalRoles["parent-user@example.com"] != "viewer" {
+		t.Errorf("expected parent-user as viewer, got %q", principalRoles["parent-user@example.com"])
+	}
+	if principalRoles["child-user@example.com"] != "editor" {
+		t.Errorf("expected child-user as editor, got %q", principalRoles["child-user@example.com"])
+	}
+}
+
+func TestGetDefaultGrants_WithWalker_ExplicitGrantOverridesOrgDefault(t *testing.T) {
+	// Project default overrides org default for the same principal.
+	r := resolverTestResolver()
+	orgNs := orgNSWithDefaults("acme", []secrets.AnnotationGrant{
+		{Principal: "bob@example.com", Role: "viewer"},
+	}, nil, t)
+	projectNs := managedProjectNS("myproject", "acme", "holos-org-acme")
+	// Project has bob as editor — should override org's viewer for bob.
+	projectNs.Annotations = map[string]string{
+		v1alpha2.AnnotationDefaultShareUsers: grantsJSON(t, []secrets.AnnotationGrant{
+			{Principal: "bob@example.com", Role: "editor"},
+		}),
+	}
+	fakeClient := fake.NewClientset(orgNs, projectNs)
+	k8s := NewK8sClient(fakeClient, r)
+	w := &resolver.Walker{Client: fakeClient, Resolver: r}
+	pr := NewProjectGrantResolver(k8s).WithWalker(w)
+
+	users, _, err := pr.GetDefaultGrants(context.Background(), "myproject")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var bobRole string
+	for _, u := range users {
+		if u.Principal == "bob@example.com" {
+			bobRole = u.Role
+			break
+		}
+	}
+	if bobRole != "editor" {
+		t.Errorf("expected bob as editor (project overrides org), got %q", bobRole)
+	}
+}

--- a/console/secrets/handler.go
+++ b/console/secrets/handler.go
@@ -650,8 +650,36 @@ func (h *Handler) resolveProjectGrants(ctx context.Context, project string) (map
 }
 
 // checkAccess verifies access using per-secret grants, then project grants.
-// Organization grants do not cascade to secret operations
+//
+// # Non-cascading access for secrets (intentional)
+//
+// Hierarchy walking is used ONLY to collect default-share grants at create
+// time (org → folders → project → new secret). It is NOT used for access
+// checks on existing secrets. This is a principled design decision:
+//
+//   - Templates are policy: it is appropriate for an org-level OWNER to apply
+//     a platform template everywhere — the template is a policy artifact that
+//     must reach every project.
+//   - Secrets are data: an org-level OWNER should NOT automatically be able to
+//     read a secret stored in a specific project namespace unless they have an
+//     explicit grant on that secret or project (ADR 007). Secrets may contain
+//     credentials that are intentionally isolated to a team.
+//
+// The access path for secrets is:
+//
+//  1. Per-secret grants (full permission via PermissionSecretsRead/Write/Delete).
+//  2. Project grants via ProjectCascadeSecretPerms (EDITORs and OWNERs may
+//     write; VIEWERs cannot read — PermissionSecretsRead never cascades).
+//
+// PermissionSecretsRead is NOT in ProjectCascadeSecretPerms. This means even a
+// project-level OWNER cannot read a specific secret via cascade — they need an
+// explicit per-secret grant. An org-level OWNER (with no project grant) is
+// denied at step 2 as well. Organization grants do not cascade at all
 // (see docs/adrs/007-org-grants-no-cascade.md).
+//
+// To gain read access through the default-share mechanism, the secret's
+// default-share grants (inherited at create time from ancestors) must include
+// the user's email or role — these appear as direct per-secret grants at step 1.
 func (h *Handler) checkAccess(
 	email string,
 	roles []string,

--- a/console/secrets/handler_test.go
+++ b/console/secrets/handler_test.go
@@ -12,8 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
-	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
-	"github.com/holos-run/holos-console/console/resolver"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -85,9 +84,9 @@ func testProjectNS() *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prj-test-namespace",
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:    v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      "test-namespace",
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "test-namespace",
 			},
 		},
 	}
@@ -101,7 +100,7 @@ func TestHandler_GetSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
 				},
 			},
 			Data: map[string][]byte{
@@ -186,7 +185,7 @@ func TestHandler_GetSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"other@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"other@example.com","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{
@@ -303,7 +302,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareRoles: `[{"principal":"owner","role":"owner"}]`,
+					v1alpha2.AnnotationShareRoles: `[{"principal":"owner","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{
@@ -379,7 +378,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{
@@ -454,7 +453,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareRoles: `[{"principal":"owner","role":"owner"}]`,
+					v1alpha2.AnnotationShareRoles: `[{"principal":"owner","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -498,7 +497,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -541,10 +540,10 @@ func TestHandler_DeleteSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
 				},
 			},
 		}
@@ -597,10 +596,10 @@ func TestHandler_DeleteSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
 				},
 			},
 		}
@@ -637,10 +636,10 @@ func TestHandler_DeleteSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
 				},
 			},
 		}
@@ -735,10 +734,10 @@ func TestHandler_DeleteSecret_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
 				},
 			},
 		}
@@ -781,10 +780,10 @@ func TestHandler_DeleteSecret_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"other@example.com","role":"editor"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"other@example.com","role":"editor"}]`,
 				},
 			},
 		}
@@ -1159,10 +1158,10 @@ func TestHandler_UpdateSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
 				},
 			},
 			Data: map[string][]byte{
@@ -1233,10 +1232,10 @@ func TestHandler_UpdateSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
 				},
 			},
 			Data: map[string][]byte{"k": []byte("v")},
@@ -1388,10 +1387,10 @@ func TestHandler_UpdateSecret_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
 				},
 			},
 			Data: map[string][]byte{"k": []byte("v")},
@@ -1442,10 +1441,10 @@ func TestHandler_UpdateSecret_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{"k": []byte("v")},
@@ -1498,7 +1497,7 @@ func TestHandler_GetSecret_MultipleKeys(t *testing.T) {
 				Name:      "multi-key-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareRoles: `[{"principal":"owner","role":"owner"}]`,
+					v1alpha2.AnnotationShareRoles: `[{"principal":"owner","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{
@@ -1553,10 +1552,10 @@ func TestHandler_ListSecrets(t *testing.T) {
 				Name:      "labeled-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
 				},
 			},
 		}
@@ -1565,7 +1564,7 @@ func TestHandler_ListSecrets(t *testing.T) {
 				Name:      "unlabeled-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
 				},
 			},
 		}
@@ -1610,10 +1609,10 @@ func TestHandler_ListSecrets(t *testing.T) {
 				Name:      "accessible-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
 				},
 			},
 		}
@@ -1622,10 +1621,10 @@ func TestHandler_ListSecrets(t *testing.T) {
 				Name:      "inaccessible-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"other@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"other@example.com","role":"owner"}]`,
 				},
 			},
 		}
@@ -1746,10 +1745,10 @@ func TestHandler_UpdateSharing(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -1830,10 +1829,10 @@ func TestHandler_UpdateSharing(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"bob@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"bob@example.com","role":"viewer"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -1968,7 +1967,7 @@ func TestHandler_GetSecretRaw(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
 				},
 			},
 			Data: map[string][]byte{
@@ -2021,7 +2020,7 @@ func TestHandler_GetSecretRaw(t *testing.T) {
 				ResourceVersion:   rv,
 				CreationTimestamp: metav1.Now(),
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"viewer"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -2069,7 +2068,7 @@ func TestHandler_GetSecretRaw(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"other@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"other@example.com","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -2267,10 +2266,10 @@ func TestHandler_UpdateSecret_StringData(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
 				},
 			},
 			Data: map[string][]byte{"old-key": []byte("old-value")},
@@ -2316,10 +2315,10 @@ func TestHandler_UpdateSecret_StringData(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"editor"}]`,
 				},
 			},
 			Data: map[string][]byte{"k": []byte("v")},
@@ -2364,10 +2363,10 @@ func TestHandler_UpdateSharing_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -2417,10 +2416,10 @@ func TestHandler_UpdateSharing_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"bob@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"bob@example.com","role":"viewer"}]`,
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -2472,10 +2471,10 @@ func TestHandler_ListSecrets_AuditLogging(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
 				},
 			},
 		}
@@ -2519,11 +2518,11 @@ func TestHandler_DescriptionAndURL(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
-				Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+				Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers:  `[{"principal":"user@example.com","role":"owner"}]`,
-					v1alpha1.AnnotationDescription: "Database credentials",
-					v1alpha1.AnnotationURL:         "https://db.example.com",
+					v1alpha2.AnnotationShareUsers:  `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationDescription: "Database credentials",
+					v1alpha2.AnnotationURL:         "https://db.example.com",
 				},
 			},
 		}
@@ -2555,9 +2554,9 @@ func TestHandler_DescriptionAndURL(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
-				Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+				Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"user@example.com","role":"owner"}]`,
 				},
 			},
 		}
@@ -2625,10 +2624,10 @@ func TestHandler_DescriptionAndURL(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
-				Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+				Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers:  `[{"principal":"user@example.com","role":"owner"}]`,
-					v1alpha1.AnnotationDescription: "Old description",
+					v1alpha2.AnnotationShareUsers:  `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationDescription: "Old description",
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -2672,11 +2671,11 @@ func TestHandler_DescriptionAndURL(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
-				Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+				Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers:  `[{"principal":"user@example.com","role":"owner"}]`,
-					v1alpha1.AnnotationDescription: "Important secret",
-					v1alpha1.AnnotationURL:         "https://important.example.com",
+					v1alpha2.AnnotationShareUsers:  `[{"principal":"user@example.com","role":"owner"}]`,
+					v1alpha2.AnnotationDescription: "Important secret",
+					v1alpha2.AnnotationURL:         "https://important.example.com",
 				},
 			},
 		}
@@ -2727,7 +2726,7 @@ func TestGetSecret_ProjectViewerCannotReadData(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-secret",
 			Namespace: "prj-test-namespace",
-			Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 		},
 		Data: map[string][]byte{"key": []byte("value")},
 	}
@@ -2764,7 +2763,7 @@ func TestGetSecret_ProjectEditorCannotReadData(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-secret",
 			Namespace: "prj-test-namespace",
-			Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 		},
 		Data: map[string][]byte{"key": []byte("value")},
 	}
@@ -2801,7 +2800,7 @@ func TestListSecrets_ProjectViewerCanListMetadata(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-secret",
 			Namespace: "prj-test-namespace",
-			Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 		},
 		Data: map[string][]byte{"key": []byte("value")},
 	}
@@ -2859,7 +2858,7 @@ func TestDeleteSecret_ProjectOwnerCanDelete(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-secret",
 			Namespace: "prj-test-namespace",
-			Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 		},
 	}
 	fakeClient := fake.NewClientset(testProjectNS(), secret)
@@ -2888,7 +2887,7 @@ func TestUpdateSharing_ProjectOwnerCanAdmin(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-secret",
 			Namespace: "prj-test-namespace",
-			Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 			UID:       types.UID("test-uid"),
 		},
 	}
@@ -2925,7 +2924,7 @@ func TestListSecrets_NoGrantsDeniesAccess(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-secret",
 			Namespace: "prj-test-namespace",
-			Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 		},
 		Data: map[string][]byte{"key": []byte("value")},
 	}
@@ -2957,7 +2956,7 @@ func TestGetSecret_NoGrantsDeniesAccess(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-secret",
 			Namespace: "prj-test-namespace",
-			Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 		},
 		Data: map[string][]byte{"key": []byte("value")},
 	}

--- a/console/secrets/k8s.go
+++ b/console/secrets/k8s.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"time"
 
-	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,7 +76,7 @@ func (c *K8sClient) GetSecret(ctx context.Context, project, name string) (*corev
 // ListSecrets retrieves secrets with the console label from the project's namespace.
 func (c *K8sClient) ListSecrets(ctx context.Context, project string) (*corev1.SecretList, error) {
 	ns := c.Resolver.ProjectNamespace(project)
-	labelSelector := v1alpha1.LabelManagedBy + "=" + v1alpha1.ManagedByValue
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue
 	slog.DebugContext(ctx, "listing secrets from kubernetes",
 		slog.String("project", project),
 		slog.String("namespace", ns),
@@ -104,21 +104,21 @@ func (c *K8sClient) CreateSecret(ctx context.Context, project, name string, data
 		return nil, fmt.Errorf("marshaling share-roles: %w", err)
 	}
 	annotations := map[string]string{
-		v1alpha1.AnnotationShareUsers: string(usersJSON),
-		v1alpha1.AnnotationShareRoles: string(rolesJSON),
+		v1alpha2.AnnotationShareUsers: string(usersJSON),
+		v1alpha2.AnnotationShareRoles: string(rolesJSON),
 	}
 	if description != "" {
-		annotations[v1alpha1.AnnotationDescription] = description
+		annotations[v1alpha2.AnnotationDescription] = description
 	}
 	if url != "" {
-		annotations[v1alpha1.AnnotationURL] = url
+		annotations[v1alpha2.AnnotationURL] = url
 	}
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 			Annotations: annotations,
 		},
@@ -139,8 +139,8 @@ func (c *K8sClient) UpdateSecret(ctx context.Context, project, name string, data
 	if err != nil {
 		return nil, err
 	}
-	if secret.Labels == nil || secret.Labels[v1alpha1.LabelManagedBy] != v1alpha1.ManagedByValue {
-		return nil, fmt.Errorf("secret %q is not managed by %s", name, v1alpha1.ManagedByValue)
+	if secret.Labels == nil || secret.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		return nil, fmt.Errorf("secret %q is not managed by %s", name, v1alpha2.ManagedByValue)
 	}
 	secret.Data = data
 	if description != nil || url != nil {
@@ -149,16 +149,16 @@ func (c *K8sClient) UpdateSecret(ctx context.Context, project, name string, data
 		}
 		if description != nil {
 			if *description == "" {
-				delete(secret.Annotations, v1alpha1.AnnotationDescription)
+				delete(secret.Annotations, v1alpha2.AnnotationDescription)
 			} else {
-				secret.Annotations[v1alpha1.AnnotationDescription] = *description
+				secret.Annotations[v1alpha2.AnnotationDescription] = *description
 			}
 		}
 		if url != nil {
 			if *url == "" {
-				delete(secret.Annotations, v1alpha1.AnnotationURL)
+				delete(secret.Annotations, v1alpha2.AnnotationURL)
 			} else {
-				secret.Annotations[v1alpha1.AnnotationURL] = *url
+				secret.Annotations[v1alpha2.AnnotationURL] = *url
 			}
 		}
 	}
@@ -176,8 +176,8 @@ func (c *K8sClient) DeleteSecret(ctx context.Context, project, name string) erro
 	if err != nil {
 		return err
 	}
-	if secret.Labels == nil || secret.Labels[v1alpha1.LabelManagedBy] != v1alpha1.ManagedByValue {
-		return fmt.Errorf("secret %q is not managed by %s", name, v1alpha1.ManagedByValue)
+	if secret.Labels == nil || secret.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		return fmt.Errorf("secret %q is not managed by %s", name, v1alpha2.ManagedByValue)
 	}
 	return c.client.CoreV1().Secrets(secret.Namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }
@@ -193,8 +193,8 @@ func (c *K8sClient) UpdateSharing(ctx context.Context, project, name string, sha
 	if err != nil {
 		return nil, err
 	}
-	if secret.Labels == nil || secret.Labels[v1alpha1.LabelManagedBy] != v1alpha1.ManagedByValue {
-		return nil, fmt.Errorf("secret %q is not managed by %s", name, v1alpha1.ManagedByValue)
+	if secret.Labels == nil || secret.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		return nil, fmt.Errorf("secret %q is not managed by %s", name, v1alpha2.ManagedByValue)
 	}
 	if secret.Annotations == nil {
 		secret.Annotations = make(map[string]string)
@@ -207,8 +207,8 @@ func (c *K8sClient) UpdateSharing(ctx context.Context, project, name string, sha
 	if err != nil {
 		return nil, fmt.Errorf("marshaling share-roles: %w", err)
 	}
-	secret.Annotations[v1alpha1.AnnotationShareUsers] = string(usersJSON)
-	secret.Annotations[v1alpha1.AnnotationShareRoles] = string(rolesJSON)
+	secret.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
+	secret.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
 	return c.client.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
 }
 
@@ -216,14 +216,14 @@ func (c *K8sClient) UpdateSharing(ctx context.Context, project, name string, sha
 // Returns an empty slice if the annotation is missing.
 // Returns an error if the annotation contains invalid JSON.
 func GetShareUsers(secret *corev1.Secret) ([]AnnotationGrant, error) {
-	return parseGrantAnnotation(secret, v1alpha1.AnnotationShareUsers)
+	return parseGrantAnnotation(secret, v1alpha2.AnnotationShareUsers)
 }
 
 // GetShareRoles parses the console.holos.run/share-roles annotation from a secret.
 // Returns nil if the annotation is absent.
 // Returns an error if the annotation contains invalid JSON.
 func GetShareRoles(secret *corev1.Secret) ([]AnnotationGrant, error) {
-	return parseGrantAnnotation(secret, v1alpha1.AnnotationShareRoles)
+	return parseGrantAnnotation(secret, v1alpha2.AnnotationShareRoles)
 }
 
 // GetDescription returns the description annotation value from a secret.
@@ -232,7 +232,7 @@ func GetDescription(secret *corev1.Secret) string {
 	if secret.Annotations == nil {
 		return ""
 	}
-	return secret.Annotations[v1alpha1.AnnotationDescription]
+	return secret.Annotations[v1alpha2.AnnotationDescription]
 }
 
 // GetURL returns the URL annotation value from a secret.
@@ -241,7 +241,7 @@ func GetURL(secret *corev1.Secret) string {
 	if secret.Annotations == nil {
 		return ""
 	}
-	return secret.Annotations[v1alpha1.AnnotationURL]
+	return secret.Annotations[v1alpha2.AnnotationURL]
 }
 
 // parseGrantAnnotation parses a JSON annotation value into a slice of AnnotationGrant.

--- a/console/secrets/k8s_test.go
+++ b/console/secrets/k8s_test.go
@@ -11,12 +11,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 )
 
 func testResolver() *resolver.Resolver {
-	return &resolver.Resolver{OrganizationPrefix: "org-", ProjectPrefix: "prj-"}
+	return &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 }
 
 // projectNS creates a project namespace fixture.
@@ -25,9 +25,9 @@ func projectNS(project string) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prj-" + project,
 			Labels: map[string]string{
-				v1alpha1.LabelManagedBy:    v1alpha1.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeProject,
-				resolver.ProjectLabel:      project,
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      project,
 			},
 		},
 	}
@@ -106,7 +106,7 @@ func TestUpdateSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 			},
 			Data: map[string][]byte{
@@ -200,7 +200,7 @@ func TestCreateSecret(t *testing.T) {
 		if result.Name != "new-secret" {
 			t.Errorf("expected name 'new-secret', got %q", result.Name)
 		}
-		if result.Labels[v1alpha1.LabelManagedBy] != v1alpha1.ManagedByValue {
+		if result.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
 			t.Errorf("expected managed-by label, got %v", result.Labels)
 		}
 		// Verify share-users annotation
@@ -258,7 +258,7 @@ func TestDeleteSecret(t *testing.T) {
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
 				Labels: map[string]string{
-					v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue,
+					v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 				},
 			},
 		}
@@ -322,7 +322,7 @@ func TestGetShareUsers(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"editor"},{"principal":"bob@example.com","role":"viewer"}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"editor"},{"principal":"bob@example.com","role":"viewer"}]`,
 				},
 			},
 		}
@@ -345,7 +345,7 @@ func TestGetShareUsers(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"editor","nbf":1000,"exp":2000}]`,
+					v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"editor","nbf":1000,"exp":2000}]`,
 				},
 			},
 		}
@@ -396,7 +396,7 @@ func TestGetShareUsers(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareUsers: `{invalid`,
+					v1alpha2.AnnotationShareUsers: `{invalid`,
 				},
 			},
 		}
@@ -412,7 +412,7 @@ func TestGetShareRoles(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareRoles: `[{"principal":"platform-team","role":"owner"},{"principal":"dev-team","role":"viewer"}]`,
+					v1alpha2.AnnotationShareRoles: `[{"principal":"platform-team","role":"owner"},{"principal":"dev-team","role":"viewer"}]`,
 				},
 			},
 		}
@@ -460,7 +460,7 @@ func TestGetShareRoles(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha1.AnnotationShareRoles: `not-json`,
+					v1alpha2.AnnotationShareRoles: `not-json`,
 				},
 			},
 		}
@@ -586,7 +586,7 @@ func TestGetDescription(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha1.AnnotationDescription: "Database credentials for production",
+					v1alpha2.AnnotationDescription: "Database credentials for production",
 				},
 			},
 		}
@@ -621,7 +621,7 @@ func TestGetURL(t *testing.T) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					v1alpha1.AnnotationURL: "https://example.com/service",
+					v1alpha2.AnnotationURL: "https://example.com/service",
 				},
 			},
 		}
@@ -680,10 +680,10 @@ func TestCreateSecretWithDescriptionAndURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if _, ok := result.Annotations[v1alpha1.AnnotationDescription]; ok {
+		if _, ok := result.Annotations[v1alpha2.AnnotationDescription]; ok {
 			t.Error("expected no description annotation when empty")
 		}
-		if _, ok := result.Annotations[v1alpha1.AnnotationURL]; ok {
+		if _, ok := result.Annotations[v1alpha2.AnnotationURL]; ok {
 			t.Error("expected no URL annotation when empty")
 		}
 	})
@@ -696,7 +696,7 @@ func TestUpdateSecretWithDescriptionAndURL(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
-				Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+				Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
 		}
@@ -723,10 +723,10 @@ func TestUpdateSecretWithDescriptionAndURL(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
-				Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+				Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationDescription: "Original desc",
-					v1alpha1.AnnotationURL:         "https://original.example.com",
+					v1alpha2.AnnotationDescription: "Original desc",
+					v1alpha2.AnnotationURL:         "https://original.example.com",
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -752,10 +752,10 @@ func TestUpdateSecretWithDescriptionAndURL(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
 				Namespace: "prj-test-namespace",
-				Labels:    map[string]string{v1alpha1.LabelManagedBy: v1alpha1.ManagedByValue},
+				Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
 				Annotations: map[string]string{
-					v1alpha1.AnnotationDescription: "Original desc",
-					v1alpha1.AnnotationURL:         "https://original.example.com",
+					v1alpha2.AnnotationDescription: "Original desc",
+					v1alpha2.AnnotationURL:         "https://original.example.com",
 				},
 			},
 			Data: map[string][]byte{"key": []byte("value")},
@@ -768,10 +768,10 @@ func TestUpdateSecretWithDescriptionAndURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if _, ok := result.Annotations[v1alpha1.AnnotationDescription]; ok {
+		if _, ok := result.Annotations[v1alpha2.AnnotationDescription]; ok {
 			t.Error("expected description annotation to be removed")
 		}
-		if _, ok := result.Annotations[v1alpha1.AnnotationURL]; ok {
+		if _, ok := result.Annotations[v1alpha2.AnnotationURL]; ok {
 			t.Error("expected URL annotation to be removed")
 		}
 	})


### PR DESCRIPTION
## Summary

- Replace all `v1alpha1.*` constants with `v1alpha2.*` in `console/secrets/k8s.go` and test files
- Extend `ProjectGrantResolver.GetDefaultGrants` in `console/projects/resolver.go` to walk the full ancestor chain (project → folders → org) when a `resolver.Walker` is configured; merge default-share grants from all levels using highest-role-wins per principal
- Wire the walker in `console/console.go` via `projects.NewProjectGrantResolver(k8s).WithWalker(nsWalker)`
- Add `console/projects/resolver_test.go` with tests for: direct-under-org, under-folder, under-nested-folders, and project-overrides-org scenarios
- Enhance `checkAccess` comment to explain the principled separation: ancestry walk is ONLY for default-share cascade at create time, NOT for access checks on existing secrets (ADR 007)

Closes: #630

## Test plan
- [x] New tests in `console/projects/resolver_test.go` cover all required ancestor cascade scenarios
- [x] Existing `console/secrets/` tests pass with v1alpha2 constants
- [x] `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1