### PR TITLE
chore: cleanup stale code and docs after default folder implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Before making changes, review `CONTRIBUTING.md` for commit message requirements.
 ## Authentication & Authorization
 
 - [Authentication](docs/agents/authentication.md) — OIDC PKCE flow, embedded Dex, test personas, and dev token endpoint.
-- [RBAC](docs/agents/rbac.md) — Three-tier grant model (org/project/secret) on K8s annotations with namespace prefixes.
+- [RBAC](docs/agents/rbac.md) — Four-tier grant model (org/folder/project/secret) on K8s annotations with namespace prefixes.
 
 ## Development Workflow
 

--- a/docs/agents/authentication.md
+++ b/docs/agents/authentication.md
@@ -30,7 +30,7 @@ curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
 
 ## Related
 
-- [RBAC](rbac.md) — Three-tier access control model that uses these identities
+- [RBAC](rbac.md) — Four-tier access control model that uses these identities
 - [Embedded Services](embedded-services.md) — How Dex is embedded in the binary
 - [Testing Patterns](testing-patterns.md) — Multi-persona E2E helpers using the dev token endpoint
 - [TLS Command Guardrail](guardrail-tls-commands.md) — Correct `--cacert` usage in examples

--- a/docs/agents/package-structure.md
+++ b/docs/agents/package-structure.md
@@ -10,9 +10,10 @@ The Go backend is organized into these packages:
   - `version.go` — Version info with embedded version files and ldflags
   - `rpc/` — ConnectRPC handler implementations and auth interceptor
   - `oidc/` — Embedded Dex OIDC provider
-  - `organizations/` — OrganizationService with K8s Namespace backend and annotation-based grants
-  - `projects/` — ProjectService with K8s Namespace backend and annotation-based grants
-  - `resolver/` — Namespace prefix resolver translating user-facing names to K8s namespace names (`{namespace-prefix}{organization-prefix}{name}` for orgs, `{namespace-prefix}{project-prefix}{name}` for projects)
+  - `folders/` — FolderService with K8s Namespace backend, slug-based identifiers, reparenting, and depth enforcement (ADR 020, ADR 022)
+  - `organizations/` — OrganizationService with K8s Namespace backend, annotation-based grants, and default folder auto-creation
+  - `projects/` — ProjectService with K8s Namespace backend, annotation-based grants, and default-folder resolution for new projects
+  - `resolver/` — Namespace prefix resolver translating user-facing names to K8s namespace names (`{namespace-prefix}{organization-prefix}{name}` for orgs, `{namespace-prefix}{folder-prefix}{name}` for folders, `{namespace-prefix}{project-prefix}{name}` for projects)
   - `secrets/` — SecretsService with K8s backend and annotation-based RBAC
   - `settings/` — ProjectSettingsService managing per-project feature flags (e.g. deployments toggle) stored as annotations on the project Namespace; deployments toggle requires org-level OWNER via `PERMISSION_PROJECT_DEPLOYMENTS_ENABLE`
   - `templates/` — Unified TemplateService; see [Template Service](template-service.md)
@@ -20,6 +21,7 @@ The Go backend is organized into these packages:
   - `dist/` — Embedded static files served at `/` (build output from frontend, not source)
 - `proto/` — Protobuf source files
   - `holos/console/v1/organizations.proto` — OrganizationService
+  - `holos/console/v1/folders.proto` — FolderService (CRUD, hierarchy, reparenting, identifier check)
   - `holos/console/v1/projects.proto` — ProjectService
   - `holos/console/v1/secrets.proto` — SecretsService
   - `holos/console/v1/project_settings.proto` — ProjectSettingsService

--- a/docs/agents/rbac.md
+++ b/docs/agents/rbac.md
@@ -1,10 +1,11 @@
 # RBAC
 
-Three-tier access control model evaluated in order (highest role wins):
+Four-tier access control model evaluated in order (highest role wins):
 
 1. **Organization-level**: Per-org grants stored as JSON annotations on K8s Namespace objects (prefix configurable via `--organization-prefix`, default `org-`)
-2. **Project-level**: Per-project grants stored as JSON annotations on K8s Namespace objects (prefix configurable via `--project-prefix`, default `prj-`)
-3. **Secret-level**: Per-secret grants stored as JSON annotations on K8s Secret objects
+2. **Folder-level**: Per-folder grants stored as JSON annotations on K8s Namespace objects (prefix configurable via `--folder-prefix`, default `fld-`)
+3. **Project-level**: Per-project grants stored as JSON annotations on K8s Namespace objects (prefix configurable via `--project-prefix`, default `prj-`)
+4. **Secret-level**: Per-secret grants stored as JSON annotations on K8s Secret objects
 
 ## Annotations
 
