### PR TITLE
feat(rbac): add PERMISSION_REPARENT and reparent logic for folders and projects

### DIFF
--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -297,6 +297,14 @@
 	clusterResources?: {[string]: [string]: #Resource}  @go(ClusterResources,map[string]map[string]Resource)
 }
 
+// --- slug_go_gen.cue ---
+
+// CheckIdentifierResult holds the outcome of a CheckIdentifier call.
+#CheckIdentifierResult: {
+	Available:           bool
+	SuggestedIdentifier: string
+}
+
 // --- types_go_gen.cue ---
 
 // TypeMeta identifies the API version and kind of a resource.

--- a/console/folders/handler.go
+++ b/console/folders/handler.go
@@ -253,7 +253,7 @@ func (h *Handler) CreateFolder(
 	}), nil
 }
 
-// UpdateFolder updates folder metadata.
+// UpdateFolder updates folder metadata and optionally reparents the folder.
 func (h *Handler) UpdateFolder(
 	ctx context.Context,
 	req *connect.Request[consolev1.UpdateFolderRequest],
@@ -289,6 +289,13 @@ func (h *Handler) UpdateFolder(
 		return nil, err
 	}
 
+	// Handle reparenting if parent_type and parent_name are set.
+	if req.Msg.ParentType != nil && req.Msg.ParentName != nil {
+		if err := h.reparentFolder(ctx, ns, claims, *req.Msg.ParentType, *req.Msg.ParentName); err != nil {
+			return nil, err
+		}
+	}
+
 	if _, err := h.k8s.UpdateFolder(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -302,6 +309,203 @@ func (h *Handler) UpdateFolder(
 	)
 
 	return connect.NewResponse(&consolev1.UpdateFolderResponse{}), nil
+}
+
+// reparentFolder validates and executes a folder reparent operation.
+// Checks PERMISSION_REPARENT on both source and destination parents,
+// enforces depth limits, and detects cycles.
+func (h *Handler) reparentFolder(
+	ctx context.Context,
+	ns *corev1.Namespace,
+	claims *rpc.Claims,
+	newParentType consolev1.ParentType,
+	newParentName string,
+) error {
+	folderName := ns.Labels[v1alpha2.LabelFolder]
+	folderNsName := ns.Name
+
+	// Resolve new parent namespace.
+	newParentNs, err := h.resolveParentNS(newParentType, newParentName)
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	// Resolve current parent namespace from the folder's label.
+	currentParentNs := ns.Labels[v1alpha2.AnnotationParent]
+	if currentParentNs == "" {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("folder %q is missing parent label", folderName))
+	}
+
+	// No-op: same parent, return success without a K8s write.
+	if currentParentNs == newParentNs {
+		return nil
+	}
+
+	// Verify new parent namespace exists.
+	newParentNamespace, err := h.k8s.GetNamespace(ctx, newParentNs)
+	if err != nil {
+		return mapK8sError(err)
+	}
+
+	// Check PERMISSION_REPARENT on the current (source) parent.
+	sourceNs, err := h.k8s.GetNamespace(ctx, currentParentNs)
+	if err != nil {
+		return mapK8sError(err)
+	}
+	if err := h.checkReparentAccess(ctx, claims, sourceNs, "source"); err != nil {
+		slog.WarnContext(ctx, "folder reparent denied on source",
+			slog.String("action", "folder_reparent_denied_source"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", folderName),
+			slog.String("source_parent", currentParentNs),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return err
+	}
+
+	// Check PERMISSION_REPARENT on the new (destination) parent.
+	if err := h.checkReparentAccess(ctx, claims, newParentNamespace, "destination"); err != nil {
+		slog.WarnContext(ctx, "folder reparent denied on destination",
+			slog.String("action", "folder_reparent_denied_destination"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("folder", folderName),
+			slog.String("dest_parent", newParentNs),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return err
+	}
+
+	// Cycle detection: walk new parent's ancestors; if the folder being moved
+	// appears, the move would create a cycle.
+	if err := h.detectCycle(ctx, folderNsName, newParentNs); err != nil {
+		return err
+	}
+
+	// Depth enforcement: compute depth at new parent, then compute subtree depth
+	// of the folder being moved. Total must not exceed maxFolderDepth.
+	newParentDepth, err := h.computeFolderDepth(ctx, newParentNs)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("computing new parent depth: %w", err))
+	}
+	subtreeDepth, err := h.computeSubtreeDepth(ctx, folderNsName)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("computing subtree depth: %w", err))
+	}
+	// newParentDepth is the number of folder levels above the new parent.
+	// subtreeDepth is the max folder depth below and including the folder being moved.
+	// The folder being moved will be at depth newParentDepth+1, and the deepest
+	// descendant at newParentDepth+subtreeDepth.
+	totalDepth := newParentDepth + subtreeDepth
+	if totalDepth > maxFolderDepth {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("reparenting would exceed maximum folder depth of %d (new depth: %d)", maxFolderDepth, totalDepth))
+	}
+
+	// Execute the reparent: update the parent label.
+	if _, err := h.k8s.UpdateParentLabel(ctx, folderName, newParentNs); err != nil {
+		return mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "folder reparented",
+		slog.String("action", "folder_reparent"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("folder", folderName),
+		slog.String("from_parent", currentParentNs),
+		slog.String("to_parent", newParentNs),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return nil
+}
+
+// checkReparentAccess verifies that the user has PERMISSION_REPARENT on the given
+// parent namespace. Uses direct grants on the parent plus org-level cascade via
+// ReparentCascadePerms.
+func (h *Handler) checkReparentAccess(ctx context.Context, claims *rpc.Claims, parentNs *corev1.Namespace, direction string) error {
+	shareUsers, _ := GetShareUsers(parentNs)
+	shareRoles, _ := GetShareRoles(parentNs)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	// Check direct grants on the parent resource.
+	if err := rbac.CheckAccessGrants(claims.Email, claims.Roles, activeUsers, activeRoles, rbac.PermissionReparent); err == nil {
+		return nil
+	}
+
+	// Check org-level cascade: org OWNERs get REPARENT on all children via ReparentCascadePerms.
+	org := ""
+	if parentNs.Labels != nil {
+		org = parentNs.Labels[v1alpha2.LabelOrganization]
+	}
+	if org != "" {
+		orgNsName := h.k8s.Resolver.OrgNamespace(org)
+		orgNs, err := h.k8s.GetNamespace(ctx, orgNsName)
+		if err == nil {
+			orgShareUsers, _ := GetShareUsers(orgNs)
+			orgShareRoles, _ := GetShareRoles(orgNs)
+			orgActiveUsers := secrets.ActiveGrantsMap(orgShareUsers, now)
+			orgActiveRoles := secrets.ActiveGrantsMap(orgShareRoles, now)
+			if err := rbac.CheckCascadeAccess(claims.Email, claims.Roles, orgActiveUsers, orgActiveRoles, rbac.PermissionReparent, rbac.ReparentCascadePerms); err == nil {
+				return nil
+			}
+		}
+	}
+
+	return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: reparent authorization denied on %s parent", direction))
+}
+
+// detectCycle walks from startNs up through ancestors. If folderNsName appears
+// in the ancestor chain, the move would create a cycle.
+func (h *Handler) detectCycle(ctx context.Context, folderNsName, startNs string) error {
+	current := startNs
+	for i := 0; i <= maxFolderDepth+1; i++ {
+		if current == folderNsName {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("reparenting would create a cycle: folder is an ancestor of the destination"))
+		}
+		ns, err := h.k8s.GetNamespace(ctx, current)
+		if err != nil {
+			return connect.NewError(connect.CodeInternal, fmt.Errorf("cycle detection: getting namespace %q: %w", current, err))
+		}
+		resourceType := ns.Labels[v1alpha2.LabelResourceType]
+		if resourceType == v1alpha2.ResourceTypeOrganization {
+			// Reached the org root, no cycle.
+			return nil
+		}
+		parent := ns.Labels[v1alpha2.AnnotationParent]
+		if parent == "" {
+			return nil
+		}
+		current = parent
+	}
+	return nil
+}
+
+// computeSubtreeDepth returns the maximum folder depth below (and including)
+// the given folder namespace. A leaf folder returns 1.
+func (h *Handler) computeSubtreeDepth(ctx context.Context, folderNsName string) (int, error) {
+	children, err := h.k8s.ListChildFolders(ctx, folderNsName)
+	if err != nil {
+		return 0, err
+	}
+	if len(children) == 0 {
+		return 1, nil
+	}
+	maxChildDepth := 0
+	for _, child := range children {
+		childDepth, err := h.computeSubtreeDepth(ctx, child.Name)
+		if err != nil {
+			return 0, err
+		}
+		if childDepth > maxChildDepth {
+			maxChildDepth = childDepth
+		}
+	}
+	return 1 + maxChildDepth, nil
 }
 
 // DeleteFolder deletes a folder.

