### PR TITLE
refactor(proto): rename cue_user_input to cue_project_input in deployment render preview

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -728,7 +728,7 @@ func (h *Handler) GetDeploymentRenderPreview(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("encoding project input: %w", err))
 	}
 	cuePlatformInput := fmt.Sprintf("platform: %s", string(platformJSON))
-	cueUserInput := fmt.Sprintf("input: %s", string(projectJSON))
+	cueProjectInput := fmt.Sprintf("input: %s", string(projectJSON))
 
 	// Render the template to produce YAML and JSON output, including linked
 	// platform templates (ADR 019). Uses renderResources so the same linking
@@ -746,7 +746,7 @@ func (h *Handler) GetDeploymentRenderPreview(
 			return connect.NewResponse(&consolev1.GetDeploymentRenderPreviewResponse{
 				CueTemplate:    cueTemplate,
 				CuePlatformInput: cuePlatformInput,
-				CueProjectInput:   cueUserInput,
+				CueProjectInput:   cueProjectInput,
 			}), nil
 		}
 
@@ -783,7 +783,7 @@ func (h *Handler) GetDeploymentRenderPreview(
 	return connect.NewResponse(&consolev1.GetDeploymentRenderPreviewResponse{
 		CueTemplate:    cueTemplate,
 		CuePlatformInput: cuePlatformInput,
-		CueProjectInput:   cueUserInput,
+		CueProjectInput:   cueProjectInput,
 		RenderedYaml:   renderedYAML,
 		RenderedJson:   renderedJSON,
 	}), nil

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -1037,7 +1037,7 @@ func TestHandler_GetDeploymentRenderPreview(t *testing.T) {
 			t.Error("expected non-empty cue_platform_input")
 		}
 		if resp.Msg.CueProjectInput == "" {
-			t.Error("expected non-empty cue_user_input")
+			t.Error("expected non-empty cue_project_input")
 		}
 	})
 
@@ -1123,10 +1123,10 @@ func TestHandler_GetDeploymentRenderPreview(t *testing.T) {
 		}
 		// User input should contain deployment name and image.
 		if !containsStr(resp.Msg.CueProjectInput, "web-app") {
-			t.Errorf("expected cue_user_input to contain deployment name, got: %q", resp.Msg.CueProjectInput)
+			t.Errorf("expected cue_project_input to contain deployment name, got: %q", resp.Msg.CueProjectInput)
 		}
 		if !containsStr(resp.Msg.CueProjectInput, "nginx") {
-			t.Errorf("expected cue_user_input to contain image, got: %q", resp.Msg.CueProjectInput)
+			t.Errorf("expected cue_project_input to contain image, got: %q", resp.Msg.CueProjectInput)
 		}
 	})
 }

--- a/frontend/src/gen/holos/console/v1/deployments_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/deployments_pb.d.ts
@@ -827,8 +827,7 @@ export declare type GetDeploymentRenderPreviewResponse = Message<"holos.console.
 
   /**
    * cue_project_input is the user-provided CUE input (name, image, tag, etc.)
-   * in CUE format. Replaces cue_user_input from v1alpha1 to align with the
-   * platform/project input terminology used in api/v1alpha2.
+   * matching the ProjectInput schema.
    *
    * @generated from field: string cue_project_input = 3;
    */

--- a/frontend/src/gen/holos/console/v1/templates_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/templates_pb.d.ts
@@ -457,7 +457,7 @@ export declare type RenderTemplateRequest = Message<"holos.console.v1.RenderTemp
   /**
    * cue_project_input contains valid CUE source that is unified with
    * cue_template at the "input" path to supply concrete values for template
-   * parameters. Replaces cue_input / cue_user_input from v1alpha1.
+   * parameters matching the ProjectInput schema.
    *
    * @generated from field: string cue_project_input = 4;
    */

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -85,7 +85,7 @@ const mockLogs = '2024-01-15T10:30:01Z Starting server...\n2024-01-15T10:30:02Z 
 const mockPreview = {
   cueTemplate: 'input: #ProjectInput\nplatform: #PlatformInput\n',
   cuePlatformInput: 'platform: {\n  project: "test-project"\n  namespace: "holos-prj-test-project"\n}',
-  cueUserInput: 'input: {\n  name: "api"\n  image: "ghcr.io/org/api"\n  tag: "v1.2.3"\n  port: 8080\n}',
+  cueProjectInput: 'input: {\n  name: "api"\n  image: "ghcr.io/org/api"\n  tag: "v1.2.3"\n  port: 8080\n}',
   renderedYaml: 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: api\n',
   renderedJson: '[]',
 }

