### PR TITLE
feat(organizations): auto-create default folder on org creation

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -53,6 +53,11 @@ const (
 	AnnotationMandatory         = "console.holos.run/mandatory"
 	AnnotationEnabled           = "console.holos.run/enabled"
 	AnnotationSettings          = "console.holos.run/project-settings"
+	// AnnotationDefaultFolder stores the identifier (slug) of the default folder
+	// for an organization. Written when the org is created and updatable via
+	// UpdateOrganization. New projects without an explicit parent are placed in
+	// this folder (ADR 022 Decision 3).
+	AnnotationDefaultFolder = "console.holos.run/default-folder"
 	// AnnotationParent is the Kubernetes namespace name of the immediate parent
 	// (organization namespace or folder namespace). Added in v1alpha2 and
 	// present on both Folder and Project namespaces. The hierarchy walk follows

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -58,6 +58,12 @@
 #AnnotationEnabled:           "console.holos.run/enabled"
 #AnnotationSettings:          "console.holos.run/project-settings"
 
+// AnnotationDefaultFolder stores the identifier (slug) of the default folder
+// for an organization. Written when the org is created and updatable via
+// UpdateOrganization. New projects without an explicit parent are placed in
+// this folder (ADR 022 Decision 3).
+#AnnotationDefaultFolder: "console.holos.run/default-folder"
+
 // AnnotationParent is the Kubernetes namespace name of the immediate parent
 // (organization namespace or folder namespace). Added in v1alpha2 and
 // present on both Folder and Project namespaces. The hierarchy walk follows

--- a/console/console.go
+++ b/console/console.go
@@ -244,16 +244,20 @@ func (s *Server) Serve(ctx context.Context) error {
 		nsResolver := &resolver.Resolver{NamespacePrefix: s.cfg.NamespacePrefix, OrganizationPrefix: s.cfg.OrganizationPrefix, FolderPrefix: s.cfg.FolderPrefix, ProjectPrefix: s.cfg.ProjectPrefix}
 		slog.Info("kubernetes client initialized")
 
+		// Folder K8s client created first so the org handler can auto-create default folders.
+		foldersK8s := folders.NewK8sClient(k8sClientset, nsResolver)
+
 		// Organization service (projectsK8s created first for linked-project precondition check)
 		orgsK8s := organizations.NewK8sClient(k8sClientset, nsResolver)
 		orgGrantResolver := organizations.NewOrgGrantResolver(orgsK8s)
 		projectsK8s := projects.NewK8sClient(k8sClientset, nsResolver)
-		orgsHandler := organizations.NewHandler(orgsK8s, projectsK8s, s.cfg.DisableOrgCreation, s.cfg.OrgCreatorUsers, s.cfg.OrgCreatorRoles)
+		folderPrefix := nsResolver.NamespacePrefix + nsResolver.FolderPrefix
+		orgsHandler := organizations.NewHandler(orgsK8s, projectsK8s, s.cfg.DisableOrgCreation, s.cfg.OrgCreatorUsers, s.cfg.OrgCreatorRoles).
+			WithFolderCreator(foldersK8s, foldersK8s, folderPrefix)
 		orgsPath, orgsHTTPHandler := consolev1connect.NewOrganizationServiceHandler(orgsHandler, protectedInterceptors)
 		mux.Handle(orgsPath, orgsHTTPHandler)
 
 		// Folder service
-		foldersK8s := folders.NewK8sClient(k8sClientset, nsResolver)
 		foldersHandler := folders.NewHandler(foldersK8s)
 		foldersPath, foldersHTTPHandler := consolev1connect.NewFolderServiceHandler(foldersHandler, protectedInterceptors)
 		mux.Handle(foldersPath, foldersHTTPHandler)

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -27,11 +27,26 @@ type ProjectLister interface {
 	ListProjects(ctx context.Context, org, parentNs string) ([]*corev1.Namespace, error)
 }
 
+// FolderCreator creates a folder namespace. Used by CreateOrganization to
+// auto-create the default folder without importing the folders package directly.
+type FolderCreator interface {
+	CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
+	NamespaceExists(ctx context.Context, nsName string) (bool, error)
+}
+
+// FolderLister retrieves folder namespaces for validation.
+type FolderLister interface {
+	GetFolder(ctx context.Context, name string) (*corev1.Namespace, error)
+}
+
 // Handler implements the OrganizationService.
 type Handler struct {
 	consolev1connect.UnimplementedOrganizationServiceHandler
 	k8s             *K8sClient
 	projectLister   ProjectLister
+	folderCreator   FolderCreator
+	folderLister    FolderLister
+	folderPrefix    string // namespace prefix + folder prefix (e.g. "holos-fld-")
 	disableCreation bool
 	creatorUsers    []string
 	creatorRoles    []string
@@ -43,6 +58,15 @@ type Handler struct {
 // creatorRoles are allowed to create organizations.
 func NewHandler(k8s *K8sClient, projectLister ProjectLister, disableCreation bool, creatorUsers, creatorRoles []string) *Handler {
 	return &Handler{k8s: k8s, projectLister: projectLister, disableCreation: disableCreation, creatorUsers: creatorUsers, creatorRoles: creatorRoles}
+}
+
+// WithFolderCreator sets the folder creator used to auto-create the default
+// folder when a new organization is created.
+func (h *Handler) WithFolderCreator(fc FolderCreator, fl FolderLister, folderPrefix string) *Handler {
+	h.folderCreator = fc
+	h.folderLister = fl
+	h.folderPrefix = folderPrefix
+	return h
 }
 
 // ListOrganizations returns all organizations the user has access to.
@@ -140,7 +164,8 @@ func (h *Handler) GetOrganization(
 	}), nil
 }
 
-// CreateOrganization creates a new organization.
+// CreateOrganization creates a new organization and its default folder.
+// If default folder creation fails, the org namespace is rolled back.
 func (h *Handler) CreateOrganization(
 	ctx context.Context,
 	req *connect.Request[consolev1.CreateOrganizationRequest],
@@ -177,6 +202,40 @@ func (h *Handler) CreateOrganization(
 		return nil, mapK8sError(err)
 	}
 
+	// Auto-create the default folder as an immediate child of the org.
+	if h.folderCreator != nil {
+		folderDisplayName := "Default"
+		if req.Msg.DefaultFolder != nil && *req.Msg.DefaultFolder != "" {
+			folderDisplayName = *req.Msg.DefaultFolder
+		}
+
+		folderName, err := h.createDefaultFolder(ctx, req.Msg.Name, folderDisplayName, claims.Email, shareUsers, shareRoles)
+		if err != nil {
+			// Rollback: delete the org namespace on default folder failure.
+			slog.ErrorContext(ctx, "default folder creation failed, rolling back org",
+				slog.String("organization", req.Msg.Name),
+				slog.Any("error", err),
+			)
+			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
+				slog.ErrorContext(ctx, "org rollback failed",
+					slog.String("organization", req.Msg.Name),
+					slog.Any("error", delErr),
+				)
+			}
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("creating default folder: %w", err))
+		}
+
+		// Store the default folder identifier on the org namespace.
+		if err := h.k8s.SetDefaultFolder(ctx, req.Msg.Name, folderName); err != nil {
+			slog.ErrorContext(ctx, "failed to set default folder annotation",
+				slog.String("organization", req.Msg.Name),
+				slog.String("folder", folderName),
+				slog.Any("error", err),
+			)
+			// Non-fatal: the org and folder exist, the annotation is just missing.
+		}
+	}
+
 	slog.InfoContext(ctx, "organization created",
 		slog.String("action", "organization_create"),
 		slog.String("resource_type", auditResourceType),
@@ -188,6 +247,25 @@ func (h *Handler) CreateOrganization(
 	return connect.NewResponse(&consolev1.CreateOrganizationResponse{
 		Name: req.Msg.Name,
 	}), nil
+}
+
+// createDefaultFolder generates an identifier from the display name and creates
+// the folder namespace as a direct child of the organization. Returns the folder
+// identifier (slug).
+func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (string, error) {
+	exists := func(ctx context.Context, nsName string) (bool, error) {
+		return h.folderCreator.NamespaceExists(ctx, nsName)
+	}
+	folderName, err := v1alpha2.GenerateIdentifier(ctx, displayName, h.folderPrefix, exists)
+	if err != nil {
+		return "", fmt.Errorf("generating folder identifier: %w", err)
+	}
+
+	orgNsName := h.k8s.resolver.OrgNamespace(orgName)
+	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, shareUsers, shareRoles); err != nil {
+		return "", fmt.Errorf("creating folder namespace: %w", err)
+	}
+	return folderName, nil
 }
 
 // UpdateOrganization updates organization metadata.
@@ -215,15 +293,43 @@ func (h *Handler) UpdateOrganization(
 	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
 	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
 
-	if err := CheckOrgWriteAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
-		slog.WarnContext(ctx, "organization update denied",
-			slog.String("action", "organization_update_denied"),
-			slog.String("resource_type", auditResourceType),
-			slog.String("organization", req.Msg.Name),
-			slog.String("sub", claims.Sub),
-			slog.String("email", claims.Email),
-		)
-		return nil, err
+	// Changing default_folder requires ADMIN (OWNER) permission.
+	if req.Msg.DefaultFolder != nil {
+		if err := CheckOrgAdminAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+			slog.WarnContext(ctx, "organization update default folder denied",
+				slog.String("action", "organization_update_denied"),
+				slog.String("resource_type", auditResourceType),
+				slog.String("organization", req.Msg.Name),
+				slog.String("sub", claims.Sub),
+				slog.String("email", claims.Email),
+			)
+			return nil, err
+		}
+	} else {
+		if err := CheckOrgWriteAccess(claims.Email, claims.Roles, activeUsers, activeRoles); err != nil {
+			slog.WarnContext(ctx, "organization update denied",
+				slog.String("action", "organization_update_denied"),
+				slog.String("resource_type", auditResourceType),
+				slog.String("organization", req.Msg.Name),
+				slog.String("sub", claims.Sub),
+				slog.String("email", claims.Email),
+			)
+			return nil, err
+		}
+	}
+
+	// Validate and update default folder if requested.
+	if req.Msg.DefaultFolder != nil {
+		newFolder := *req.Msg.DefaultFolder
+		if newFolder == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("default_folder must not be empty"))
+		}
+		if err := h.validateDefaultFolder(ctx, req.Msg.Name, newFolder); err != nil {
+			return nil, err
+		}
+		if err := h.k8s.SetDefaultFolder(ctx, req.Msg.Name, newFolder); err != nil {
+			return nil, mapK8sError(err)
+		}
 	}
 
 	if _, err := h.k8s.UpdateOrganization(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
@@ -239,6 +345,26 @@ func (h *Handler) UpdateOrganization(
 	)
 
 	return connect.NewResponse(&consolev1.UpdateOrganizationResponse{}), nil
+}
+
+// validateDefaultFolder checks that the referenced folder exists and is an
+// immediate child of the organization (parent label matches org namespace).
+func (h *Handler) validateDefaultFolder(ctx context.Context, orgName, folderName string) error {
+	if h.folderLister == nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("folder lister not configured"))
+	}
+	folderNs, err := h.folderLister.GetFolder(ctx, folderName)
+	if err != nil {
+		return connect.NewError(connect.CodeNotFound, fmt.Errorf("folder %q not found: %w", folderName, err))
+	}
+	// Verify the folder is a direct child of the org.
+	orgNsName := h.k8s.resolver.OrgNamespace(orgName)
+	parentNs := folderNs.Labels[v1alpha2.AnnotationParent]
+	if parentNs != orgNsName {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("folder %q is not an immediate child of organization %q", folderName, orgName))
+	}
+	return nil
 }
 
 // DeleteOrganization deletes a managed organization.
