### PR TITLE
feat(ui): add Dev Tools panel with persona switcher

### DIFF
--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -81,11 +81,15 @@ vi.mock('@/components/create-org-dialog', () => ({
 vi.mock('@/components/create-project-dialog', () => ({
   CreateProjectDialog: () => <div data-testid="create-project-dialog" />,
 }))
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn(),
+}))
 
 import { useOrg } from '@/lib/org-context'
 import { useProject } from '@/lib/project-context'
 import { useVersion } from '@/queries/version'
 import { useGetProjectSettings } from '@/queries/project-settings'
+import { getConsoleConfig } from '@/lib/console-config'
 import { AppSidebar } from './app-sidebar'
 
 function setDefaults() {
@@ -103,6 +107,7 @@ function setDefaults() {
   })
   ;(useVersion as Mock).mockReturnValue({ data: { version: 'v0.0.0-test' } })
   ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: false }, isPending: false })
+  ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: false })
 }
 
 describe('AppSidebar', () => {
@@ -395,5 +400,41 @@ describe('AppSidebar — Templates nav item conditional visibility', () => {
     render(<AppSidebar />)
     const link = screen.getByRole('link', { name: /^deployments$/i })
     expect(link.getAttribute('href')).toBe('/projects/my-project/deployments')
+  })
+})
+
+describe('AppSidebar — Dev Tools conditional visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setDefaults()
+  })
+
+  it('renders Dev Tools link when devToolsEnabled is true', () => {
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
+    render(<AppSidebar />)
+    expect(screen.getByText('Dev Tools')).toBeInTheDocument()
+  })
+
+  it('does not render Dev Tools link when devToolsEnabled is false', () => {
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: false })
+    render(<AppSidebar />)
+    expect(screen.queryByText('Dev Tools')).not.toBeInTheDocument()
+  })
+
+  it('Dev Tools link points to /dev-tools', () => {
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
+    render(<AppSidebar />)
+    const link = screen.getByRole('link', { name: /dev tools/i })
+    expect(link.getAttribute('href')).toBe('/dev-tools')
+  })
+
+  it('Dev Tools appears before About in DOM order', () => {
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
+    render(<AppSidebar />)
+    const items = screen.getAllByRole('listitem')
+    const devToolsIdx = items.findIndex((el) => el.textContent?.includes('Dev Tools'))
+    const aboutIdx = items.findIndex((el) => el.textContent?.includes('About'))
+    expect(devToolsIdx).toBeGreaterThanOrEqual(0)
+    expect(aboutIdx).toBeGreaterThan(devToolsIdx)
   })
 })

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Plus,
   Settings,
   User,
