### PR TITLE
fix: skip K8s write for no-op reparent in folders and projects

### DIFF
--- a/console/folders/handler.go
+++ b/console/folders/handler.go
@@ -315,8 +315,12 @@ func (h *Handler) UpdateFolder(
 		}
 	}
 
-	if _, err := h.k8s.UpdateFolder(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
-		return nil, mapK8sError(err)
+	// Only issue a K8s write when metadata fields are provided; skip when the
+	// request is a reparent-only operation (or a no-op same-parent reparent).
+	if req.Msg.DisplayName != nil || req.Msg.Description != nil {
+		if _, err := h.k8s.UpdateFolder(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
+			return nil, mapK8sError(err)
+		}
 	}
 
 	slog.InfoContext(ctx, "folder updated",

--- a/console/folders/handler_test.go
+++ b/console/folders/handler_test.go
@@ -36,6 +36,13 @@ func contextWithClaims(email string, groups ...string) context.Context {
 
 // newTestHandler creates a handler with a fake K8s client pre-populated with namespaces.
 func newTestHandler(namespaces ...*corev1.Namespace) *Handler {
+	handler, _ := newTestHandlerWithClient(namespaces...)
+	return handler
+}
+
+// newTestHandlerWithClient creates a handler and returns the fake K8s clientset
+// so tests can inspect the actions taken.
+func newTestHandlerWithClient(namespaces ...*corev1.Namespace) (*Handler, *fake.Clientset) {
 	objs := make([]runtime.Object, len(namespaces))
 	for i, ns := range namespaces {
 		objs[i] = ns
@@ -43,7 +50,7 @@ func newTestHandler(namespaces ...*corev1.Namespace) *Handler {
 	fakeClient := fake.NewClientset(objs...)
 	k8s := NewK8sClient(fakeClient, testResolver())
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
-	return NewHandler(k8s)
+	return NewHandler(k8s), fakeClient
 }
 
 // folderNSWithGrants creates a folder namespace with share-users annotation.
@@ -902,6 +909,36 @@ func TestUpdateFolder_Reparent_SameParentIsNoop(t *testing.T) {
 	}))
 	if err != nil {
 		t.Fatalf("expected no error (no-op), got %v", err)
+	}
+}
+
+func TestUpdateFolder_Reparent_SameParentSkipsK8sWrite(t *testing.T) {
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	f := folderNSWithGrants("rp-noop-2", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	handler, fakeClient := newTestHandlerWithClient(orgNs, f)
+	ctx := contextWithClaims("alice@example.com")
+
+	// Record action count before the call.
+	beforeActions := len(fakeClient.Actions())
+
+	// Move to same parent with no metadata changes.
+	newParentType := consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	newParentName := "acme"
+	_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+		Name:       "rp-noop-2",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify no update actions were issued after the initial get.
+	afterActions := fakeClient.Actions()
+	for _, action := range afterActions[beforeActions:] {
+		if action.GetVerb() == "update" {
+			t.Fatalf("expected no K8s update for same-parent reparent with no metadata changes, but got update action on %s", action.GetResource().Resource)
+		}
 	}
 }
 

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -373,8 +373,12 @@ func (h *Handler) UpdateProject(
 		}
 	}
 
-	if _, err := h.k8s.UpdateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
-		return nil, mapK8sError(err)
+	// Only issue a K8s write when metadata fields are provided; skip when the
+	// request is a reparent-only operation (or a no-op same-parent reparent).
+	if req.Msg.DisplayName != nil || req.Msg.Description != nil {
+		if _, err := h.k8s.UpdateProject(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
+			return nil, mapK8sError(err)
+		}
 	}
 
 	slog.InfoContext(ctx, "project updated",

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -856,13 +856,20 @@ func (m *mockOrgResolver) GetOrgGrants(_ context.Context, _ string) (map[string]
 }
 
 func newHandlerWithOrg(orgResolver OrgResolver, namespaces ...*corev1.Namespace) *Handler {
+	handler, _ := newHandlerWithOrgAndClient(orgResolver, namespaces...)
+	return handler
+}
+
+// newHandlerWithOrgAndClient creates a handler and returns the fake K8s
+// clientset so tests can inspect the actions taken.
+func newHandlerWithOrgAndClient(orgResolver OrgResolver, namespaces ...*corev1.Namespace) (*Handler, *fake.Clientset) {
 	objs := make([]runtime.Object, len(namespaces))
 	for i, ns := range namespaces {
 		objs[i] = ns
 	}
 	fakeClient := fake.NewClientset(objs...)
 	k8s := NewK8sClient(fakeClient, testResolver())
-	return NewHandler(k8s, orgResolver)
+	return NewHandler(k8s, orgResolver), fakeClient
 }
 
 // managedNSWithOrg creates a managed project namespace associated with an org.
@@ -1582,6 +1589,42 @@ func TestUpdateProject_Reparent_SameParentIsNoop(t *testing.T) {
 	}))
 	if err != nil {
 		t.Fatalf("expected no error (no-op), got %v", err)
+	}
+}
+
+func TestUpdateProject_Reparent_SameParentSkipsK8sWrite(t *testing.T) {
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	folder := folderNSWithGrants("rp-prj-noop2", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	prj := projectNSWithParent("rp-prj-noop2-test", "acme", "holos-fld-rp-prj-noop2", `[{"principal":"alice@example.com","role":"editor"}]`)
+
+	handler, fakeClient := newHandlerWithOrgAndClient(
+		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
+		orgNs, folder, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	// Record action count before the call.
+	beforeActions := len(fakeClient.Actions())
+
+	// Move to same parent with no metadata changes.
+	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+	newParentName := "rp-prj-noop2"
+	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+		Name:       "rp-prj-noop2-test",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify no update actions were issued after the initial get.
+	afterActions := fakeClient.Actions()
+	for _, action := range afterActions[beforeActions:] {
+		if action.GetVerb() == "update" {
+			t.Fatalf("expected no K8s update for same-parent reparent with no metadata changes, but got update action on %s", action.GetResource().Resource)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Guard `k8s.UpdateFolder` and `k8s.UpdateProject` calls behind a nil-check on `DisplayName` and `Description`
- When a reparent request targets the same parent and no metadata fields are provided, the handler now skips the K8s namespace update entirely
- Adds tests verifying no K8s update action is issued for same-parent reparent with no metadata changes

Closes #725

## Test plan
- [x] `TestUpdateFolder_Reparent_SameParentSkipsK8sWrite` — verifies no update action for same-parent folder reparent
- [x] `TestUpdateProject_Reparent_SameParentSkipsK8sWrite` — verifies no update action for same-parent project reparent
- [x] All existing `TestUpdateFolder_Reparent_*` tests pass
- [x] All existing `TestUpdateProject_Reparent_*` tests pass
- [x] `make test-go` passes

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)