@@ -17,6 +18,7 @@ Metadata annotations on org/project namespaces: `console.holos.run/display-name`
 Three-part naming: `{namespace-prefix}{type-prefix}{name}`
 
 - Organizations: `{namespace-prefix}{organization-prefix}{name}` (resource-type label: `organization`)
+- Folders: `{namespace-prefix}{folder-prefix}{name}` (resource-type label: `folder`, organization label for scoping, parent label for hierarchy)
 - Projects: `{namespace-prefix}{project-prefix}{name}` (resource-type label: `project`, optional organization label for IAM inheritance, project label stores project name)
 
 The `--namespace-prefix` flag (default `"holos-"`) prefixes all console-managed namespace names, enabling multi-instance isolation in the same cluster (e.g., `prod-org-acme`, `ci-prj-api`).
@@ -24,6 +26,8 @@ The `--namespace-prefix` flag (default `"holos-"`) prefixes all console-managed 
 ## Organization Creation
 
 Organization creation is controlled by `--disable-org-creation`, `--org-creator-users`, and `--org-creator-roles` CLI flags. By default all authenticated principals can create organizations (implicit grant). Setting `--disable-org-creation` disables this implicit grant; explicit `--org-creator-users` and `--org-creator-roles` lists are still honored.
+
+Creating an organization also auto-creates a default folder (slug-based identifier, e.g., `holos-fld-default`) as an immediate child. The default folder's identifier is stored in the `console.holos.run/default-folder` annotation on the organization namespace. See [Resource Naming Guardrail](guardrail-resource-naming.md) for the slug-based naming model.
 
 ## Roles Claim
 
@@ -34,6 +38,8 @@ The `--roles-claim` flag (default `"groups"`) configures which OIDC token claim 
 Roles: VIEWER (1), EDITOR (2), OWNER (3) defined in `proto/holos/console/v1/rbac.proto`
 
 `PERMISSION_TEMPLATES_WRITE` is required to create, update, or delete templates at any scope. It is granted to EDITORs and OWNERs via the unified `TemplateCascadePerms` cascade table in `console/rbac/rbac.go`.
+
+`PERMISSION_REPARENT` is required to move a folder or project to a different parent. It is granted only to OWNERs via the `ReparentCascadePerms` cascade table. The caller must hold this permission on both the source parent and the destination parent. This is deliberately more restrictive than WRITE because reparenting changes RBAC inheritance chains (ADR 022 Decision 6).
 
 ## Related
 

--- a/docs/permissions-guide.md
+++ b/docs/permissions-guide.md
@@ -8,6 +8,8 @@ Each permission should control a single capability. Avoid bundling unrelated act
 
 **Good**: `PERMISSION_PROJECT_DEPLOYMENTS_ENABLE` controls only the ability to toggle the deployments feature flag on a project.
 
+**Good**: `PERMISSION_REPARENT` controls only the ability to move a folder or project to a different parent. It is separate from WRITE because reparenting changes RBAC inheritance chains — an EDITOR who can modify folder metadata should not be able to move a subtree into a scope where they gain elevated permissions (ADR 022 Decision 6).
+
 **Bad**: `PERMISSION_PROJECT_SETTINGS_WRITE` covering both deployments toggle and future settings (too broad to delegate independently).
 
 When a new action could reasonably be granted independently of existing permissions, create a dedicated permission rather than reusing an existing one.
