### PR TITLE
docs: sweep AGENTS.md and docs/ for pre-ADR-016 references

### DIFF
--- a/docs/advanced-user-guide.md
+++ b/docs/advanced-user-guide.md
@@ -78,7 +78,7 @@ reference secrets as container environment variables via `SecretKeyRef`.
 | `UpdateSharing` | `ROLE_OWNER` on secret | Replaces the per-user and per-role sharing grants on the secret without touching its data. |
 | `GetSecretRaw` | `PERMISSION_SECRETS_READ` | Returns the verbatim JSON of the backing Kubernetes Secret. |
 
-### DeploymentTemplateService
+### TemplateService (deployment templates — project scope)
 
 _Deployment templates_ are project-scoped CUE programs that define what
 Kubernetes resources a deployment creates. A template declares what
@@ -279,7 +279,7 @@ Navigate to **Organizations > my-org > Platform Templates** and click
 
 Paste the following CUE into the **Template** editor. This is the canonical
 go-httpbin org-level example — an identical version is embedded in the server
-at `console/org_templates/example_httpbin_platform.cue`.
+at `console/templates/example_httpbin_platform.cue`.
 
 ```cue
 // Org-level template — evaluated at organization scope.
@@ -639,10 +639,10 @@ contacted.
 | Who | What | RPC |
 |-----|------|-----|
 | Platform engineer | Enable deployments on the project | `ProjectSettingsService.UpdateProjectSettings` |
-| Platform engineer | Author and enable the org-level template | `OrgTemplateService.CreateOrgTemplate` + `UpdateOrgTemplate` |
-| Platform engineer | Preview the org-level template | `OrgTemplateService.RenderOrgTemplate` |
-| Project engineer | Create the deployment template | `DeploymentTemplateService.CreateDeploymentTemplate` |
-| Project engineer | Preview the deployment template | `DeploymentTemplateService.RenderDeploymentTemplate` |
+| Platform engineer | Author and enable the org-level template | `TemplateService.CreateTemplate` + `UpdateTemplate` |
+| Platform engineer | Preview the org-level template | `TemplateService.RenderDeploymentTemplate` |
+| Project engineer | Create the deployment template | `TemplateService.CreateTemplate` |
+| Project engineer | Preview the deployment template | `TemplateService.RenderDeploymentTemplate` |
 | Project owner | Deploy an instance | `DeploymentService.CreateDeployment` |
 | Project owner | Check deployment health | `DeploymentService.GetDeploymentStatus` |
 | Project owner | Tail logs | `DeploymentService.GetDeploymentLogs` |

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -701,7 +701,7 @@ input: #ProjectInput & {
 ```
 
 The `*value | _` syntax makes `value` the CUE default while `_` (top) allows any override. At
-render time, the backend calls `FillPath("input", userInput)` to unify the form values with
+render time, the backend calls `FillPath("input", projectInput)` to unify the form values with
 `input`. If a field is left at its zero value in the form, the CUE default wins. If the user
 fills in a value, that concrete value wins.
 

--- a/docs/rpc-service-definitions.md
+++ b/docs/rpc-service-definitions.md
@@ -17,9 +17,10 @@ proto/                          # Protobuf source files
     version.proto               # VersionService
     organizations.proto         # OrganizationService
     projects.proto              # ProjectService
+    folders.proto               # FolderService
     secrets.proto               # SecretsService
     project_settings.proto      # ProjectSettingsService
-    deployment_templates.proto  # DeploymentTemplateService
+    templates.proto             # TemplateService (organization, folder, and project scopes)
     deployments.proto           # DeploymentService (CRUD, status, logs, command/args override, env vars, K8s resource listing, render preview)
     rbac.proto                  # Role definitions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -146,7 +146,7 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/components/raw-view.test.tsx` | JSON pretty-print, field filtering, copy |
 | `src/components/secret-data-editor.test.tsx` | Editor add/remove key |
 | `src/components/secret-data-viewer.test.tsx` | Viewer reveal/hide/copy |
-| `src/components/cue-template-editor.test.tsx` | CUE editor: textarea, onChange, readOnly, save button, preview tab (system/user input, rendered YAML), render error, render status indicator |
+| `src/components/cue-template-editor.test.tsx` | CUE editor: textarea, onChange, readOnly, save button, preview tab (platform input, project input, rendered YAML), render error, render status indicator |
 | `src/components/env-var-editor.test.tsx` | Env var editor: add/remove rows, literal value, secretKeyRef, configMapKeyRef, name/key select population |
 | `src/components/linkified-text.test.tsx` | LinkifiedText: plain text, single/multiple URLs, mid-sentence URL, empty/undefined, link styling |
 | `src/routes/_authenticated/-about.test.tsx` | About page: Server Version card, license card |

--- a/frontend/src/components/cue-template-editor.test.tsx
+++ b/frontend/src/components/cue-template-editor.test.tsx
@@ -116,14 +116,14 @@ describe('CueTemplateEditor', () => {
     expect(onSave).toHaveBeenCalledTimes(1)
   })
 
