### PR TITLE
chore(folders): cleanup stale code after Data/Resource view addition

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/folders/$folderName/-folder-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/folders/$folderName/-folder-detail.test.tsx
@@ -26,12 +26,10 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-vi.mock('@/lib/auth', () => ({ useAuth: vi.fn() }))
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { useGetFolder, useGetFolderRaw, useUpdateFolder } from '@/queries/folders'
 import { useGetOrganization } from '@/queries/organizations'
-import { useAuth } from '@/lib/auth'
 import { FolderDetailPage } from './index'
 
 const mockFolder = {
@@ -70,11 +68,6 @@ function setupMocks(overrides: { folder?: Partial<typeof mockFolder>; org?: Part
   ;(useUpdateFolder as Mock).mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue({}),
     isPending: false,
-  })
-  ;(useAuth as Mock).mockReturnValue({
-    isAuthenticated: true,
-    isLoading: false,
-    user: { profile: { email: 'alice@example.com', groups: [] } },
   })
 }
 

--- a/frontend/src/routes/_authenticated/orgs/$orgName/folders/-$folderName.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/folders/-$folderName.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'


### PR DESCRIPTION
## Summary
- Remove unused `fireEvent` import from `-$folderName.test.tsx` (only `userEvent` is used for interactions)
- Remove unnecessary `useAuth` mock, import, and setup from `-folder-detail.test.tsx` (the component does not call `useAuth` directly; all query hooks are fully mocked at the module level)

Closes: #680

## Test plan
- [x] All 36 folder tests pass
- [x] `make generate` succeeds (UI build + TypeScript type checking)
- [x] `make test` passes (642 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code) · agent-3