### PR TITLE
docs(adr): ADR-023 multi-persona test identities and dev tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,30 @@ OIDC PKCE flow: Requires `--enable-insecure-dex` flag for embedded Dex at `/dex/
 
 Backend auth: `LazyAuthInterceptor` in `console/rpc/auth.go` verifies JWTs from the `Authorization: Bearer` header and stores `rpc.Claims` in context. Lazy initialization avoids startup race with embedded Dex.
 
+#### Test Personas
+
+When running with `--enable-insecure-dex`, embedded Dex registers four test identities (defined in `console/oidc/config.go`):
+
+| Persona | Email | Groups | RBAC Role | Password |
+|---------|-------|--------|-----------|----------|
+| Admin (default) | `admin@localhost` | `["owner"]` | OWNER | (auto-login) |
+| Platform Engineer | `platform@localhost` | `["owner"]` | OWNER | `verysecret` |
+| Product Engineer | `product@localhost` | `["editor"]` | EDITOR | `verysecret` |
+| SRE | `sre@localhost` | `["viewer"]` | VIEWER | `verysecret` |
+
+The admin user is authenticated automatically via the auto-login connector. The other three personas are available via the dev token endpoint and the Dev Tools UI.
+
+**Dev token endpoint** (`POST /api/dev/token`): Obtain a signed OIDC ID token for any test persona. Requires `--enable-insecure-dex`. See `docs/dev-token-endpoint.md` for full API reference.
+
+```bash
+curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+  -X POST https://localhost:8443/api/dev/token \
+  -H "Content-Type: application/json" \
+  -d '{"email":"sre@localhost"}'
+```
+
+**Dev Tools UI** (`/dev-tools`): Enable with `--enable-dev-tools` (passed automatically by `make run`). Provides an interactive persona switcher that injects tokens into sessionStorage without a Dex redirect. See ADR 023 for design rationale.
+
 ### RBAC
 
 Three-tier access control model evaluated in order (highest role wins):
@@ -394,6 +418,8 @@ See `docs/testing.md` for the complete decision rule, the ConnectRPC mock patter
 **UI unit tests**: Vitest + React Testing Library + jsdom. Mock query hooks (`@/queries/*`) with `vi.mock()` and `vi.fn()`. Route-directory test files must be prefixed with `-` (e.g. `-about.test.tsx`) so TanStack Router's generator ignores them. Run with `make test-ui`.
 
 **E2E tests**: Playwright in `frontend/e2e/`. `make test-e2e` orchestrates the full stack (builds Go binary, starts Go backend on :8443 and Vite on :5173). For tight iteration, start servers once and run targeted tests — see `docs/e2e-testing.md` for the full workflow including K8s-backed tests.
+
+**Multi-persona E2E helpers**: `frontend/e2e/helpers.ts` exports `getPersonaToken()`, `switchPersona()`, `loginAsPersona()`, and `apiGrantOrgAccess()` for tests that verify RBAC behavior across different roles. These helpers use the dev token endpoint (`POST /api/dev/token`) to obtain tokens and inject them into sessionStorage. See `docs/e2e-testing.md` for usage patterns.
 
 See `docs/frontend-patterns.md` for common UI patterns (copy-to-clipboard, toast notifications).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,31 @@ The `reuseExistingServer` option detects when servers are already running and sk
 
 The embedded Dex OIDC provider is enabled by `make run` via `--enable-insecure-dex` and auto-logs in during local development. See [docs/authentication.md](docs/authentication.md) for detailed documentation including external OIDC provider configuration.
 
+### Dev Tools and Persona Switching
+
+`make run` passes `--enable-dev-tools`, which exposes a Dev Tools page at `/dev-tools` in the sidebar. The Dev Tools page provides an interactive persona switcher to test the application as different RBAC roles without restarting the server.
+
+Available personas:
+
+| Persona | Email | Role |
+|---------|-------|------|
+| Platform Engineer | `platform@localhost` | Owner |
+| Product Engineer | `product@localhost` | Editor |
+| SRE | `sre@localhost` | Viewer |
+
+To switch personas in the UI: navigate to Dev Tools in the sidebar and click a persona card.
+
+To obtain tokens for API testing via the command line:
+
+```bash
+curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
+  -X POST https://localhost:8443/api/dev/token \
+  -H "Content-Type: application/json" \
+  -d '{"email":"product@localhost"}' | jq -r .id_token
+```
+
+See [docs/dev-token-endpoint.md](docs/dev-token-endpoint.md) for the full API reference.
+
 ## Commit Messages
 
 All commit messages must follow this format and include the root-cause analysis for why the issue happened, with citations to sources (for example, deep links to GitHub issues that describe the problem and its cause):

--- a/docs/adrs/023-multi-persona-test-identities.md
+++ b/docs/adrs/023-multi-persona-test-identities.md
@@ -1,0 +1,192 @@
+# ADR 023: Multi-Persona Test Identities and Dev Tools
+
+## Status
+
+Accepted
+
+## Context
+
+Prior to this change, the embedded Dex OIDC provider configured a single
+auto-login connector that authenticated every user as `admin@localhost` with
+the `owner` group. This design was sufficient for single-user development but
+made it impossible to test RBAC behavior across different roles without an
+external identity provider.
+
+Effective RBAC testing requires multiple identities with distinct group
+memberships so that Viewer, Editor, and Owner permission boundaries can be
+verified in E2E tests and during interactive development. The solution must:
+
+1. Preserve the zero-credential auto-login experience for the common case
+   (developer starts `make run` and immediately has full access).
+2. Provide additional identities with different RBAC roles.
+3. Allow programmatic token acquisition for E2E test helpers and CLI scripts.
+4. Allow interactive persona switching in the browser without a full Dex
+   redirect round-trip.
+5. Keep all dev-only surface area gated behind explicit opt-in flags so it
+   cannot leak into production.
+
+## Decisions
+
+### Decision 1: Static test users registered in embedded Dex
+
+Four test users are defined as a Go-level constant table (`TestUsers` in
+`console/oidc/config.go`). Each user has a unique email, UserID,
+DisplayName, and group membership:
+
+| Persona | Email | Groups | RBAC Role |
+|---------|-------|--------|-----------|
+| Admin (default) | `admin@localhost` | `["owner"]` | OWNER |
+| Platform Engineer | `platform@localhost` | `["owner"]` | OWNER |
+| Product Engineer | `product@localhost` | `["editor"]` | EDITOR |
+| SRE | `sre@localhost` | `["viewer"]` | VIEWER |
+
+All four users share the password `verysecret` (the `DefaultPassword`
+constant). The admin user is the identity produced by the auto-login
+connector; the other three represent the three RBAC tiers.
+
+**Why static, in-code registration (not config files or environment
+variables)?** Test personas must be deterministic and reproducible.
+Externalizing them would add configuration surface area without benefit --
+these are development-only identities whose values are fixed by design.
+
+**Why four users when there are only three RBAC roles?** The admin user
+is retained for backwards compatibility with the auto-login connector.
+The three additional personas (Platform Engineer, Product Engineer, SRE)
+map one-to-one to the Owner, Editor, Viewer roles, making test assertions
+unambiguous.
+
+### Decision 2: Dev token-exchange endpoint using Dex signing keys (not ROPC)
+
+A `POST /api/dev/token` endpoint accepts `{"email": "<user>"}` and returns
+a signed OIDC ID token for any registered test user. The endpoint is gated
+behind `--enable-insecure-dex` (returns 404 when Dex is not running).
+
+The token is minted directly using Dex's signing keys retrieved from the
+in-memory Dex storage (`DexState.Storage.GetKeys`). This produces tokens
+that are structurally identical to those Dex issues through the standard
+OIDC authorization code flow -- same issuer, audience, signing algorithm,
+and claim structure.
+
+**Why direct signing rather than ROPC (Resource Owner Password Credentials)?**
+ROPC would require registering password connectors in Dex for each test user.
+Dex shows a connector selection page when multiple connectors are registered,
+which breaks the auto-login experience (Decision 1 requires that the default
+`make run` flow authenticates without user interaction). Direct signing avoids
+this conflict entirely: no additional connectors are registered, the auto-login
+connector remains the only connector, and the token endpoint mints tokens
+independently.
+
+The `DexState` struct exposes the Dex `Storage`, `Issuer`, and `ClientID`
+fields so the token exchange handler can construct valid tokens without
+coupling to Dex's internal token issuance pipeline.
+
+### Decision 3: Separate `--enable-dev-tools` flag
+
+A new `--enable-dev-tools` CLI flag (default `false`) controls whether the
+frontend Dev Tools UI is available. When enabled, the server injects a
+`window.__CONSOLE_CONFIG__` script tag into the HTML with
+`{"devToolsEnabled": true}`. The frontend reads this via `getConsoleConfig()`
+and conditionally renders the Dev Tools sidebar item and `/dev-tools` route.
+
+**Why a separate flag rather than bundling with `--enable-insecure-dex`?**
+The two flags control different security surfaces:
+
+- `--enable-insecure-dex` controls whether the embedded OIDC provider runs
+  and the dev token endpoint is available. This is a backend concern.
+- `--enable-dev-tools` controls whether the frontend exposes UI that allows
+  persona switching. This is a UI surface area concern.
+
+An operator might want the embedded Dex provider (for convenient local
+development) without the persona switcher UI (to avoid confusion during
+demos). Keeping the flags independent preserves this flexibility.
+
+`make run` passes both flags. E2E tests pass `--enable-insecure-dex` (for
+token acquisition) but do not require `--enable-dev-tools` since tests use
+programmatic token injection, not the UI switcher.
+
+### Decision 4: Frontend persona switcher via token injection
+
+The Dev Tools page (`/dev-tools`) displays three persona cards (Platform
+Engineer, Product Engineer, SRE). Clicking a persona:
+
+1. Calls `POST /api/dev/token` with the persona's email.
+2. Constructs an oidc-client-ts `User` object from the response.
+3. Writes it to `sessionStorage` under the `oidc.user:{authority}:{client_id}`
+   key.
+4. Reloads the page so the auth provider picks up the new identity.
+
+**Why token injection into sessionStorage rather than a full Dex redirect?**
+A Dex redirect flow would require the user to navigate to Dex, select a
+connector (if multiple are registered), enter credentials, and wait for the
+callback. Token injection is instant and preserves the current page state
+(after reload). It also avoids the connector selection problem described in
+Decision 2.
+
+The persona switcher reuses the same token exchange endpoint that E2E test
+helpers use, ensuring consistency between interactive and automated workflows.
+
+### Decision 5: Three personas mapping to RBAC tiers
+
+The UI persona switcher exposes three personas (excluding the admin user):
+
+| Persona | Email | Groups | Role Badge |
+|---------|-------|--------|------------|
+| Platform Engineer | `platform@localhost` | `["owner"]` | Owner |
+| Product Engineer | `product@localhost` | `["editor"]` | Editor |
+| SRE | `sre@localhost` | `["viewer"]` | Viewer |
+
+**Why exclude admin from the switcher?** The admin user is the auto-login
+identity -- the user is already authenticated as admin when they open Dev
+Tools. Including admin in the switcher would add a fourth option with the
+same permissions as Platform Engineer (both are `owner` group), creating
+confusion without testing value.
+
+**Why these persona names?** They represent the three primary user archetypes
+of the Holos Console: the platform team that manages infrastructure (owner
+access), the product team that deploys applications (editor access), and
+the SRE team that monitors and observes (viewer access).
+
+## Consequences
+
+### Positive
+
+- **RBAC testing without external providers.** Developers and CI can verify
+  all three permission tiers using only `make run`.
+
+- **E2E test isolation.** Each test can authenticate as a specific persona
+  without shared mutable state. The `loginAsPersona()`, `switchPersona()`,
+  and `getPersonaToken()` helpers in `frontend/e2e/helpers.ts` provide a
+  clean API for multi-persona test scenarios.
+
+- **Interactive debugging.** The Dev Tools persona switcher lets developers
+  quickly see how the UI behaves for different roles without restarting the
+  server or using browser incognito windows.
+
+- **Auto-login preserved.** The default `make run` experience is unchanged:
+  `admin@localhost` is auto-logged in with owner permissions.
+
+### Negative
+
+- **Four hardcoded test users.** Adding a new persona requires a code change
+  in `console/oidc/config.go` and corresponding updates to the frontend
+  persona definitions in `frontend/src/lib/dev-tools.ts`.
+
+- **Token endpoint bypasses Dex's authorization flow.** The direct-signing
+  approach means the dev token endpoint does not exercise Dex's token
+  issuance pipeline. This is acceptable because the endpoint is for testing,
+  not for production authentication.
+
+- **Separate flag burden.** Operators running local development must pass
+  both `--enable-insecure-dex` and `--enable-dev-tools` for the full
+  experience. `make run` handles this automatically.
+
+## References
+
+- #695: Parent tracking issue (multi-persona test identities with dev tools)
+- #696: Static test users in embedded Dex
+- #697: Dev token-exchange endpoint
+- #698: `--enable-dev-tools` flag and config injection
+- #699: Dev Tools UI with persona switcher
+- #700: E2E test helpers for multi-persona
+- ADR 008: `--enable-insecure-dex` flag
+- ADR 010: `/api/debug/oidc` endpoint risk acceptance

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -68,6 +68,31 @@ export HOLOS_DEX_INITIAL_ADMIN_USERNAME=myuser
 ./holos-console --enable-insecure-dex --cert certs/tls.crt --key certs/tls.key
 ```
 
+## Test Personas
+
+When running with `--enable-insecure-dex`, embedded Dex registers four test identities with distinct RBAC roles. These personas enable testing permission boundaries without an external identity provider.
+
+| Persona | Email | Groups | RBAC Role | UserID |
+|---------|-------|--------|-----------|--------|
+| Admin (default) | `admin@localhost` | `["owner"]` | OWNER | `test-admin-001` |
+| Platform Engineer | `platform@localhost` | `["owner"]` | OWNER | `test-platform-001` |
+| Product Engineer | `product@localhost` | `["editor"]` | EDITOR | `test-product-001` |
+| SRE | `sre@localhost` | `["viewer"]` | VIEWER | `test-sre-001` |
+
+All non-admin users share the password `verysecret`. The admin user authenticates automatically via the auto-login connector (no credentials required).
+
+The persona definitions live in `console/oidc/config.go` as the `TestUsers` variable.
+
+### Dev Token Endpoint
+
+The `POST /api/dev/token` endpoint provides programmatic token acquisition for any registered test user. This is used by E2E test helpers and the Dev Tools persona switcher. See [docs/dev-token-endpoint.md](dev-token-endpoint.md) for the full API reference.
+
+### Dev Tools UI
+
+When `--enable-dev-tools` is also set (included in `make run`), a Dev Tools page at `/dev-tools` provides an interactive persona switcher. Clicking a persona card injects a signed token into sessionStorage and reloads the page, instantly switching the authenticated identity without a Dex redirect.
+
+See [ADR 023](adrs/023-multi-persona-test-identities.md) for the design rationale.
+
 ## Authentication Flow
 
 1. **User clicks Login** - React SPA calls `login()` from `useAuth()` hook
@@ -83,6 +108,7 @@ export HOLOS_DEX_INITIAL_ADMIN_USERNAME=myuser
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--enable-insecure-dex` | `false` | Enable the built-in Dex OIDC provider with auto-login |
+| `--enable-dev-tools` | `false` | Enable Dev Tools UI (persona switcher at `/dev-tools`) |
 | `--issuer` | (none) | OIDC issuer URL for token validation |
 | `--client-id` | `holos-console` | Expected audience for tokens |
 | `--listen` | `:8443` | Address to listen on |

--- a/docs/dev-token-endpoint.md
+++ b/docs/dev-token-endpoint.md
@@ -114,3 +114,10 @@ The token claims include `iss`, `sub`, `aud`, `exp`, `iat`, `email`, `email_veri
 ## Security
 
 This endpoint is for **local development only**. It requires no authentication and returns tokens for any registered test user. It is gated behind `--enable-insecure-dex` to prevent accidental exposure in production.
+
+## See Also
+
+- [ADR 023](adrs/023-multi-persona-test-identities.md) -- Design decisions for the multi-persona test identity system
+- [Authentication](authentication.md) -- Overview of the OIDC authentication system and test personas
+- [E2E Testing](e2e-testing.md) -- Multi-persona E2E test patterns using this endpoint
+- [CONTRIBUTING.md](../CONTRIBUTING.md) -- Dev tools setup and persona switching for local development

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -80,10 +80,64 @@ The CI e2e job installs k3s so the full service stack (orgs, projects, secrets) 
 
 Tests that require Kubernetes time out in CI without k3s because `OrganizationService` and `ProjectService` are not registered when no kubeconfig is available.
 
+## Multi-Persona Tests
+
+E2E tests can authenticate as different test personas to verify RBAC behavior. The helpers in `frontend/e2e/helpers.ts` use the dev token endpoint (`POST /api/dev/token`) to obtain signed OIDC tokens and inject them into `sessionStorage`.
+
+### Available Helpers
+
+| Helper | Purpose |
+|--------|---------|
+| `getPersonaToken(page, email)` | Fetch a signed ID token for a persona |
+| `switchPersona(page, email)` | Inject a persona's token and reload |
+| `loginAsPersona(page, email)` | Auto-login as admin, then switch to persona |
+| `apiGrantOrgAccess(page, org, email, role)` | Grant a persona a role on an org |
+
+### Email Constants
+
+```ts
+import {
+  ADMIN_EMAIL,              // admin@localhost
+  PLATFORM_ENGINEER_EMAIL,  // platform@localhost
+  PRODUCT_ENGINEER_EMAIL,   // product@localhost
+  SRE_EMAIL,                // sre@localhost
+} from './helpers'
+```
+
+### Example: Test RBAC across personas
+
+```ts
+test('editor cannot delete org', async ({ page }) => {
+  // Login as admin (owner) and create an org
+  await loginAsPersona(page, ADMIN_EMAIL)
+  await apiCreateOrg(page, 'test-org')
+  await apiGrantOrgAccess(page, 'test-org', PRODUCT_ENGINEER_EMAIL, 2) // EDITOR
+
+  // Switch to product engineer (editor role)
+  await switchPersona(page, PRODUCT_ENGINEER_EMAIL)
+
+  // Verify the editor cannot delete the org
+  // ... assertion logic ...
+
+  // Cleanup as admin
+  await switchPersona(page, ADMIN_EMAIL)
+  await apiDeleteOrg(page, 'test-org')
+})
+```
+
+### Notes
+
+- The dev token endpoint is available whenever `--enable-insecure-dex` is set (always in E2E).
+- `loginAsPersona()` first completes the auto-login flow (authenticating as admin), then switches to the requested persona if it is not admin.
+- `switchPersona()` can be called mid-test to change identities without restarting the browser.
+- The `multi-persona.spec.ts` test file demonstrates token acquisition, persona switching, and RBAC grant verification patterns.
+
 ## Which Tests Need Kubernetes
 
 | Test file | Tests | Needs K8s? |
 |-----------|-------|-----------|
 | `e2e/auth.spec.ts` | All | No |
+| `e2e/multi-persona.spec.ts` | Token endpoint tests (first 5) | No |
+| `e2e/multi-persona.spec.ts` | RBAC grant tests | Yes |
 | `e2e/secrets.spec.ts` | sidebar navigation (first 2) | No |
 | `e2e/secrets.spec.ts` | create/update/list secrets, add key | Yes |


### PR DESCRIPTION
## Summary
- Add ADR-023 documenting the five design decisions for the multi-persona test identity system: static Dex users, dev token-exchange via signing keys (not ROPC), separate `--enable-dev-tools` flag, frontend persona switcher via token injection, and three personas mapping to RBAC tiers
- Update AGENTS.md with test persona table and multi-persona E2E helper reference in Authentication and Testing Patterns sections
- Update CONTRIBUTING.md with dev tools setup and persona switching guidance
- Update docs/authentication.md with test persona table, dev token endpoint, dev tools UI, and `--enable-dev-tools` CLI flag
- Update docs/e2e-testing.md with multi-persona test patterns, helper reference, and worked example
- Add cross-links in docs/dev-token-endpoint.md to ADR-023 and related docs

Closes #701

## Test plan
- [x] `make test` passes (docs-only changes, no code modifications)
- [x] All 659 unit tests pass
- [ ] Review ADR-023 covers all five decisions from the acceptance criteria
- [ ] Verify cross-links between docs are correct

> Local E2E was not run (docs-only changes, no E2E relevance). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) · agent-1