### PR TITLE
feat(e2e): update test helpers for multi-persona token acquisition

### DIFF
--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -4,6 +4,20 @@ import type { Page } from '@playwright/test'
 export const DEFAULT_USERNAME = 'admin'
 export const DEFAULT_PASSWORD = 'verysecret'
 
+// Persona email constants matching TestUsers in console/oidc/config.go.
+export const ADMIN_EMAIL = 'admin@localhost'
+export const PLATFORM_ENGINEER_EMAIL = 'platform@localhost'
+export const PRODUCT_ENGINEER_EMAIL = 'product@localhost'
+export const SRE_EMAIL = 'sre@localhost'
+
+/** Response from the POST /api/dev/token endpoint. */
+export interface TokenExchangeResponse {
+  id_token: string
+  email: string
+  groups: string[]
+  expires_in: number
+}
+
 /**
  * Build a Dex OIDC authorize URL with PKCE parameters.
  */
@@ -300,4 +314,191 @@ export async function selectOrg(page: Page, orgName: string): Promise<void> {
   await page.getByTestId('org-picker').waitFor({ timeout: 5000 })
   await page.getByTestId('org-picker').click()
   await page.getByRole('menuitem', { name: orgName }).click()
+}
+
+/**
+ * Get a valid ID token for a test persona via the dev token endpoint.
+ * The backend must be running with --enable-insecure-dex for this endpoint
+ * to be available.
+ */
+export async function getPersonaToken(
+  page: Page,
+  email: string,
+): Promise<TokenExchangeResponse> {
+  return page.evaluate(async (email) => {
+    const resp = await fetch('/api/dev/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+    if (!resp.ok) {
+      const text = await resp.text()
+      throw new Error(`Token exchange failed (${resp.status}): ${text}`)
+    }
+    return resp.json()
+  }, email)
+}
+
+/**
+ * Inject a persona's OIDC token into sessionStorage so the app treats the
+ * browser as authenticated for that user. This constructs an oidc-client-ts
+ * compatible User object keyed by `oidc.user:{authority}:{client_id}`.
+ *
+ * Call page.reload() after this to pick up the new token.
+ */
+async function injectPersonaSession(
+  page: Page,
+  tokenData: TokenExchangeResponse,
+): Promise<void> {
+  await page.evaluate((data) => {
+    // Discover the OIDC storage key pattern from existing session (if any),
+    // or construct from the well-known defaults.
+    const existingKey = Object.keys(sessionStorage).find((k) =>
+      k.startsWith('oidc.user:'),
+    )
+
+    // Parse authority and client_id from the existing key, or use defaults.
+    let authority: string
+    let clientId: string
+    if (existingKey) {
+      const parts = existingKey.replace('oidc.user:', '').split(':')
+      // Key format: oidc.user:<authority>:<client_id>
+      // authority may contain colons (https://...), client_id is the last segment.
+      clientId = parts.pop()!
+      authority = parts.join(':')
+    } else {
+      authority = `${window.location.origin}/dex`
+      clientId = 'holos-console'
+    }
+
+    // Clear all existing OIDC sessions
+    Object.keys(sessionStorage)
+      .filter((k) => k.startsWith('oidc.user:'))
+      .forEach((k) => sessionStorage.removeItem(k))
+
+    // Build an oidc-client-ts User-compatible object.
+    // The token is an ID token from Dex; we use it as both id_token and
+    // access_token since the backend verifies JWTs on the access_token header.
+    const now = Math.floor(Date.now() / 1000)
+    const user = {
+      id_token: data.id_token,
+      access_token: data.id_token,
+      token_type: 'Bearer',
+      scope: 'openid profile email groups',
+      expires_at: now + data.expires_in,
+      profile: {
+        sub: '', // Will be filled by the token itself
+        email: data.email,
+        email_verified: true,
+        groups: data.groups,
+        iss: authority,
+        aud: clientId,
+        iat: now,
+        exp: now + data.expires_in,
+      },
+    }
+
+    const key = `oidc.user:${authority}:${clientId}`
+    sessionStorage.setItem(key, JSON.stringify(user))
+  }, tokenData)
+}
+
+/**
+ * Switch the current browser session to a different persona.
+ * Clears the existing OIDC session, fetches a new token via the dev endpoint,
+ * injects it into sessionStorage, and reloads the page.
+ *
+ * The page must have already loaded the app (any route) so that
+ * fetch('/api/dev/token') can reach the backend.
+ */
+export async function switchPersona(page: Page, email: string): Promise<void> {
+  const tokenData = await getPersonaToken(page, email)
+  await injectPersonaSession(page, tokenData)
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+}
+
+/**
+ * Perform initial login as a specific persona. Navigates to /profile to
+ * trigger the auto-login OIDC flow (which authenticates as admin by default),
+ * then immediately switches to the requested persona via token exchange.
+ *
+ * Use this at the start of a test to begin authenticated as a specific persona.
+ */
+export async function loginAsPersona(page: Page, email: string): Promise<void> {
+  // First, establish a session via the normal OIDC flow (logs in as admin).
+  await loginViaProfilePage(page)
+  // If the requested persona is admin, we are already done.
+  if (email === ADMIN_EMAIL) return
+  // Switch to the desired persona.
+  await switchPersona(page, email)
+}
+
+/**
+ * Grant a user a specific role on an organization via the RPC API.
+ * Role values: 1 = VIEWER, 2 = EDITOR, 3 = OWNER.
+ * Preserves existing grants by fetching the current sharing state first.
+ */
+export async function apiGrantOrgAccess(
+  page: Page,
+  orgName: string,
+  principal: string,
+  role: number,
+): Promise<void> {
+  const { token } = await getRpcAuth(page)
+  await page.evaluate(
+    async ({ orgName, principal, role, token }) => {
+      // Fetch current org to get existing grants
+      const getResp = await fetch(
+        '/holos.console.v1.OrganizationService/GetOrganization',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Connect-Protocol-Version': '1',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ name: orgName }),
+        },
+      )
+      if (!getResp.ok) {
+        const text = await getResp.text()
+        throw new Error(`GetOrganization failed (${getResp.status}): ${text}`)
+      }
+      const orgData = await getResp.json()
+      const org = orgData.organization
+
+      // Build updated user grants list: replace or add the target principal.
+      const existingUserGrants: Array<{ principal: string; role: number }> =
+        org?.userGrants ?? []
+      const filtered = existingUserGrants.filter(
+        (g: { principal: string }) => g.principal !== principal,
+      )
+      filtered.push({ principal, role })
+
+      const resp = await fetch(
+        '/holos.console.v1.OrganizationService/UpdateOrganizationSharing',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Connect-Protocol-Version': '1',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            name: orgName,
+            userGrants: filtered,
+            roleGrants: org?.roleGrants ?? [],
+          }),
+        },
+      )
+      if (!resp.ok) {
+        const text = await resp.text()
+        throw new Error(
+          `UpdateOrganizationSharing failed (${resp.status}): ${text}`,
+        )
+      }
+    },
+    { orgName, principal, role, token },
+  )
 }

