### PR TITLE
feat(ui): reorder sidebar, add default folder to org settings, folder picker in create project

### DIFF
--- a/frontend/src/components/-app-sidebar.test.tsx
+++ b/frontend/src/components/-app-sidebar.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// Mock TanStack Router
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children: React.ReactNode }) =>
+    <a {...props}>{children}</a>,
+  useRouter: () => ({ state: { location: { pathname: '/orgs/test-org/projects' } } }),
+}))
+
+// Mock org and project contexts
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn(),
+}))
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: () => ({ devToolsEnabled: false }),
+}))
+vi.mock('@/queries/version', () => ({
+  useVersion: () => ({ data: { version: '0.1.0' } }),
+}))
+vi.mock('@/queries/project-settings', () => ({
+  useGetProjectSettings: () => ({ data: null }),
+}))
+
+// Mock sidebar UI components to simplify rendering
+vi.mock('@/components/ui/sidebar', () => ({
+  Sidebar: ({ children }: { children: React.ReactNode }) => <div data-testid="sidebar">{children}</div>,
+  SidebarContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarGroupContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarGroupLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarHeader: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => <div {...props}>{children}</div>,
+  SidebarMenu: ({ children }: { children: React.ReactNode }) => <ul data-testid="sidebar-menu">{children}</ul>,
+  SidebarMenuButton: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => <div {...props}>{children}</div>,
+  SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <li>{children}</li>,
+  SidebarSeparator: () => <hr />,
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => <div onClick={onClick}>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children: React.ReactNode; variant?: string; size?: string }) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/create-org-dialog', () => ({
+  CreateOrgDialog: () => null,
+}))
+vi.mock('@/components/create-project-dialog', () => ({
+  CreateProjectDialog: () => null,
+}))
+
+import { useOrg } from '@/lib/org-context'
+import { useProject } from '@/lib/project-context'
+import { AppSidebar } from './app-sidebar'
+
+describe('AppSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders Folders before Projects in the org nav', () => {
+    ;(useOrg as Mock).mockReturnValue({
+      selectedOrg: 'test-org',
+      organizations: [{ name: 'test-org', displayName: 'Test Org' }],
+      setSelectedOrg: vi.fn(),
+      isLoading: false,
+    })
+    ;(useProject as Mock).mockReturnValue({
+      projects: [],
+      selectedProject: null,
+      setSelectedProject: vi.fn(),
+      isLoading: false,
+    })
+
+    render(<AppSidebar />)
+
+    const foldersItem = screen.getByText('Folders')
+    const projectsItem = screen.getByText('Projects')
+
+    // Both items should be rendered
+    expect(foldersItem).toBeInTheDocument()
+    expect(projectsItem).toBeInTheDocument()
+
+    // Folders should appear before Projects in DOM order
+    const sidebarMenus = screen.getAllByTestId('sidebar-menu')
+    // The org nav menu is the first menu in SidebarContent
+    const orgMenu = sidebarMenus[0]
+    const items = orgMenu.querySelectorAll('li')
+    const labels = Array.from(items).map((li) => li.textContent)
+
+    expect(labels.indexOf('Folders')).toBeLessThan(labels.indexOf('Projects'))
+  })
+})