@@ -551,6 +677,7 @@ func buildOrganization(k8s *K8sClient, ns interface{ GetName() string }, shareUs
 			org.DisplayName = annotations[v1alpha2.AnnotationDisplayName]
 			org.Description = annotations[v1alpha2.AnnotationDescription]
 			org.CreatorEmail = annotations[v1alpha2.AnnotationCreatorEmail]
+			org.DefaultFolder = annotations[v1alpha2.AnnotationDefaultFolder]
 		}
 		// Populate default sharing grants and creation timestamp from typed namespace
 		if nsTyped, ok := ns.(*corev1.Namespace); ok {

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -227,12 +227,19 @@ func (h *Handler) CreateOrganization(
 
 		// Store the default folder identifier on the org namespace.
 		if err := h.k8s.SetDefaultFolder(ctx, req.Msg.Name, folderName); err != nil {
-			slog.ErrorContext(ctx, "failed to set default folder annotation",
+			slog.ErrorContext(ctx, "failed to set default folder annotation, rolling back",
 				slog.String("organization", req.Msg.Name),
 				slog.String("folder", folderName),
 				slog.Any("error", err),
 			)
-			// Non-fatal: the org and folder exist, the annotation is just missing.
+			// Roll back: the org contract requires default_folder to be set.
+			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
+				slog.ErrorContext(ctx, "org rollback after annotation failure failed",
+					slog.String("organization", req.Msg.Name),
+					slog.Any("error", delErr),
+				)
+			}
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("setting default folder annotation: %w", err))
 		}
 	}
 