-  it('renders preview tab with platform input, user input, and rendered YAML sections', async () => {
+  it('renders preview tab with platform input, project input, and rendered YAML sections', async () => {
     const user = userEvent.setup()
     render(
       <CueTemplateEditor
         cueTemplate="content"
         onChange={vi.fn()}
-        defaultPlatformInput="system: {}"
-        defaultUserInput="input: {}"
+        defaultPlatformInput="platform: {}"
+        defaultProjectInput="input: {}"
         useRenderFn={makeRenderFn('apiVersion: v1\nkind: ReferenceGrant')}
       />
     )
@@ -132,7 +132,7 @@ describe('CueTemplateEditor', () => {
     await user.click(screen.getByRole('tab', { name: /preview/i }))
 
     expect(screen.getByRole('textbox', { name: /platform input/i })).toBeInTheDocument()
-    expect(screen.getByRole('textbox', { name: /user input/i })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /project input/i })).toBeInTheDocument()
     expect(screen.getByLabelText('Rendered YAML')).toBeInTheDocument()
     expect(screen.getByLabelText('Rendered YAML')).toHaveTextContent('ReferenceGrant')
   })

--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -83,8 +83,8 @@ export interface CueTemplateEditorProps {
   isSaving?: boolean
   /** Default platform input for the preview tab */
   defaultPlatformInput?: string
-  /** Default user input for the preview tab */
-  defaultUserInput?: string
+  /** Default project input for the preview tab */
+  defaultProjectInput?: string
   /** Hook to use for rendering (injectable for testability) */
   useRenderFn: RenderFn
 }
@@ -101,12 +101,12 @@ export function CueTemplateEditor({
   onSave,
   isSaving = false,
   defaultPlatformInput = '',
-  defaultUserInput = '',
+  defaultProjectInput = '',
   useRenderFn,
 }: CueTemplateEditorProps) {
   const [activeTab, setActiveTab] = useState('editor')
   const [cuePlatformInput, setCuePlatformInput] = useState(defaultPlatformInput)
-  const [cueInput, setCueInput] = useState(defaultUserInput)
+  const [cueInput, setCueInput] = useState(defaultProjectInput)
 
   const debouncedCueInput = useDebouncedValue(cueInput, 500)
   const debouncedCuePlatformInput = useDebouncedValue(cuePlatformInput, 500)
@@ -169,10 +169,10 @@ export function CueTemplateEditor({
           />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="cue-input-editor">User Input (deployment parameters)</Label>
+          <Label htmlFor="cue-input-editor">Project Input (deployment parameters)</Label>
           <Textarea
             id="cue-input-editor"
-            aria-label="User Input"
+            aria-label="Project Input"
             value={cueInput}
             onChange={(e) => setCueInput(e.target.value)}
             rows={6}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
@@ -75,7 +75,7 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
   const canWrite = userRole === Role.OWNER
 
   const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
-  const defaultUserInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
+  const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   const handleSave = async () => {
     try {
@@ -221,7 +221,7 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
               onSave={canWrite ? handleSave : undefined}
               isSaving={updateMutation.isPending}
               defaultPlatformInput={defaultPlatformInput}
-              defaultUserInput={defaultUserInput}
+              defaultProjectInput={defaultProjectInput}
               useRenderFn={useRenderOrgTemplate}
             />
           </div>

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -381,7 +381,7 @@ export function DeploymentDetailPage({
                     onChange={() => {}}
                     readOnly={true}
                     defaultPlatformInput={preview.cuePlatformInput}
-                    defaultUserInput={preview.cueProjectInput}
+                    defaultProjectInput={preview.cueProjectInput}
                     useRenderFn={useRenderDeploymentTemplate}
                   />
                 ) : null}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -78,7 +78,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const canDelete = userRole === Role.OWNER
 
   const defaultPlatformInput = `platform: {\n  project:          "${projectName}"\n  namespace:        "holos-prj-${projectName}"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
-  const defaultUserInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
+  const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   const handleSave = async () => {
     try {
@@ -282,7 +282,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
               onSave={handleSave}
               isSaving={updateMutation.isPending}
               defaultPlatformInput={defaultPlatformInput}
-              defaultUserInput={defaultUserInput}
+              defaultProjectInput={defaultProjectInput}
               useRenderFn={useRenderDeploymentTemplate}
             />
           </div>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -244,12 +244,12 @@ describe('DeploymentTemplateDetailPage', () => {
     expect(screen.getByRole('textbox', { name: /platform input/i })).toBeInTheDocument()
   })
 
-  it('User Input textarea is rendered in the preview tab', async () => {
+  it('Project Input textarea is rendered in the preview tab', async () => {
     setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n')
     const user = userEvent.setup()
     render(<DeploymentTemplateDetailPage />)
     await user.click(screen.getByRole('tab', { name: /preview/i }))
-    expect(screen.getByRole('textbox', { name: /user input/i })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /project input/i })).toBeInTheDocument()
   })
 
   it('Platform Input textarea contains project, namespace, and claims with email', async () => {
@@ -263,16 +263,16 @@ describe('DeploymentTemplateDetailPage', () => {
     expect(platformInput.value).toContain('email')
   })
 
-  it('User Input textarea contains name, image, tag, and port', async () => {
+  it('Project Input textarea contains name, image, tag, and port', async () => {
     setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n')
     const user = userEvent.setup()
     render(<DeploymentTemplateDetailPage projectName="test-project" templateName="web-app" />)
     await user.click(screen.getByRole('tab', { name: /preview/i }))
-    const userInput = screen.getByRole('textbox', { name: /user input/i }) as HTMLTextAreaElement
-    expect(userInput.value).toContain('name')
-    expect(userInput.value).toContain('image')
-    expect(userInput.value).toContain('tag')
-    expect(userInput.value).toContain('port')
+    const projectInput = screen.getByRole('textbox', { name: /project input/i }) as HTMLTextAreaElement
+    expect(projectInput.value).toContain('name')
+    expect(projectInput.value).toContain('image')
+    expect(projectInput.value).toContain('tag')
+    expect(projectInput.value).toContain('port')
   })
 
   it('useRenderDeploymentTemplate receives separate platform and project inputs', async () => {
@@ -287,12 +287,12 @@ describe('DeploymentTemplateDetailPage', () => {
     expect(lastCall[3]).toContain('platform:')
   })
 
-  it('modifying User Input calls useRenderDeploymentTemplate with updated value', async () => {
+  it('modifying Project Input calls useRenderDeploymentTemplate with updated value', async () => {
     setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n')
     const user = userEvent.setup()
     render(<DeploymentTemplateDetailPage />)
     await user.click(screen.getByRole('tab', { name: /preview/i }))
-    const inputEditor = screen.getByRole('textbox', { name: /user input/i })
+    const inputEditor = screen.getByRole('textbox', { name: /project input/i })
     fireEvent.change(inputEditor, { target: { value: 'input: { name: "custom" }' } })
     // With the identity mock for useDebouncedValue, debounced value equals raw value immediately
     expect(useRenderDeploymentTemplate as Mock).toHaveBeenCalledWith(
@@ -426,8 +426,8 @@ describe('DeploymentTemplateDetailPage', () => {
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
       await user.click(screen.getByRole('tab', { name: /preview/i }))
-      // Change the user input — raw state will differ from debounced value
-      const inputEditor = screen.getByRole('textbox', { name: /user input/i })
+      // Change the project input — raw state will differ from debounced value
+      const inputEditor = screen.getByRole('textbox', { name: /project input/i })
       await act(async () => {
         fireEvent.change(inputEditor, { target: { value: 'new-value' } })
       })
@@ -440,7 +440,7 @@ describe('DeploymentTemplateDetailPage', () => {
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
       await user.click(screen.getByRole('tab', { name: /preview/i }))
-      const inputEditor = screen.getByRole('textbox', { name: /user input/i })
+      const inputEditor = screen.getByRole('textbox', { name: /project input/i })
       await act(async () => {
         fireEvent.change(inputEditor, { target: { value: 'new-value' } })
       })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -194,15 +194,15 @@ describe('CreateTemplatePage', () => {
     expect(platformInput).toContain('email')
   })
 
-  it('useRenderDeploymentTemplate is called with user input (not project/namespace)', () => {
+  it('useRenderDeploymentTemplate is called with project input (not platform project/namespace)', () => {
     render(<CreateTemplatePage projectName="test-project" />)
     const calls = (useRenderDeploymentTemplate as Mock).mock.calls
     expect(calls.length).toBeGreaterThan(0)
-    // 2nd arg is cueInput (user input)
-    const userInput = calls[0][1]
-    expect(userInput).toContain('input:')
-    expect(userInput).not.toContain('project:')
-    expect(userInput).not.toContain('namespace:')
+    // 2nd arg is cueInput (project input)
+    const projectInput = calls[0][1]
+    expect(projectInput).toContain('input:')
+    expect(projectInput).not.toContain('project:')
+    expect(projectInput).not.toContain('namespace:')
   })
 
   describe('Load httpbin Example button', () => {


### PR DESCRIPTION
## Summary
- Replace pre-ADR-016 `userInput` variable name with `projectInput` in `docs/cue-template-guide.md`
- Update `docs/rpc-service-definitions.md` directory listing: replace stale `deployment_templates.proto` / `DeploymentTemplateService` with `templates.proto` / `TemplateService`; add missing `folders.proto`
- Update `docs/advanced-user-guide.md`: rename stale section header and RPC names (`OrgTemplateService`, `DeploymentTemplateService`) to the unified `TemplateService`; fix `console/org_templates/` path to `console/templates/`
- Update `docs/testing.md`: replace "system/user input" description with "platform input, project input"
- Rename `CueTemplateEditor` prop `defaultUserInput` → `defaultProjectInput` and update label text "User Input" → "Project Input" to match canonical `#ProjectInput` terminology
- Update all callers and test assertions to use the new prop name and label

Closes: #642

## Test plan
- [x] `make test-ui` passes (645 tests)
- [x] `rg -i 'SystemInput|UserInput|systemResources|userInput' docs/ AGENTS.md` returns zero hits outside ADRs
- [x] `rg -i 'positional.*template|unification.*all enabled' docs/ AGENTS.md` returns zero hits outside ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1