### PR TITLE
docs(adr): move revoked ADRs 014 and 015 to docs/adrs/revoked/

### DIFF
--- a/docs/adrs/016-config-management-resource-schema.md
+++ b/docs/adrs/016-config-management-resource-schema.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — revokes [ADR 014](014-config-management-resource-schema.md)
+Accepted — revokes [ADR 014](revoked/014-config-management-resource-schema.md)
 
 ## CUE Unification: No Distinction Between "Write" and "Constrain"
 
@@ -625,7 +625,7 @@ collapsed permission set, scope discriminator, and cross-level linking model.
 - [ADR 012: Structured Resource Output for CUE Templates](012-structured-resource-output.md)
 - [ADR 013: Separate System and User Input Trust Boundary](013-separate-system-user-template-input.md)
 - [ADR 007: Organization Grants Do Not Cascade](007-org-grants-no-cascade.md)
-- [ADR 014: Configuration Management Resource Schema (revoked)](014-config-management-resource-schema.md)
+- [ADR 014: Configuration Management Resource Schema (revoked)](revoked/014-config-management-resource-schema.md)
 - [ADR 017: Configuration Management RBAC Levels](017-config-management-rbac-levels.md)
 - [ADR 020: v1alpha2 Folder Hierarchy, Package Layout, and Secrets Semantics](020-v1alpha2-folder-hierarchy.md)
 - [ADR 021: Unified Template Service and Collapsed Template Permissions](021-unified-template-service.md)

--- a/docs/adrs/017-config-management-rbac-levels.md
+++ b/docs/adrs/017-config-management-rbac-levels.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — revokes [ADR 015](015-config-management-rbac-levels.md)
+Accepted — revokes [ADR 015](revoked/015-config-management-rbac-levels.md)
 
 ## CUE Unification: No Distinction Between "Write" and "Constrain"
 
@@ -431,8 +431,8 @@ Viewer and above.
 - [ADR 007: Organization Grants Do Not Cascade](007-org-grants-no-cascade.md)
 - [ADR 012: Structured Resource Output for CUE Templates](012-structured-resource-output.md)
 - [ADR 013: Separate System and User Input Trust Boundary](013-separate-system-user-template-input.md)
-- [ADR 014: Configuration Management Resource Schema (revoked)](014-config-management-resource-schema.md)
-- [ADR 015: Configuration Management RBAC Levels (revoked)](015-config-management-rbac-levels.md)
+- [ADR 014: Configuration Management Resource Schema (revoked)](revoked/014-config-management-resource-schema.md)
+- [ADR 015: Configuration Management RBAC Levels (revoked)](revoked/015-config-management-rbac-levels.md)
 - [ADR 016: Configuration Management Resource Schema](016-config-management-resource-schema.md)
 - [ADR 019: Explicit Platform Template Linking](019-explicit-template-linking.md) — which ancestor templates participate in unification
 - [ADR 020: v1alpha2 Folder Hierarchy, Package Layout, and Secrets Semantics](020-v1alpha2-folder-hierarchy.md) — implementation specification for the walk algorithm and folder authorization

--- a/docs/adrs/revoked/014-config-management-resource-schema.md
+++ b/docs/adrs/revoked/014-config-management-resource-schema.md
@@ -1,8 +1,13 @@
 # ADR 014: Configuration Management Resource Schema
 
+> **REVOKED** — This ADR has been superseded by
+> [ADR 016](../016-config-management-resource-schema.md). Do not use this
+> document for implementation decisions. It is preserved for historical context
+> only.
+
 ## Status
 
-Revoked by [ADR 016](016-config-management-resource-schema.md)
+Revoked by [ADR 016](../016-config-management-resource-schema.md)
 
 ## Context
 
@@ -54,7 +59,7 @@ does (see ADR 015).
 The diagram below shows how templates, inputs, and resource collections fit
 together. Start here if you are new to the system and want to build a template.
 
-![Resource Model](014-resource-model.svg)
+![Resource Model](../014-resource-model.svg)
 
 ## Decisions
 
@@ -562,6 +567,6 @@ api/
 
 ## References
 