+  Wrench,
   ChevronsUpDown,
 } from 'lucide-react'
 import {
@@ -36,15 +37,22 @@ import {
 import { Button } from '@/components/ui/button'
 import { useOrg } from '@/lib/org-context'
 import { useProject } from '@/lib/project-context'
+import { getConsoleConfig } from '@/lib/console-config'
 import { useVersion } from '@/queries/version'
 import { useGetProjectSettings } from '@/queries/project-settings'
 import { CreateOrgDialog } from '@/components/create-org-dialog'
 import { CreateProjectDialog } from '@/components/create-project-dialog'
 
-const bottomItems = [
-  { label: 'About', to: '/about' as const, icon: Info },
-  { label: 'Profile', to: '/profile' as const, icon: User },
-]
+function getBottomItems() {
+  const { devToolsEnabled } = getConsoleConfig()
+  return [
+    ...(devToolsEnabled
+      ? [{ label: 'Dev Tools', to: '/dev-tools' as const, icon: Wrench }]
+      : []),
+    { label: 'About', to: '/about' as const, icon: Info },
+    { label: 'Profile', to: '/profile' as const, icon: User },
+  ]
+}
 
 export function AppSidebar() {
   const { data: versionData } = useVersion()
@@ -200,7 +208,7 @@ export function AppSidebar() {
       <SidebarFooter>
         <SidebarSeparator />
         <SidebarMenu>
-          {bottomItems.map((item) => (
+          {getBottomItems().map((item) => (
             <SidebarMenuItem key={item.label}>
               <SidebarMenuButton asChild isActive={pathname.startsWith(item.to)}>
                 <Link to={item.to}>

--- a/frontend/src/lib/dev-tools.ts
+++ b/frontend/src/lib/dev-tools.ts
@@ -1,0 +1,84 @@
+/**
+ * Dev Tools helpers: persona definitions and token exchange client.
+ *
+ * These are only used when devToolsEnabled is true in the console config
+ * (controlled by the --enable-dev-tools server flag).
+ */
+
+/** A test persona available for switching in the dev tools panel. */
+export interface Persona {
+  /** Short identifier (e.g. "platform"). */
+  id: string
+  /** Human-readable label shown in the UI. */
+  label: string
+  /** Email address used for token exchange. */
+  email: string
+  /** OIDC groups assigned to this persona. */
+  groups: string[]
+  /** Role badge text derived from the groups. */
+  role: 'Owner' | 'Editor' | 'Viewer'
+}
+
+/**
+ * Static list of test personas matching the TestUsers defined in
+ * console/oidc/config.go. The admin user is omitted because the persona
+ * switcher focuses on the three workflow roles.
+ */
+export const personas: Persona[] = [
+  {
+    id: 'platform',
+    label: 'Platform Engineer',
+    email: 'platform@localhost',
+    groups: ['owner'],
+    role: 'Owner',
+  },
+  {
+    id: 'product',
+    label: 'Product Engineer',
+    email: 'product@localhost',
+    groups: ['editor'],
+    role: 'Editor',
+  },
+  {
+    id: 'sre',
+    label: 'SRE',
+    email: 'sre@localhost',
+    groups: ['viewer'],
+    role: 'Viewer',
+  },
+]
+
+/** Response from the POST /api/dev/token endpoint. */
+export interface TokenExchangeResponse {
+  id_token: string
+  email: string
+  groups: string[]
+  expires_in: number
+}
+
+/**
+ * Exchange an email for a signed OIDC token via the dev token endpoint.
+ * Throws on network or server errors.
+ */
+export async function exchangeToken(email: string): Promise<TokenExchangeResponse> {
+  const resp = await fetch('/api/dev/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  })
+  if (!resp.ok) {
+    const text = await resp.text()
+    throw new Error(`Token exchange failed (${resp.status}): ${text}`)
+  }
+  return resp.json()
+}
+
+/**
+ * Derive a role label from OIDC groups. Returns the highest-privilege role
+ * found in the groups array.
+ */
+export function roleFromGroups(groups: string[]): 'Owner' | 'Editor' | 'Viewer' {
+  if (groups.includes('owner')) return 'Owner'
+  if (groups.includes('editor')) return 'Editor'
+  return 'Viewer'
+}

--- a/frontend/src/routes/_authenticated/-dev-tools.test.tsx
+++ b/frontend/src/routes/_authenticated/-dev-tools.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, within } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({}),
+  }
+})
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+  getUserManager: vi.fn().mockReturnValue({
+    settings: { authority: 'https://localhost:8443/dex', client_id: 'holos-console' },
+  }),
+}))
+
+vi.mock('@/lib/transport', () => ({
+  tokenRef: { current: null },
+}))
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { useAuth } from '@/lib/auth'
+import { getConsoleConfig } from '@/lib/console-config'
+import { DevToolsPage } from './dev-tools'
+
+function mockAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
+  ;(useAuth as Mock).mockReturnValue({
+    user: {
+      access_token: 'test-access-token',
+      id_token: 'test-id-token',
+      profile: {
+        email: 'platform@localhost',
+        sub: 'test-platform-001',
+        groups: ['owner'],
+      },
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    getAccessToken: vi.fn(),
+    refreshTokens: vi.fn(),
+    lastRefreshStatus: 'idle' as const,
+    lastRefreshTime: null,
+    lastRefreshError: null,
+    error: null,
+    ...overrides,
+  })
+}
+
+/** Helper to find a Card by its title text and return the card element. */
+function getCardByTitle(title: string): HTMLElement {
+  const heading = screen.getByText(title)
+  // Walk up to the card element (the element with data-slot="card")
+  let el: HTMLElement | null = heading
+  while (el && el.getAttribute('data-slot') !== 'card') {
+    el = el.parentElement
+  }
+  if (!el) throw new Error(`Could not find card element for title: ${title}`)
+  return el
+}
+
+describe('DevToolsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
+    mockAuth()
+  })
+
+  it('renders Current Identity card with email', () => {
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Current Identity')
+    expect(within(card).getByText('platform@localhost')).toBeInTheDocument()
+  })
+
+  it('renders groups from the current user profile', () => {
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Current Identity')
+    expect(within(card).getByText('owner')).toBeInTheDocument()
+  })
+
+  it('renders role badge for the current identity', () => {
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Current Identity')
+    expect(within(card).getByText('Owner')).toBeInTheDocument()
+  })
+
+  it('renders Persona Switcher card with all three personas', () => {
+    render(<DevToolsPage />)
+    expect(screen.getByText('Persona Switcher')).toBeInTheDocument()
+    expect(screen.getByText('Platform Engineer')).toBeInTheDocument()
+    expect(screen.getByText('Product Engineer')).toBeInTheDocument()
+    expect(screen.getByText('SRE')).toBeInTheDocument()
+  })
+
+  it('renders Quick Token card', () => {
+    render(<DevToolsPage />)
+    expect(screen.getByText('Quick Token')).toBeInTheDocument()
+  })
+
+  it('shows not-available message when devToolsEnabled is false', () => {
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: false })
+    render(<DevToolsPage />)
+    expect(screen.getByText(/dev tools are not enabled/i)).toBeInTheDocument()
+  })
+
+  it('shows sign-in prompt when not authenticated', () => {
+    mockAuth({ isAuthenticated: false, user: null })
+    render(<DevToolsPage />)
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+  })
+
+  it('renders curl example in quick token card', () => {
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Quick Token')
+    expect(within(card).getByText(/curl example/i)).toBeInTheDocument()
+  })
+
+  it('renders the current user email and role for a different persona', () => {
+    mockAuth({
+      user: {
+        access_token: 'tok',
+        id_token: 'id-tok',
+        profile: {
+          email: 'sre@localhost',
+          sub: 'test-sre-001',
+          groups: ['viewer'],
+        },
+      } as ReturnType<typeof useAuth>['user'],
+    })
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Current Identity')
+    expect(within(card).getByText('sre@localhost')).toBeInTheDocument()
+    expect(within(card).getByText('Viewer')).toBeInTheDocument()
+  })
+
+  it('marks the current persona as active in the switcher', () => {
+    render(<DevToolsPage />)
+    // The Platform Engineer card should show "Current" text since profile email is platform@localhost
+    expect(screen.getByText('Current')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/dev-tools.tsx
+++ b/frontend/src/routes/_authenticated/dev-tools.tsx
@@ -1,0 +1,332 @@
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Copy, Eye, EyeOff } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAuth } from '@/lib/auth'
+import { getConsoleConfig } from '@/lib/console-config'
+import { personas, exchangeToken, roleFromGroups, type Persona } from '@/lib/dev-tools'
+import { getUserManager } from '@/lib/auth'
+import { tokenRef } from '@/lib/transport'
+
+export const Route = createFileRoute('/_authenticated/dev-tools')({
+  component: DevToolsPage,
+})
+
+export function DevToolsPage() {
+  const { devToolsEnabled } = getConsoleConfig()
+  const { user, isAuthenticated, isLoading, login } = useAuth()
+  const [switching, setSwitching] = useState<string | null>(null)
+  const [tokenRevealed, setTokenRevealed] = useState(false)
+
+  if (!devToolsEnabled) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-muted-foreground">Dev tools are not enabled. Start the server with <code className="font-mono">--enable-dev-tools</code> to use this page.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <span className="text-sm">Loading...</span>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!isAuthenticated || !user) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <p className="text-muted-foreground">Sign in to use dev tools.</p>
+          <Button onClick={() => login('/dev-tools')}>Sign In</Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const profile = user.profile as Record<string, unknown> | undefined
+  const email = profile?.email ? String(profile.email) : 'unknown'
+  const sub = profile?.sub ? String(profile.sub) : 'unknown'
+  const groups = Array.isArray(profile?.groups) ? (profile!.groups as string[]) : []
+  const role = roleFromGroups(groups)
+
+  const idToken = user.id_token ?? ''
+
+  const handleSwitchPersona = async (persona: Persona) => {
+    if (persona.email === email) return
+    setSwitching(persona.id)
+    try {
+      const resp = await exchangeToken(persona.email)
+
+      // Build a synthetic OIDC User object and store it in sessionStorage
+      // under the key oidc-client-ts uses, then reload to pick up the new identity.
+      const userManager = getUserManager()
+      const settings = userManager.settings
+      const storeKey = `oidc.user:${settings.authority}:${settings.client_id}`
+
+      const syntheticUser = {
+        id_token: resp.id_token,
+        access_token: resp.id_token,
+        token_type: 'Bearer',
+        scope: 'openid profile email groups offline_access',
+        expires_at: Math.floor(Date.now() / 1000) + resp.expires_in,
+        profile: {
+          iss: settings.authority,
+          sub: `dev-${persona.id}`,
+          aud: settings.client_id,
+          exp: Math.floor(Date.now() / 1000) + resp.expires_in,
+          iat: Math.floor(Date.now() / 1000),
+          email: resp.email,
+          email_verified: true,
+          groups: resp.groups,
+          name: persona.label,
+        },
+      }
+
+      sessionStorage.setItem(storeKey, JSON.stringify(syntheticUser))
+      tokenRef.current = resp.id_token
+      window.location.reload()
+    } catch (err) {
+      toast.error(`Failed to switch persona: ${err instanceof Error ? err.message : String(err)}`)
+      setSwitching(null)
+    }
+  }
+
+  const handleCopyToken = () => {
+    navigator.clipboard.writeText(idToken)
+    toast.success('Copied to clipboard')
+  }
+
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://localhost:8443'
+
+  const curlCmd =
+    `curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \\\n` +
+    `  ${origin}/holos.console.v1.OrganizationService/ListOrganizations \\\n` +
+    `  -H "Content-Type: application/json" \\\n` +
+    `  -H "Connect-Protocol-Version: 1" \\\n` +
+    `  -H "Authorization: Bearer ${idToken}" \\\n` +
+    `  -d '{}'`
+
+  const handleCopyCurl = () => {
+    navigator.clipboard.writeText(curlCmd)
+    toast.success('Copied to clipboard')
+  }
+
+  return (
+    <div className="space-y-4">
+      <CurrentIdentityCard
+        email={email}
+        sub={sub}
+        groups={groups}
+        role={role}
+      />
+      <PersonaSwitcherCard
+        currentEmail={email}
+        switching={switching}
+        onSwitch={handleSwitchPersona}
+      />
+      <QuickTokenCard
+        idToken={idToken}
+        tokenRevealed={tokenRevealed}
+        onToggleReveal={() => setTokenRevealed((v) => !v)}
+        onCopyToken={handleCopyToken}
+        curlCmd={curlCmd}
+        onCopyCurl={handleCopyCurl}
+      />
+    </div>
+  )
+}
+
+function CurrentIdentityCard({
+  email,
+  sub,
+  groups,
+  role,
+}: {
+  email: string
+  sub: string
+  groups: string[]
+  role: string
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Current Identity</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">Email</p>
+          <p className="font-mono">{email}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">Subject</p>
+          <p className="font-mono">{sub}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">Groups</p>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {groups.length > 0 ? (
+              groups.map((g) => (
+                <Badge key={g} variant="outline">
+                  {g}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-muted-foreground">None</span>
+            )}
+          </div>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">Role</p>
+          <Badge variant="default">{role}</Badge>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function PersonaSwitcherCard({
+  currentEmail,
+  switching,
+  onSwitch,
+}: {
+  currentEmail: string
+  switching: string | null
+  onSwitch: (persona: Persona) => void
+}) {
+  const roleBadgeVariant = (role: string): 'default' | 'secondary' | 'outline' => {
+    if (role === 'Owner') return 'default'
+    if (role === 'Editor') return 'secondary'
+    return 'outline'
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Persona Switcher</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {personas.map((persona) => {
+            const isCurrent = persona.email === currentEmail
+            const isSwitching = switching === persona.id
+            return (
+              <button
+                key={persona.id}
+                type="button"
+                disabled={isCurrent || switching !== null}
+                onClick={() => onSwitch(persona)}
+                className={`rounded-lg border p-4 text-left transition-colors ${
+                  isCurrent
+                    ? 'border-primary bg-primary/10'
+                    : 'border-border hover:border-primary/50 hover:bg-accent'
+                } ${switching !== null && !isSwitching ? 'opacity-50' : ''}`}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span className="font-medium">{persona.label}</span>
+                  <Badge variant={roleBadgeVariant(persona.role)}>{persona.role}</Badge>
+                </div>
+                <p className="text-sm text-muted-foreground font-mono">{persona.email}</p>
+                {isCurrent && (
+                  <p className="text-xs text-primary mt-2">Current</p>
+                )}
+                {isSwitching && (
+                  <p className="text-xs text-muted-foreground mt-2">Switching...</p>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function QuickTokenCard({
+  idToken,
+  tokenRevealed,
+  onToggleReveal,
+  onCopyToken,
+  curlCmd,
+  onCopyCurl,
+}: {
+  idToken: string
+  tokenRevealed: boolean
+  onToggleReveal: () => void
+  onCopyToken: () => void
+  curlCmd: string
+  onCopyCurl: () => void
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Quick Token</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">ID Token</p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              aria-label={tokenRevealed ? 'Hide token' : 'Reveal token'}
+              onClick={onToggleReveal}
+            >
+              {tokenRevealed ? (
+                <>
+                  <EyeOff className="h-3.5 w-3.5 mr-1" />
+                  Hide
+                </>
+              ) : (
+                <>
+                  <Eye className="h-3.5 w-3.5 mr-1" />
+                  Reveal
+                </>
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              aria-label="Copy token"
+              onClick={onCopyToken}
+            >
+              <Copy className="h-3.5 w-3.5 mr-1" />
+              Copy
+            </Button>
+          </div>
+          <pre className="rounded-md bg-muted p-4 text-xs font-mono overflow-auto whitespace-pre break-all">
+            {tokenRevealed ? idToken : '••••••••••••••••••••'}
+          </pre>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">
+            curl example (Connect protocol)
+          </p>
+          <div className="relative">
+            <pre className="rounded-md bg-muted p-4 text-xs font-mono overflow-auto whitespace-pre">
+              {curlCmd}
+            </pre>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Copy curl command"
+              className="absolute top-2 right-2 h-7 w-7"
+              onClick={onCopyCurl}
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- Add conditional Dev Tools sidebar item (Wrench icon) that appears when `devToolsEnabled` is true
- Add `/dev-tools` route with Current Identity, Persona Switcher, and Quick Token cards
- Persona switching uses the `/api/dev/token` endpoint to mint a token for the target persona, injects it into sessionStorage, and reloads the page
- Add `frontend/src/lib/dev-tools.ts` with persona definitions, token exchange client, and roleFromGroups utility
- Add 14 unit tests (4 sidebar conditional visibility + 10 page tests)

Closes #699

## Test plan
- [ ] `make test` passes (659 UI tests, all Go tests)
- [ ] Dev Tools sidebar item appears when `--enable-dev-tools` is passed
- [ ] Dev Tools sidebar item is hidden when `--enable-dev-tools` is not passed
- [ ] Current Identity card shows the authenticated user's email, groups, and role
- [ ] Persona Switcher shows Platform Engineer, Product Engineer, and SRE buttons
- [ ] Clicking a persona triggers token exchange and page reload with the new identity
- [ ] Quick Token card shows masked ID token with reveal/copy and curl example

Generated with [Claude Code](https://claude.com/claude-code) · agent-1