### PR TITLE
fix: reset folder state when switching organizations in create project dialog

### DIFF
--- a/frontend/src/components/create-project-dialog.test.tsx
+++ b/frontend/src/components/create-project-dialog.test.tsx
@@ -212,6 +212,58 @@ describe('CreateProjectDialog', () => {
     })
   })
 
+  it('resets folder state when organization changes so submit uses org as parent', async () => {
+    // Both orgs have no default folder. The user manually selects folder-a
+    // from org-a, then switches to org-b and submits. Without an explicit
+    // reset the folder state retains 'folder-a', causing handleSubmit to send
+    // parentType=FOLDER + parentName='folder-a' — an invalid cross-org link.
+    mockMutateAsync.mockResolvedValue({ name: 'new-project' })
+    ;(useListOrganizations as Mock).mockReturnValue({
+      data: {
+        organizations: [
+          { name: 'org-a', displayName: 'Org A' },
+          { name: 'org-b', displayName: 'Org B' },
+        ],
+      },
+      isLoading: false,
+    })
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { defaultFolder: '' },
+      isPending: false,
+      error: null,
+    })
+    ;(useListFolders as Mock).mockImplementation((org: string) => {
+      if (org === 'org-a') return { data: [{ name: 'folder-a', displayName: 'Folder A' }], isPending: false, error: null }
+      return { data: [], isPending: false, error: null }
+    })
+
+    render(<CreateProjectDialog open={true} onOpenChange={onOpenChange} defaultOrganization="org-a" />)
+
+    // Manually select folder-a from org-a's folder list.
+    const folderSelect = screen.getByLabelText('Folder') as HTMLSelectElement
+    fireEvent.change(folderSelect, { target: { value: 'folder-a' } })
+    expect(folderSelect.value).toBe('folder-a')
+
+    // Switch to org-b.
+    const orgSelect = screen.getByLabelText('Organization') as HTMLSelectElement
+    fireEvent.change(orgSelect, { target: { value: 'org-b' } })
+
+    // Fill in required fields and submit.
+    fireEvent.change(screen.getByPlaceholderText(/my project/i), { target: { value: 'Test' } })
+    fireEvent.submit(screen.getByRole('form'))
+
+    // The submit must use organization as the parent (folder was cleared).
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: 'org-b',
+          parentType: 1, // ParentType.ORGANIZATION
+          parentName: 'org-b',
+        })
+      )
+    })
+  })
+
   it('does not close dialog on error', async () => {
     mockMutateAsync.mockRejectedValue(new Error('server error'))
     render(<CreateProjectDialog open={true} onOpenChange={onOpenChange} defaultOrganization="my-org" />)

--- a/frontend/src/components/create-project-dialog.tsx
+++ b/frontend/src/components/create-project-dialog.tsx
@@ -49,12 +49,17 @@ export function CreateProjectDialog({
   // Fetch org data to get the default folder
   const { data: orgData } = useGetOrganization(organization)
 
+  // Reset folder when the selected organization changes to avoid stale
+  // cross-org folder references (the backend rejects them, but the UX
+  // should not allow submission in that state).
+  useEffect(() => {
+    setFolder('')
+  }, [organization])
+
   // When the org data loads (or changes), pre-select the org's default folder
   useEffect(() => {
     if (orgData?.defaultFolder) {
       setFolder(orgData.defaultFolder)
-    } else {
-      setFolder('')
     }
   }, [orgData?.defaultFolder])
 


### PR DESCRIPTION
## Summary
- Add a `useEffect` that resets `folder` to `''` when `organization` changes, preventing stale cross-org folder references
- The reset runs before the default-folder effect, so the new org's default folder is still applied when data loads
- Remove the `else { setFolder('') }` branch from the default-folder effect (now handled by the org-change effect)

Closes #731

## Test plan
- [x] New test: `resets folder state when organization changes so submit uses org as parent` — selects folder-a under org-a, switches to org-b, submits, verifies parentType=ORGANIZATION with parentName='org-b'
- [x] All 12 CreateProjectDialog tests pass
- [x] `make test-ui` — all 687 tests pass

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)