### PR TITLE
chore: final verification baseline after v1alpha2 cutover and cleanup

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -25,7 +25,7 @@ Three roles interact with the deployment feature:
 | Role | What they do |
 |------|-------------|
 | **Product engineer** | Writes deployment templates in their project. Defines image, ports, env vars, and other application config. |
-| **Site reliability engineer (SRE)** | Writes templates at a folder level (planned `v1alpha2`) to enforce operational standards — resource limits, health checks, monitoring sidecars — across a group of projects. |
+| **Site reliability engineer (SRE)** | Writes templates at a folder level to enforce operational standards — resource limits, health checks, monitoring sidecars — across a group of projects. |
 | **Platform engineer** | Writes platform templates at the organization level to enforce platform-wide policy — network routing, security standards, namespace quotas. |
 
 These roles are not mutually exclusive. A single person may operate at multiple
@@ -42,7 +42,7 @@ value using CUE unification.
 ```
 Organization  (platform engineer writes platform templates here)
     │
-    ├── Folder  (SRE writes templates here — planned v1alpha2)
+    ├── Folder  (SRE writes templates here)
     │     │
     │     └── Folder  (up to 3 folder levels supported)
     │           │
@@ -54,10 +54,10 @@ together:
 
 ![Resource Model](adrs/014-resource-model.svg)
 
-In `v1alpha1`, the hierarchy is Organization → Project (two levels). Folder
-support is planned for `v1alpha2`. The schema is designed to accommodate folders
-from the start so that adding them in `v1alpha2` does not require breaking
-changes.
+In `v1alpha2`, the hierarchy is Organization → Folder* → Project where folders
+are optional and up to three levels deep. Organization templates (platform
+templates) and folder templates are collected at render time and unified with the
+project deployment template.
 
 ### Who writes templates at each level
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -11,7 +11,7 @@ import { Info } from 'lucide-react'
 import { useCreateTemplate, useRenderTemplate, makeProjectScope } from '@/queries/templates'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 
-const DEFAULT_CUE_TEMPLATE = `// Use generated type definitions from api/v1alpha1 (prepended by renderer).
+const DEFAULT_CUE_TEMPLATE = `// Use generated type definitions from api/v1alpha2 (prepended by renderer).
 // Additional CUE constraints narrow the generated types for this template.
 input: #ProjectInput & {
   name: =~"^[a-z][a-z0-9-]*$"
@@ -93,7 +93,7 @@ const EXAMPLE_HTTPBIN_TEMPLATE = `// Project-level deployment template for go-ht
 // Pair with console/org_templates/example_httpbin_platform.cue to add an
 // HTTPRoute that routes gateway traffic to the Service.
 
-// Use generated type definitions from api/v1alpha1 (prepended by renderer).
+// Use generated type definitions from api/v1alpha2 (prepended by renderer).
 // Additional CUE constraints narrow the generated types for this template.
 input: #ProjectInput & {
 	name:  =~"^[a-z][a-z0-9-]*$" // DNS label


### PR DESCRIPTION
## Summary

- Ran full verification suite: `make generate`, `make test`, `make vet`
- All checks pass: 14 Go packages, 638 UI unit tests across 42 test files
- Fixed two stale `v1alpha1` references found during verification:
  - `docs/deployment-guide.md`: removed "planned v1alpha2" language for folders (folders are now live)
  - `frontend/src/routes/.../templates/new.tsx`: corrected two inline CUE comments from `api/v1alpha1` to `api/v1alpha2`

### Verification Results

| Check | Result |
|-------|--------|
| `make generate` (no uncommitted diffs) | PASS |
| Go tests (14 packages, race detector) | PASS |
| UI unit tests (638 tests, 42 files) | PASS |
| `make vet` | PASS |
| `rg -i 'v1alpha1'` (only historical ADR/comment mentions) | PASS |
| `rg -i 'system template\|system input'` (only historical mentions) | PASS |
| `rg -i 'cue_user_input\|cueUserInput'` (zero hits) | PASS |

### Notes

- `make lint` fails locally due to golangci-lint v2.1.6 built with go1.24 vs project go1.25.0. CI does not run `make lint` (only `make vet`), so this is a local environment issue, not a regression.
- `make test-e2e` and `scripts/browser-self-service` require a running k3d cluster; this PR documents the code verification and fixes the stale references found.

Closes: #644

## Test plan
- [x] `make generate` produces no uncommitted diffs
- [x] `make test` passes (Go + UI unit tests)
- [x] `make vet` clean
- [x] `rg -i 'v1alpha1'` returns only historical mentions
- [x] `rg -i 'system template|system input'` returns only historical mentions
- [x] `rg -i 'cue_user_input|cueUserInput'` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-1