### PR TITLE
feat: ancestor template walk and PlatformInput.Folders in deployment renderer

### DIFF
--- a/api/v1alpha1/input.go
+++ b/api/v1alpha1/input.go
@@ -39,6 +39,12 @@ type PlatformInput struct {
 	GatewayNamespace string `json:"gatewayNamespace" yaml:"gatewayNamespace" cue:"gatewayNamespace"`
 	// Organization is the parent organization name.
 	Organization string `json:"organization"     yaml:"organization"     cue:"organization"`
+	// Folders is the ordered list of folder names in the ancestor chain from
+	// the organization down to (but not including) the project. The first
+	// element is the immediate child of the organization; the last element is
+	// the immediate parent of the project. Empty when the project has no folder
+	// ancestors. Available in CUE templates as platform.folders.
+	Folders []string `json:"folders,omitempty" yaml:"folders,omitempty" cue:"folders?"`
 	// Claims carries the OIDC ID token claims of the authenticated user.
 	Claims Claims `json:"claims"           yaml:"claims"           cue:"claims"`
 }

--- a/console/console.go
+++ b/console/console.go
@@ -322,9 +322,11 @@ func (s *Server) Serve(ctx context.Context) error {
 		if dynamicClient != nil {
 			deploymentsApplier = deployments.NewApplier(dynamicClient)
 		}
+		projectFolderResolver := projects.NewProjectFolderResolver(projectsK8s, nsWalker)
 		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templates.NewProjectScopedResolver(templatesK8s), &deployments.CueRenderer{}, deploymentsApplier).
 			WithOrgProvider(projectsK8s).
-			WithOrgTemplateProvider(templatesK8s)
+			WithOrgTemplateProvider(templatesK8s).
+			WithAncestorWalker(projectFolderResolver)
 		deploymentsPath, deploymentsHTTPHandler := consolev1connect.NewDeploymentServiceHandler(deploymentsHandler, protectedInterceptors)
 		mux.Handle(deploymentsPath, deploymentsHTTPHandler)
 	} else {

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	v1alpha1 "github.com/holos-run/holos-console/api/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
@@ -53,14 +54,24 @@ const DefaultGatewayNamespace = "istio-ingress"
 // Renderer evaluates CUE templates with deployment parameters.
 type Renderer interface {
 	Render(ctx context.Context, cueSource string, platform v1alpha1.PlatformInput, project v1alpha1.ProjectInput) ([]unstructured.Unstructured, error)
-	// RenderWithOrgTemplates unifies one or more platform template CUE sources
-	// with the deployment template before filling in platform and project inputs.
-	RenderWithOrgTemplates(ctx context.Context, deploymentCUE string, orgTemplateCUESources []string, platform v1alpha1.PlatformInput, project v1alpha1.ProjectInput) ([]unstructured.Unstructured, error)
+	// RenderWithAncestorTemplates unifies one or more ancestor (organization- and
+	// folder-level) template CUE sources with the deployment template before
+	// filling in platform and project inputs.
+	RenderWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha1.PlatformInput, project v1alpha1.ProjectInput) ([]unstructured.Unstructured, error)
 }
 
 // OrgProvider resolves the organization for a project.
 type OrgProvider interface {
 	GetProjectOrg(ctx context.Context, project string) (string, error)
+}
+
+// AncestorWalker resolves the folder ancestry for a project namespace.
+// It returns the list of folder user-facing names from the organization down
+// to (but not including) the project (i.e. org → folder1 → folder2 → project
+// yields ["folder1", "folder2"] when folder namespaces exist). Used to
+// populate PlatformInput.Folders so CUE templates can reference platform.folders.
+type AncestorWalker interface {
+	GetProjectFolders(ctx context.Context, project string) ([]string, error)
 }
 
 // OrgTemplateProvider resolves platform template CUE sources for render (ADR 019).
@@ -85,15 +96,16 @@ type ResourceApplier interface {
 // Handler implements the DeploymentService.
 type Handler struct {
 	consolev1connect.UnimplementedDeploymentServiceHandler
-	k8s                    *K8sClient
-	projectResolver        ProjectResolver
-	settingsResolver       SettingsResolver
-	templateResolver       TemplateResolver
-	renderer               Renderer
-	applier                ResourceApplier
-	logReader              LogReader
-	orgProvider            OrgProvider
+	k8s                 *K8sClient
+	projectResolver     ProjectResolver
+	settingsResolver    SettingsResolver
+	templateResolver    TemplateResolver
+	renderer            Renderer
+	applier             ResourceApplier
+	logReader           LogReader
+	orgProvider         OrgProvider
 	orgTemplateProvider OrgTemplateProvider
+	ancestorWalker      AncestorWalker
 }
 
 // NewHandler creates a DeploymentService handler.
@@ -119,6 +131,14 @@ func (h *Handler) WithOrgProvider(op OrgProvider) *Handler {
 // for loading enabled platform templates at render time.
 func (h *Handler) WithOrgTemplateProvider(stp OrgTemplateProvider) *Handler {
 	h.orgTemplateProvider = stp
+	return h
+}
+
+// WithAncestorWalker configures the handler with an AncestorWalker for
+// resolving folder ancestry. When set, PlatformInput.Folders is populated
+// so CUE templates can reference platform.folders.
+func (h *Handler) WithAncestorWalker(aw AncestorWalker) *Handler {
+	h.ancestorWalker = aw
 	return h
 }
 
@@ -160,7 +180,7 @@ func (h *Handler) renderResources(ctx context.Context, project, cueSource string
 		return h.renderer.Render(ctx, cueSource, platform, projectInput)
 	}
 
-	return h.renderer.RenderWithOrgTemplates(ctx, cueSource, orgTemplateSources, platform, projectInput)
+	return h.renderer.RenderWithAncestorTemplates(ctx, cueSource, orgTemplateSources, platform, projectInput)
 }
 
 // ListDeployments returns all deployments in a project.
@@ -303,7 +323,7 @@ func (h *Handler) CreateDeployment(
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("template %q not found in project %q", req.Msg.Template, project))
 		}
 		cueSource = tmplCM.Data[cueTemplateKey]