--- a/frontend/src/components/-create-project-dialog.test.tsx
+++ b/frontend/src/components/-create-project-dialog.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('@/queries/organizations', () => ({
+  useListOrganizations: vi.fn(),
+  useGetOrganization: vi.fn(),
+}))
+vi.mock('@/queries/projects', () => ({
+  useCreateProject: vi.fn(),
+}))
+vi.mock('@/queries/folders', () => ({
+  useListFolders: vi.fn(),
+}))
+vi.mock('@/gen/holos/console/v1/folders_pb', () => ({
+  ParentType: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2 },
+}))
+vi.mock('@/lib/auth', () => ({ useAuth: vi.fn() }))
+
+import { useListOrganizations, useGetOrganization } from '@/queries/organizations'
+import { useCreateProject } from '@/queries/projects'
+import { useListFolders } from '@/queries/folders'
+import { CreateProjectDialog } from './create-project-dialog'
+
+const mockOrgs = [
+  { name: 'acme', displayName: 'Acme Corp' },
+  { name: 'other', displayName: 'Other Org' },
+]
+
+const mockFolders = [
+  { name: 'default', displayName: 'Default', organization: 'acme' },
+  { name: 'staging', displayName: 'Staging', organization: 'acme' },
+]
+
+const mockMutateAsync = vi.fn().mockResolvedValue({ name: 'my-project' })
+
+function setup(defaultOrganization?: string) {
+  ;(useListOrganizations as Mock).mockReturnValue({
+    data: { organizations: mockOrgs },
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { defaultFolder: 'default' },
+    isPending: false,
+    error: null,
+  })
+  ;(useListFolders as Mock).mockReturnValue({
+    data: mockFolders,
+    isPending: false,
+    error: null,
+  })
+  ;(useCreateProject as Mock).mockReturnValue({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  })
+
+  return render(
+    <CreateProjectDialog
+      open={true}
+      onOpenChange={vi.fn()}
+      defaultOrganization={defaultOrganization}
+    />,
+  )
+}
+
+describe('CreateProjectDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMutateAsync.mockResolvedValue({ name: 'my-project' })
+  })
+
+  it('renders the Folder combobox', () => {
+    setup('acme')
+    const folderCombobox = screen.getByRole('combobox', { name: /folder/i })
+    expect(folderCombobox).toBeInTheDocument()
+  })
+
+  it('defaults folder to the org default folder', async () => {
+    setup('acme')
+    // The org has defaultFolder='default', so the combobox should show "Default"
+    await waitFor(() => {
+      const folderCombobox = screen.getByRole('combobox', { name: /folder/i })
+      expect(folderCombobox).toHaveTextContent('Default')
+    })
+  })
+
+  it('includes "None (organization root)" option in folder picker', () => {
+    setup('acme')
+    const folderCombobox = screen.getByRole('combobox', { name: /folder/i })
+    fireEvent.click(folderCombobox)
+    expect(screen.getByText('None (organization root)')).toBeInTheDocument()
+  })
+
+  it('shows folder display names in the picker', () => {
+    setup('acme')
+    const folderCombobox = screen.getByRole('combobox', { name: /folder/i })
+    fireEvent.click(folderCombobox)
+    expect(screen.getByText('Staging')).toBeInTheDocument()
+  })
+
+  it('sends parentType=FOLDER and parentName when a folder is selected', async () => {
+    setup('acme')
+    // Wait for the default folder to be set
+    await waitFor(() => {
+      const folderCombobox = screen.getByRole('combobox', { name: /folder/i })
+      expect(folderCombobox).toHaveTextContent('Default')
+    })
+
+    // Fill in required fields
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Project' } })
+
+    // Submit the form
+    const form = screen.getByRole('form')
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentType: 2, // FOLDER
+          parentName: 'default',
+          organization: 'acme',
+        }),
+      )
+    })
+  })
+
+  it('sends parentType=ORGANIZATION when "None" is selected', async () => {
+    // Set up with no default folder
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { defaultFolder: '' },
+      isPending: false,
+      error: null,
+    })
+
+    render(
+      <CreateProjectDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        defaultOrganization="acme"
+      />,
+    )
+
+    // Fill in required fields
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Project' } })
+
+    // Submit the form
+    const form = screen.getByRole('form')
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentType: 1, // ORGANIZATION
+          parentName: 'acme',
+          organization: 'acme',
+        }),
+      )
+    })
+  })
+})

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -80,16 +80,16 @@ export function AppSidebar() {
   }> = selectedOrg
     ? [
         {
-          label: 'Projects',
-          to: '/orgs/$orgName/projects' as const,
-          params: { orgName: selectedOrg },
-          icon: FolderKanban,
-        },
-        {
           label: 'Folders',
           to: '/orgs/$orgName/folders' as const,
           params: { orgName: selectedOrg },
           icon: Folder,
+        },
+        {
+          label: 'Projects',
+          to: '/orgs/$orgName/projects' as const,
+          params: { orgName: selectedOrg },
+          icon: FolderKanban,
         },
         {
           label: 'Org Settings',

--- a/frontend/src/components/create-project-dialog.test.tsx
+++ b/frontend/src/components/create-project-dialog.test.tsx
@@ -5,12 +5,21 @@ import React from 'react'
 
 vi.mock('@/queries/organizations', () => ({
   useListOrganizations: vi.fn(),
+  useGetOrganization: vi.fn(),
   useCreateOrganization: vi.fn(),
 }))
 
 vi.mock('@/queries/projects', () => ({
   useListProjects: vi.fn(),
   useCreateProject: vi.fn(),
+}))
+
+vi.mock('@/queries/folders', () => ({
+  useListFolders: vi.fn(),
+}))
+
+vi.mock('@/gen/holos/console/v1/folders_pb', () => ({
+  ParentType: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2 },
 }))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
@@ -82,8 +91,9 @@ vi.mock('@/components/ui/combobox', () => ({
   ),
 }))
 
