### PR TITLE
feat(oidc): add dev token-exchange endpoint for programmatic persona tokens

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -370,7 +370,7 @@ func (s *Server) Serve(ctx context.Context) error {
 			redirectURIs = append(redirectURIs, viteRedirectURI)
 		}
 
-		oidcHandler, err := oidc.NewHandler(ctx, oidc.Config{
+		oidcHandler, dexState, err := oidc.NewHandler(ctx, oidc.Config{
 			Issuer:          s.cfg.Issuer,
 			ClientID:        s.cfg.ClientID,
 			RedirectURIs:    redirectURIs,
@@ -384,6 +384,12 @@ func (s *Server) Serve(ctx context.Context) error {
 
 		// Mount Dex at /dex/ - Dex handles the full path internally since issuer includes /dex
 		mux.Handle("/dex/", oidcHandler)
+
+		// Mount dev token-exchange endpoint for programmatic persona tokens.
+		// This endpoint mints real OIDC ID tokens signed by Dex's keys for any
+		// registered test user, enabling API testing without a browser flow.
+		mux.HandleFunc("/api/dev/token", oidc.HandleTokenExchange(dexState))
+		slog.Info("dev token-exchange endpoint mounted", "path", "/api/dev/token")
 
 		slog.Info("embedded OIDC provider mounted", "path", "/dex/", "issuer", s.cfg.Issuer)
 	}

--- a/console/oidc/oidc.go
+++ b/console/oidc/oidc.go
@@ -52,18 +52,35 @@ func init() {
 	}
 }
 
+// DexState holds references to the Dex server internals that other handlers
+// need (e.g., the dev token-exchange endpoint reads signing keys from storage).
+type DexState struct {
+	// Storage is the Dex storage backend. The token exchange handler uses it
+	// to retrieve signing keys so it can mint OIDC ID tokens directly.
+	Storage storage.Storage
+
+	// Issuer is the OIDC issuer URL (e.g., "https://localhost:8443/dex").
+	Issuer string
+
+	// ClientID is the OAuth2 client ID for the SPA.
+	ClientID string
+}
+
 // NewHandler creates an http.Handler for the embedded OIDC identity provider.
 // The issuer must include the full URL with the mount path (e.g., "https://localhost:8443/dex").
 // The handler should be mounted at the path suffix of the issuer URL.
-func NewHandler(ctx context.Context, cfg Config) (http.Handler, error) {
+//
+// It also returns a DexState that other handlers (e.g., the dev token-exchange
+// endpoint) can use to access Dex internals such as signing keys.
+func NewHandler(ctx context.Context, cfg Config) (http.Handler, *DexState, error) {
 	if cfg.Issuer == "" {
-		return nil, fmt.Errorf("issuer is required")
+		return nil, nil, fmt.Errorf("issuer is required")
 	}
 	if cfg.ClientID == "" {
-		return nil, fmt.Errorf("clientID is required")
+		return nil, nil, fmt.Errorf("clientID is required")
 	}
 	if len(cfg.RedirectURIs) == 0 {
-		return nil, fmt.Errorf("at least one redirectURI is required")
+		return nil, nil, fmt.Errorf("at least one redirectURI is required")
 	}
 
 	logger := cfg.Logger
@@ -92,7 +109,7 @@ func NewHandler(ctx context.Context, cfg Config) (http.Handler, error) {
 		Groups:   []string{"owner"},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal auto connector config: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal auto connector config: %w", err)
 	}
 
 	// Single auto-login connector for development. Dex auto-redirects when
@@ -131,7 +148,7 @@ func NewHandler(ctx context.Context, cfg Config) (http.Handler, error) {
 			"3s",                         // reuseInterval (handle network retries)
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create refresh token policy: %w", err)
+			return nil, nil, fmt.Errorf("failed to create refresh token policy: %w", err)
 		}
 		serverConfig.RefreshTokenPolicy = refreshPolicy
 	}
@@ -139,7 +156,7 @@ func NewHandler(ctx context.Context, cfg Config) (http.Handler, error) {
 	// Create Dex server
 	dexServer, err := server.NewServer(ctx, serverConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create dex server: %w", err)
+		return nil, nil, fmt.Errorf("failed to create dex server: %w", err)
 	}
 
 	logger.Info("embedded OIDC provider initialized",
@@ -148,5 +165,11 @@ func NewHandler(ctx context.Context, cfg Config) (http.Handler, error) {
 		"username", GetUsername(),
 	)
 
-	return dexServer, nil
+	state := &DexState{
+		Storage:  store,
+		Issuer:   cfg.Issuer,
+		ClientID: cfg.ClientID,
+	}
+
+	return dexServer, state, nil
 }

--- a/console/oidc/oidc_test.go
+++ b/console/oidc/oidc_test.go
@@ -15,7 +15,7 @@ func TestNewHandler_Success(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	// Create OIDC handler with valid configuration
-	handler, err := oidc.NewHandler(ctx, oidc.Config{
+	handler, state, err := oidc.NewHandler(ctx, oidc.Config{
 		Issuer:       "https://test.example.com/dex",
 		ClientID:     "test-client",
 		RedirectURIs: []string{"https://test.example.com/callback"},
@@ -30,6 +30,11 @@ func TestNewHandler_Success(t *testing.T) {
 		t.Error("NewHandler() returned nil handler")
 	}
 
+	// Verify state is not nil
+	if state == nil {
+		t.Error("NewHandler() returned nil state")
+	}
+
 	// Verify handler implements http.Handler
 	var _ http.Handler = handler
 }
@@ -41,7 +46,7 @@ func TestNewHandler_RegistersSingleAutoConnector(t *testing.T) {
 	// NewHandler should succeed with only the auto-login connector.
 	// A single connector ensures Dex auto-redirects without showing
 	// a connector selection page, which E2E tests depend on.
-	handler, err := oidc.NewHandler(ctx, oidc.Config{
+	handler, _, err := oidc.NewHandler(ctx, oidc.Config{
 		Issuer:       "https://test.example.com/dex",
 		ClientID:     "test-client",
 		RedirectURIs: []string{"https://test.example.com/callback"},
@@ -94,7 +99,7 @@ func TestNewHandler_ValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := oidc.NewHandler(ctx, tt.config)
+			_, _, err := oidc.NewHandler(ctx, tt.config)
 			if err == nil {
 				t.Error("NewHandler() expected error, got nil")
 			}

--- a/console/oidc/token_exchange.go
+++ b/console/oidc/token_exchange.go
@@ -1,0 +1,239 @@
+package oidc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// TokenExchangeRequest is the JSON body for POST /api/dev/token.
+type TokenExchangeRequest struct {
+	Email string `json:"email"`
+}
+
+// TokenExchangeResponse is the JSON response from POST /api/dev/token.
+type TokenExchangeResponse struct {
+	IDToken   string   `json:"id_token"`
+	Email     string   `json:"email"`
+	Groups    []string `json:"groups"`
+	ExpiresIn int64    `json:"expires_in"`
+}
+
+// idTokenClaims mirrors the OIDC ID token claims structure used by Dex.
+// We define our own copy because Dex's idTokenClaims type is unexported.
+type idTokenClaims struct {
+	Issuer        string   `json:"iss"`
+	Subject       string   `json:"sub"`
+	Audience      audience `json:"aud"`
+	Expiry        int64    `json:"exp"`
+	IssuedAt      int64    `json:"iat"`
+	Email         string   `json:"email,omitempty"`
+	EmailVerified *bool    `json:"email_verified,omitempty"`
+	Groups        []string `json:"groups,omitempty"`
+	Name          string   `json:"name,omitempty"`
+}
+
+// audience implements custom JSON marshalling to match Dex's behavior:
+// a single-element audience is serialized as a string, not an array.
+type audience []string
+
+func (a audience) MarshalJSON() ([]byte, error) {
+	if len(a) == 1 {
+		return json.Marshal(a[0])
+	}
+	return json.Marshal([]string(a))
+}
+
+// HandleTokenExchange returns an http.HandlerFunc that mints OIDC ID tokens
+// for registered test users. The tokens are signed using Dex's signing keys
+// retrieved from the Dex storage, so they pass the LazyAuthInterceptor JWT
+// verification.
+//
+// If state is nil (Dex not enabled), the handler returns 404.
+func HandleTokenExchange(state *DexState) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if state == nil {
+			http.Error(w, "dev token endpoint not available (Dex not enabled)", http.StatusNotFound)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Limit request body to 1KB to prevent abuse.
+		r.Body = http.MaxBytesReader(w, r.Body, 1024)
+
+		var req TokenExchangeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		if req.Email == "" {
+			http.Error(w, "email is required", http.StatusBadRequest)
+			return
+		}
+
+		// Look up the user in the test users registry.
+		var user *TestUser
+		for i := range TestUsers {
+			if TestUsers[i].Email == req.Email {
+				user = &TestUsers[i]
+				break
+			}
+		}
+		if user == nil {
+			http.Error(w, fmt.Sprintf("unknown test user email: %q", req.Email), http.StatusBadRequest)
+			return
+		}
+
+		// Mint an ID token signed with Dex's signing keys.
+		token, expiresIn, err := mintIDToken(r.Context(), state, user)
+		if err != nil {
+			slog.Error("failed to mint dev token", "email", req.Email, "error", err)
+			http.Error(w, "failed to mint token", http.StatusInternalServerError)
+			return
+		}
+
+		resp := TokenExchangeResponse{
+			IDToken:   token,
+			Email:     user.Email,
+			Groups:    user.Groups,
+			ExpiresIn: expiresIn,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// mintIDToken creates a signed OIDC ID token for the given test user using
+// the signing keys from Dex's storage. The token structure matches what Dex
+// produces for the openid, email, groups, and profile scopes.
+func mintIDToken(ctx context.Context, state *DexState, user *TestUser) (string, int64, error) {
+	keys, err := state.Storage.GetKeys(ctx)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to get signing keys: %w", err)
+	}
+
+	signingKey := keys.SigningKey
+	if signingKey == nil {
+		return "", 0, fmt.Errorf("no signing key available (Dex may not have initialized yet)")
+	}
+
+	alg, err := signatureAlgorithm(signingKey)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to determine signature algorithm: %w", err)
+	}
+
+	now := time.Now()
+	expiresIn := int64(3600) // 1 hour
+	expiry := now.Add(time.Duration(expiresIn) * time.Second)
+
+	// Encode the subject the same way Dex does: a protobuf-encoded
+	// IDTokenSubject{user_id, conn_id} that is base64-RawURL-encoded.
+	// The connector ID is "holos" (our auto connector).
+	subject, err := encodeSubject(user.UserID, "holos")
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to encode subject: %w", err)
+	}
+
+	emailVerified := true
+	claims := idTokenClaims{
+		Issuer:        state.Issuer,
+		Subject:       subject,
+		Audience:      audience{state.ClientID},
+		Expiry:        expiry.Unix(),
+		IssuedAt:      now.Unix(),
+		Email:         user.Email,
+		EmailVerified: &emailVerified,
+		Groups:        user.Groups,
+		Name:          user.DisplayName,
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to marshal claims: %w", err)
+	}
+
+	token, err := signPayload(signingKey, alg, payload)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	return token, expiresIn, nil
+}
+
+// encodeSubject encodes a userID and connectorID into the Dex subject format.
+// Dex uses a protobuf-encoded IDTokenSubject message that is then
+// base64-RawURL-encoded. The proto message has two string fields:
+//
+//	message IDTokenSubject {
+//	    string user_id = 1;
+//	    string conn_id = 2;
+//	}
+//
+// We manually encode the protobuf wire format to avoid importing
+// dex/server/internal (which is a Go internal package).
+func encodeSubject(userID, connID string) (string, error) {
+	// Proto wire format: field 1 (tag=1, wiretype=2) + length + bytes,
+	// then field 2 (tag=2, wiretype=2) + length + bytes.
+	var buf []byte
+	buf = protowire.AppendTag(buf, 1, protowire.BytesType)
+	buf = protowire.AppendString(buf, userID)
+	buf = protowire.AppendTag(buf, 2, protowire.BytesType)
+	buf = protowire.AppendString(buf, connID)
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// signatureAlgorithm determines the JWS algorithm for the given key.
+// This mirrors Dex's signatureAlgorithm function.
+func signatureAlgorithm(jwk *jose.JSONWebKey) (jose.SignatureAlgorithm, error) {
+	if jwk.Key == nil {
+		return "", fmt.Errorf("no signing key")
+	}
+	switch key := jwk.Key.(type) {
+	case *rsa.PrivateKey:
+		return jose.RS256, nil
+	case *ecdsa.PrivateKey:
+		switch key.Params() {
+		case elliptic.P256().Params():
+			return jose.ES256, nil
+		case elliptic.P384().Params():
+			return jose.ES384, nil
+		case elliptic.P521().Params():
+			return jose.ES512, nil
+		default:
+			return "", fmt.Errorf("unsupported ecdsa curve")
+		}
+	default:
+		return "", fmt.Errorf("unsupported signing key type %T", jwk.Key)
+	}
+}
+
+// signPayload signs a JSON payload using the given JWK and algorithm.
+// This mirrors Dex's signPayload function.
+func signPayload(key *jose.JSONWebKey, alg jose.SignatureAlgorithm, payload []byte) (string, error) {
+	signingKey := jose.SigningKey{Key: key, Algorithm: alg}
+	signer, err := jose.NewSigner(signingKey, &jose.SignerOptions{})
+	if err != nil {
+		return "", fmt.Errorf("new signer: %w", err)
+	}
+	sig, err := signer.Sign(payload)
+	if err != nil {
+		return "", fmt.Errorf("signing payload: %w", err)
+	}
+	return sig.CompactSerialize()
+}

--- a/console/oidc/token_exchange_test.go
+++ b/console/oidc/token_exchange_test.go
@@ -1,0 +1,245 @@
+package oidc_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/holos-run/holos-console/console/oidc"
+)
+
+// newDexState creates a real Dex instance and returns its DexState for testing.
+func newDexState(t *testing.T) *oidc.DexState {
+	t.Helper()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	_, state, err := oidc.NewHandler(ctx, oidc.Config{
+		Issuer:       "https://test.example.com/dex",
+		ClientID:     "test-client",
+		RedirectURIs: []string{"https://test.example.com/callback"},
+		Logger:       logger,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	return state
+}
+
+func TestHandleTokenExchange_Success(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	body := `{"email":"platform@localhost"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp oidc.TokenExchangeResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.IDToken == "" {
+		t.Error("id_token is empty")
+	}
+	if resp.Email != "platform@localhost" {
+		t.Errorf("email = %q, want %q", resp.Email, "platform@localhost")
+	}
+	if len(resp.Groups) != 1 || resp.Groups[0] != "owner" {
+		t.Errorf("groups = %v, want [owner]", resp.Groups)
+	}
+	if resp.ExpiresIn <= 0 {
+		t.Errorf("expires_in = %d, want > 0", resp.ExpiresIn)
+	}
+}
+
+func TestHandleTokenExchange_AllUsers(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	for _, user := range oidc.TestUsers {
+		t.Run(user.ID, func(t *testing.T) {
+			body, _ := json.Marshal(map[string]string{"email": user.Email})
+			req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			handler(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+
+			var resp oidc.TokenExchangeResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if resp.Email != user.Email {
+				t.Errorf("email = %q, want %q", resp.Email, user.Email)
+			}
+			if len(resp.Groups) != len(user.Groups) {
+				t.Fatalf("groups length = %d, want %d", len(resp.Groups), len(user.Groups))
+			}
+			for i, g := range resp.Groups {
+				if g != user.Groups[i] {
+					t.Errorf("groups[%d] = %q, want %q", i, g, user.Groups[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHandleTokenExchange_UnknownEmail(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	body := `{"email":"nobody@localhost"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+}
+
+func TestHandleTokenExchange_EmptyEmail(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	body := `{"email":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+}
+
+func TestHandleTokenExchange_InvalidJSON(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	body := `not json`
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+}
+
+func TestHandleTokenExchange_WrongMethod(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dev/token", nil)
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleTokenExchange_NilState(t *testing.T) {
+	// When Dex is disabled, the handler receives nil state.
+	handler := oidc.HandleTokenExchange(nil)
+
+	body := `{"email":"admin@localhost"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleTokenExchange_ResponseContentType(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	body := `{"email":"admin@localhost"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+func TestHandleTokenExchange_BodyTooLarge(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	// Send a body larger than the limit
+	largeBody := make([]byte, 2*1024*1024) // 2MB
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBuffer(largeBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	// Should fail with bad request (invalid JSON after truncation)
+	if rr.Code == http.StatusOK {
+		t.Fatal("expected non-200 status for oversized body")
+	}
+}
+
+func TestHandleTokenExchange_TokenFormat(t *testing.T) {
+	state := newDexState(t)
+	handler := oidc.HandleTokenExchange(state)
+
+	body := `{"email":"admin@localhost"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp oidc.TokenExchangeResponse
+	data, _ := io.ReadAll(rr.Body)
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// ID token should be a JWT (3 dot-separated parts)
+	parts := bytes.Split([]byte(resp.IDToken), []byte("."))
+	if len(parts) != 3 {
+		t.Errorf("id_token has %d parts, want 3 (JWT format)", len(parts))
+	}
+}

--- a/docs/api-access.md
+++ b/docs/api-access.md
@@ -62,6 +62,19 @@ set -o history
 `set +o history` disables recording for the current shell session.
 `set -o history` re-enables it after you paste.
 
+### Programmatic token acquisition (local development)
+
+When running with `--enable-insecure-dex`, the dev token endpoint provides
+tokens for any registered test persona without a browser flow. See
+[docs/dev-token-endpoint.md](dev-token-endpoint.md) for full details.
+
+```bash
+export HOLOS_ID_TOKEN=$(curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+  -X POST https://localhost:8443/api/dev/token \
+  -H "Content-Type: application/json" \
+  -d '{"email":"platform@localhost"}' | jq -r .id_token)
+```
+
 ## Calling an RPC with curl (Connect protocol — recommended)
 
 All examples assume a valid TLS certificate. For local development, run

--- a/docs/dev-token-endpoint.md
+++ b/docs/dev-token-endpoint.md
@@ -1,0 +1,116 @@
+# Dev Token Endpoint
+
+The dev token endpoint provides programmatic access to OIDC ID tokens for any registered test user. This enables API testing, E2E tests, and CLI workflows without requiring a browser-based OIDC flow.
+
+## Availability
+
+The endpoint is only available when the embedded Dex OIDC provider is enabled via `--enable-insecure-dex`. It is not mounted otherwise and returns 404.
+
+## Endpoint
+
+```
+POST /api/dev/token
+Content-Type: application/json
+```
+
+### Request
+
+```json
+{
+  "email": "platform@localhost"
+}
+```
+
+The `email` field must match one of the registered test users:
+
+| Email | Role | Groups |
+|-------|------|--------|
+| `admin@localhost` | Admin (Owner) | `["owner"]` |
+| `platform@localhost` | Platform Engineer (Owner) | `["owner"]` |
+| `product@localhost` | Product Engineer (Editor) | `["editor"]` |
+| `sre@localhost` | SRE (Viewer) | `["viewer"]` |
+
+### Response
+
+```json
+{
+  "id_token": "eyJhbGciOiJSUzI1NiIs...",
+  "email": "platform@localhost",
+  "groups": ["owner"],
+  "expires_in": 3600
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id_token` | string | A signed OIDC ID token (JWT) that passes `LazyAuthInterceptor` verification |
+| `email` | string | The email address of the authenticated user |
+| `groups` | string[] | The OIDC groups included in the token |
+| `expires_in` | integer | Token lifetime in seconds (3600 = 1 hour) |
+
+### Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Email is empty, not recognized, or request body is invalid JSON |
+| 404 | Dex is not enabled (`--enable-insecure-dex` not set) |
+| 405 | Request method is not POST |
+| 500 | Internal error (e.g., Dex signing keys not yet initialized) |
+
+## Usage Examples
+
+### Obtain a token with curl
+
+```bash
+curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+  -X POST https://localhost:8443/api/dev/token \
+  -H "Content-Type: application/json" \
+  -d '{"email":"platform@localhost"}'
+```
+
+### Use the token to call an RPC
+
+```bash
+# Get a token
+TOKEN=$(curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+  -X POST https://localhost:8443/api/dev/token \
+  -H "Content-Type: application/json" \
+  -d '{"email":"platform@localhost"}' | jq -r .id_token)
+
+# Call an RPC with the token
+curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+  -H "Connect-Protocol-Version: 1" \
+  -H "Authorization: Bearer $TOKEN" \
+  https://localhost:8443/holos.console.v1.VersionService/GetVersion
+```
+
+### Switch personas in a test script
+
+```bash
+for email in admin@localhost platform@localhost product@localhost sre@localhost; do
+  TOKEN=$(curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+    -X POST https://localhost:8443/api/dev/token \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$email\"}" | jq -r .id_token)
+  echo "=== $email ==="
+  curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+    -H "Connect-Protocol-Version: 1" \
+    -H "Authorization: Bearer $TOKEN" \
+    https://localhost:8443/holos.console.v1.OrganizationService/ListOrganizations \
+    -d '{}'
+done
+```
+
+## Implementation Details
+
+The endpoint mints tokens directly using Dex's signing keys from the in-memory storage. This approach:
+
+- Produces tokens identical in structure to those Dex issues through the standard OIDC flow
+- Avoids registering additional Dex connectors (which would break auto-login by causing Dex to show a connector selection page)
+- Uses the same signing key and algorithm that Dex uses for all other tokens
+
+The token claims include `iss`, `sub`, `aud`, `exp`, `iat`, `email`, `email_verified`, `groups`, and `name`, matching the scopes `openid`, `email`, `groups`, and `profile`.
+
+## Security
+
+This endpoint is for **local development only**. It requires no authentication and returns tokens for any registered test user. It is gated behind `--enable-insecure-dex` to prevent accidental exposure in production.


### PR DESCRIPTION
## Summary

- Add `POST /api/dev/token` endpoint that mints real OIDC ID tokens for any registered test user
- Tokens are signed using Dex's signing keys (retrieved from storage), so they pass `LazyAuthInterceptor` JWT verification
- Endpoint is gated behind `--enable-insecure-dex` (only mounted when embedded Dex is enabled)
- Returns 400 for unknown emails, 404 when Dex is disabled, 405 for non-POST methods
- Avoids registering additional Dex connectors (which would break auto-login by showing connector selection page)
- `NewHandler` now returns a `DexState` struct alongside the HTTP handler, providing access to Dex's storage for key retrieval
- Add documentation at `docs/dev-token-endpoint.md` with curl examples
- Cross-reference from `docs/api-access.md`

Closes #697

## Test plan

- [x] `make test-go` passes (all Go tests including new token exchange tests)
- [x] `make test-ui` passes (642 tests)
- [x] `make generate` succeeds
- [ ] `go test -v -run TestHandleTokenExchange ./console/oidc/` -- 9 test cases covering success, all users, unknown email, empty email, invalid JSON, wrong method, nil state, body too large, content type, and JWT format

Generated with [Claude Code](https://claude.com/claude-code) · agent-1