-		linkedOrgTemplates = linkedOrgTemplatesFromAnnotation(tmplCM)
+		linkedOrgTemplates = linkedTemplateNamesFromAnnotation(tmplCM)
 	}
 
 	envInputs, err := validateEnvVars(req.Msg.Env)
@@ -330,7 +350,7 @@ func (h *Handler) CreateDeployment(
 	// the operation is all-or-nothing.
 	if h.renderer != nil && h.applier != nil {
 		ns := h.k8s.Resolver.ProjectNamespace(project)
-		platformIn := h.buildPlatformInput(project, ns, claims)
+		platformIn := h.buildPlatformInput(ctx, project, ns, claims)
 		projectIn := v1alpha1.ProjectInput{
 			Name:    name,
 			Image:   req.Msg.Image,
@@ -450,12 +470,12 @@ func (h *Handler) UpdateDeployment(
 				)
 			} else {
 				cueSource = tmplCM.Data[cueTemplateKey]
-				linkedOrgTemplatesUpdate = linkedOrgTemplatesFromAnnotation(tmplCM)
+				linkedOrgTemplatesUpdate = linkedTemplateNamesFromAnnotation(tmplCM)
 			}
 		}
 
 		ns := h.k8s.Resolver.ProjectNamespace(project)
-		platformIn := h.buildPlatformInput(project, ns, claims)
+		platformIn := h.buildPlatformInput(ctx, project, ns, claims)
 		projectIn := v1alpha1.ProjectInput{
 			Name:    name,
 			Image:   image,
@@ -682,11 +702,11 @@ func (h *Handler) GetDeploymentRenderPreview(
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("template %q not found in project %q", templateName, project))
 	}
 	cueTemplate := tmplCM.Data[cueTemplateKey]
-	linkedOrgTemplatesPreview := linkedOrgTemplatesFromAnnotation(tmplCM)
+	linkedOrgTemplatesPreview := linkedTemplateNamesFromAnnotation(tmplCM)
 
 	// Build platform input from authenticated claims and resolved namespace.
 	ns := h.k8s.Resolver.ProjectNamespace(project)
-	platformIn := h.buildPlatformInput(project, ns, claims)
+	platformIn := h.buildPlatformInput(ctx, project, ns, claims)
 
 	// Build project input from the deployment's stored fields.
 	projectIn := v1alpha1.ProjectInput{
@@ -936,7 +956,10 @@ func defaultPort(port int) int {
 }
 
 // buildPlatformInput constructs a v1alpha1.PlatformInput from handler context.
-func (h *Handler) buildPlatformInput(project, namespace string, claims *rpc.Claims) v1alpha1.PlatformInput {
+// When an AncestorWalker is configured, Folders is populated with the ordered
+// list of folder names in the ancestor chain (org → folders → project) so CUE
+// templates can reference platform.folders.
+func (h *Handler) buildPlatformInput(ctx context.Context, project, namespace string, claims *rpc.Claims) v1alpha1.PlatformInput {
 	pi := v1alpha1.PlatformInput{
 		Project:          project,
 		Namespace:        namespace,
@@ -954,30 +977,72 @@ func (h *Handler) buildPlatformInput(project, namespace string, claims *rpc.Clai
 			Groups:        claims.Roles,
 		}
 	}
+	if h.ancestorWalker != nil {
+		folders, err := h.ancestorWalker.GetProjectFolders(ctx, project)
+		if err != nil {
+			slog.WarnContext(ctx, "could not resolve folder ancestry for platform input",
+				slog.String("project", project),
+				slog.Any("error", err),
+			)
+		} else {
+			pi.Folders = folders
+		}
+	}
 	return pi
 }
 
-// linkedOrgTemplatesFromAnnotation reads the linked org template names from the
-// console.holos.run/linked-org-templates annotation on a deployment template ConfigMap.
-// Returns nil if the annotation is absent or unparseable.
-func linkedOrgTemplatesFromAnnotation(cm *corev1.ConfigMap) []string {
+// linkedTemplateNamesFromAnnotation reads the linked template names from a
+// deployment template ConfigMap. It prefers the v1alpha2
+// console.holos.run/linked-templates annotation (JSON array of
+// {scope, scope_name, name} objects) and falls back to the legacy
+// console.holos.run/linked-org-templates annotation (JSON array of strings).
+// Returns only the template names (for compatibility with OrgTemplateProvider
+// which expects names, not full refs). Returns nil if no annotation is present
+// or if parsing fails.
+func linkedTemplateNamesFromAnnotation(cm *corev1.ConfigMap) []string {
 	if cm == nil || cm.Annotations == nil {
 		return nil
 	}
-	raw, ok := cm.Annotations[v1alpha1.AnnotationLinkedOrgTemplates]
-	if !ok || raw == "" {
-		return nil
+
+	// v1alpha2: console.holos.run/linked-templates — JSON array of {scope, scope_name, name}
+	if raw, ok := cm.Annotations[v1alpha2.AnnotationLinkedTemplates]; ok && raw != "" {
+		var refs []struct {
+			Scope     string `json:"scope"`
+			ScopeName string `json:"scope_name"`
+			Name      string `json:"name"`
+		}
+		if err := json.Unmarshal([]byte(raw), &refs); err != nil {
+			slog.Warn("failed to parse linked-templates annotation",
+				slog.String("name", cm.Name),
+				slog.String("namespace", cm.Namespace),
+				slog.Any("error", err),
+			)
+		} else {
+			names := make([]string, 0, len(refs))
+			for _, ref := range refs {
+				if ref.Name != "" {
+					names = append(names, ref.Name)
+				}
+			}
+			return names
+		}
 	}
-	var names []string
-	if err := json.Unmarshal([]byte(raw), &names); err != nil {
-		slog.Warn("failed to parse linked-org-templates annotation",
-			slog.String("name", cm.Name),
-			slog.String("namespace", cm.Namespace),
-			slog.Any("error", err),
-		)
-		return nil
+
+	// Legacy v1alpha1: console.holos.run/linked-org-templates — JSON array of strings.
+	if raw, ok := cm.Annotations[v1alpha1.AnnotationLinkedOrgTemplates]; ok && raw != "" {
+		var names []string
+		if err := json.Unmarshal([]byte(raw), &names); err != nil {
+			slog.Warn("failed to parse linked-org-templates annotation",
+				slog.String("name", cm.Name),
+				slog.String("namespace", cm.Namespace),
+				slog.Any("error", err),
+			)
+			return nil
+		}
+		return names
 	}
-	return names
+
+	return nil
 }
 
 // stringSliceFromConfigMap decodes a JSON string slice from the given ConfigMap data key.

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -104,7 +104,7 @@ func (s *stubRenderer) Render(_ context.Context, _ string, platform v1alpha1.Pla
 	return s.resources, s.err
 }
 
-func (s *stubRenderer) RenderWithOrgTemplates(_ context.Context, _ string, _ []string, platform v1alpha1.PlatformInput, project v1alpha1.ProjectInput) ([]unstructured.Unstructured, error) {
+func (s *stubRenderer) RenderWithAncestorTemplates(_ context.Context, _ string, _ []string, platform v1alpha1.PlatformInput, project v1alpha1.ProjectInput) ([]unstructured.Unstructured, error) {
 	s.called = true
 	s.lastPlatform = platform
 	s.lastProject = project

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -58,12 +58,13 @@ func (r *CueRenderer) Render(ctx context.Context, cueSource string, platform v1a
 	}
 }
 
-// RenderWithOrgTemplates evaluates the deployment template unified with zero or
-// more platform template CUE sources. Each platform template is unified with the
-// deployment template before filling in the platform and project inputs.
-// All templates can define values for both projectResources and platformResources.
-// The renderer reads both collections when platform templates are present (organization/folder level).
-func (r *CueRenderer) RenderWithOrgTemplates(ctx context.Context, deploymentCUE string, orgTemplateCUESources []string, platform v1alpha1.PlatformInput, project v1alpha1.ProjectInput) ([]unstructured.Unstructured, error) {
+// RenderWithAncestorTemplates evaluates the deployment template unified with zero
+// or more ancestor template CUE sources (organization- and folder-level). Each
+// ancestor template is concatenated with the deployment template before filling in
+// the platform and project inputs. All templates can define values for both
+// projectResources and platformResources. The renderer reads both collections when
+// ancestor templates are present (organization/folder level).
+func (r *CueRenderer) RenderWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha1.PlatformInput, project v1alpha1.ProjectInput) ([]unstructured.Unstructured, error) {
 	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
 	defer cancel()
 
@@ -73,7 +74,7 @@ func (r *CueRenderer) RenderWithOrgTemplates(ctx context.Context, deploymentCUE 
 	}
 	ch := make(chan result, 1)
 	go func() {
-		resources, err := evaluateWithOrgTemplates(deploymentCUE, orgTemplateCUESources, platform, project)
+		resources, err := evaluateWithOrgTemplates(deploymentCUE, ancestorTemplateCUESources, platform, project)
 		ch <- result{resources, err}
 	}()
 

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -1211,7 +1211,7 @@ projectResources: {
 
 // systemBothCollectionsTemplate is a platform template that defines resources in
 // both projectResources and platformResources. This validates that
-// RenderWithOrgTemplates returns resources from both collections.
+// RenderWithAncestorTemplates returns resources from both collections.
 const systemBothCollectionsTemplate = `
 
 projectResources: {
@@ -1269,6 +1269,7 @@ platform: #Platform
 	namespace:        string
 	gatewayNamespace: string
 	organization:     string
+	folders?: [...string]
 	claims: {
 		iss:            string
 		sub:            string
@@ -1336,7 +1337,7 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 	}
 
 	t.Run("platform template resources are included when unified with deployment template", func(t *testing.T) {
-		resources, err := renderer.RenderWithOrgTemplates(context.Background(),
+		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
 			deploymentTemplateForUnification,
 			[]string{systemUnificationTemplate},
 			system, user,
@@ -1367,7 +1368,7 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 	})
 
 	t.Run("no platform templates returns only deployment resources", func(t *testing.T) {
-		resources, err := renderer.RenderWithOrgTemplates(context.Background(),
+		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
 			deploymentTemplateForUnification,
 			nil,
 			system, user,
@@ -1386,7 +1387,7 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 	// ADR 016 key insight: any template at any level can define values in any
 	// collection. A platform template is not restricted to platformResources only.
 	t.Run("platform template contributing to projectResources is unified", func(t *testing.T) {
-		resources, err := renderer.RenderWithOrgTemplates(context.Background(),
+		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
 			deploymentTemplateForUnification,
 			[]string{systemProjectResourcesTemplate},
 			system, user,
@@ -1412,10 +1413,10 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 		}
 	})
 
-	// Validate that RenderWithOrgTemplates returns resources from both
+	// Validate that RenderWithAncestorTemplates returns resources from both
 	// projectResources and platformResources when a platform template defines both.
 	t.Run("platform template defining both collections returns all resources", func(t *testing.T) {
-		resources, err := renderer.RenderWithOrgTemplates(context.Background(),
+		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
 			deploymentTemplateForUnification,
 			[]string{systemBothCollectionsTemplate},
 			system, user,
@@ -1482,10 +1483,10 @@ func TestCueRenderer_LevelBasedResourceReading(t *testing.T) {
 		}
 	})
 
-	// RenderWithOrgTemplates() uses evaluateWithOrgTemplates() — the
+	// RenderWithAncestorTemplates() uses evaluateWithOrgTemplates() — the
 	// org/folder level path. It must read BOTH projectResources and platformResources.
-	t.Run("RenderWithOrgTemplates reads both projectResources and platformResources", func(t *testing.T) {
-		resources, err := renderer.RenderWithOrgTemplates(context.Background(),
+	t.Run("RenderWithAncestorTemplates reads both projectResources and platformResources", func(t *testing.T) {
+		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
 			systemOutputTemplate,
 			nil, // no additional platform templates; the deployment template itself defines platformResources
 			v1alpha1.PlatformInput{Project: "my-project", Namespace: namespace},
@@ -1765,11 +1766,11 @@ func TestCueRenderer_ClosedStructKindConstraint(t *testing.T) {
 	// Sub-test 1: allowed kinds succeed.
 	// The org template closes projectResources.namespacedResources to Deployment,
 	// Service, ServiceAccount. The project template produces exactly those three
-	// kinds. RenderWithOrgTemplates should succeed and return all expected
+	// kinds. RenderWithAncestorTemplates should succeed and return all expected
 	// resources: 3 project resources (Deployment, Service, ServiceAccount) from
 	// projectResources + 1 HTTPRoute from platformResources = 4 total.
 	t.Run("allowed kinds succeed", func(t *testing.T) {
-		resources, err := renderer.RenderWithOrgTemplates(
+		resources, err := renderer.RenderWithAncestorTemplates(
 			context.Background(),
 			closedStructProjectTemplate,
 			[]string{closedStructOrgTemplate},
@@ -1802,7 +1803,7 @@ func TestCueRenderer_ClosedStructKindConstraint(t *testing.T) {
 	// closed struct error), matching the documented error:
 	//   projectResources.namespacedResources.<ns>.RoleBinding: field not allowed
 	t.Run("disallowed kind fails with CUE closed struct error", func(t *testing.T) {
-		_, err := renderer.RenderWithOrgTemplates(
+		_, err := renderer.RenderWithAncestorTemplates(
 			context.Background(),
 			closedStructProjectTemplateForbidden,
 			[]string{closedStructOrgTemplate},
@@ -1882,12 +1883,12 @@ func TestCueRenderer_HttpbinExample(t *testing.T) {
 	}
 
 	// Sub-test 1: Templates render together.
-	// RenderWithOrgTemplates with the org platform template and the
+	// RenderWithAncestorTemplates with the org platform template and the
 	// project template as deployment template must produce 4 resources:
 	// 3 project resources (ServiceAccount, Deployment, Service) from
 	// projectResources + 1 platform resource (HTTPRoute) from platformResources.
 	t.Run("templates render together producing 4 resources", func(t *testing.T) {
-		resources, err := renderer.RenderWithOrgTemplates(
+		resources, err := renderer.RenderWithAncestorTemplates(
 			context.Background(),
 			projectTemplate,
 			[]string{platformTemplate},
@@ -1944,7 +1945,7 @@ projectResources: namespacedResources: (platform.namespace): {
 		// have a template that produces a disallowed kind alongside the allowed ones.
 		projectWithForbidden := projectTemplate + forbiddenAddition
 
-		_, err := renderer.RenderWithOrgTemplates(
+		_, err := renderer.RenderWithAncestorTemplates(
 			context.Background(),
 			projectWithForbidden,
 			[]string{platformTemplate},
@@ -1984,6 +1985,253 @@ projectResources: namespacedResources: (platform.namespace): {
 			if !kindSet[expected] {
 				t.Errorf("expected %s resource in standalone output", expected)
 			}
+		}
+	})
+}
+
+// foldersTemplate accesses platform.folders in a resource annotation.
+// Used to verify that PlatformInput.Folders is propagated into CUE templates.
+// The template sets an annotation to the first folder name when folders are present.
+const foldersTemplate = `
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:          string
+	namespace:        string
+	gatewayNamespace: string
+	organization:     string
+	folders?: [...string]
+	claims: {
+		iss:            string
+		sub:            string
+		exp:            int
+		iat:            int
+		email:          string
+		email_verified: bool
+	}
+}
+
+// _firstFolder is the first folder name, or "none" when the list is absent/empty.
+_firstFolder: *"none" | string
+if platform.folders != _|_ {
+	if len(platform.folders) > 0 {
+		_firstFolder: platform.folders[0]
+	}
+}
+
+projectResources: {
+	namespacedResources: (platform.namespace): {
+		ServiceAccount: (input.name): {
+			apiVersion: "v1"
+			kind:       "ServiceAccount"
+			metadata: {
+				name:      input.name
+				namespace: platform.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+					"app.kubernetes.io/name":       input.name
+				}
+				annotations: {
+					"test.holos.run/first-folder": _firstFolder
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// TestCueRenderer_FoldersPropagation verifies that PlatformInput.Folders
+// is propagated into CUE templates via platform.folders.
+func TestCueRenderer_FoldersPropagation(t *testing.T) {
+	renderer := &CueRenderer{}
+	namespace := "prj-my-project"
+
+	t.Run("folders list is available in template when populated", func(t *testing.T) {
+		platform := v1alpha1.PlatformInput{
+			Project:          "my-project",
+			Namespace:        namespace,
+			GatewayNamespace: "istio-ingress",
+			Organization:     "my-org",
+			Folders:          []string{"platform", "payments"},
+			Claims: v1alpha1.Claims{
+				Iss:           "https://example.com",
+				Sub:           "u1",
+				Exp:           9999999999,
+				Iat:           1000000000,
+				Email:         "test@example.com",
+				EmailVerified: true,
+			},
+		}
+		project := v1alpha1.ProjectInput{
+			Name:  "web-app",
+			Image: "nginx",
+			Tag:   "1.25",
+			Port:  8080,
+		}
+		resources, err := renderer.Render(context.Background(), foldersTemplate, platform, project)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resources) != 1 {
+			t.Fatalf("expected 1 resource, got %d", len(resources))
+		}
+		annotations := resources[0].GetAnnotations()
+		got := annotations["test.holos.run/first-folder"]
+		if got != "platform" {
+			t.Errorf("expected first-folder annotation 'platform', got %q", got)
+		}
+	})
+
+	t.Run("nil folders renders without error and uses default value", func(t *testing.T) {
+		platform := v1alpha1.PlatformInput{
+			Project:          "my-project",
+			Namespace:        namespace,
+			GatewayNamespace: "istio-ingress",
+			Organization:     "my-org",
+			Folders:          nil, // no folders — omitted from JSON
+			Claims: v1alpha1.Claims{
+				Iss:           "https://example.com",
+				Sub:           "u1",
+				Exp:           9999999999,
+				Iat:           1000000000,
+				Email:         "test@example.com",
+				EmailVerified: true,
+			},
+		}
+		project := v1alpha1.ProjectInput{
+			Name:  "web-app",
+			Image: "nginx",
+			Tag:   "1.25",
+			Port:  8080,
+		}
+		resources, err := renderer.Render(context.Background(), foldersTemplate, platform, project)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resources) != 1 {
+			t.Fatalf("expected 1 resource, got %d", len(resources))
+		}
+		annotations := resources[0].GetAnnotations()
+		got := annotations["test.holos.run/first-folder"]
+		if got != "none" {
+			t.Errorf("expected first-folder annotation 'none', got %q", got)
+		}
+	})
+}
+
+// folderPlatformTemplate simulates a folder-level platform template that
+// contributes a resource using platform.folders to identify the folder context.
+const folderPlatformTemplate = `
+
+platformResources: {
+	namespacedResources: (platform.namespace): {
+		ServiceAccount: "folder-sa": {
+			apiVersion: "v1"
+			kind:       "ServiceAccount"
+			metadata: {
+				name:      "folder-sa"
+				namespace: platform.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+					"app.kubernetes.io/name":       "folder-sa"
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// TestCueRenderer_AncestorTemplateWalk verifies that
+// RenderWithAncestorTemplates correctly unifies folder-level and org-level
+// platform templates with the deployment template.
+func TestCueRenderer_AncestorTemplateWalk(t *testing.T) {
+	renderer := &CueRenderer{}
+	namespace := "prj-my-project"
+
+	platform := v1alpha1.PlatformInput{
+		Project:          "my-project",
+		Namespace:        namespace,
+		GatewayNamespace: "istio-ingress",
+		Organization:     "my-org",
+		Folders:          []string{"payments"},
+		Claims: v1alpha1.Claims{
+			Iss:           "https://example.com",
+			Sub:           "u1",
+			Exp:           9999999999,
+			Iat:           1000000000,
+			Email:         "test@example.com",
+			EmailVerified: true,
+		},
+	}
+	project := v1alpha1.ProjectInput{
+		Name:  "web-app",
+		Image: "nginx",
+		Tag:   "1.25",
+		Port:  8080,
+	}
+
+	t.Run("folder-level platform template unified with deployment template", func(t *testing.T) {
+		resources, err := renderer.RenderWithAncestorTemplates(
+			context.Background(),
+			deploymentTemplateForUnification,
+			[]string{folderPlatformTemplate},
+			platform,
+			project,
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// Expect: 1 Deployment from deployment template + 1 ServiceAccount from folder platform template.
+		if len(resources) != 2 {
+			t.Fatalf("expected 2 resources (Deployment + folder ServiceAccount), got %d: %v",
+				len(resources), resourceKinds(resources))
+		}
+		nameSet := make(map[string]bool)
+		for _, r := range resources {
+			nameSet[r.GetName()] = true
+		}
+		if !nameSet["web-app"] {
+			t.Error("expected Deployment 'web-app' from deployment template")
+		}
+		if !nameSet["folder-sa"] {
+			t.Error("expected ServiceAccount 'folder-sa' from folder platform template")
+		}
+	})
+
+	t.Run("multiple ancestor templates (org + folder) are all unified", func(t *testing.T) {
+		resources, err := renderer.RenderWithAncestorTemplates(
+			context.Background(),
+			deploymentTemplateForUnification,
+			[]string{systemUnificationTemplate, folderPlatformTemplate},
+			platform,
+			project,
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// Expect: 1 Deployment + 1 SA from org template (system-from-web-app) + 1 SA from folder template (folder-sa).
+		if len(resources) != 3 {
+			t.Fatalf("expected 3 resources, got %d: %v", len(resources), resourceKinds(resources))
+		}
+		nameSet := make(map[string]bool)
+		for _, r := range resources {
+			nameSet[r.GetName()] = true
+		}
+		if !nameSet["web-app"] {
+			t.Error("expected Deployment 'web-app'")
+		}
+		if !nameSet["system-from-web-app"] {
+			t.Error("expected ServiceAccount 'system-from-web-app' from org template")
+		}
+		if !nameSet["folder-sa"] {
+			t.Error("expected ServiceAccount 'folder-sa' from folder template")
 		}
 	})
 }

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -242,6 +242,52 @@ func (c *K8sClient) GetProjectOrg(ctx context.Context, project string) (string, 
 	return GetOrganization(ns), nil
 }
 
+// ProjectFolderResolver wraps K8sClient and a Walker to implement
+// deployments.AncestorWalker by resolving the folder ancestry of a project.
+type ProjectFolderResolver struct {
+	k8s    *K8sClient
+	walker walkerAncestors
+}
+
+// walkerAncestors is the minimal interface needed from resolver.Walker.
+type walkerAncestors interface {
+	WalkAncestors(ctx context.Context, startNs string) ([]*corev1.Namespace, error)
+}
+
+// NewProjectFolderResolver creates a resolver that returns folder names for a project.
+func NewProjectFolderResolver(k8s *K8sClient, walker walkerAncestors) *ProjectFolderResolver {
+	return &ProjectFolderResolver{k8s: k8s, walker: walker}
+}
+
+// GetProjectFolders returns the ordered list of folder names in the ancestor chain
+// from the organization down to (but not including) the project.
+// Implements deployments.AncestorWalker.
+func (r *ProjectFolderResolver) GetProjectFolders(ctx context.Context, project string) ([]string, error) {
+	if r.walker == nil {
+		return nil, nil
+	}
+	projectNs := r.k8s.Resolver.ProjectNamespace(project)
+	ancestors, err := r.walker.WalkAncestors(ctx, projectNs)
+	if err != nil {
+		return nil, fmt.Errorf("walking ancestors for project %q: %w", project, err)
+	}
+
+	// ancestors is child→parent order (project first, org last).
+	// Reverse to get org→project order, then extract only folder namespaces.
+	var folders []string
+	for i := len(ancestors) - 1; i >= 0; i-- {
+		ns := ancestors[i]
+		kind, name, err := r.k8s.Resolver.ResourceTypeFromNamespace(ns.Name)
+		if err != nil {
+			continue
+		}
+		if kind == v1alpha2.ResourceTypeFolder {
+			folders = append(folders, name)
+		}
+	}
+	return folders, nil
+}
+
 // GetDisplayName returns the display-name annotation value from a namespace.
 func GetDisplayName(ns *corev1.Namespace) string {
 	if ns.Annotations == nil {

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -310,7 +310,7 @@ platform template that provides an HTTPRoute and constrains which resource kinds
 project templates may produce, paired with a project-level template that deploys
 [go-httpbin](https://github.com/mccutchen/go-httpbin). Use this as a reference
 for the ADR 016 Decision 9 constraint pattern. The examples below are the actual
-embedded templates (`console/org_templates/example_httpbin_platform.cue` and
+embedded templates (`console/templates/example_httpbin_platform.cue` and
 `console/templates/example_httpbin.cue`) available via the **Load httpbin
 Example** buttons in the platform template create dialog and the deployment
 template create page.
@@ -602,9 +602,9 @@ The set of platform templates that participate in a render is:
 render_set = (mandatory AND enabled) UNION (enabled AND name IN linked_list)
 ```
 
-The `linked_list` is the `linked_org_templates` annotation on the deployment
-template ConfigMap (JSON string array, annotation key
-`console.holos.run/linked-org-templates`). Disabled templates are never
+The `linked_list` is derived from the `console.holos.run/linked-templates`
+annotation on the deployment template ConfigMap (v1alpha2 format: JSON array of
+`{scope, scope_name, name}` objects). Disabled templates are never
 included, even if they appear in the linked list.
 
 **Authoring implications**
@@ -955,7 +955,7 @@ Resources placed in `platformResources.namespacedResources` and
   (ADR 016 Decision 8) in Go code: when rendering a project-level template (`Render()`),
   it does not read `platformResources` from the evaluated CUE value. A project template
   that defines `platformResources` fields is valid CUE but the values are silently
-  ignored. Only the organization/folder-level path (`RenderWithOrgTemplates()`) reads
+  ignored. Only the organization/folder-level path (`RenderWithAncestorTemplates()`) reads
   both collections.
 - **Always applied alongside user resources** — the render engine collects resources
   from all four output fields at the organization/folder level and applies them in a
@@ -1156,8 +1156,8 @@ codebase. Use it for advanced troubleshooting or when developing new features.
 |------|---------|
 | `console/templates/default_template.cue` | Default CUE template. Narrows generated `#ProjectInput` and `#PlatformInput` types with additional CUE constraints, defines `_envSpec` env var transformation, `_annotations` helper (stamps `platform.claims.email`), `#Namespaced`/`#Cluster` structural constraints, and resource definitions nested under `projectResources.namespacedResources`/`projectResources.clusterResources`. Embedded into the Go binary via `console/templates/embed.go`. No `package` declaration — the renderer prepends the generated schema. |
 | `console/templates/embed.go` | `//go:embed` directive that loads `default_template.cue` as the fallback template. |
-| `console/org_templates/default_referencegrant.cue` | Built-in example HTTPRoute platform template (code: `OrgTemplate`). References `input.name` and `platform.gatewayNamespace` — designed to be unified with the deployment template at deploy time. Contributes resources to `platformResources.namespacedResources`. Seeded as disabled (not mandatory) on first `ListOrgTemplates` access. Embedded via `console/org_templates/embed.go`. No `package` declaration. |
-| `api/v1alpha1/` | Go type definitions for `PlatformInput`, `ProjectInput`, `Claims`, `EnvVar`, `KeyRef`, `PlatformResources`, `ProjectResources`. CUE schemas (`#PlatformInput`, `#ProjectInput`, etc.) are generated from these types via `cue get go` and embedded into the binary. The renderer prepends the generated schema before compiling any template. |
+| `console/templates/default_referencegrant.cue` | Built-in example HTTPRoute platform template. References `input.name` and `platform.gatewayNamespace` — designed to be unified with the deployment template at deploy time. Contributes resources to `platformResources.namespacedResources`. Seeded as disabled (not mandatory) on first `ListTemplates` access. Embedded via `console/templates/embed.go`. No `package` declaration. |
+| `api/v1alpha1/` | Go type definitions for `PlatformInput`, `ProjectInput`, `Claims`, `EnvVar`, `KeyRef`, `PlatformResources`, `ProjectResources`. CUE schemas (`#PlatformInput`, `#ProjectInput`, etc.) are generated from these types via `cue get go` and embedded into the binary. The renderer prepends the generated schema before compiling any template. `PlatformInput.Folders` (v1alpha2, `folders?`) carries the ordered folder ancestor names from the organization down to the project. |
 
 ### Go Rendering Pipeline
 
@@ -1166,36 +1166,28 @@ Two render paths exist — one for the deployment service and one for the templa
 | File | Purpose |
 |------|---------|
 | `console/deployments/render.go` | `CueRenderer.Render()` — project-level render path: prepends generated schema, compiles CUE source, fills `"input"` and `"platform"`, then calls `evaluateStructured(..., false)` which reads only `projectResources` (ADR 016 Decision 8 hard boundary — `platformResources` is intentionally skipped). |
-| `console/deployments/render.go` | `CueRenderer.RenderWithOrgTemplates()` — organization/folder-level render path: unifies platform template sources with the deployment template before compilation, then calls `evaluateStructured(..., true)` which reads both `projectResources` and `platformResources`. |
+| `console/deployments/render.go` | `CueRenderer.RenderWithAncestorTemplates()` — organization/folder-level render path: unifies ancestor (org + folder) template sources with the deployment template before compilation, then calls `evaluateStructured(..., true)` which reads both `projectResources` and `platformResources`. |
 | `console/deployments/render.go` | `CueRenderer.RenderWithCueInput()` — template preview path: concatenates generated schema, CUE source, and a raw CUE input string before compilation so cross-references (e.g. `input.name` used in platform templates) resolve correctly. Extracts `platform.namespace` from the compiled value. Calls `evaluateStructured(..., true)` to read both collections. |
-| `console/deployments/render.go` | `PlatformInput`, `ProjectInput` structs in `api/v1alpha1` — split Go representation of template inputs. `PlatformInput` (project, namespace, gatewayNamespace, organization, claims) is trusted backend context; `ProjectInput` (name, image, tag, etc.) is user-supplied. |
+| `console/deployments/render.go` | `PlatformInput`, `ProjectInput` structs in `api/v1alpha1` — split Go representation of template inputs. `PlatformInput` (project, namespace, gatewayNamespace, organization, folders, claims) is trusted backend context; `ProjectInput` (name, image, tag, etc.) is user-supplied. |
 | `console/deployments/render.go` | `validateResource()` — enforces kind allowlist and managed-by label on a single resource. `evaluateStructured(unified, ns, readPlatformResources)` reads `projectResources.*` always and `platformResources.*` only when `readPlatformResources` is true; dispatches to `walkNamespacedResources()` and `walkClusterResources()` which add namespace-match and struct-key consistency checks. |
 | `console/deployments/apply.go` | `Applier.Apply()` — injects ownership label, performs server-side apply with field manager `console.holos.run`. |
 | `console/deployments/apply.go` | `Applier.Reconcile()` — calls `Apply()` then deletes owned resources whose (kind, name) is not in the desired set (orphan cleanup). Used by `UpdateDeployment`. Orphan cleanup is skipped if apply fails so the previously working state is preserved. |
 | `console/deployments/apply.go` | `Applier.Cleanup()` — deletes all resources matching the ownership label selector. Used by `DeleteDeployment` (unconditional removal) and `CreateDeployment` rollback. |
 
-### Template Service
+### Template Service (unified, ADR 021)
 
 | File | Purpose |
 |------|---------|
-| `console/templates/handler.go` | `DeploymentTemplateService` handler — CRUD for templates stored as ConfigMaps. |
-| `console/templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `deployment-template` resource-type label. |
+| `console/templates/handler.go` | Unified `TemplateService` handler — scope-aware CRUD for templates at organization, folder, and project levels. Dispatches access checks to `OrgGrantResolver`, `FolderGrantResolver`, or `ProjectGrantResolver` depending on scope. `collectAncestorTemplates()` walks the hierarchy (org → folders → project) to build the render set. |
+| `console/templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `console.holos.run/template-scope` label (`organization|folder|project`), `mandatory` and `enabled` annotations. `ListOrgTemplateSourcesForRender(ctx, org, linkedNames)` implements the explicit linking formula `(mandatory AND enabled) UNION (enabled AND name IN linkedNames)` (satisfies `deployments.OrgTemplateProvider`). |
+| `console/templates/apply.go` | `MandatoryTemplateApplier.ApplyMandatoryOrgTemplates()` — walks the full ancestor chain and applies all mandatory+enabled templates at project creation time. |
 | `console/templates/render_adapter.go` | `CueRendererAdapter` — wraps `deployments.CueRenderer` to produce YAML and structured object data for the template preview RPC. |
-
-### Platform Template Service (code: `OrgTemplateService`)
-
-| File | Purpose |
-|------|---------|
-| `console/org_templates/handler.go` | `OrgTemplateService` handler — CRUD and render for org-scoped platform templates stored as ConfigMaps. Edit access requires `PERMISSION_ORG_TEMPLATES_WRITE`. |
-| `console/org_templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `org-template` resource-type label, `mandatory` and `enabled` annotations. Seeds `default_referencegrant.cue` (HTTPRoute example) on first `ListOrgTemplates`. `ListOrgTemplateSourcesForRender(ctx, org, linkedNames)` implements the explicit linking formula `(mandatory AND enabled) UNION (enabled AND name IN linkedNames)` (satisfies `deployments.OrgTemplateProvider`). |
-| `console/org_templates/apply.go` | `MandatoryTemplateApplier.ApplyMandatoryOrgTemplates()` — called by the projects service after project namespace creation to apply platform templates that are both `mandatory=true` AND `enabled=true`. |
 
 ### Deployment Service
 
 | File | Purpose |
 |------|---------|
-| `console/deployments/handler.go` | Create flow — builds `PlatformInput` and `ProjectInput`, calls `renderResources()`, then `Apply()`. All-or-nothing: if render or apply fails, `rollbackCreate()` calls `Cleanup()` then `DeleteDeployment()` to remove partial state. Update flow uses `Reconcile()` instead of `Apply()` so orphaned resources are cleaned up after a successful apply. |
-| `console/deployments/handler.go:607-656` | `protoToEnvVarInput()` / `envVarInputToProto()` — converts between protobuf `EnvVar` and `EnvVarInput` for CUE. |
+| `console/deployments/handler.go` | Create flow — builds `PlatformInput` (including `Folders` from `AncestorWalker`) and `ProjectInput`, calls `renderResources()`, then `Apply()`. All-or-nothing: if render or apply fails, `rollbackCreate()` calls `Cleanup()` then `DeleteDeployment()` to remove partial state. Update flow uses `Reconcile()` instead of `Apply()` so orphaned resources are cleaned up after a successful apply. `linkedTemplateNamesFromAnnotation()` reads the v1alpha2 `console.holos.run/linked-templates` annotation (with legacy fallback to `console.holos.run/linked-org-templates`). |
 | `console/deployments/k8s.go` | ConfigMap storage for deployment state: image, tag, template, command, args, env stored as data keys. |
 
 ### Protobuf Definitions
@@ -1203,8 +1195,7 @@ Two render paths exist — one for the deployment service and one for the templa
 | File | Purpose |
 |------|---------|
 | `proto/holos/console/v1/deployments.proto` | `Deployment`, `EnvVar`, `SecretKeyRef`, `ConfigMapKeyRef` messages; `DeploymentService` RPCs. |
-| `proto/holos/console/v1/deployment_templates.proto` | `DeploymentTemplate` message; `DeploymentTemplateService` RPCs including `RenderDeploymentTemplate`. |
-| `proto/holos/console/v1/org_templates.proto` | `OrgTemplate` message (platform template); `OrgTemplateService` RPCs including `RenderOrgTemplate`. |
+| `proto/holos/console/v1/templates.proto` | Unified `Template` message with `TemplateScopeRef` discriminator; `TemplateService` RPCs covering all three scopes. |
 
 ### Generated Code
 


### PR DESCRIPTION
## Summary
- Add `Folders []string` to `PlatformInput` so CUE templates can access `platform.folders` (ordered list from org → project)
- Rename `RenderWithOrgTemplates` → `RenderWithAncestorTemplates` to accurately reflect that it accepts org + folder ancestor sources
- Add `AncestorWalker` interface to deployment handler; wire `ProjectFolderResolver` (new in `console/projects/k8s.go`) to populate `Folders`
- Update `linkedTemplateNamesFromAnnotation` to support v1alpha2 `console.holos.run/linked-templates` format with legacy fallback
- Add `TestCueRenderer_FoldersPropagation` and `TestCueRenderer_AncestorTemplateWalk` test suites

Closes: #632

## Test plan
- [x] `go test ./...` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1