@@ -355,7 +362,10 @@ func (h *Handler) validateDefaultFolder(ctx context.Context, orgName, folderName
 	}
 	folderNs, err := h.folderLister.GetFolder(ctx, folderName)
 	if err != nil {
-		return connect.NewError(connect.CodeNotFound, fmt.Errorf("folder %q not found: %w", folderName, err))
+		if errors.IsNotFound(err) {
+			return connect.NewError(connect.CodeNotFound, fmt.Errorf("folder %q not found", folderName))
+		}
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("looking up folder %q: %w", folderName, err))
 	}
 	// Verify the folder is a direct child of the org.
 	orgNsName := h.k8s.resolver.OrgNamespace(orgName)

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -3,12 +3,14 @@ package organizations
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
 
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -57,6 +59,7 @@ type testHandlerOpts struct {
 	creatorUsers       []string
 	creatorRoles       []string
 	projectLister      ProjectLister
+	withFolderCreator  bool
 }
 
 func newTestHandler(namespaces ...*corev1.Namespace) *Handler {
@@ -69,10 +72,80 @@ func newTestHandlerWithOpts(opts testHandlerOpts, namespaces ...*corev1.Namespac
 		objs[i] = ns
 	}
 	fakeClient := fake.NewClientset(objs...)
-	k8s := NewK8sClient(fakeClient, testResolver())
+	r := testResolver()
+	k8s := NewK8sClient(fakeClient, r)
 	handler := NewHandler(k8s, opts.projectLister, opts.disableOrgCreation, opts.creatorUsers, opts.creatorRoles)
+
+	if opts.withFolderCreator {
+		fc := &k8sFolderCreator{client: fakeClient, resolver: r}
+		folderPrefix := r.NamespacePrefix + r.FolderPrefix
+		handler.WithFolderCreator(fc, fc, folderPrefix)
+	}
+
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	return handler
+}
+
+// k8sFolderCreator implements FolderCreator and FolderLister for tests.
+type k8sFolderCreator struct {
+	client   *fake.Clientset
+	resolver *resolver.Resolver
+	createFn func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
+}
+
+func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	if f.createFn != nil {
+		return f.createFn(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles)
+	}
+	usersJSON, _ := json.Marshal(shareUsers)
+	rolesJSON, _ := json.Marshal(shareRoles)
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareUsers: string(usersJSON),
+		v1alpha2.AnnotationShareRoles: string(rolesJSON),
+	}
+	if displayName != "" {
+		annotations[v1alpha2.AnnotationDisplayName] = displayName
+	}
+	if creatorEmail != "" {
+		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: f.resolver.FolderNamespace(name),
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelFolder:       name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+	return f.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+}
+
+func (f *k8sFolderCreator) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
+	_, err := f.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (f *k8sFolderCreator) GetFolder(ctx context.Context, name string) (*corev1.Namespace, error) {
+	nsName := f.resolver.FolderNamespace(name)
+	ns, err := f.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if ns.Labels == nil || ns.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeFolder {
+		return nil, fmt.Errorf("namespace %q is not a folder", nsName)
+	}
+	return ns, nil
 }
 
 // ---- ListOrganizations tests ----
