### PR TITLE
chore(skills): cleanup stale references after E2E gating changes

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -156,7 +156,7 @@ EOF
 
 The `Closes #<number>` line automatically closes the issue when the PR is merged. Use the issue number you are implementing (the sub-issue number when dispatched from a parent).
 
-**Stop here.** Do not loop on CI checks, capture screenshots, or merge. The PR is open and ready for a human or another agent to review, fix CI, and merge. This boundary exists because code review (e.g., `/review-pr`) is being integrated into the workflow -- until that integration is complete, each PR should be reviewed before further work proceeds.
+**Stop here.** Do not loop on CI checks, capture screenshots, or merge. The PR is open and ready for review. The `/implement-plan` skill handles the review-fix-merge cycle via `/review-pr` when orchestrating sub-issues. When `/implement-issue` is invoked standalone, a human or separate agent should review before merging.
 
 ## Key Conventions
 
@@ -166,6 +166,6 @@ The `Closes #<number>` line automatically closes the issue when the PR is merged
 - **make generate**: Always run before committing if proto or generated files are involved
 - **E2E decision-making**: Assess whether `make test-e2e` is warranted using the E2E relevance heuristic (see Step 6). Run it locally when relevant and the environment supports it; otherwise note the skip in the PR description
 - **Cleanup phase**: Every implementation ends with a cleanup commit
-- **Stop at PR**: Do not loop on CI, capture screenshots, or merge -- stop after opening the PR
+- **Stop at PR**: Do not loop on CI, capture screenshots, or merge -- stop after opening the PR. The `/implement-plan` skill handles review and merge
 - **Single issues only**: If the issue has sub-issues, stop and direct the user to `/implement-plan`
 - **Close the right issue**: PRs close the specific issue being worked on (`Closes #<sub-issue>` for sub-issues, not the parent)

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -291,7 +291,7 @@ Then provide guidance based on the classification:
 
 ## Fix-Review Loop
 
-When used during implementation (integrated into the implement-issue workflow):
+When used during implementation (integrated into the implement-plan workflow):
 
 ```
 1. Implementation complete, PR open, CI green

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,6 +594,7 @@ Current skills:
 | `implement-issue` | Implement a single GitHub issue end-to-end (branch, code, PR) |
 | `implement-plan` | Execute a full plan: iterate sub-issues, implement (Opus), review (Codex), fix, merge or escalate |
 | `plan-issue` | Create implementation plans as GitHub issue hierarchies |
+| `reset-agent` | Reset the current agent worktree to a clean state on origin/main |
 | `review-pr` | Cross-model PR review (currently Codex CLI backend) |
 
 ## Contributing


### PR DESCRIPTION
## Summary
- Add missing `reset-agent` skill to the AGENTS.md skill table (6 skills on disk, only 5 were listed)
- Fix stale cross-reference in `review-pr/SKILL.md`: the fix-review loop is integrated into the `implement-plan` workflow, not `implement-issue`
- Update `implement-issue/SKILL.md` "Stop here" note and Key Conventions to accurately describe the existing review integration in `implement-plan` (was incorrectly described as "being integrated")

Closes #694

## Test plan
- [x] `make test` passes (44 test files, 645 tests)
- [x] No contradictions between implement-plan and implement-issue regarding E2E testing behavior
- [x] E2E relevance heuristic defined in implement-plan (Step 6a), referenced from implement-issue (Step 6) -- no duplication drift
- [x] AGENTS.md skill table matches skills on disk (6 entries)
- [x] review-pr skill has no stale cross-references

> Local E2E was not run (doc-only changes, no runtime behavior affected). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) · ${SLOT}