### PR TITLE
fix: address non-critical review findings from PR #734

### DIFF
--- a/frontend/src/queries/folders.ts
+++ b/frontend/src/queries/folders.ts
@@ -89,7 +89,7 @@ export function useUpdateFolder(organization: string, name: string) {
       client.updateFolder({ organization, name, ...params }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
-      queryClient.invalidateQueries({ queryKey: folderGetKey(name, organization) })
+      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
     },
   })
 }

--- a/frontend/src/routes/_authenticated/orgs/$orgName/folders/$folderName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/folders/$folderName.tsx
@@ -1,10 +1,5 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/folders/$folderName')({
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: '/folders/$folderName',
-      params: { folderName: params.folderName },
-    })
-  },
+  component: () => <Outlet />,
 })


### PR DESCRIPTION
## Summary

- Convert the legacy folder layout route (`orgs/$orgName/folders/$folderName.tsx`) from an unconditional `beforeLoad` redirect to a pass-through `<Outlet />` component. The previous redirect fired before child routes, breaking navigation to `/orgs/$orgName/folders/$folderName/templates` — it would redirect to `/folders/$folderName` instead of letting the child `templates.tsx` redirect to `/folders/$folderName/templates`.
- Broaden `useUpdateFolder` cache invalidation from `folderGetKey(name, organization)` to `['folders', 'get']`. The folder detail page calls `useGetFolder(folderName)` without an organization, caching under a different key than what `useUpdateFolder` was invalidating. After editing a folder, the page showed stale data until a full reload.

Closes #737

## Test plan
- [ ] Visit `/orgs/<org>/folders/<folder>/templates` and verify it redirects to `/folders/<folder>/templates` (not `/folders/<folder>`)
- [ ] Visit `/orgs/<org>/folders/<folder>` and verify it redirects to `/folders/<folder>` (index redirect still works)
- [ ] Edit a folder's display name or description on the detail page and verify the page updates immediately without a full reload
- [ ] All 686 UI tests pass (`make test-ui`)
- [ ] All Go tests pass (`make test-go`)

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)