@@ -765,6 +838,351 @@ func TestCreateOrganization_NamespacePrefixIncluded(t *testing.T) {
 	if ns.Name != "prod-org-acme" {
 		t.Errorf("expected namespace name 'prod-org-acme', got %q", ns.Name)
 	}
+}
+
+// ---- Default folder creation tests ----
+
+func TestCreateOrganization_CreatesDefaultFolder(t *testing.T) {
+	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true})
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+		Name:        "test-df-org",
+		DisplayName: "Test Org",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "test-df-org" {
+		t.Errorf("expected org name 'test-df-org', got %q", resp.Msg.Name)
+	}
+
+	// Verify the default folder namespace was created with slug "default".
+	fc := handler.folderCreator.(*k8sFolderCreator)
+	folderNsName := handler.k8s.resolver.NamespacePrefix + handler.k8s.resolver.FolderPrefix + "default"
+	ns, err := fc.client.CoreV1().Namespaces().Get(context.Background(), folderNsName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected default folder namespace %q to exist, got %v", folderNsName, err)
+	}
+	if ns.Labels[v1alpha2.LabelOrganization] != "test-df-org" {
+		t.Errorf("expected folder org label 'test-df-org', got %q", ns.Labels[v1alpha2.LabelOrganization])
+	}
+	if ns.Labels[v1alpha2.AnnotationParent] != "holos-org-test-df-org" {
+		t.Errorf("expected folder parent 'holos-org-test-df-org', got %q", ns.Labels[v1alpha2.AnnotationParent])
+	}
+	if ns.Annotations[v1alpha2.AnnotationDisplayName] != "Default" {
+		t.Errorf("expected folder display name 'Default', got %q", ns.Annotations[v1alpha2.AnnotationDisplayName])
+	}
+
+	// Verify default folder annotation on the org namespace.
+	orgNs, err := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-test-df-org", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected org namespace to exist, got %v", err)
+	}
+	if orgNs.Annotations[v1alpha2.AnnotationDefaultFolder] != "default" {
+		t.Errorf("expected default-folder annotation 'default', got %q", orgNs.Annotations[v1alpha2.AnnotationDefaultFolder])
+	}
+}
+
+func TestCreateOrganization_CreatesDefaultFolderWithCustomName(t *testing.T) {
+	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true})
+	ctx := contextWithClaims("alice@example.com")
+
+	customName := "Engineering"
+	_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+		Name:          "test-custom-org",
+		DefaultFolder: &customName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// The slug for "Engineering" is "engineering".
+	fc := handler.folderCreator.(*k8sFolderCreator)
+	folderNsName := "holos-fld-engineering"
+	ns, err := fc.client.CoreV1().Namespaces().Get(context.Background(), folderNsName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected folder namespace %q to exist, got %v", folderNsName, err)
+	}
+	if ns.Annotations[v1alpha2.AnnotationDisplayName] != "Engineering" {
+		t.Errorf("expected display name 'Engineering', got %q", ns.Annotations[v1alpha2.AnnotationDisplayName])
+	}
+}
+
+func TestCreateOrganization_DefaultFolderCollisionAddsSuffix(t *testing.T) {
+	// Pre-create a namespace that would collide with the default folder slug.
+	existingFolder := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-default",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+			},
+		},
+	}
+	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true}, existingFolder)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+		Name: "test-collision-org",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "test-collision-org" {
+		t.Errorf("expected org name 'test-collision-org', got %q", resp.Msg.Name)
+	}
+
+	// Verify the org has a default folder annotation with a suffixed identifier.
+	fc := handler.folderCreator.(*k8sFolderCreator)
+	orgNs, err := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-test-collision-org", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected org namespace to exist, got %v", err)
+	}
+	dfAnnotation := orgNs.Annotations[v1alpha2.AnnotationDefaultFolder]
+	if dfAnnotation == "" {
+		t.Fatal("expected default-folder annotation to be set")
+	}
+	if dfAnnotation == "default" {
+		t.Error("expected a suffixed folder identifier due to collision, got 'default'")
+	}
+	// Verify the suffixed folder namespace exists.
+	suffixedNsName := "holos-fld-" + dfAnnotation
+	if _, err := fc.client.CoreV1().Namespaces().Get(context.Background(), suffixedNsName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected suffixed folder namespace %q to exist, got %v", suffixedNsName, err)
+	}
+}
+
+func TestCreateOrganization_DefaultFolderCreatorIsOwner(t *testing.T) {
+	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true})
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+		Name: "test-owner-org",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	fc := handler.folderCreator.(*k8sFolderCreator)
+	ns, err := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-fld-default", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected default folder to exist, got %v", err)
+	}
+
+	var grants []secrets.AnnotationGrant
+	if err := json.Unmarshal([]byte(ns.Annotations[v1alpha2.AnnotationShareUsers]), &grants); err != nil {
+		t.Fatalf("failed to parse share-users: %v", err)
+	}
+	found := false
+	for _, g := range grants {
+		if g.Principal == "alice@example.com" && g.Role == "owner" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected creator as owner in folder share-users, got %v", grants)
+	}
+}
+
+func TestCreateOrganization_RollbackOnFolderFailure(t *testing.T) {
+	objs := []runtime.Object{}
+	fakeClient := fake.NewClientset(objs...)
+	r := testResolver()
+	k8s := NewK8sClient(fakeClient, r)
+	handler := NewHandler(k8s, nil, false, nil, nil)
+
+	// Use a folder creator that always fails.
+	failFC := &k8sFolderCreator{
+		client:   fakeClient,
+		resolver: r,
+		createFn: func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+			return nil, fmt.Errorf("simulated folder creation failure")
+		},
+	}
+	folderPrefix := r.NamespacePrefix + r.FolderPrefix
+	handler.WithFolderCreator(failFC, failFC, folderPrefix)
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+		Name: "test-rollback-org",
+	}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Verify the org namespace was cleaned up.
+	_, getErr := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-org-test-rollback-org", metav1.GetOptions{})
+	if !k8serrors.IsNotFound(getErr) {
+		t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
+	}
+}
+
+func TestGetOrganization_IncludesDefaultFolder(t *testing.T) {
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	ns.Annotations[v1alpha2.AnnotationDefaultFolder] = "my-default"
+
+	handler := newTestHandler(ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.GetOrganization(ctx, connect.NewRequest(&consolev1.GetOrganizationRequest{Name: "acme"}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Organization.DefaultFolder != "my-default" {
+		t.Errorf("expected default_folder 'my-default', got %q", resp.Msg.Organization.DefaultFolder)
+	}
+}
+
+func TestListOrganizations_IncludesDefaultFolder(t *testing.T) {
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	ns.Annotations[v1alpha2.AnnotationDefaultFolder] = "projects"
+
+	handler := newTestHandler(ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.ListOrganizations(ctx, connect.NewRequest(&consolev1.ListOrganizationsRequest{}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resp.Msg.Organizations) != 1 {
+		t.Fatalf("expected 1 org, got %d", len(resp.Msg.Organizations))
+	}
+	if resp.Msg.Organizations[0].DefaultFolder != "projects" {
+		t.Errorf("expected default_folder 'projects', got %q", resp.Msg.Organizations[0].DefaultFolder)
+	}
+}
+
+// ---- UpdateOrganization default folder tests ----
+
+func TestUpdateOrganization_UpdateDefaultFolder(t *testing.T) {
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	ns.Annotations[v1alpha2.AnnotationDefaultFolder] = "default"
+
+	// Create the target folder namespace.
+	folderNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-engineering",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: "acme",
+				v1alpha2.LabelFolder:       "engineering",
+				v1alpha2.AnnotationParent:  "holos-org-acme",
+			},
+		},
+	}
+
+	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true}, ns, folderNs)
+	ctx := contextWithClaims("alice@example.com")
+
+	newFolder := "engineering"
+	_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+		Name:          "acme",
+		DefaultFolder: &newFolder,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify the annotation was updated.
+	fc := handler.folderCreator.(*k8sFolderCreator)
+	orgNs, err := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-acme", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected org namespace to exist, got %v", err)
+	}
+	if orgNs.Annotations[v1alpha2.AnnotationDefaultFolder] != "engineering" {
+		t.Errorf("expected default-folder 'engineering', got %q", orgNs.Annotations[v1alpha2.AnnotationDefaultFolder])
+	}
+}
+
+func TestUpdateOrganization_UpdateDefaultFolder_NonexistentFolder(t *testing.T) {
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true}, ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	nonexistent := "nonexistent"
+	_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+		Name:          "acme",
+		DefaultFolder: &nonexistent,
+	}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeNotFound {
+		t.Errorf("expected CodeNotFound, got %v", connectErr.Code())
+	}
+}
+
+func TestUpdateOrganization_UpdateDefaultFolder_WrongOrg(t *testing.T) {
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+
+	// Create a folder that belongs to a different org.
+	folderNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-other-folder",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: "other-org",
+				v1alpha2.LabelFolder:       "other-folder",
+				v1alpha2.AnnotationParent:  "holos-org-other-org",
+			},
+		},
+	}
+
+	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true}, ns, folderNs)
+	ctx := contextWithClaims("alice@example.com")
+
+	wrongFolder := "other-folder"
+	_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+		Name:          "acme",
+		DefaultFolder: &wrongFolder,
+	}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeInvalidArgument {
+		t.Errorf("expected CodeInvalidArgument, got %v", connectErr.Code())
+	}
+}
+
+func TestUpdateOrganization_UpdateDefaultFolder_EditorDenied(t *testing.T) {
+	// Editors can update display_name/description but NOT default_folder.
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	newFolder := "some-folder"
+	_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+		Name:          "acme",
+		DefaultFolder: &newFolder,
+	}))
+	assertPermissionDenied(t, err)
+}
+
+func TestUpdateOrganization_UpdateDefaultFolder_EmptyValue(t *testing.T) {
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	empty := ""
+	_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+		Name:          "acme",
+		DefaultFolder: &empty,
+	}))
+	assertInvalidArgument(t, err)
 }
 
 // ---- Helpers ----

