### PR TITLE
feat(cli): add --enable-dev-tools flag and console config injection

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -34,6 +34,7 @@ var (
 	orgCreatorRoles    string
 	rolesClaim         string
 	enableInsecureDex  bool
+	enableDevTools     bool
 	logHealthChecks    bool
 	logLevel           string
 )
@@ -80,6 +81,7 @@ func Command() *cobra.Command {
 
 	// OIDC flags
 	cmd.Flags().BoolVar(&enableInsecureDex, "enable-insecure-dex", false, "Enable the built-in Dex OIDC provider with auto-login (INSECURE: intended for local development only)")
+	cmd.Flags().BoolVar(&enableDevTools, "enable-dev-tools", false, "Enable development tools in the web UI (persona switcher, token panel)")
 	cmd.Flags().StringVar(&origin, "origin", "", "Public-facing base URL of the console for OIDC redirect URIs (e.g., https://holos-console.example.com)")
 	cmd.Flags().StringVar(&issuer, "issuer", "", "OIDC issuer URL for token validation (e.g., https://idp.example.com/dex)")
 	cmd.Flags().StringVar(&clientID, "client-id", "holos-console", "Expected audience for tokens")
@@ -249,6 +251,7 @@ func Run(cmd *cobra.Command, args []string) error {
 		OrgCreatorRoles:    splitCSV(orgCreatorRoles),
 		RolesClaim:         rolesClaim,
 		LogHealthChecks:    logHealthChecks,
+		EnableDevTools:     enableDevTools,
 	}
 
 	server := console.New(cfg)

--- a/console/console.go
+++ b/console/console.go
@@ -128,6 +128,11 @@ type Config struct {
 	// LogHealthChecks enables logging of /healthz and /readyz requests.
 	// Default: false (suppresses health check logging to reduce noise from Kubernetes probes).
 	LogHealthChecks bool
+
+	// EnableDevTools enables development tools in the web UI
+	// (persona switcher, dev token panel).
+	// Default: false (disabled).
+	EnableDevTools bool
 }
 
 // OIDCConfig is the OIDC configuration injected into the frontend.
@@ -136,6 +141,12 @@ type OIDCConfig struct {
 	ClientID              string `json:"client_id"`
 	RedirectURI           string `json:"redirect_uri"`
 	PostLogoutRedirectURI string `json:"post_logout_redirect_uri"`
+}
+
+// ConsoleConfig is the console configuration injected into the frontend
+// via window.__CONSOLE_CONFIG__.
+type ConsoleConfig struct {
+	DevToolsEnabled bool `json:"devToolsEnabled"`
 }
 
 // deriveRedirectURI derives the OIDC redirect URI from the console origin.
@@ -411,7 +422,13 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 	}
 
