### PR TITLE
fix(skills): replace hardcoded codex path with portable lookup script

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -21,16 +21,13 @@ Currently uses the OpenAI Codex CLI as the review backend. The backend is swappa
 
 ### 1. Preflight
 
-Verify codex is available:
+Verify codex is available using the helper script:
 
 ```bash
-CODEX="/Users/u6136576/.nvm/versions/node/v24.12.0/bin/codex"
-if ! [ -x "$CODEX" ]; then
-  echo "ERROR: codex CLI not found at $CODEX"
-  echo "Install with: npm install -g @openai/codex"
-  # Stop here -- abort the skill
-fi
+eval "$(scripts/check-codex)"
 ```
+
+If the script exits non-zero, **abort the skill** -- codex is not installed.
 
 Log the codex version for debugging:
 
@@ -112,7 +109,7 @@ The prompt must contain:
 Use `codex exec review` with the prompted mode. The `--base` flag and `[PROMPT]` are mutually exclusive in the codex CLI, so embed scope instructions in the prompt.
 
 ```bash
-CODEX="/Users/u6136576/.nvm/versions/node/v24.12.0/bin/codex"
+# $CODEX was set by scripts/check-codex in step 1
 
 # Build ACCEPTANCE_CRITERIA section
 ACCEPTANCE_CRITERIA=""

--- a/scripts/check-codex
+++ b/scripts/check-codex
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# check-codex — Locate the codex CLI and verify it is executable.
+#
+# Usage:
+#   eval "$(scripts/check-codex)"   # sets CODEX to the resolved path
+#
+# Exits non-zero with a diagnostic message if codex is not found.
+
+set -euo pipefail
+
+CODEX="$(command -v codex 2>/dev/null || true)"
+
+if [[ -z "$CODEX" || ! -x "$CODEX" ]]; then
+  echo "ERROR: codex CLI not found on PATH" >&2
+  echo "Install with: npm install -g @openai/codex" >&2
+  exit 1
+fi
+
+echo "CODEX=\"${CODEX}\""


### PR DESCRIPTION
## Summary
- Remove hardcoded `/Users/u6136576/.nvm/versions/node/v24.12.0/bin/codex` path from `review-pr` skill
- Add `scripts/check-codex` helper that resolves the codex binary via PATH
- Update the skill to use the helper script for portable codex discovery

## Test plan
- [ ] `scripts/check-codex` exits 0 and prints `CODEX="..."` when codex is installed
- [ ] `scripts/check-codex` exits non-zero with a diagnostic when codex is not on PATH
- [ ] No hardcoded user paths remain in `.claude/skills/`

Generated with [Claude Code](https://claude.com/claude-code) · ${SLOT}