--- a/console/organizations/k8s.go
+++ b/console/organizations/k8s.go
@@ -166,6 +166,29 @@ func (c *K8sClient) DeleteOrganization(ctx context.Context, name string) error {
 	return c.client.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
 }
 
+// SetDefaultFolder sets the default-folder annotation on the org namespace.
+func (c *K8sClient) SetDefaultFolder(ctx context.Context, name, folderName string) error {
+	ns, err := c.GetOrganization(ctx, name)
+	if err != nil {
+		return err
+	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	ns.Annotations[v1alpha2.AnnotationDefaultFolder] = folderName
+	_, err = c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+	return err
+}
+
+// GetDefaultFolder reads the default-folder annotation from an org namespace.
+// Returns empty string if not set.
+func GetDefaultFolder(ns *corev1.Namespace) string {
+	if ns.Annotations == nil {
+		return ""
+	}
+	return ns.Annotations[v1alpha2.AnnotationDefaultFolder]
+}
+
 // UpdateOrganizationSharing updates the sharing annotations on an organization namespace.
 func (c *K8sClient) UpdateOrganizationSharing(ctx context.Context, name string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	slog.DebugContext(ctx, "updating organization sharing in kubernetes",

--- a/console/organizations/k8s_test.go
+++ b/console/organizations/k8s_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func testResolver() *resolver.Resolver {
-	return &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", ProjectPrefix: "prj-"}
+	return &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 }
 
 func TestListOrganizations_ReturnsOnlyOrgNamespaces(t *testing.T) {
@@ -530,6 +530,62 @@ func TestUpdateOrgDefaultSharing_RejectsNonOrg(t *testing.T) {
 	_, err := k8s.UpdateOrganizationDefaultSharing(context.Background(), "fake", nil, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+// ---- Default folder K8s tests ----
+
+func TestSetDefaultFolder_WritesAnnotation(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-acme",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				resolver.ResourceTypeLabel: resolver.ResourceTypeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	if err := k8s.SetDefaultFolder(context.Background(), "acme", "my-folder"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	updated, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-org-acme", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected namespace to exist, got %v", err)
+	}
+	if updated.Annotations[v1alpha2.AnnotationDefaultFolder] != "my-folder" {
+		t.Errorf("expected default-folder 'my-folder', got %q", updated.Annotations[v1alpha2.AnnotationDefaultFolder])
+	}
+}
+
+func TestGetDefaultFolder_ReadsAnnotation(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-acme",
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDefaultFolder: "engineering",
+			},
+		},
+	}
+	if got := GetDefaultFolder(ns); got != "engineering" {
+		t.Errorf("expected 'engineering', got %q", got)
+	}
+}
+
+func TestGetDefaultFolder_ReturnsEmptyWhenAbsent(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-acme",
+		},
+	}
+	if got := GetDefaultFolder(ns); got != "" {
+		t.Errorf("expected empty string, got %q", got)
 	}
 }
 