--- a/frontend/e2e/multi-persona.spec.ts
+++ b/frontend/e2e/multi-persona.spec.ts
@@ -196,26 +196,24 @@ test.describe('Multi-Persona RBAC', () => {
     // Login as SRE (who was granted VIEWER on the org in the previous test)
     await loginAsPersona(page, SRE_EMAIL)
 
-    // Verify SRE can see the org in the orgs list
-    await page.goto('/')
+    // Navigate to profile and verify the org is accessible via the sidebar.
+    // Use /profile so the sidebar is loaded with org data.
+    await page.goto('/profile')
     await page.waitForLoadState('networkidle')
 
-    // The org should appear in the sidebar org picker or in the org list.
-    // Check the sidebar org picker for the org name.
-    const orgPickerVisible = await page
-      .getByTestId('org-picker')
-      .isVisible({ timeout: 5000 })
-      .catch(() => false)
-
-    if (orgPickerVisible) {
-      await page.getByTestId('org-picker').click()
-      await expect(
-        page.getByRole('menuitem', { name: orgName }),
-      ).toBeVisible({ timeout: 5000 })
-    } else {
-      // If no org picker, the org should appear somewhere on the page
-      await expect(page.getByText(orgName)).toBeVisible({ timeout: 5000 })
+    // On mobile viewports, open the sidebar drawer first.
+    const sidebarTrigger = page.getByRole('button', { name: /toggle sidebar/i })
+    if (await sidebarTrigger.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await sidebarTrigger.click()
+      await page.waitForTimeout(500) // Wait for drawer animation
     }
+
+    // The org should appear in the sidebar org picker.
+    await page.getByTestId('org-picker').waitFor({ timeout: 5000 })
+    await page.getByTestId('org-picker').click()
+    await expect(
+      page.getByRole('menuitem', { name: orgName }),
+    ).toBeVisible({ timeout: 5000 })
   })
 
   test('product engineer can access the org with editor privileges', async ({
@@ -224,22 +222,22 @@ test.describe('Multi-Persona RBAC', () => {
     // Login as product engineer (who was granted EDITOR on the org)
     await loginAsPersona(page, PRODUCT_ENGINEER_EMAIL)
 
-    // Verify product engineer can see the org
-    await page.goto('/')
+    // Navigate to profile and verify the org is accessible via the sidebar.
+    await page.goto('/profile')
     await page.waitForLoadState('networkidle')
 
-    const orgPickerVisible = await page
-      .getByTestId('org-picker')
-      .isVisible({ timeout: 5000 })
-      .catch(() => false)
-
-    if (orgPickerVisible) {
-      await page.getByTestId('org-picker').click()
-      await expect(
-        page.getByRole('menuitem', { name: orgName }),
-      ).toBeVisible({ timeout: 5000 })
-    } else {
-      await expect(page.getByText(orgName)).toBeVisible({ timeout: 5000 })
+    // On mobile viewports, open the sidebar drawer first.
+    const sidebarTrigger = page.getByRole('button', { name: /toggle sidebar/i })
+    if (await sidebarTrigger.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await sidebarTrigger.click()
+      await page.waitForTimeout(500) // Wait for drawer animation
     }
+
+    // The org should appear in the sidebar org picker.
+    await page.getByTestId('org-picker').waitFor({ timeout: 5000 })
+    await page.getByTestId('org-picker').click()
+    await expect(
+      page.getByRole('menuitem', { name: orgName }),
+    ).toBeVisible({ timeout: 5000 })
   })
 })

--- a/frontend/e2e/multi-persona.spec.ts
+++ b/frontend/e2e/multi-persona.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect } from '@playwright/test'
+import {
+  loginAsPersona,
+  switchPersona,
+  getPersonaToken,
+  apiCreateOrg,
+  apiDeleteOrg,
+  apiGrantOrgAccess,
+  PLATFORM_ENGINEER_EMAIL,
+  PRODUCT_ENGINEER_EMAIL,
+  SRE_EMAIL,
+  ADMIN_EMAIL,
+} from './helpers'
+
+/**
+ * E2E tests for multi-persona token acquisition and RBAC verification.
+ *
+ * These tests verify that:
+ * 1. The dev token endpoint returns valid tokens for each persona
+ * 2. Persona switching works correctly in the browser session
+ * 3. RBAC grants are respected across different personas
+ *
+ * The dev token endpoint (/api/dev/token) is available whenever
+ * --enable-insecure-dex is enabled, which is always the case in E2E tests.
+ *
+ * Tests that create K8s resources (orgs) require a running cluster.
+ * Run with: make test-e2e
+ */
+
+test.describe('Dev Token Endpoint', () => {
+  test('should return a valid token for the platform engineer persona', async ({
+    page,
+  }) => {
+    // Navigate to /profile to establish a page context with the app loaded
+    await page.goto('/profile')
+    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
+    // Wait for the page to settle (auto-login may redirect)
+    await page.waitForLoadState('networkidle')
+
+    const tokenData = await getPersonaToken(page, PLATFORM_ENGINEER_EMAIL)
+
+    expect(tokenData.id_token).toBeTruthy()
+    expect(tokenData.email).toBe(PLATFORM_ENGINEER_EMAIL)
+    expect(tokenData.groups).toContain('owner')
+    expect(tokenData.expires_in).toBeGreaterThan(0)
+  })
+
+  test('should return a valid token for the product engineer persona', async ({
+    page,
+  }) => {
+    await page.goto('/profile')
+    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
+    await page.waitForLoadState('networkidle')
+
+    const tokenData = await getPersonaToken(page, PRODUCT_ENGINEER_EMAIL)
+
+    expect(tokenData.id_token).toBeTruthy()
+    expect(tokenData.email).toBe(PRODUCT_ENGINEER_EMAIL)
+    expect(tokenData.groups).toContain('editor')
+    expect(tokenData.expires_in).toBeGreaterThan(0)
+  })
+
+  test('should return a valid token for the SRE persona', async ({ page }) => {
+    await page.goto('/profile')
+    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
+    await page.waitForLoadState('networkidle')
+
+    const tokenData = await getPersonaToken(page, SRE_EMAIL)
+
+    expect(tokenData.id_token).toBeTruthy()
+    expect(tokenData.email).toBe(SRE_EMAIL)
+    expect(tokenData.groups).toContain('viewer')
+    expect(tokenData.expires_in).toBeGreaterThan(0)
+  })
+
+  test('should reject unknown email addresses', async ({ page }) => {
+    await page.goto('/profile')
+    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
+    await page.waitForLoadState('networkidle')
+
+    const error = await page
+      .evaluate(async () => {
+        const resp = await fetch('/api/dev/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: 'unknown@example.com' }),
+        })
+        return { status: resp.status, body: await resp.text() }
+      })
+      .catch((err) => ({ status: 0, body: String(err) }))
+
+    expect(error.status).toBe(400)
+    expect(error.body).toContain('unknown test user email')
+  })
+})
+
+test.describe('Persona Switching', () => {
+  test('should login as platform engineer and show correct email', async ({
+    page,
+  }) => {
+    await loginAsPersona(page, PLATFORM_ENGINEER_EMAIL)
+
+    // Verify the profile page shows the platform engineer's email
+    await page.goto('/profile')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(PLATFORM_ENGINEER_EMAIL)).toBeVisible({
+      timeout: 10000,
+    })
+  })
+
+  test('should switch from admin to SRE persona', async ({ page }) => {
+    // Start as admin
+    await loginAsPersona(page, ADMIN_EMAIL)
+    await page.goto('/profile')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(ADMIN_EMAIL)).toBeVisible({ timeout: 10000 })
+
+    // Switch to SRE
+    await switchPersona(page, SRE_EMAIL)
+    await page.goto('/profile')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(SRE_EMAIL)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('should switch between all three non-admin personas', async ({
+    page,
+  }) => {
+    // Login as platform engineer
+    await loginAsPersona(page, PLATFORM_ENGINEER_EMAIL)
+    await page.goto('/profile')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(PLATFORM_ENGINEER_EMAIL)).toBeVisible({
+      timeout: 10000,
+    })
+
+    // Switch to product engineer
+    await switchPersona(page, PRODUCT_ENGINEER_EMAIL)
+    await page.goto('/profile')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(PRODUCT_ENGINEER_EMAIL)).toBeVisible({
+      timeout: 10000,
+    })
+
+    // Switch to SRE
+    await switchPersona(page, SRE_EMAIL)
+    await page.goto('/profile')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(SRE_EMAIL)).toBeVisible({ timeout: 10000 })
+  })
+})
+
+test.describe('Multi-Persona RBAC', () => {
+  // These tests require a K8s cluster for org creation.
+  // They are skipped gracefully if the cluster is unavailable.
+
+  const orgName = `e2e-persona-${Date.now()}`
+
+  test.afterAll(async ({ browser }) => {
+    // Clean up: delete the test org as admin (who always has access)
+    const context = await browser.newContext({ ignoreHTTPSErrors: true })
+    const page = await context.newPage()
+    try {
+      await loginAsPersona(page, ADMIN_EMAIL)
+      await apiDeleteOrg(page, orgName)
+    } catch {
+      // Best-effort cleanup; org may not exist if test was skipped
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('platform engineer can create an org and grant SRE viewer access', async ({
+    page,
+  }) => {
+    // Login as platform engineer (owner role)
+    await loginAsPersona(page, PLATFORM_ENGINEER_EMAIL)
+
+    // Create an org — the creator is automatically OWNER
+    try {
+      await apiCreateOrg(page, orgName)
+    } catch (err) {
+      // If org creation fails (e.g. no K8s cluster), skip this test gracefully
+      test.skip(true, `Org creation failed (K8s cluster may be unavailable): ${err}`)
+      return
+    }
+
+    // Grant SRE viewer access
+    await apiGrantOrgAccess(page, orgName, SRE_EMAIL, 1) // 1 = VIEWER
+    // Grant product engineer editor access
+    await apiGrantOrgAccess(page, orgName, PRODUCT_ENGINEER_EMAIL, 2) // 2 = EDITOR
+  })
+
+  test('SRE can list the org after being granted viewer access', async ({
+    page,
+  }) => {
+    // Login as SRE (who was granted VIEWER on the org in the previous test)
+    await loginAsPersona(page, SRE_EMAIL)
+
+    // Verify SRE can see the org in the orgs list
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // The org should appear in the sidebar org picker or in the org list.
+    // Check the sidebar org picker for the org name.
+    const orgPickerVisible = await page
+      .getByTestId('org-picker')
+      .isVisible({ timeout: 5000 })
+      .catch(() => false)
+
+    if (orgPickerVisible) {
+      await page.getByTestId('org-picker').click()
+      await expect(
+        page.getByRole('menuitem', { name: orgName }),
+      ).toBeVisible({ timeout: 5000 })
+    } else {
+      // If no org picker, the org should appear somewhere on the page
+      await expect(page.getByText(orgName)).toBeVisible({ timeout: 5000 })
+    }
+  })
+
+  test('product engineer can access the org with editor privileges', async ({
+    page,
+  }) => {
+    // Login as product engineer (who was granted EDITOR on the org)
+    await loginAsPersona(page, PRODUCT_ENGINEER_EMAIL)
+
+    // Verify product engineer can see the org
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const orgPickerVisible = await page
+      .getByTestId('org-picker')
+      .isVisible({ timeout: 5000 })
+      .catch(() => false)
+
+    if (orgPickerVisible) {
+      await page.getByTestId('org-picker').click()
+      await expect(
+        page.getByRole('menuitem', { name: orgName }),
+      ).toBeVisible({ timeout: 5000 })
+    } else {
+      await expect(page.getByText(orgName)).toBeVisible({ timeout: 5000 })
+    }
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -70,6 +70,12 @@ export default defineConfig({
         secure: false,
         changeOrigin: true,
       },
+      // Proxy dev API endpoints (e.g. token exchange) to the Go backend.
+      '/api/dev': {
+        target: backendUrl,
+        secure: false,
+        changeOrigin: true,
+      },
     },
   },
 })

--- a/scripts/browser-login
+++ b/scripts/browser-login
@@ -6,15 +6,46 @@
 # (no Dex cookies). For fresh sessions, navigates to /profile and clicks
 # "Sign In" to trigger the full OIDC flow through the Dex auto-connector.
 #
-# Usage: scripts/browser-login [--session-name NAME]
+# Usage: scripts/browser-login [--session-name NAME] [--persona EMAIL]
 #   Default session name: holos-dev
+#   Default persona: (none — uses the admin auto-connector login)
+#
+# Persona emails (from console/oidc/config.go):
+#   platform@localhost  — Platform Engineer (Owner)
+#   product@localhost   — Product Engineer (Editor)
+#   sre@localhost       — SRE (Viewer)
+#
+# When --persona is given, the script first performs the normal OIDC login
+# (as admin via the auto-connector), then exchanges the persona email for a
+# signed token via /api/dev/token and injects it into sessionStorage.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=browser-env
 source "$SCRIPT_DIR/browser-env"
 
-SESSION_NAME="${1:-holos-dev}"
+SESSION_NAME="holos-dev"
+PERSONA_EMAIL=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session-name)
+      SESSION_NAME="$2"
+      shift 2
+      ;;
+    --persona)
+      PERSONA_EMAIL="$2"
+      shift 2
+      ;;
+    *)
+      # Legacy positional argument: session name
+      SESSION_NAME="$1"
+      shift
+      ;;
+  esac
+done
+
 AB="agent-browser --session-name $SESSION_NAME"
 
 SCREENSHOTS_DIR="tmp/screenshots"
@@ -71,6 +102,68 @@ if [[ -z "$TOKEN_KEY" || "$TOKEN_KEY" == "undefined" || "$TOKEN_KEY" == "null" ]
 fi
 
 echo "OK: OIDC token present (key: $TOKEN_KEY)"
+
+# If a persona was requested, switch to it via the dev token endpoint.
+if [[ -n "$PERSONA_EMAIL" ]]; then
+  echo "Switching to persona: $PERSONA_EMAIL..."
+
+  # Fetch a signed token for the persona via the dev token endpoint.
+  TOKEN_JSON=$($AB eval "
+    fetch('/api/dev/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: '$PERSONA_EMAIL' }),
+    }).then(r => {
+      if (!r.ok) throw new Error('Token exchange failed: ' + r.status);
+      return r.json();
+    }).then(d => JSON.stringify(d))
+  " 2>/dev/null)
+
+  if [[ -z "$TOKEN_JSON" || "$TOKEN_JSON" == "undefined" ]]; then
+    echo "FAIL: Token exchange failed for persona $PERSONA_EMAIL"
+    exit 1
+  fi
+
+  # Inject the persona token into sessionStorage, replacing the admin session.
+  $AB eval "
+    (function() {
+      var data = $TOKEN_JSON;
+      // Find and parse the existing OIDC key to get authority and client_id
+      var key = Object.keys(sessionStorage).find(function(k) { return k.startsWith('oidc.user:'); });
+      if (!key) throw new Error('No OIDC session key found');
+      // Clear all OIDC sessions
+      Object.keys(sessionStorage).filter(function(k) { return k.startsWith('oidc.user:'); }).forEach(function(k) { sessionStorage.removeItem(k); });
+      // Build oidc-client-ts User object
+      var now = Math.floor(Date.now() / 1000);
+      var user = {
+        id_token: data.id_token,
+        access_token: data.id_token,
+        token_type: 'Bearer',
+        scope: 'openid profile email groups',
+        expires_at: now + data.expires_in,
+        profile: {
+          sub: '',
+          email: data.email,
+          email_verified: true,
+          groups: data.groups,
+          iss: key.split(':').slice(1, -1).join(':'),
+          aud: key.split(':').pop(),
+          iat: now,
+          exp: now + data.expires_in,
+        },
+      };
+      sessionStorage.setItem(key, JSON.stringify(user));
+      return 'ok';
+    })()
+  " 2>/dev/null
+
+  # Reload to pick up the new token
+  $AB open "$HOLOS_LOGIN_URL/profile"
+  $AB wait --load networkidle
+  $AB wait 1000
+
+  echo "OK: Switched to persona $PERSONA_EMAIL"
+fi
 
 # Save success screenshot
 $AB screenshot "$SCREENSHOTS_DIR/login-success.png"


### PR DESCRIPTION
## Summary
- Add persona email constants (`PLATFORM_ENGINEER_EMAIL`, `PRODUCT_ENGINEER_EMAIL`, `SRE_EMAIL`, `ADMIN_EMAIL`) to E2E helpers
- Add `getPersonaToken(page, email)` helper that fetches tokens via `/api/dev/token`
- Add `switchPersona(page, email)` helper that injects a new OIDC session into sessionStorage
- Add `loginAsPersona(page, email)` helper for initial authentication as a specific persona
- Add `apiGrantOrgAccess(page, orgName, principal, role)` helper for granting org-level access
- Add `multi-persona.spec.ts` with three test groups: Dev Token Endpoint, Persona Switching, and Multi-Persona RBAC
- Add `--persona EMAIL` flag to `scripts/browser-login` for agent/developer persona switching
- Fix Vite proxy to forward `/api/dev/` requests to Go backend (required for dev token endpoint)

Closes #700

## Test plan
- [x] `make test` passes (Go + UI unit tests)
- [ ] `make test-e2e` — Dev Token Endpoint and Persona Switching tests pass; Multi-Persona RBAC tests require a K8s cluster and skip gracefully if unavailable
- [ ] CI E2E check validates the full suite

> Local E2E run identified a Vite proxy gap (`/api/dev/token` was returning 404 through the Vite dev server). Fixed in the `fix(vite): proxy /api/dev/ requests to Go backend` commit. Re-run pending.

Generated with [Claude Code](https://claude.com/claude-code) · agent-1