--- a/gen/holos/console/v1/deployments.pb.go
+++ b/gen/holos/console/v1/deployments.pb.go
@@ -1782,8 +1782,7 @@ type GetDeploymentRenderPreviewResponse struct {
 	// authenticated context; template authors can trust these values.
 	CuePlatformInput string `protobuf:"bytes,2,opt,name=cue_platform_input,json=cuePlatformInput,proto3" json:"cue_platform_input,omitempty"`
 	// cue_project_input is the user-provided CUE input (name, image, tag, etc.)
-	// in CUE format. Replaces cue_user_input from v1alpha1 to align with the
-	// platform/project input terminology used in api/v1alpha2.
+	// matching the ProjectInput schema.
 	CueProjectInput string `protobuf:"bytes,3,opt,name=cue_project_input,json=cueProjectInput,proto3" json:"cue_project_input,omitempty"`
 	// rendered_yaml is the rendered Kubernetes manifests as multi-document YAML.
 	RenderedYaml string `protobuf:"bytes,4,opt,name=rendered_yaml,json=renderedYaml,proto3" json:"rendered_yaml,omitempty"`

--- a/gen/holos/console/v1/templates.pb.go
+++ b/gen/holos/console/v1/templates.pb.go
@@ -919,7 +919,7 @@ type RenderTemplateRequest struct {
 	CuePlatformInput string `protobuf:"bytes,3,opt,name=cue_platform_input,json=cuePlatformInput,proto3" json:"cue_platform_input,omitempty"`
 	// cue_project_input contains valid CUE source that is unified with
 	// cue_template at the "input" path to supply concrete values for template
-	// parameters. Replaces cue_input / cue_user_input from v1alpha1.
+	// parameters matching the ProjectInput schema.
 	CueProjectInput string `protobuf:"bytes,4,opt,name=cue_project_input,json=cueProjectInput,proto3" json:"cue_project_input,omitempty"`
 	// linked_templates lists scope-qualified template references to include in
 	// preview unification. Allows draft templates to preview their effective

--- a/proto/holos/console/v1/deployments.proto
+++ b/proto/holos/console/v1/deployments.proto
@@ -247,8 +247,7 @@ message GetDeploymentRenderPreviewResponse {
   // authenticated context; template authors can trust these values.
   string cue_platform_input = 2;
   // cue_project_input is the user-provided CUE input (name, image, tag, etc.)
-  // in CUE format. Replaces cue_user_input from v1alpha1 to align with the
-  // platform/project input terminology used in api/v1alpha2.
+  // matching the ProjectInput schema.
   string cue_project_input = 3;
   // rendered_yaml is the rendered Kubernetes manifests as multi-document YAML.
   string rendered_yaml = 4;

--- a/proto/holos/console/v1/templates.proto
+++ b/proto/holos/console/v1/templates.proto
@@ -205,7 +205,7 @@ message RenderTemplateRequest {
   string cue_platform_input = 3;
   // cue_project_input contains valid CUE source that is unified with
   // cue_template at the "input" path to supply concrete values for template
-  // parameters. Replaces cue_input / cue_user_input from v1alpha1.
+  // parameters matching the ProjectInput schema.
   string cue_project_input = 4;
   // linked_templates lists scope-qualified template references to include in
   // preview unification. Allows draft templates to preview their effective


### PR DESCRIPTION
## Summary
- Renames Go handler variable `cueUserInput` → `cueProjectInput` in `console/deployments/handler.go` to match the proto field name
- Updates stale error message strings in `handler_test.go` from `cue_user_input` → `cue_project_input`
- Renames the frontend unit test mock key `cueUserInput` → `cueProjectInput` in the deployment detail test
- Removes historical "Replaces cue_user_input from v1alpha1" migration notes from proto comments in `deployments.proto` and `templates.proto` since the migration is complete
- Runs `make generate` to regenerate TypeScript `.d.ts` and Go `.pb.go` files from the updated proto comments

Closes: #637

## Test plan
- [x] `rg 'cue_user_input|cueUserInput'` across proto/Go/TypeScript returns zero hits
- [x] `make generate` passes
- [x] `make test` passes (42 test files, 645 UI tests, all Go packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1