--- a/frontend/e2e/folders.spec.ts
+++ b/frontend/e2e/folders.spec.ts
@@ -42,7 +42,7 @@ test.describe('Folder list page', () => {
     await apiDeleteOrg(page, orgName)
   })
 
-  test('empty folder list shows empty state', async ({ page }) => {
+  test('new org has default folder', async ({ page }) => {
     await loginViaProfilePage(page)
 
     const orgName = `e2e-no-folders-${Date.now()}`
@@ -51,8 +51,8 @@ test.describe('Folder list page', () => {
     await page.goto(`/orgs/${orgName}/folders`)
     await page.waitForLoadState('networkidle')
 
-    // No folders → empty state text
-    await expect(page.getByText(/no folders/i)).toBeVisible({ timeout: 10000 })
+    // A new org auto-creates a "Default" folder — verify it appears
+    await expect(page.locator('span.font-medium', { hasText: 'Default' })).toBeVisible({ timeout: 10000 })
 
     await apiDeleteOrg(page, orgName)
   })


### PR DESCRIPTION
## Summary
- Add `AnnotationDefaultFolder` (`console.holos.run/default-folder`) constant to `api/v1alpha2/annotations.go`
- Auto-create a "Default" folder (slug-based identifier) as an immediate child of the org during `CreateOrganization`
- Support custom default folder display name via `default_folder` field on `CreateOrganizationRequest`
- Handle slug collisions using `v1alpha2.GenerateIdentifier` (appends 6-digit random suffix)
- Rollback org namespace if default folder creation fails
- Store default folder identifier as annotation on the org namespace
- Populate `default_folder` field in `GetOrganization` and `ListOrganizations` responses
- Support updating default folder via `UpdateOrganization` (requires OWNER/admin permission)
- Validate that the referenced folder exists and is an immediate child of the org
- Add `FolderCreator` and `FolderLister` interfaces to decouple org handler from folders package
- Wire folder K8s client into org handler in `console.go`
- Add 17 new test cases covering all acceptance criteria

Closes #672

## Test plan
- [x] `make test` passes (Go + UI unit tests)
- [x] `make generate` produces clean output
- [x] `go vet ./console/organizations/` passes
- [x] Org creation creates default folder with slug identifier `default`
- [x] Custom display name produces correct slug
- [x] Collision handling appends random suffix
- [x] Creator is OWNER on the folder
- [x] Org rollback on folder creation failure
- [x] `GetOrganization` and `ListOrganizations` populate `default_folder`
- [x] `UpdateOrganization` with valid folder updates annotation
- [x] `UpdateOrganization` with nonexistent folder returns NotFound
- [x] `UpdateOrganization` with folder in wrong org returns InvalidArgument
- [x] Editor denied for `default_folder` change (requires OWNER)
- [x] Empty `default_folder` value rejected

Generated with [Claude Code](https://claude.com/claude-code) · agent-2