### PR TITLE
feat(skills): add reset-agent skill and script for fast agent resets

### DIFF
--- a/.claude/skills/reset-agent/SKILL.md
+++ b/.claude/skills/reset-agent/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: reset-agent
+description: Reset the current agent worktree to a clean state on origin/main. Use when the user says "reset this agent", "reset agent", "start fresh", or wants to discard all local changes and return to main. Runs the reset-agent script which determines the agent slot from PWD, fetches origin, resets the feature branch to origin/main, and cleans the working directory.
+version: 1.0.0
+---
+
+# Reset Agent
+
+Reset the current agent worktree to a clean state aligned with origin/main.
+
+## Workflow
+
+Run the reset script:
+
+```bash
+scripts/reset-agent
+```
+
+The script:
+1. Determines the agent slot from the working directory (e.g. `agent-3`)
+2. Fetches origin
+3. Switches to or creates the `feat/agent-N` branch
+4. Hard-resets the branch to `origin/main`
+5. Sets the branch to track `origin/main`
+6. Cleans untracked files
+7. Exits with code 1 to signal the reset is complete
+
+After the script runs, report the final state (branch, commit SHA) and stop. Do not continue with any prior task context -- the reset means any previous work is discarded.

--- a/scripts/reset-agent
+++ b/scripts/reset-agent
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# reset-agent — Reset the current agent worktree to a clean state on origin/main.
+#
+# Determines the agent slot from PWD (e.g. agent-3), fetches origin, resets
+# the local feature branch to origin/main, sets tracking, and ensures a clean
+# working directory. Exits 1 so callers know this was a deliberate reset, not
+# a continuation of normal work.
+set -euo pipefail
+
+# Determine agent slot from PWD
+SLOT=$(echo "$PWD" | grep -o 'agent-[0-9]*' | head -1)
+if [[ -z "$SLOT" ]]; then
+  echo "ERROR: Could not determine agent slot from PWD: $PWD" >&2
+  exit 1
+fi
+BRANCH="feat/${SLOT}"
+
+echo "Resetting ${SLOT} to origin/main..."
+
+# Fetch latest
+git fetch origin
+
+# Ensure we are on the agent feature branch
+CURRENT=$(git branch --show-current)
+if [[ "$CURRENT" != "$BRANCH" ]]; then
+  # If the branch exists locally, switch to it; otherwise create it
+  if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    git checkout "$BRANCH"
+  else
+    git checkout -b "$BRANCH" origin/main
+  fi
+fi
+
+# Reset the branch to origin/main
+git reset --hard origin/main
+
+# Set tracking to origin/main
+git branch --set-upstream-to=origin/main "$BRANCH"
+
+# Clean any untracked files and directories
+git clean -fd
+
+echo "Agent ${SLOT} reset to $(git rev-parse --short HEAD) on branch ${BRANCH} tracking origin/main."
+exit 1


### PR DESCRIPTION
## Summary
- Add `scripts/reset-agent` — determines agent slot from PWD, fetches origin, resets `feat/agent-N` branch to `origin/main`, sets tracking, cleans untracked files, exits 1
- Add `.claude/skills/reset-agent/SKILL.md` — skill that invokes the script via `/reset-agent`
- `UserPromptSubmit` hook matching "reset this agent" configured in `.claude/settings.json` (gitignored, local to each worktree)

## Test plan
- [ ] `scripts/reset-agent` correctly identifies agent slot from PWD
- [ ] Script resets branch to origin/main and leaves a clean working directory
- [ ] `/reset-agent` skill invokes the script
- [ ] "reset this agent" triggers the hook → skill → script chain

Generated with [Claude Code](https://claude.com/claude-code)