-import { useListOrganizations } from '@/queries/organizations'
+import { useListOrganizations, useGetOrganization } from '@/queries/organizations'
 import { useCreateProject } from '@/queries/projects'
+import { useListFolders } from '@/queries/folders'
 import { CreateProjectDialog } from './create-project-dialog'
 
 describe('CreateProjectDialog', () => {
@@ -96,18 +106,29 @@ describe('CreateProjectDialog', () => {
       data: { organizations: [{ name: 'my-org', displayName: 'My Org' }] },
       isLoading: false,
     })
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { defaultFolder: '' },
+      isPending: false,
+      error: null,
+    })
+    ;(useListFolders as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
     ;(useCreateProject as Mock).mockReturnValue({
       mutateAsync: mockMutateAsync,
       isPending: false,
     })
   })
 
-  it('renders org select, displayName, name, and description when open', () => {
+  it('renders org select, folder select, displayName, name, and description when open', () => {
     render(<CreateProjectDialog open={true} onOpenChange={onOpenChange} />)
     expect(screen.getByPlaceholderText(/my-project/i)).toBeDefined()
     expect(screen.getByPlaceholderText(/my project/i)).toBeDefined()
     expect(screen.getByPlaceholderText(/optional description/i)).toBeDefined()
-    expect(screen.getByTestId('select')).toBeDefined()
+    expect(screen.getByLabelText('Organization')).toBeDefined()
+    expect(screen.getByLabelText('Folder')).toBeDefined()
   })
 
   it('does not render when closed', () => {
@@ -117,7 +138,7 @@ describe('CreateProjectDialog', () => {
 
   it('pre-selects defaultOrganization in the org select', () => {
     render(<CreateProjectDialog open={true} onOpenChange={onOpenChange} defaultOrganization="my-org" />)
-    const select = screen.getByTestId('select') as HTMLSelectElement
+    const select = screen.getByLabelText('Organization') as HTMLSelectElement
     expect(select.value).toBe('my-org')
   })
 

--- a/frontend/src/components/create-project-dialog.tsx
+++ b/frontend/src/components/create-project-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import {
   Dialog,
@@ -13,8 +13,10 @@ import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Combobox } from '@/components/ui/combobox'
-import { useListOrganizations } from '@/queries/organizations'
+import { useListOrganizations, useGetOrganization } from '@/queries/organizations'
 import { useCreateProject } from '@/queries/projects'
+import { useListFolders } from '@/queries/folders'
+import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import { toSlug } from '@/lib/slug'
 
 export interface CreateProjectDialogProps {
@@ -35,10 +37,26 @@ export function CreateProjectDialog({
   const [nameEdited, setNameEdited] = useState(false)
   const [description, setDescription] = useState('')
   const [organization, setOrganization] = useState(defaultOrganization ?? '')
+  const [folder, setFolder] = useState('')
   const [error, setError] = useState<string | null>(null)
 
   const { data: orgsData } = useListOrganizations()
   const organizations = orgsData?.organizations ?? []
+
+  // Fetch folders for the selected organization
+  const { data: folders } = useListFolders(organization, ParentType.ORGANIZATION, organization)
+
+  // Fetch org data to get the default folder
+  const { data: orgData } = useGetOrganization(organization)
+
+  // When the org data loads (or changes), pre-select the org's default folder
+  useEffect(() => {
+    if (orgData?.defaultFolder) {
+      setFolder(orgData.defaultFolder)
+    } else {
+      setFolder('')
+    }
+  }, [orgData?.defaultFolder])
 
   const { mutateAsync, isPending } = useCreateProject()
   const navigate = useNavigate()
@@ -65,10 +83,13 @@ export function CreateProjectDialog({
     e.preventDefault()
     setError(null)
     try {
-      const response = await mutateAsync({ name, displayName, description, organization })
+      const parentType = folder ? ParentType.FOLDER : ParentType.ORGANIZATION
+      const parentName = folder || organization
+      const response = await mutateAsync({ name, displayName, description, organization, parentType, parentName })
       setName('')
       setDisplayName('')
       setDescription('')
+      setFolder('')
       setNameEdited(false)
       onCreated?.(response.name)
       onOpenChange(false)
@@ -107,6 +128,24 @@ export function CreateProjectDialog({
                 placeholder="Select organization"
                 searchPlaceholder="Search organizations..."
                 emptyMessage="No organizations found."
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="project-folder">Folder</Label>
+              <Combobox
+                aria-label="Folder"
+                items={[
+                  { value: '', label: 'None (organization root)' },
+                  ...(folders ?? []).map((f) => ({
+                    value: f.name,
+                    label: f.displayName || f.name,
+                  })),
+                ]}
+                value={folder}
+                onValueChange={setFolder}
+                placeholder="Select folder"
+                searchPlaceholder="Search folders..."
+                emptyMessage="No folders found."
               />
             </div>
             <div className="space-y-1">

--- a/frontend/src/queries/organizations.ts
+++ b/frontend/src/queries/organizations.ts
@@ -62,7 +62,7 @@ export function useUpdateOrganization() {
   const client = useMemo(() => createClient(OrganizationService, transport), [transport])
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (params: { name: string; displayName?: string; description?: string }) =>
+    mutationFn: (params: { name: string; displayName?: string; description?: string; defaultFolder?: string }) =>
       client.updateOrganization(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['connect-query'] })

--- a/frontend/src/queries/projects.ts
+++ b/frontend/src/queries/projects.ts
@@ -37,7 +37,7 @@ export function useCreateProject() {
   const client = useMemo(() => createClient(ProjectService, transport), [transport])
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (params: { name: string; displayName?: string; description?: string; organization: string }) =>
+    mutationFn: (params: { name: string; displayName?: string; description?: string; organization: string; parentType?: number; parentName?: string }) =>
       client.createProject(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['connect-query'] })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx
@@ -25,6 +25,13 @@ vi.mock('@/queries/organizations', () => ({
   useDeleteOrganization: vi.fn(),
 }))
 
+vi.mock('@/queries/folders', () => ({
+  useListFolders: vi.fn(),
+}))
+vi.mock('@/gen/holos/console/v1/folders_pb', () => ({
+  ParentType: { ORGANIZATION: 1, FOLDER: 2 },
+}))
+
 vi.mock('@/lib/auth', () => ({ useAuth: vi.fn() }))
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
@@ -36,8 +43,14 @@ import {
   useUpdateOrganizationDefaultSharing,
   useDeleteOrganization,
 } from '@/queries/organizations'
+import { useListFolders } from '@/queries/folders'
 import { useAuth } from '@/lib/auth'
 import { OrgSettingsPage } from './index'
+
+const mockFolders = [
+  { name: 'default', displayName: 'Default', organization: 'test-org' },
+  { name: 'staging', displayName: 'Staging', organization: 'test-org' },
+]
 
 const mockOrg = {
   name: 'test-org',
@@ -49,6 +62,7 @@ const mockOrg = {
   roleGrants: [],
   defaultUserGrants: [{ principal: 'bob@example.com', role: 1 }],
   defaultRoleGrants: [{ principal: 'engineering', role: 2 }],
+  defaultFolder: 'default',
   userRole: 3, // OWNER
 }
 
@@ -79,6 +93,11 @@ function setupMocks(overrides: Partial<typeof mockOrg> = {}) {
   })
   ;(useDeleteOrganization as Mock).mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+    error: null,
+  })
+  ;(useListFolders as Mock).mockReturnValue({
+    data: mockFolders,
     isPending: false,
     error: null,
   })
@@ -338,6 +357,62 @@ describe('OrgSettingsPage', () => {
       const mutateAsync = (useDeleteOrganization as Mock).mock.results[0].value.mutateAsync
       await waitFor(() => {
         expect(mutateAsync).toHaveBeenCalledWith({ name: 'test-org' })
+      })
+    })
+  })
+
+  describe('Default Folder section', () => {
+    it('renders Default Folder section for owners', () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      expect(screen.getByText('Default Folder')).toBeInTheDocument()
+    })
+
+    it('hides Default Folder section for non-owners', () => {
+      setupMocks({ userRole: 1 }) // VIEWER
+      render(<OrgSettingsPage />)
+      expect(screen.queryByText('Default Folder')).not.toBeInTheDocument()
+    })
+
+    it('renders Combobox with folder display names', () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      // The combobox should show the current default folder's display name
+      const combobox = screen.getByRole('combobox', { name: /default folder/i })
+      expect(combobox).toBeInTheDocument()
+      // "Default" is the display name of the currently selected folder
+      expect(combobox).toHaveTextContent('Default')
+    })
+
+    it('displays link to current default folder', () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      // The "Current" label and the display name link should appear
+      expect(screen.getByText('Current')).toBeInTheDocument()
+      // The folder display name is rendered as a link
+      const links = screen.getAllByText('Default')
+      // At least one should be a link (the one in the "Current" row)
+      const linkElements = links.filter((el) => el.tagName === 'A')
+      expect(linkElements.length).toBeGreaterThan(0)
+    })
+
+    it('does not display current folder link when no default folder is set', () => {
+      setupMocks({ defaultFolder: '' })
+      render(<OrgSettingsPage />)
+      expect(screen.queryByText('Current')).not.toBeInTheDocument()
+    })
+
+    it('calls updateOrganization with defaultFolder when folder is changed', async () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      const combobox = screen.getByRole('combobox', { name: /default folder/i })
+      fireEvent.click(combobox)
+      // Select "Staging" folder
+      const stagingOption = screen.getByText('Staging')
+      fireEvent.click(stagingOption)
+      const mutateAsync = (useUpdateOrganization as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({ name: 'test-org', defaultFolder: 'staging' })
       })
     })
   })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
@@ -20,7 +20,9 @@ import { Check, Pencil, X, Table2, Braces, ChevronRight } from 'lucide-react'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { ViewModeToggle } from '@/components/view-mode-toggle'
 import { RawView } from '@/components/raw-view'
+import { Combobox } from '@/components/ui/combobox'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import {
   useGetOrganization,
   useGetOrganizationRaw,
@@ -29,6 +31,7 @@ import {
   useUpdateOrganizationDefaultSharing,
   useDeleteOrganization,
 } from '@/queries/organizations'
+import { useListFolders } from '@/queries/folders'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/')({
   component: OrgSettingsRoute,
@@ -72,6 +75,18 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
 
   // Delete dialog
   const [deleteOpen, setDeleteOpen] = useState(false)
+
+  // Folders for default folder picker
+  const { data: folders } = useListFolders(orgName, ParentType.ORGANIZATION, orgName)
+
+  const handleSaveDefaultFolder = async (folderName: string) => {
+    try {
+      await updateOrganization.mutateAsync({ name: orgName, defaultFolder: folderName })
+      toast.success('Default folder updated')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
+  }
 
   const handleSaveDisplayName = async () => {
     try {
@@ -145,6 +160,11 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
   const roleGrants = (org?.roleGrants ?? []) as Grant[]
   const defaultUserGrants = (org?.defaultUserGrants ?? []) as Grant[]
   const defaultRoleGrants = (org?.defaultRoleGrants ?? []) as Grant[]
+  const defaultFolder = org?.defaultFolder ?? ''
+  const folderItems = (folders ?? []).map((f) => ({
+    value: f.name,
+    label: f.displayName || f.name,
+  }))
 
   return (
     <Card>
@@ -292,6 +312,43 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
                 )}
               </div>
             </div>
+
+            {/* Default Folder section — visible only to owners */}
+            {isOwner && (
+              <div className="space-y-4">
+                <h3 className="text-sm font-medium">Default Folder</h3>
+                <Separator />
+                <p className="text-sm text-muted-foreground">
+                  New projects will be created in this folder by default.
+                </p>
+                <div className="flex items-center gap-2">
+                  <span className="w-32 text-sm text-muted-foreground shrink-0">Folder</span>
+                  <div className="flex-1">
+                    <Combobox
+                      aria-label="Default Folder"
+                      items={folderItems}
+                      value={defaultFolder}
+                      onValueChange={handleSaveDefaultFolder}
+                      placeholder="Select default folder"
+                      searchPlaceholder="Search folders..."
+                      emptyMessage="No folders found."
+                    />
+                  </div>
+                </div>
+                {defaultFolder && (
+                  <div className="flex items-center gap-2">
+                    <span className="w-32 text-sm text-muted-foreground shrink-0">Current</span>
+                    <Link
+                      to="/orgs/$orgName/folders/$folderName"
+                      params={{ orgName, folderName: defaultFolder }}
+                      className="text-sm text-primary underline"
+                    >
+                      {folderItems.find((f) => f.value === defaultFolder)?.label ?? defaultFolder}
+                    </Link>
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Sharing section */}
             <SharingPanel

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,5 +1,19 @@
 import '@testing-library/jest-dom/vitest'
 
+// Polyfill ResizeObserver for jsdom (used by cmdk/Combobox)
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+// Polyfill scrollIntoView for jsdom (used by cmdk)
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}
+
 if (!window.matchMedia) {
   window.matchMedia = (query: string) => ({
     matches: false,


### PR DESCRIPTION
## Summary
- Reorder sidebar org nav to show Folders before Projects
- Add a Default Folder section to org settings (owner-only) with a Combobox to view/change the default folder, calling UpdateOrganization with defaultFolder
- Add a Folder Combobox to the Create Project dialog that lists org folders, pre-selects the org default folder, and sends parentType/parentName on submit
- Add jsdom polyfills (ResizeObserver, scrollIntoView) for cmdk/Combobox test compatibility
- Update useUpdateOrganization and useCreateProject query hooks to accept new fields

Closes #675

## Test plan
- [x] `make test-ui` passes (672 tests)
- [x] `make test-go` passes
- [x] `make generate` succeeds
- [ ] CI checks pass

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) · agent-2