-	uiHandler := newUIHandler(uiContent, oidcConfig)
+	// Create console config for frontend injection
+	var consoleConfig *ConsoleConfig
+	if s.cfg.EnableDevTools {
+		consoleConfig = &ConsoleConfig{DevToolsEnabled: true}
+	}
+
+	uiHandler := newUIHandler(uiContent, oidcConfig, consoleConfig)
 
 	// Redirect /ui to / for backwards compatibility
 	mux.HandleFunc("/ui", func(w http.ResponseWriter, r *http.Request) {
@@ -597,12 +614,13 @@ func logRequests(next http.Handler, logHealthChecks bool) http.Handler {
 }
 
 type uiHandler struct {
-	fs         fs.FS
-	oidcConfig *OIDCConfig
+	fs            fs.FS
+	oidcConfig    *OIDCConfig
+	consoleConfig *ConsoleConfig
 }
 
-func newUIHandler(uiContent fs.FS, oidcConfig *OIDCConfig) *uiHandler {
-	return &uiHandler{fs: uiContent, oidcConfig: oidcConfig}
+func newUIHandler(uiContent fs.FS, oidcConfig *OIDCConfig, consoleConfig *ConsoleConfig) *uiHandler {
+	return &uiHandler{fs: uiContent, oidcConfig: oidcConfig, consoleConfig: consoleConfig}
 }
 
 func (h *uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -636,6 +654,15 @@ func (h *uiHandler) serveIndex(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			script := fmt.Sprintf(`<script>window.__OIDC_CONFIG__=%s;</script>`, configJSON)
 			// Insert before </head>
+			data = bytes.Replace(data, []byte("</head>"), []byte(script+"</head>"), 1)
+		}
+	}
+
+	// Inject console config if available
+	if h.consoleConfig != nil {
+		configJSON, err := json.Marshal(h.consoleConfig)
+		if err == nil {
+			script := fmt.Sprintf(`<script>window.__CONSOLE_CONFIG__=%s;</script>`, configJSON)
 			data = bytes.Replace(data, []byte("</head>"), []byte(script+"</head>"), 1)
 		}
 	}

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -5,7 +5,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 func TestLogRequests_HealthCheck_Suppressed(t *testing.T) {
@@ -73,6 +75,70 @@ func TestHandleUserInfo_Removed(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected /api/userinfo to return 404 (removed), got %d", rec.Code)
+	}
+}
+
+func TestServeIndex_InjectsConsoleConfig(t *testing.T) {
+	// When ConsoleConfig is provided, serveIndex should inject
+	// window.__CONSOLE_CONFIG__ into the HTML <head>.
+	fakeFS := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body></body></html>`),
+		},
+	}
+
+	consoleConfig := &ConsoleConfig{DevToolsEnabled: true}
+	h := newUIHandler(fakeFS, nil, consoleConfig)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `window.__CONSOLE_CONFIG__={"devToolsEnabled":true}`) {
+		t.Errorf("expected console config injection in HTML, got:\n%s", body)
+	}
+}
+
+func TestServeIndex_NoConsoleConfig(t *testing.T) {
+	// When ConsoleConfig is nil, serveIndex should NOT inject
+	// window.__CONSOLE_CONFIG__ into the HTML.
+	fakeFS := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body></body></html>`),
+		},
+	}
+
+	h := newUIHandler(fakeFS, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, `__CONSOLE_CONFIG__`) {
+		t.Errorf("expected no console config injection when config is nil, got:\n%s", body)
+	}
+}
+
+func TestServeIndex_ConsoleConfigDevToolsDisabled(t *testing.T) {
+	// When DevToolsEnabled is false, the injection should reflect that.
+	fakeFS := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body></body></html>`),
+		},
+	}
+
+	consoleConfig := &ConsoleConfig{DevToolsEnabled: false}
+	h := newUIHandler(fakeFS, nil, consoleConfig)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `window.__CONSOLE_CONFIG__={"devToolsEnabled":false}`) {
+		t.Errorf("expected devToolsEnabled:false in console config, got:\n%s", body)
 	}
 }
 

--- a/frontend/src/lib/console-config.test.ts
+++ b/frontend/src/lib/console-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getConsoleConfig } from './console-config'
+
+describe('getConsoleConfig', () => {
+  afterEach(() => {
+    // Clean up global between tests
+    delete window.__CONSOLE_CONFIG__
+  })
+
+  it('returns injected config when window.__CONSOLE_CONFIG__ is set', () => {
+    window.__CONSOLE_CONFIG__ = { devToolsEnabled: true }
+    const config = getConsoleConfig()
+    expect(config.devToolsEnabled).toBe(true)
+  })
+
+  it('returns devToolsEnabled false when injected as false', () => {
+    window.__CONSOLE_CONFIG__ = { devToolsEnabled: false }
+    const config = getConsoleConfig()
+    expect(config.devToolsEnabled).toBe(false)
+  })
+
+  it('returns default config with devToolsEnabled false when global is not set', () => {
+    const config = getConsoleConfig()
+    expect(config.devToolsEnabled).toBe(false)
+  })
+})

--- a/frontend/src/lib/console-config.ts
+++ b/frontend/src/lib/console-config.ts
@@ -1,0 +1,21 @@
+/**
+ * Console configuration injected by the Go server into index.html
+ * via window.__CONSOLE_CONFIG__.
+ */
+interface ConsoleConfig {
+  devToolsEnabled: boolean
+}
+
+declare global {
+  interface Window {
+    __CONSOLE_CONFIG__?: ConsoleConfig
+  }
+}
+
+/**
+ * Returns the console configuration, falling back to safe defaults
+ * when the global is not injected (e.g., during tests or static preview).
+ */
+export function getConsoleConfig(): ConsoleConfig {
+  return window.__CONSOLE_CONFIG__ ?? { devToolsEnabled: false }
+}

--- a/scripts/run
+++ b/scripts/run
@@ -14,6 +14,7 @@ make build
 
 exec ./bin/holos-console \
     --enable-insecure-dex \
+    --enable-dev-tools \
     --cert certs/tls.crt \
     --key certs/tls.key \
     --ca-cert "$(mkcert -CAROOT)/rootCA.pem" \


### PR DESCRIPTION
## Summary
- Add `--enable-dev-tools` CLI flag (default `false`) wired to `Config.EnableDevTools`
- Add `ConsoleConfig` struct injected as `window.__CONSOLE_CONFIG__` into `index.html`, following the same pattern as `window.__OIDC_CONFIG__`
- Add `frontend/src/lib/console-config.ts` with `getConsoleConfig()` that reads the global with safe defaults (`{devToolsEnabled: false}`)
- Update `scripts/run` to pass `--enable-dev-tools` for local development
- Go unit tests verify HTML injection for enabled, disabled, and nil config cases
- Frontend unit tests verify the global reader for all three states

Closes #698

## Test plan
- [x] `make test` passes (645 tests)
- [x] `make generate` succeeds
- [ ] Go tests verify `window.__CONSOLE_CONFIG__` injection with `devToolsEnabled: true`, `false`, and nil
- [ ] Frontend tests verify `getConsoleConfig()` reads the global correctly and returns defaults when unset

Generated with [Claude Code](https://claude.com/claude-code) · agent-1