--- a/console/folders/handler_test.go
+++ b/console/folders/handler_test.go
@@ -720,6 +720,170 @@ func TestCheckFolderIdentifier_Unauthenticated(t *testing.T) {
 	assertUnauthenticated(t, err)
 }
 
+// ---- UpdateFolder reparent tests ----
+
+func TestUpdateFolder_Reparent_SuccessOrgOwner(t *testing.T) {
+	// Alice is org owner, so she can reparent any folder within the org.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	// Folder under org root.
+	f := folderNSWithGrants("rp-eng-1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	// Second folder to move under.
+	f2 := folderNSWithGrants("rp-team-1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(orgNs, f, f2)
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-team-1"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-eng-1",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify the parent label was updated.
+	resp, err := handler.GetFolder(ctx, connect.NewRequest(&consolev1.GetFolderRequest{Name: "rp-eng-1"}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Folder.ParentType != consolev1.ParentType_PARENT_TYPE_FOLDER {
+		t.Errorf("expected PARENT_TYPE_FOLDER, got %v", resp.Msg.Folder.ParentType)
+	}
+	if resp.Msg.Folder.ParentName != "rp-team-1" {
+		t.Errorf("expected parent_name 'rp-team-1', got %q", resp.Msg.Folder.ParentName)
+	}
+}
+
+func TestUpdateFolder_Reparent_DeniedOnSource(t *testing.T) {
+	// Alice is only editor on the source parent, Bob is owner on org.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"bob@example.com","role":"owner"}]`)
+	// Folder under org with alice as editor.
+	srcFolder := folderNSWithGrants("rp-src-1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	destFolder := folderNSWithGrants("rp-dest-1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	// Folder to reparent - under srcFolder.
+	child := folderNSWithGrants("rp-child-1", "acme", "holos-fld-rp-src-1", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(orgNs, srcFolder, destFolder, child)
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-dest-1"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-child-1",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	assertPermissionDenied(t, err)
+}
+
+func TestUpdateFolder_Reparent_DeniedOnDestination(t *testing.T) {
+	// Alice is owner on the source parent but not on the destination.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"bob@example.com","role":"owner"}]`)
+	srcFolder := folderNSWithGrants("rp-src-2", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	destFolder := folderNSWithGrants("rp-dest-2", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	child := folderNSWithGrants("rp-child-2", "acme", "holos-fld-rp-src-2", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(orgNs, srcFolder, destFolder, child)
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-dest-2"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-child-2",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	assertPermissionDenied(t, err)
+}
+
+func TestUpdateFolder_Reparent_SameParentIsNoop(t *testing.T) {
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	f := folderNSWithGrants("rp-noop-1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler := newTestHandler(orgNs, f)
+	ctx := contextWithClaims("alice@example.com")
+
+	// Move to same parent (org).
+	newParentType := consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	newParentName := "acme"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-noop-1",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error (no-op), got %v", err)
+	}
+}
+
+func TestUpdateFolder_Reparent_CycleDetection(t *testing.T) {
+	// Hierarchy: org -> folderA -> folderB
+	// Try to move folderA under folderB (cycle).
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	folderA := folderNSWithGrants("rp-cycle-a", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	folderB := folderNSWithGrants("rp-cycle-b", "acme", "holos-fld-rp-cycle-a", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(orgNs, folderA, folderB)
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-cycle-b"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-cycle-a",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	assertInvalidArgument(t, err)
+}
+
+func TestUpdateFolder_Reparent_DepthViolation(t *testing.T) {
+	// Hierarchy: org -> f1 -> f2 -> f3 (all at depth 3)
+	// Try to move f1 (with subtree f2->f3) under f3.
+	// Actually, that would also be a cycle. Let's create a different scenario:
+	// org -> a1 -> a2 -> a3 (depth 3)
+	// org -> b1
+	// Try to move a1 (subtree depth 3) under b1 → would be depth 4, which exceeds maxFolderDepth.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	a1 := folderNSWithGrants("rp-depth-a1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	a2 := folderNSWithGrants("rp-depth-a2", "acme", "holos-fld-rp-depth-a1", `[{"principal":"alice@example.com","role":"owner"}]`)
+	a3 := folderNSWithGrants("rp-depth-a3", "acme", "holos-fld-rp-depth-a2", `[{"principal":"alice@example.com","role":"owner"}]`)
+	b1 := folderNSWithGrants("rp-depth-b1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(orgNs, a1, a2, a3, b1)
+	ctx := contextWithClaims("alice@example.com")
+
+	// Move a1 (subtree depth=3: a1->a2->a3) under b1.
+	// b1 is at depth 1 from org. a1 subtree adds 3 more. Total = 1+3 = 4 > maxFolderDepth(3).
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-depth-b1"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-depth-a1",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	assertInvalidArgument(t, err)
+}
+
+func TestUpdateFolder_Reparent_DepthAllowed(t *testing.T) {
+	// org -> leaf (depth 1, subtree depth 1)
+	// org -> b1 -> b2 (b2 is at depth 2)
+	// Move leaf under b2 → total = 2 + 1 = 3 ≤ maxFolderDepth(3). Allowed.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	leaf := folderNSWithGrants("rp-depthok-leaf", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	b1 := folderNSWithGrants("rp-depthok-b1", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	b2 := folderNSWithGrants("rp-depthok-b2", "acme", "holos-fld-rp-depthok-b1", `[{"principal":"alice@example.com","role":"owner"}]`)
+	handler := newTestHandler(orgNs, leaf, b1, b2)
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-depthok-b2"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-depthok-leaf",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
 // ---- helpers ----
 
 func assertUnauthenticated(t *testing.T, err error) {

--- a/console/folders/k8s.go
+++ b/console/folders/k8s.go
@@ -192,6 +192,23 @@ func (c *K8sClient) UpdateFolder(ctx context.Context, name string, displayName, 
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 
+// UpdateParentLabel updates the parent label on a folder namespace.
+func (c *K8sClient) UpdateParentLabel(ctx context.Context, name, newParentNs string) (*corev1.Namespace, error) {
+	slog.DebugContext(ctx, "updating folder parent label in kubernetes",
+		slog.String("name", name),
+		slog.String("newParent", newParentNs),
+	)
+	ns, err := c.GetFolder(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	ns.Labels[v1alpha2.AnnotationParent] = newParentNs
+	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+}
+
 // DeleteFolder deletes a managed folder namespace.
 func (c *K8sClient) DeleteFolder(ctx context.Context, name string) error {
 	slog.DebugContext(ctx, "deleting folder from kubernetes",

--- a/console/folders/k8s_test.go
+++ b/console/folders/k8s_test.go
@@ -279,6 +279,29 @@ func TestNamespaceExists_ReturnsFalseForMissing(t *testing.T) {
 	}
 }
 
+func TestUpdateParentLabel_UpdatesLabel(t *testing.T) {
+	ns := folderNS("rp-upd", "acme", "holos-org-acme")
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	result, err := k8s.UpdateParentLabel(context.Background(), "rp-upd", "holos-fld-new-parent")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Labels[v1alpha2.AnnotationParent] != "holos-fld-new-parent" {
+		t.Errorf("expected parent label 'holos-fld-new-parent', got %q", result.Labels[v1alpha2.AnnotationParent])
+	}
+
+	// Verify persisted in the fake client.
+	fetched, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-fld-rp-upd", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fetched.Labels[v1alpha2.AnnotationParent] != "holos-fld-new-parent" {
+		t.Errorf("expected persisted parent label 'holos-fld-new-parent', got %q", fetched.Labels[v1alpha2.AnnotationParent])
+	}
+}
+
 func TestListChildProjects_ReturnsChildren(t *testing.T) {
 	prj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -425,7 +425,9 @@ func (h *Handler) reparentProject(
 	}
 
 	// Check PERMISSION_REPARENT on the new (destination) parent.
-	if err := h.checkReparentAccess(ctx, claims, newParentNamespace, org, "destination"); err != nil {
+	// Use the destination parent's org for cascade, not the source org.
+	destOrg := newParentNamespace.Labels[v1alpha2.LabelOrganization]
+	if err := h.checkReparentAccess(ctx, claims, newParentNamespace, destOrg, "destination"); err != nil {
 		slog.WarnContext(ctx, "project reparent denied on destination",
 			slog.String("action", "project_reparent_denied_destination"),
 			slog.String("resource_type", auditResourceType),

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -348,6 +348,13 @@ func (h *Handler) UpdateProject(
 		return nil, err
 	}
 
+	// Handle reparenting if parent_type and parent_name are set.
+	if req.Msg.ParentType != nil && req.Msg.ParentName != nil {
+		if err := h.reparentProject(ctx, ns, claims, *req.Msg.ParentType, *req.Msg.ParentName); err != nil {
+			return nil, err
+		}
+	}
+
 	if _, err := h.k8s.UpdateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -362,6 +369,116 @@ func (h *Handler) UpdateProject(
 	)
 
 	return connect.NewResponse(&consolev1.UpdateProjectResponse{}), nil
+}
+
+// reparentProject validates and executes a project reparent operation.
+// Checks PERMISSION_REPARENT on both source and destination parents.
+// Projects have no children so no depth or cycle checks are needed.
+func (h *Handler) reparentProject(
+	ctx context.Context,
+	ns *corev1.Namespace,
+	claims *rpc.Claims,
+	newParentType consolev1.ParentType,
+	newParentName string,
+) error {
+	projectName := ns.Labels[v1alpha2.LabelProject]
+	org := GetOrganization(ns)
+
+	// Resolve new parent namespace.
+	newParentNs, err := h.resolveParentNS(newParentType, newParentName)
+	if err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	// Resolve current parent namespace from the project's label.
+	currentParentNs := ns.Labels[v1alpha2.AnnotationParent]
+	if currentParentNs == "" {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("project %q is missing parent label", projectName))
+	}
+
+	// No-op: same parent, return success without a K8s write.
+	if currentParentNs == newParentNs {
+		return nil
+	}
+
+	// Verify new parent namespace exists.
+	newParentNamespace, err := h.k8s.GetNamespace(ctx, newParentNs)
+	if err != nil {
+		return mapK8sError(err)
+	}
+
+	// Check PERMISSION_REPARENT on the current (source) parent.
+	sourceNs, err := h.k8s.GetNamespace(ctx, currentParentNs)
+	if err != nil {
+		return mapK8sError(err)
+	}
+	if err := h.checkReparentAccess(ctx, claims, sourceNs, org, "source"); err != nil {
+		slog.WarnContext(ctx, "project reparent denied on source",
+			slog.String("action", "project_reparent_denied_source"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("project", projectName),
+			slog.String("source_parent", currentParentNs),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return err
+	}
+
+	// Check PERMISSION_REPARENT on the new (destination) parent.
+	if err := h.checkReparentAccess(ctx, claims, newParentNamespace, org, "destination"); err != nil {
+		slog.WarnContext(ctx, "project reparent denied on destination",
+			slog.String("action", "project_reparent_denied_destination"),
+			slog.String("resource_type", auditResourceType),
+			slog.String("project", projectName),
+			slog.String("dest_parent", newParentNs),
+			slog.String("sub", claims.Sub),
+			slog.String("email", claims.Email),
+		)
+		return err
+	}
+
+	// Execute the reparent: update the parent label.
+	if _, err := h.k8s.UpdateParentLabel(ctx, projectName, newParentNs); err != nil {
+		return mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "project reparented",
+		slog.String("action", "project_reparent"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("project", projectName),
+		slog.String("from_parent", currentParentNs),
+		slog.String("to_parent", newParentNs),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return nil
+}
+
+// checkReparentAccess verifies that the user has PERMISSION_REPARENT on the given
+// parent namespace. Uses direct grants on the parent plus org-level cascade via
+// ReparentCascadePerms.
+func (h *Handler) checkReparentAccess(ctx context.Context, claims *rpc.Claims, parentNs *corev1.Namespace, org, direction string) error {
+	shareUsers, _ := GetShareUsers(parentNs)
+	shareRoles, _ := GetShareRoles(parentNs)
+	now := time.Now()
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+
+	// Check direct grants on the parent resource.
+	if err := rbac.CheckAccessGrants(claims.Email, claims.Roles, activeUsers, activeRoles, rbac.PermissionReparent); err == nil {
+		return nil
+	}
+
+	// Check org-level cascade: org OWNERs get REPARENT on all children via ReparentCascadePerms.
+	if org != "" {
+		orgUsers, orgRoles := h.resolveOrgGrants(ctx, org)
+		if err := rbac.CheckCascadeAccess(claims.Email, claims.Roles, orgUsers, orgRoles, rbac.PermissionReparent, rbac.ReparentCascadePerms); err == nil {
+			return nil
+		}
+	}
+
+	return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: reparent authorization denied on %s parent", direction))
 }
 
 // DeleteProject deletes a managed namespace.

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1350,6 +1350,179 @@ func TestCheckProjectIdentifier_Unauthenticated(t *testing.T) {
 	assertUnauthenticated(t, err)
 }
 
+// ---- UpdateProject reparent tests ----
+
+// projectNSWithParent creates a project namespace with org, parent, and grants.
+func projectNSWithParent(name, org, parentNs, shareUsersJSON string) *corev1.Namespace {
+	ns := managedNSWithOrg(name, org, shareUsersJSON)
+	ns.Labels[v1alpha2.AnnotationParent] = parentNs
+	return ns
+}
+
+// orgNSWithGrants creates an org namespace with share-users annotation.
+func orgNSWithGrants(name, shareUsersJSON string) *corev1.Namespace {
+	annotations := map[string]string{}
+	if shareUsersJSON != "" {
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				v1alpha2.LabelOrganization: name,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// folderNSWithGrants creates a folder namespace with share-users annotation.
+func folderNSWithGrants(name, org, parentNs, shareUsersJSON string) *corev1.Namespace {
+	annotations := map[string]string{}
+	if shareUsersJSON != "" {
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelFolder:       name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+func TestUpdateProject_Reparent_SuccessOrgOwner(t *testing.T) {
+	// Alice is org owner, so she can reparent projects within the org via cascade.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	srcFolder := folderNSWithGrants("rp-prj-src", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	destFolder := folderNSWithGrants("rp-prj-dest", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	prj := projectNSWithParent("rp-prj-test", "acme", "holos-fld-rp-prj-src", `[{"principal":"alice@example.com","role":"editor"}]`)
+
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
+		orgNs, srcFolder, destFolder, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-prj-dest"
+	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+		Name:       "rp-prj-test",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestUpdateProject_Reparent_DeniedOnSource(t *testing.T) {
+	// Alice is editor on source parent but not org owner → denied.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"bob@example.com","role":"owner"}]`)
+	srcFolder := folderNSWithGrants("rp-prj-src2", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	destFolder := folderNSWithGrants("rp-prj-dest2", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	prj := projectNSWithParent("rp-prj-denied-src", "acme", "holos-fld-rp-prj-src2", `[{"principal":"alice@example.com","role":"editor"}]`)
+
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"bob@example.com": "owner"}},
+		orgNs, srcFolder, destFolder, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-prj-dest2"
+	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+		Name:       "rp-prj-denied-src",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	assertPermissionDenied(t, err)
+}
+
+func TestUpdateProject_Reparent_DeniedOnDestination(t *testing.T) {
+	// Alice is owner on source parent but editor on destination → denied.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"bob@example.com","role":"owner"}]`)
+	srcFolder := folderNSWithGrants("rp-prj-src3", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	destFolder := folderNSWithGrants("rp-prj-dest3", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	prj := projectNSWithParent("rp-prj-denied-dest", "acme", "holos-fld-rp-prj-src3", `[{"principal":"alice@example.com","role":"editor"}]`)
+
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"bob@example.com": "owner"}},
+		orgNs, srcFolder, destFolder, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-prj-dest3"
+	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+		Name:       "rp-prj-denied-dest",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	assertPermissionDenied(t, err)
+}
+
+func TestUpdateProject_Reparent_SameParentIsNoop(t *testing.T) {
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	folder := folderNSWithGrants("rp-prj-noop", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	prj := projectNSWithParent("rp-prj-noop-test", "acme", "holos-fld-rp-prj-noop", `[{"principal":"alice@example.com","role":"editor"}]`)
+
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
+		orgNs, folder, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	// Move to same parent (folder rp-prj-noop).
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-prj-noop"
+	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+		Name:       "rp-prj-noop-test",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error (no-op), got %v", err)
+	}
+}
+
+func TestUpdateProject_Reparent_MoveFromFolderToOrg(t *testing.T) {
+	// Move a project from a folder to the org root.
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	folder := folderNSWithGrants("rp-prj-fld2org", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	prj := projectNSWithParent("rp-prj-fld2org-test", "acme", "holos-fld-rp-prj-fld2org", `[{"principal":"alice@example.com","role":"editor"}]`)
+
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
+		orgNs, folder, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	newParentName := "acme"
+	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+		Name:       "rp-prj-fld2org-test",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
 func TestCreateProject_CleansUpNamespaceOnApplierFailure(t *testing.T) {
 	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
 	fakeClient := fake.NewClientset(existing)

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -186,6 +186,29 @@ func (c *K8sClient) UpdateProject(ctx context.Context, name string, displayName,
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 
+// UpdateParentLabel updates the parent label on a project namespace.
+func (c *K8sClient) UpdateParentLabel(ctx context.Context, name, newParentNs string) (*corev1.Namespace, error) {
+	slog.DebugContext(ctx, "updating project parent label in kubernetes",
+		slog.String("name", name),
+		slog.String("newParent", newParentNs),
+	)
+	ns, err := c.GetProject(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	ns.Labels[v1alpha2.AnnotationParent] = newParentNs
+	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+}
+
+// GetNamespace retrieves any namespace by its full Kubernetes name.
+// Used for resolving parent namespaces during reparent validation.
+func (c *K8sClient) GetNamespace(ctx context.Context, nsName string) (*corev1.Namespace, error) {
+	return c.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+}
+
 // DeleteProject deletes a managed project namespace.
 // Returns an error if the namespace does not have the managed-by label.
 func (c *K8sClient) DeleteProject(ctx context.Context, name string) error {

--- a/console/projects/k8s_test.go
+++ b/console/projects/k8s_test.go
@@ -691,6 +691,62 @@ func TestBuildProject_NoAnnotation_EmptyCreatorEmail(t *testing.T) {
 	}
 }
 
+func TestUpdateParentLabel_UpdatesLabel(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-rp-test",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      "rp-test",
+				v1alpha2.LabelOrganization: "acme",
+				v1alpha2.AnnotationParent:  "holos-fld-old-parent",
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	result, err := k8s.UpdateParentLabel(context.Background(), "rp-test", "holos-fld-new-parent")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Labels[v1alpha2.AnnotationParent] != "holos-fld-new-parent" {
+		t.Errorf("expected parent label 'holos-fld-new-parent', got %q", result.Labels[v1alpha2.AnnotationParent])
+	}
+
+	// Verify persisted.
+	fetched, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-prj-rp-test", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if fetched.Labels[v1alpha2.AnnotationParent] != "holos-fld-new-parent" {
+		t.Errorf("expected persisted parent label 'holos-fld-new-parent', got %q", fetched.Labels[v1alpha2.AnnotationParent])
+	}
+}
+
+func TestGetNamespace_ReturnsNamespace(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-acme",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(ns)
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	result, err := k8s.GetNamespace(context.Background(), "holos-org-acme")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Name != "holos-org-acme" {
+		t.Errorf("expected 'holos-org-acme', got %q", result.Name)
+	}
+}
+
 func TestNamespaceExists_ReturnsTrueForExisting(t *testing.T) {
 	ns := managedNS("frontend", "")
 	fakeClient := fake.NewClientset(ns)

--- a/console/rbac/rbac.go
+++ b/console/rbac/rbac.go
@@ -68,6 +68,8 @@ const (
 	PermissionProjectSettingsWrite = consolev1.Permission_PERMISSION_PROJECT_SETTINGS_WRITE
 
 	PermissionProjectDeploymentsEnable = consolev1.Permission_PERMISSION_PROJECT_DEPLOYMENTS_ENABLE
+
+	PermissionReparent = consolev1.Permission_PERMISSION_REPARENT
 )
 
 // rolePermissions defines which permissions each role has.
@@ -148,6 +150,7 @@ var rolePermissions = map[Role]map[Permission]bool{
 		PermissionTemplatesAdmin:       true,
 		PermissionProjectSettingsRead:  true,
 		PermissionProjectSettingsWrite: true,
+		PermissionReparent:             true,
 	},
 }
 
@@ -351,6 +354,16 @@ var TemplateCascadePerms = CascadeTable{
 		PermissionTemplatesWrite:  true,
 		PermissionTemplatesDelete: true,
 		PermissionTemplatesAdmin:  true,
+	},
+}
+
+// ReparentCascadePerms defines what reparent permissions each role grants via
+// cascade. Org-level OWNERs can reparent folders and projects within the org.
+// Reparenting is OWNER-only because it changes RBAC inheritance chains
+// (ADR 022 Decision 4).
+var ReparentCascadePerms = CascadeTable{
+	RoleOwner: {
+		PermissionReparent: true,
 	},
 }
 

--- a/console/rbac/rbac_test.go
+++ b/console/rbac/rbac_test.go
@@ -585,6 +585,74 @@ func TestTemplateCascadePerms(t *testing.T) {
 	})
 }
 
+func TestHasPermission_ReparentPermission(t *testing.T) {
+	t.Run("viewer cannot reparent", func(t *testing.T) {
+		if HasPermission(RoleViewer, PermissionReparent) {
+			t.Error("viewer should not have reparent")
+		}
+	})
+
+	t.Run("editor cannot reparent", func(t *testing.T) {
+		if HasPermission(RoleEditor, PermissionReparent) {
+			t.Error("editor should not have reparent")
+		}
+	})
+
+	t.Run("owner can reparent", func(t *testing.T) {
+		if !HasPermission(RoleOwner, PermissionReparent) {
+			t.Error("owner should have reparent")
+		}
+	})
+}
+
+func TestReparentCascadePerms(t *testing.T) {
+	t.Run("viewer cannot reparent via cascade", func(t *testing.T) {
+		if HasCascadePermission(RoleViewer, PermissionReparent, ReparentCascadePerms) {
+			t.Error("viewer should not have reparent via cascade")
+		}
+	})
+
+	t.Run("editor cannot reparent via cascade", func(t *testing.T) {
+		if HasCascadePermission(RoleEditor, PermissionReparent, ReparentCascadePerms) {
+			t.Error("editor should not have reparent via cascade")
+		}
+	})
+
+	t.Run("owner can reparent via cascade", func(t *testing.T) {
+		if !HasCascadePermission(RoleOwner, PermissionReparent, ReparentCascadePerms) {
+			t.Error("owner should have reparent via cascade")
+		}
+	})
+
+	t.Run("CheckCascadeAccess grants org OWNER reparent", func(t *testing.T) {
+		err := CheckCascadeAccess(
+			"owner@example.com",
+			nil,
+			map[string]string{"owner@example.com": "owner"},
+			nil,
+			PermissionReparent,
+			ReparentCascadePerms,
+		)
+		if err != nil {
+			t.Errorf("expected access granted for OWNER, got %v", err)
+		}
+	})
+
+	t.Run("CheckCascadeAccess denies org EDITOR reparent", func(t *testing.T) {
+		err := CheckCascadeAccess(
+			"editor@example.com",
+			nil,
+			map[string]string{"editor@example.com": "editor"},
+			nil,
+			PermissionReparent,
+			ReparentCascadePerms,
+		)
+		if err == nil {
+			t.Error("expected access denied for EDITOR reparent, got nil")
+		}
+	})
+}
+
 func TestCheckAccessGrants(t *testing.T) {
 	t.Run("user grant allows access", func(t *testing.T) {
 		err := CheckAccessGrants(


### PR DESCRIPTION
## Summary
- Add `PERMISSION_REPARENT` to `RoleOwner` permission set (OWNER-only, not EDITOR or VIEWER)
- Add `ReparentCascadePerms` cascade table: org-level OWNER cascades REPARENT to all children
- Implement reparent logic in `UpdateFolder`: validates REPARENT on both source and destination parents, enforces depth limits (max 3 levels), detects cycles, and no-ops when same parent
- Implement reparent logic in `UpdateProject`: validates REPARENT on both source and destination parents, no-ops when same parent
- Add `UpdateParentLabel` K8s methods for both folders and projects
- Add `GetNamespace` method to projects K8s client for parent resolution

Closes #673

## Test plan
- [x] RBAC tests: PERMISSION_REPARENT owner-only, cascade grants org OWNER, denies EDITOR/VIEWER
- [x] Folder reparent tests: success via org owner, denied on source, denied on destination, same-parent no-op, cycle detection, depth violation, depth allowed
- [x] Project reparent tests: success via org owner, denied on source, denied on destination, same-parent no-op, move from folder to org
- [x] K8s tests: UpdateParentLabel for folders and projects, GetNamespace
- [x] `make test` passes (Go + UI)
- [x] `make generate` passes

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) · agent-2