@@ -61,6 +63,20 @@ var TemplateCascadePerms = rbac.CascadeTable{
 same table (`TemplateCascadePerms`) applies uniformly at every scope level (ADR 021 Decision 2)
 — a VIEWER can read, an EDITOR can write, and an OWNER has full control regardless of whether
 the template is org-scoped, folder-scoped, or project-scoped.
+
+A third cascade table controls reparenting access at organization and folder scope:
+
+```go
+var ReparentCascadePerms = rbac.CascadeTable{
+    rbac.RoleOwner: {
+        rbac.PermissionReparent: true,
+    },
+}
+```
+
+`PERMISSION_REPARENT` is granted only to OWNERs. The caller must hold this permission on both the
+source parent and the destination parent to move a folder or project. This is deliberately more
+restrictive than WRITE because reparenting changes RBAC inheritance chains (ADR 022 Decision 6).
 
 To check access: resolve the user's best role from grants at the parent scope, then look up permissions in the cascade table.
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,6 +1,6 @@
 # Role-Based Access Control (RBAC)
 
-holos-console uses a three-tier access control model combining **organization-level grants**, **project-level grants**, and **per-secret sharing grants**.
+holos-console uses a four-tier access control model combining **organization-level grants**, **folder-level grants**, **project-level grants**, and **per-secret sharing grants**.
 
 ## Organizations
 
@@ -18,9 +18,15 @@ Organization creation is controlled by CLI flags rather than grant-based authori
 
 The creator is automatically added as owner on the new organization.
 
+## Folders
+
+A **folder** is a Kubernetes Namespace with the name `{namespace-prefix}{folder-prefix}{name}` (defaults: empty namespace prefix, `fld-` folder prefix) and the label `console.holos.run/resource-type=folder`. Folders are optional intermediate grouping levels between an Organization and a Project (ADR 020). The `console.holos.run/organization` label scopes the folder to an organization. The `console.holos.run/parent` label stores the parent namespace name (organization or another folder). Maximum folder depth is 3 levels between an organization and a project (ADR 020 Decision 5).
+
+A **default folder** is auto-created when an organization is created. Its identifier is derived from the display name (default: "Default") using slug-based naming (ADR 022 Decision 3). The organization stores the default folder's identifier in the `console.holos.run/default-folder` annotation. New projects without an explicit parent are placed in the default folder.
+
 ## Projects
 
-A **project** is a Kubernetes Namespace with the name `{namespace-prefix}{project-prefix}{name}` (defaults: empty namespace prefix, `prj-` project prefix) and the label `console.holos.run/resource-type=project`. Projects are global resources — the `console.holos.run/organization` label is optional and represents an IAM association, not a containment relationship. The project name is stored in the `console.holos.run/project` label. Permission grants are stored as annotations on the Namespace resource.
+A **project** is a Kubernetes Namespace with the name `{namespace-prefix}{project-prefix}{name}` (defaults: empty namespace prefix, `prj-` project prefix) and the label `console.holos.run/resource-type=project`. Projects are global resources — the `console.holos.run/organization` label is optional and represents an IAM association, not a containment relationship. The project name is stored in the `console.holos.run/project` label. The `console.holos.run/parent` label stores the parent namespace name (organization or folder). Permission grants are stored as annotations on the Namespace resource.
 
 Project grants cascade to all secrets within the project. Users see only projects where they have at least viewer-level access (directly or via an associated organization).
 
@@ -31,13 +37,15 @@ User-facing names are translated to Kubernetes namespace names using a three-par
 | Resource | Pattern | CLI Flags | Default | Example (`--namespace-prefix=prod-`) |
 |---|---|---|---|---|
 | Organization | `{namespace-prefix}{org-prefix}{name}` | `--namespace-prefix`, `--organization-prefix` | `""`, `org-` | `acme` → `prod-org-acme` |
+| Folder | `{namespace-prefix}{fld-prefix}{name}` | `--namespace-prefix`, `--folder-prefix` | `""`, `fld-` | `default` → `prod-fld-default` |
 | Project | `{namespace-prefix}{prj-prefix}{name}` | `--namespace-prefix`, `--project-prefix` | `""`, `prj-` | `api` → `prod-prj-api` |
 
 When `--namespace-prefix` is empty (the default), the naming scheme is unchanged from the two-part `{type-prefix}{name}` form (e.g., `org-acme`, `prj-api`).
 
 Namespaces are distinguished by labels:
-- `console.holos.run/resource-type`: `organization` or `project`
-- `console.holos.run/organization`: the organization name (optional, on project namespaces)
+- `console.holos.run/resource-type`: `organization`, `folder`, or `project`
+- `console.holos.run/organization`: the organization name (on folder and project namespaces)
+- `console.holos.run/parent`: the parent namespace name (on folder and project namespaces)
 - `console.holos.run/project`: the project name (on project namespaces)
 
 ## Access Evaluation
@@ -83,8 +91,9 @@ Metadata annotations are stored on organization and project Namespace resources:
 
 | Annotation | Resource | Description |
 |---|---|---|
-| `console.holos.run/display-name` | Organization, Project | Human-readable display name |
-| `console.holos.run/creator-email` | Organization, Project | Email address of the user who created the resource |
+| `console.holos.run/display-name` | Organization, Folder, Project | Human-readable display name |
+| `console.holos.run/creator-email` | Organization, Folder, Project | Email address of the user who created the resource |
+| `console.holos.run/default-folder` | Organization | Identifier of the default folder for new projects |
 
 The `creator-email` annotation is written at creation time from the authenticated user's OIDC email claim. It is read-only after creation and surfaced in the settings UI.
 
@@ -134,6 +143,8 @@ Parent grants do **not** implicitly grant full access to child resources:
 
 `PERMISSION_PROJECTS_CREATE` requires owner on **at least one existing project** or owner on the target organization (checked via a separate authorization path, not cascade).
 
+`PERMISSION_REPARENT` is required to move a folder or project to a different parent. The caller must hold this permission on **both** the source parent and the destination parent. It is granted only to OWNERs via the `ReparentCascadePerms` cascade table (ADR 022 Decision 6).
+
 Organization creation is controlled by CLI flags (`--disable-org-creation`, `--org-creator-users`, `--org-creator-roles`), not by grant-based authorization.
 
 ## Organization Default Sharing
@@ -156,6 +167,22 @@ metadata:
     console.holos.run/creator-email: "alice@example.com"
     console.holos.run/share-users: '[{"principal":"alice@example.com","role":"owner"}]'
     console.holos.run/share-roles: '[{"principal":"dev-team","role":"editor"}]'
+    console.holos.run/default-folder: "default"
+---
+# Default folder namespace (auto-created with the organization)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fld-default
+  labels:
+    app.kubernetes.io/managed-by: console.holos.run
+    console.holos.run/resource-type: folder
+    console.holos.run/organization: my-org
+    console.holos.run/parent: org-my-org
+  annotations:
+    console.holos.run/display-name: "Default"
+    console.holos.run/creator-email: "alice@example.com"
+    console.holos.run/share-users: '[{"principal":"alice@example.com","role":"owner"}]'
 ---
 # Project namespace (optionally associated with the organization)
 apiVersion: v1
@@ -204,6 +231,17 @@ In this example:
 | Delete secrets | - | - | Yes |
 | Update sharing grants | - | - | Yes |
 
+### Folder Permissions
+
+| Permission | Viewer | Editor | Owner |
+|---|---|---|---|
+| List folders | Yes | Yes | Yes |
+| Read folder metadata | Yes | Yes | Yes |
+| Update folder metadata | - | Yes | Yes |
+| Delete folder | - | - | Yes |
+| Update folder sharing | - | - | Yes |
+| Reparent folder | - | - | Yes (on both source and destination parents) |
+
 ### Project Permissions
 
 | Permission | Viewer | Editor | Owner |
@@ -214,6 +252,7 @@ In this example:
 | Delete project | - | - | Yes |
 | Update project sharing | - | - | Yes |
 | Create new projects | - | - | Yes (on any project or org) |
+| Reparent project | - | - | Yes (on both source and destination parents) |
 
 ### Organization Permissions
 

--- a/frontend/src/gen/holos/console/v1/projects_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/projects_pb.d.ts
@@ -272,7 +272,8 @@ export declare type CreateProjectRequest = Message<"holos.console.v1.CreateProje
 
   /**
    * parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-   * When unset, defaults to organization.
+   * When unset, defaults to the organization's default folder (ADR 022 Decision 5).
+   * Falls back to the organization if no default folder is configured.
    *
    * @generated from field: string parent_name = 8;
    */

--- a/gen/holos/console/v1/projects.pb.go
+++ b/gen/holos/console/v1/projects.pb.go
@@ -400,7 +400,8 @@ type CreateProjectRequest struct {
 	// Defaults to PARENT_TYPE_ORGANIZATION when unset.
 	ParentType ParentType `protobuf:"varint,7,opt,name=parent_type,json=parentType,proto3,enum=holos.console.v1.ParentType" json:"parent_type,omitempty"`
 	// parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-	// When unset, defaults to organization.
+	// When unset, defaults to the organization's default folder (ADR 022 Decision 5).
+	// Falls back to the organization if no default folder is configured.
 	ParentName    string `protobuf:"bytes,8,opt,name=parent_name,json=parentName,proto3" json:"parent_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/holos/console/v1/projects.proto
+++ b/proto/holos/console/v1/projects.proto
@@ -130,7 +130,8 @@ message CreateProjectRequest {
   // Defaults to PARENT_TYPE_ORGANIZATION when unset.
   ParentType parent_type = 7;
   // parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-  // When unset, defaults to organization.
+  // When unset, defaults to the organization's default folder (ADR 022 Decision 5).
+  // Falls back to the organization if no default folder is configured.
   string parent_name = 8;
 }
 


### PR DESCRIPTION
## Summary
- Update RBAC docs from three-tier to four-tier model (org/folder/project/secret)
- Add PERMISSION_REPARENT documentation to permissions-guide.md and docs/rbac.md
- Add console/folders/ package and folders.proto to package-structure.md
- Add folder section with default folder behavior to docs/rbac.md
- Fix stale proto comment on CreateProjectRequest.parent_name to reference default folder
- Update docs/agents/authentication.md cross-link to match four-tier model

Closes #677

## Test plan
- [x] `make generate` succeeds
- [x] `make test` passes (all Go + UI tests green)
- [x] `go vet ./...` passes with no issues
- [x] No stale TODO/FIXME comments related to folder/reparent work
- [x] No random-only numeric identifiers in test fixtures
- [x] ADR 022 accurately documents slug-based global namespace model

Generated with [Claude Code](https://claude.com/claude-code) - agent-2