### PR TITLE
docs: scrub 'system template' terminology across codebase and docs

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -658,8 +658,8 @@ func (h *Handler) ListNamespaceConfigMaps(
 	}), nil
 }
 
-// GetDeploymentRenderPreview returns the CUE template source, system input,
-// user input, and rendered output for a deployment.
+// GetDeploymentRenderPreview returns the CUE template source, platform input,
+// project input, and rendered output for a deployment.
 func (h *Handler) GetDeploymentRenderPreview(
 	ctx context.Context,
 	req *connect.Request[consolev1.GetDeploymentRenderPreviewRequest],

--- a/console/templates/default_template.cue
+++ b/console/templates/default_template.cue
@@ -158,7 +158,7 @@ projectResources: {
 
 			// ReferenceGrant allows HTTPRoute resources in the gateway namespace to
 			// reference Service resources in the project namespace.
-			// This enables system templates (such as the example HTTPRoute template)
+			// This enables platform templates (such as the example HTTPRoute template)
 			// to expose deployments via the gateway.
 			// See: https://gateway-api.sigs.k8s.io/api-types/referencegrant/
 			ReferenceGrant: "allow-gateway-httproute": {

--- a/console/templates/example_httpbin.cue
+++ b/console/templates/example_httpbin.cue
@@ -2,7 +2,7 @@
 // Produces: ServiceAccount, Deployment, Service.
 // Allowed by the org constraint: Deployment, Service, ServiceAccount.
 //
-// Pair with console/system_templates/example_httpbin_platform.cue to add an
+// Pair with console/templates/example_httpbin_platform.cue to add an
 // HTTPRoute that routes gateway traffic to the Service.
 
 // Use generated type definitions from api/v1alpha2 (prepended by renderer).
@@ -100,7 +100,7 @@ projectResources: {
 			}
 
 			// Service exposes port 80 → container port input.port (named "http").
-			// The HTTPRoute in the org system template routes gateway traffic here.
+			// The HTTPRoute in the org platform template routes gateway traffic here.
 			Service: (input.name): {
 				apiVersion: "v1"
 				kind:       "Service"

--- a/console/templates/example_httpbin_platform.cue
+++ b/console/templates/example_httpbin_platform.cue
@@ -1,4 +1,4 @@
-// Org-level system template — evaluated at organization scope.
+// Org-level platform template — evaluated at organization scope.
 // Any changes here affect every project in the org.
 //
 // This template does two things:
@@ -10,7 +10,7 @@
 //
 // Pair with console/templates/example_httpbin.cue for the project-level template.
 
-// input and platform are available because system templates are unified with
+// input and platform are available because platform templates are unified with
 // the deployment template before evaluation (ADR 016 Decision 8).
 input: #ProjectInput & {
 	port: >0 & <=65535 | *8080

--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -155,7 +155,7 @@ export function CueTemplateEditor({
       </TabsContent>
       <TabsContent value="preview" className="mt-4 space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="cue-system-input-editor">Platform Input</Label>
+          <Label htmlFor="cue-platform-input-editor">Platform Input</Label>
           <p className="text-xs text-muted-foreground">
             These values are set by the console at deployment time and include the authenticated user&apos;s OIDC claims.
           </p>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -275,12 +275,12 @@ describe('DeploymentTemplateDetailPage', () => {
     expect(userInput.value).toContain('port')
   })
 
-  it('useRenderDeploymentTemplate receives separate system and user inputs', async () => {
+  it('useRenderDeploymentTemplate receives separate platform and project inputs', async () => {
     setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n')
     const user = userEvent.setup()
     render(<DeploymentTemplateDetailPage />)
     await user.click(screen.getByRole('tab', { name: /preview/i }))
-    // The 4th arg is the system input string
+    // The 4th arg is the platform input string
     const calls = (useRenderDeploymentTemplate as Mock).mock.calls
     const lastCall = calls[calls.length - 1]
     expect(lastCall[1]).toContain('input:')

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -188,10 +188,10 @@ describe('CreateTemplatePage', () => {
     const calls = (useRenderDeploymentTemplate as Mock).mock.calls
     expect(calls.length).toBeGreaterThan(0)
     // 4th arg is cuePlatformInput
-    const systemInput = calls[0][3]
-    expect(systemInput).toContain('platform:')
-    expect(systemInput).toContain('claims')
-    expect(systemInput).toContain('email')
+    const platformInput = calls[0][3]
+    expect(platformInput).toContain('platform:')
+    expect(platformInput).toContain('claims')
+    expect(platformInput).toContain('email')
   })
 
   it('useRenderDeploymentTemplate is called with user input (not project/namespace)', () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -243,7 +243,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const [error, setError] = useState<string | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
 
-  const previewCueSystemInput = `platform: {
+  const previewCuePlatformInput = `platform: {
 \tproject:          "${projectName}"
 \tnamespace:        "holos-prj-${projectName}"
 \tgatewayNamespace: "istio-ingress"
@@ -269,7 +269,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
     debouncedCueTemplate,
     previewCueInput,
     previewOpen,
-    previewCueSystemInput,
+    previewCuePlatformInput,
   )
 
   const handleLoadHttpbinExample = () => {

--- a/scripts/pr-456/capture
+++ b/scripts/pr-456/capture
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Capture visual verification screenshots for PR #456
-# Shows the split system/user input areas in the template editor preview tab.
+# Shows the split platform/project input areas in the template editor preview tab.
 set -euo pipefail
 
 # Environment variables set by scripts/browser-capture-pr:
@@ -17,8 +17,8 @@ agent-browser screenshot "${PR_SCREENSHOT_DIR}/01-template-editor-tab.png"
 agent-browser eval "(() => { const tabs = Array.from(document.querySelectorAll('[role=tab]')); const previewTab = tabs.find(t => t.textContent.trim() === 'Preview'); if (previewTab) { previewTab.focus(); previewTab.click(); return 'clicked'; } return 'not found'; })()"
 sleep 2
 
-# Take screenshot of the top of the Preview tab showing System Input textarea
-agent-browser screenshot "${PR_SCREENSHOT_DIR}/02-template-preview-system-input.png"
+# Take screenshot of the top of the Preview tab showing Platform Input textarea
+agent-browser screenshot "${PR_SCREENSHOT_DIR}/02-template-preview-platform-input.png"
 
 # Scroll down to see the User Input textarea
 agent-browser scroll down 400

--- a/scripts/pr-479/capture
+++ b/scripts/pr-479/capture
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Capture screenshots for PR #479: system templates UI
+# Capture screenshots for PR #479: platform templates UI
 set -euo pipefail
 
 # PR_SCREENSHOT_DIR and HOLOS_BACKEND_URL are set by browser-capture-pr
 
-# Capture the org settings page (shows new System Templates section)
+# Capture the org settings page (shows new Platform Templates section)
 agent-browser navigate --url "${HOLOS_BACKEND_URL}/orgs/default/settings" \
-  --screenshot "${PR_SCREENSHOT_DIR}/org-settings-system-templates-link.png" || true
+  --screenshot "${PR_SCREENSHOT_DIR}/org-settings-platform-templates-link.png" || true
 
-# Capture the system templates list page
-agent-browser navigate --url "${HOLOS_BACKEND_URL}/orgs/default/settings/system-templates" \
-  --screenshot "${PR_SCREENSHOT_DIR}/system-templates-list.png" || true
+# Capture the platform templates list page
+agent-browser navigate --url "${HOLOS_BACKEND_URL}/orgs/default/settings/org-templates" \
+  --screenshot "${PR_SCREENSHOT_DIR}/platform-templates-list.png" || true

--- a/scripts/pr-498/capture
+++ b/scripts/pr-498/capture
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Capture screenshots for PR #498: system template unification
+# Capture screenshots for PR #498: platform template unification
 # This PR changes the CUE template system to use package deployment
-# and adds gatewayNamespace to #System schema.
+# and adds gatewayNamespace to #PlatformInput schema.
 #
 # The frontend changes are in the CUE template editor defaults:
-# - #System schema in DEFAULT_CUE_TEMPLATE now includes gatewayNamespace
-# - Preview system inputs in template editors include gatewayNamespace
-# - System template defaultUserInput includes mock deployment values
+# - #PlatformInput schema in DEFAULT_CUE_TEMPLATE now includes gatewayNamespace
+# - Preview platform inputs in template editors include gatewayNamespace
+# - Platform template defaultProjectInput includes mock deployment values
 #
-# We capture the system templates page and deployment template editor
+# We capture the platform templates page and deployment template editor
 # to visually verify these changes are reflected in the UI.
 
 SCREENSHOT_DIR="${PR_SCREENSHOT_DIR:-docs/screenshots/pr-498}"

--- a/scripts/pr-500/capture
+++ b/scripts/pr-500/capture
@@ -14,12 +14,12 @@ mkdir -p "$SCREENSHOT_DIR"
 echo "Logging in..."
 scripts/browser-login
 
-echo "Capturing system templates list page with enabled/disabled badges..."
-agent-browser navigate "$BACKEND_URL/orgs/acme/settings/system-templates" \
-  --screenshot "$SCREENSHOT_DIR/system-templates-list.png"
+echo "Capturing platform templates list page with enabled/disabled badges..."
+agent-browser navigate "$BACKEND_URL/orgs/acme/settings/org-templates" \
+  --screenshot "$SCREENSHOT_DIR/platform-templates-list.png"
 
-echo "Capturing system template detail page with enabled toggle and clone button..."
-agent-browser navigate "$BACKEND_URL/orgs/acme/settings/system-templates/reference-grant" \
-  --screenshot "$SCREENSHOT_DIR/system-template-detail-enabled-toggle.png"
+echo "Capturing platform template detail page with enabled toggle and clone button..."
+agent-browser navigate "$BACKEND_URL/orgs/acme/settings/org-templates/reference-grant" \
+  --screenshot "$SCREENSHOT_DIR/platform-template-detail-enabled-toggle.png"
 
 echo "Screenshots saved to $SCREENSHOT_DIR"


### PR DESCRIPTION
## Summary
- Replace all prose and comment uses of "system template" / "system input" with the canonical "platform template" / "platform input" per the AGENTS.md Terminology rule
- Fix a stale `htmlFor` attribute in `cue-template-editor.tsx` (was pointing to nonexistent `cue-system-input-editor`, now correctly points to `cue-platform-input-editor`)
- Rename `previewCueSystemInput` variable to `previewCuePlatformInput` in `new.tsx`
- Update prose in historical capture scripts for PRs #456, #479, #498, #500
- Code identifiers (`OrgTemplate`, `OrgCascadeTemplatePerms`, etc.) are unchanged per convention

Remaining occurrences of "system template" are intentional:
- `AGENTS.md` Terminology section — used in the "Incorrect" column of the examples table and in the rule definition itself
- `docs/glossary.md` Naming History Note — explicitly historical context

Closes: #638

## Test plan
- [x] `rg -i 'system template|systemtemplate|system input|systeminput' --glob '!docs/adrs/**'` returns only intentional/historical references
- [x] `make test-ui` — all 645 tests pass
- [x] `make test-go` — all Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1