-- [ADR 012: Structured Resource Output for CUE Templates](012-structured-resource-output.md)
-- [ADR 013: Separate System and User Input Trust Boundary](013-separate-system-user-template-input.md)
-- [ADR 007: Organization Grants Do Not Cascade](007-org-grants-no-cascade.md)
+- [ADR 012: Structured Resource Output for CUE Templates](../012-structured-resource-output.md)
+- [ADR 013: Separate System and User Input Trust Boundary](../013-separate-system-user-template-input.md)
+- [ADR 007: Organization Grants Do Not Cascade](../007-org-grants-no-cascade.md)

--- a/docs/adrs/revoked/015-config-management-rbac-levels.md
+++ b/docs/adrs/revoked/015-config-management-rbac-levels.md
@@ -1,8 +1,12 @@
 # ADR 015: Configuration Management RBAC Levels
 
+> **REVOKED** — This ADR has been superseded by
+> [ADR 017](../017-config-management-rbac-levels.md). Do not use this document
+> for implementation decisions. It is preserved for historical context only.
+
 ## Status
 
-Revoked by [ADR 017](017-config-management-rbac-levels.md)
+Revoked by [ADR 017](../017-config-management-rbac-levels.md)
 
 ## Context
 
@@ -45,7 +49,7 @@ they are explained in terms of what they mean for the template author.
 
 For a visual overview of how the hierarchy, templates, inputs, and resource
 collections fit together, see the
-[Resource Model diagram in ADR 014](014-resource-model.svg).
+[Resource Model diagram in ADR 014](../014-resource-model.svg).
 
 ## Decisions
 
@@ -358,8 +362,8 @@ Viewer and above.
 
 ## References
 
-- [ADR 007: Organization Grants Do Not Cascade](007-org-grants-no-cascade.md)
-- [ADR 012: Structured Resource Output for CUE Templates](012-structured-resource-output.md)
-- [ADR 013: Separate System and User Input Trust Boundary](013-separate-system-user-template-input.md)
-- [ADR 014: Configuration Management Resource Schema](014-config-management-resource-schema.md)
-- [Permissions Guide](../permissions-guide.md) — cascade table pattern and naming conventions
+- [ADR 007: Organization Grants Do Not Cascade](../007-org-grants-no-cascade.md)
+- [ADR 012: Structured Resource Output for CUE Templates](../012-structured-resource-output.md)
+- [ADR 013: Separate System and User Input Trust Boundary](../013-separate-system-user-template-input.md)
+- [ADR 014: Configuration Management Resource Schema (revoked)](014-config-management-resource-schema.md)
+- [Permissions Guide](../../permissions-guide.md) — cascade table pattern and naming conventions

--- a/docs/adrs/revoked/README.md
+++ b/docs/adrs/revoked/README.md
@@ -1,0 +1,12 @@
+# Revoked ADRs
+
+This directory contains ADRs that have been revoked and superseded by later
+decisions. They are preserved for historical context only.
+
+Do not use these documents for implementation decisions. Each file carries a
+bold **REVOKED** notice at the top with a link to its superseding ADR.
+
+| ADR | Title | Superseded by |
+|-----|-------|---------------|
+| [014](014-config-management-resource-schema.md) | Configuration Management Resource Schema | [ADR 016](../016-config-management-resource-schema.md) |
+| [015](015-config-management-rbac-levels.md) | Configuration Management RBAC Levels | [ADR 017](../017-config-management-rbac-levels.md) |


### PR DESCRIPTION
## Summary

- Move `docs/adrs/014-config-management-resource-schema.md` and `docs/adrs/015-config-management-rbac-levels.md` to `docs/adrs/revoked/`
- Add a bold **REVOKED** callout block at the top of each file pointing to its superseding ADR
- Fix all relative links in the moved files to account for the new subdirectory depth
- Update cross-references in ADR 016 and ADR 017 to point to the new file locations
- Add `docs/adrs/revoked/README.md` with a table mapping each revoked ADR to its superseding ADR

Closes: #640

## Test plan

- [ ] `docs/adrs/revoked/` directory exists with 014, 015, and README.md
- [ ] Each revoked ADR has a visible REVOKED callout block at the top
- [ ] Links in ADR 016 and 017 pointing to the revoked ADRs resolve correctly
- [ ] Links within the revoked ADRs (to other ADRs, SVG, and permissions-guide) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1