### PR TITLE
fix: add depth filtering and stronger test assertions for folder parent picker

### DIFF
--- a/frontend/src/routes/_authenticated/folders/$folderName/-folder-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-folder-detail.test.tsx
@@ -186,20 +186,46 @@ describe('FolderDetailPage', () => {
       })
     })
 
-    it('excludes self and descendants from parent options', () => {
+    it('excludes self and descendants from parent options', async () => {
       setupMocks()
       render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
       fireEvent.click(screen.getByRole('button', { name: /change parent/i }))
-      // After clicking Change Parent, the combobox renders. The trigger shows
-      // the current parent value and the items list is built from parentOptions.
-      // Verify by checking the combobox trigger exists and then inspect items:
-      const combobox = screen.getByRole('combobox', { name: /parent picker/i })
-      expect(combobox).toBeInTheDocument()
-      // The trigger text should show the current parent (org root), which
-      // confirms the combobox was rendered with the correct current value.
-      // We verify the filtered options indirectly by confirming that clicking
-      // "Other Folder" in the popover triggers the reparent flow (tested in
-      // the "shows confirmation dialog" test above).
+      // Open the combobox popover to inspect rendered items.
+      fireEvent.click(screen.getByRole('combobox', { name: /parent picker/i }))
+      await waitFor(() => {
+        // Valid option: other-folder must be present in the popover.
+        expect(screen.getByText('Other Folder')).toBeInTheDocument()
+      })
+      // Descendant (child-folder) must be excluded from the options.
+      // child-folder does not appear anywhere else on the page, so absence
+      // from the DOM confirms it was filtered out of the combobox items.
+      expect(screen.queryByText('Child Folder')).not.toBeInTheDocument()
+    })
+
+    it('excludes folders that would exceed max folder depth', async () => {
+      // Hierarchy: org -> level1 -> level2 -> level3
+      // Moving test-folder (which has child-folder, subtreeDepth=2) under
+      // level2 would produce depth 2+2=4 > maxFolderDepth(3). So level2
+      // must be excluded. level1 (depth 1+2=3) is allowed.
+      const deepFolders = [
+        { name: 'test-folder', displayName: 'Test Folder', parentType: 1, parentName: 'test-org' },
+        { name: 'child-folder', displayName: 'Child Folder', parentType: 2, parentName: 'test-folder' },
+        { name: 'level1', displayName: 'Level 1', parentType: 1, parentName: 'test-org' },
+        { name: 'level2', displayName: 'Level 2', parentType: 2, parentName: 'level1' },
+        { name: 'level3', displayName: 'Level 3', parentType: 2, parentName: 'level2' },
+      ]
+      setupMocks({ folders: deepFolders })
+      render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
+      fireEvent.click(screen.getByRole('button', { name: /change parent/i }))
+      fireEvent.click(screen.getByRole('combobox', { name: /parent picker/i }))
+      await waitFor(() => {
+        // level1 (depth=1) is valid: 1+2=3 <= 3
+        expect(screen.getByText('Level 1')).toBeInTheDocument()
+        // level2 (depth=2) is invalid: 2+2=4 > 3
+        expect(screen.queryByText('Level 2')).not.toBeInTheDocument()
+        // level3 is a descendant of level2, excluded by depth (3+2=5 > 3)
+        expect(screen.queryByText('Level 3')).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -117,11 +117,52 @@ export function FolderDetailPage({
     }
   }
 
-  // Build parent picker options: org root + all folders except self and descendants
+  // Depth helpers: mirrors backend computeFolderDepth / computeSubtreeDepth.
+  // maxFolderDepth must match console/folders/handler.go:maxFolderDepth.
+  const maxFolderDepth = 3
+
+  // computeFolderDepth: count folder levels from a folder up to the org root.
+  // Org root = 0, folder directly under org = 1, nested under another folder = 2, etc.
+  const computeFolderDepth = (name: string): number => {
+    if (!allFolders) return 0
+    let depth = 0
+    let current = name
+    for (let i = 0; i <= maxFolderDepth; i++) {
+      const f = allFolders.find((fld) => fld.name === current)
+      if (!f) return depth
+      depth++ // count this folder as a level
+      if (f.parentType !== ParentType.FOLDER) return depth
+      current = f.parentName
+    }
+    return depth
+  }
+
+  // computeSubtreeDepth: max folder depth below and including a folder. Leaf = 1.
+  const computeSubtreeDepth = (name: string): number => {
+    if (!allFolders) return 1
+    const children = allFolders.filter(
+      (f) => f.parentType === ParentType.FOLDER && f.parentName === name,
+    )
+    if (children.length === 0) return 1
+    return 1 + Math.max(...children.map((c) => computeSubtreeDepth(c.name)))
+  }
+
+  const subtreeDepth = computeSubtreeDepth(folderName)
+
+  // Build parent picker options: org root + folders that pass all filters:
+  // not self, not a descendant, and would not exceed maxFolderDepth.
   const parentOptions: ComboboxItem[] = [
     { value: `org:${orgName}`, label: `${org?.displayName || orgName} (organization root)` },
     ...(allFolders ?? [])
-      .filter((f) => f.name !== folderName && !descendantNames.has(f.name))
+      .filter((f) => {
+        if (f.name === folderName || descendantNames.has(f.name)) return false
+        // Depth check: the folder being moved (with its subtree) would sit
+        // under this candidate. candidateDepth counts folder levels above
+        // the candidate; placing a subtree of subtreeDepth under it yields
+        // candidateDepth + subtreeDepth total depth.
+        const candidateDepth = computeFolderDepth(f.name)
+        return candidateDepth + subtreeDepth <= maxFolderDepth
+      })
       .map((f) => ({ value: `folder:${f.name}`, label: f.displayName || f.name })),
   ]
 


### PR DESCRIPTION
## Summary
- Add client-side depth filtering to the folder parent picker that mirrors the backend's `computeFolderDepth` / `computeSubtreeDepth` logic
- Candidates where `candidateDepth + subtreeDepth > maxFolderDepth` (3) are excluded from the combobox options
- Strengthen the "excludes self and descendants" test to actually open the popover and assert that `child-folder` is absent and `other-folder` is present
- Add a new test verifying depth-invalid folders are excluded from parent options

Closes #736

## Test plan
- [x] `excludes self and descendants from parent options` — opens popover, asserts child-folder absent, other-folder present
- [x] `excludes folders that would exceed max folder depth` — verifies level2 (depth=2, subtree=2, total=4>3) excluded, level1 (depth=1, total=3) included
- [x] All 12 FolderDetailPage tests pass
- [x] `make test-ui` — all 687 tests pass

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)