### PR TITLE
docs: add collection-index and searchable-collections guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ Before making changes, review `CONTRIBUTING.md` for commit message requirements.
 - [Terminology](docs/agents/guardrail-terminology.md) — Use "platform template" not "system template" for org/folder-level templates.
 - [Resource Naming](docs/agents/guardrail-resource-naming.md) — Slug-based identifiers with six-digit collision suffix, never random-only.
 - [URL Scheme](docs/agents/guardrail-url-scheme.md) — Top-level resources get dedicated URL prefixes; never nest one top-level resource under another.
+- [Collection Index Pages](docs/agents/guardrail-collection-index.md) — Every resource collection must have an index/listing page at the root URL; settings live at a `/settings` subroute.
+- [Searchable Collections](docs/agents/guardrail-searchable-collections.md) — All index pages and dynamic-collection combo boxes must include a search/filter input using TanStack Table `globalFilterFn: 'includesString'`.
 
 ## Planning & Execution
 

--- a/docs/agents/guardrail-collection-index.md
+++ b/docs/agents/guardrail-collection-index.md
@@ -1,0 +1,45 @@
+# Guardrail: Collection Index Pages
+
+**Every resource collection must have an index/listing page at the collection root URL.** When a user navigates to a resource type (e.g., `/orgs/$orgName/projects`), they land on an index page that lists all items in that collection. Resource settings and detail views live at dedicated subroutes, not at the collection root.
+
+## URL Structure
+
+| URL | Purpose |
+|-----|---------|
+| `/orgs/$orgName/projects` | **Index page** -- lists all projects in the org |
+| `/projects/$projectName/secrets` | **Index page** -- lists all secrets in the project |
+| `/projects/$projectName/settings` | **Settings page** -- project configuration |
+| `/folders/$folderName/templates` | **Index page** -- lists folder-scoped templates |
+
+The index page is the default view when navigating to a resource collection. Settings always live at a dedicated `/settings` subroute, never at the collection root.
+
+## Standard Index Page Structure
+
+Index pages follow a consistent structure:
+
+1. **Card with header** -- collection title and a "Create" action button
+2. **Search input** -- filter the collection (see [Searchable Collections](guardrail-searchable-collections.md))
+3. **Data table** -- TanStack Table with columns appropriate to the resource type
+4. **Pagination** -- shown when results exceed the page size
+5. **Empty state** -- message and create action when the collection is empty
+
+## Triggers
+
+Apply this rule when:
+- Adding a new resource type that has a collection (list) view
+- Adding route files under `frontend/src/routes/`
+- Restructuring navigation or URL hierarchy
+
+## Incorrect Patterns
+
+| Pattern | Why it is wrong |
+|---------|-----------------|
+| Collection root shows settings | Settings belong at `/settings`; the root should list items |
+| Collection root redirects to first item | Users expect to see the full collection, not a single item |
+| No index page for a browsable collection | Every collection the user can navigate to needs a listing |
+
+## Related
+
+- [URL Scheme](guardrail-url-scheme.md) -- top-level resource URL conventions
+- [Searchable Collections](guardrail-searchable-collections.md) -- all index pages must include search/filter
+- [UI Architecture](ui-architecture.md) -- TanStack Router and component library

--- a/docs/agents/guardrail-searchable-collections.md
+++ b/docs/agents/guardrail-searchable-collections.md
@@ -1,0 +1,66 @@
+# Guardrail: Searchable Collections
+
+**All index/listing pages and all combo boxes displaying dynamic collections must include a search or filter input.** Users should never scroll through an unfiltered list to find an item.
+
+## Standard Pattern: TanStack Table Global Filter
+
+Index pages use TanStack Table with client-side global filtering:
+
+```tsx
+const [globalFilter, setGlobalFilter] = useState('')
+
+const table = useReactTable({
+  data: items,
+  columns,
+  state: { globalFilter },
+  onGlobalFilterChange: setGlobalFilter,
+  globalFilterFn: 'includesString',
+  getCoreRowModel: getCoreRowModel(),
+  getFilteredRowModel: getFilteredRowModel(),
+})
+```
+
+The search input renders above the table:
+
+```tsx
+<Input
+  placeholder="Search items…"
+  value={globalFilter}
+  onChange={(e) => setGlobalFilter(e.target.value)}
+  className="max-w-sm"
+/>
+```
+
+`globalFilterFn: 'includesString'` is the standard filter function. It performs case-insensitive substring matching across all columns.
+
+## Standard Pattern: Combobox
+
+Combo boxes for dynamic collections use the `Combobox` component (`frontend/src/components/ui/combobox.tsx`), which has a built-in `CommandInput` search field. No additional wiring is needed -- the search behavior is provided by the `cmdk` command palette underneath.
+
+## Triggers
+
+Apply this rule when:
+- Creating a new index/listing page under `frontend/src/routes/`
+- Adding a combo box or dropdown that displays a dynamic collection
+- Reviewing a page that lists resources fetched from an API
+
+## Incorrect Patterns
+
+| Pattern | Why it is wrong |
+|---------|-----------------|
+| Index page with no search input | Users cannot find items without scrolling the entire list |
+| `Select` for a dynamic collection | `Select` has no search; use `Combobox` instead (see [Selection Components](selection-components.md)) |
+| Custom filter logic instead of `globalFilterFn` | Inconsistent behavior; use the TanStack Table built-in |
+
+## Existing Examples
+
+| Page | File | Pattern used |
+|------|------|-------------|
+| Projects index | `frontend/src/routes/_authenticated/orgs/$orgName/projects/index.tsx` | `globalFilterFn: 'includesString'` |
+| Folders index | `frontend/src/routes/_authenticated/orgs/$orgName/folders/index.tsx` | `globalFilterFn: 'includesString'` |
+
+## Related
+
+- [Collection Index Pages](guardrail-collection-index.md) -- every collection needs an index page
+- [Selection Components](selection-components.md) -- Combobox vs Select decision rule
+- [UI Architecture](ui-architecture.md) -- TanStack Table and component library


### PR DESCRIPTION
## Summary

- Add `docs/agents/guardrail-collection-index.md` codifying that every resource collection must have an index/listing page at the root URL with settings at a `/settings` subroute
- Add `docs/agents/guardrail-searchable-collections.md` codifying that all index pages and dynamic-collection combo boxes must include a search/filter input using TanStack Table `globalFilterFn: 'includesString'`
- Register both guardrails in the `AGENTS.md` guardrails table

Closes #749

## Test plan

- [x] Both markdown files render correctly
- [x] Cross-links resolve to existing documents (guardrail-url-scheme.md, selection-components.md, ui-architecture.md)
- [x] AGENTS.md guardrails table includes both new entries
- No code changes -- documentation only

> Local E2E was not run (documentation-only change, no code affected).

Generated with [Claude Code](https://claude.com/claude-code)

---
*agent-2*