### PR TITLE
feat(folders): add folder index page with searchable sortable data grid

### DIFF
--- a/frontend/e2e/folder-rbac.spec.ts
+++ b/frontend/e2e/folder-rbac.spec.ts
@@ -43,8 +43,8 @@ test.describe('Folder RBAC - owner can manage folder', () => {
     await page.waitForLoadState('networkidle')
     await expect(page.locator('span.font-medium', { hasText: folderName })).toBeVisible({ timeout: 10000 })
 
-    // Navigate to folder detail — delete button should be visible for owner
-    await page.goto(`/folders/${folderName}`)
+    // Navigate to folder settings — delete button should be visible for owner
+    await page.goto(`/folders/${folderName}/settings`)
     await page.waitForLoadState('networkidle')
     await expect(page.getByRole('button', { name: /delete folder/i })).toBeVisible({
       timeout: 10000,
@@ -65,7 +65,7 @@ test.describe('Folder RBAC - owner can manage folder', () => {
     await apiCreateOrg(page, orgName)
     await apiCreateFolder(page, folderName, orgName, 1, orgName)
 
-    await page.goto(`/folders/${folderName}`)
+    await page.goto(`/folders/${folderName}/settings`)
     await page.waitForLoadState('networkidle')
 
     // Org owner should see the sharing section (Settings section with edit controls)

--- a/frontend/e2e/folders.spec.ts
+++ b/frontend/e2e/folders.spec.ts
@@ -68,7 +68,7 @@ test.describe('Folder detail page', () => {
     await apiCreateOrg(page, orgName)
     await apiCreateFolder(page, folderName, orgName, 1, orgName)
 
-    await page.goto(`/folders/${folderName}`)
+    await page.goto(`/folders/${folderName}/settings`)
     await page.waitForLoadState('networkidle')
 
     // Folder name should appear in the page heading (use role to avoid strict mode violations
@@ -103,10 +103,10 @@ test.describe('Nested folder workflow', () => {
     await page.waitForLoadState('networkidle')
     await expect(page.locator('span.font-medium', { hasText: parentFolder })).toBeVisible({ timeout: 10000 })
 
-    // Navigate to parent folder detail page — heading should show the folder name
+    // Navigate to parent folder index page — card title should show the folder name
     await page.goto(`/folders/${parentFolder}`)
     await page.waitForLoadState('networkidle')
-    await expect(page.getByRole('heading', { name: parentFolder })).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('[data-slot="card-title"]', { hasText: parentFolder })).toBeVisible({ timeout: 10000 })
 
     // Cleanup (child first, then parent, then org)
     await apiDeleteFolder(page, childFolder, orgName)
@@ -126,12 +126,12 @@ test.describe('Nested folder workflow', () => {
     await apiCreateFolder(page, folderName, orgName, 1, orgName)
     await apiCreateProject(page, projectName, orgName)
 
-    // Navigate to the folder detail page
+    // Navigate to the folder index page
     await page.goto(`/folders/${folderName}`)
     await page.waitForLoadState('networkidle')
 
-    // Folder name should be visible in the page heading
-    await expect(page.getByRole('heading', { name: folderName })).toBeVisible({ timeout: 10000 })
+    // Folder name should be visible in the card title
+    await expect(page.locator('[data-slot="card-title"]', { hasText: folderName })).toBeVisible({ timeout: 10000 })
 
     // Cleanup
     await apiDeleteProject(page, projectName)

--- a/frontend/src/queries/projects.ts
+++ b/frontend/src/queries/projects.ts
@@ -19,6 +19,20 @@ export function useListProjects(organization: string) {
   )
 }
 
+export function useListProjectsByParent(organization: string, parentType?: ParentType, parentName?: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(ProjectService, transport), [transport])
+  return useTanstackQuery({
+    queryKey: ['projects', 'listByParent', organization, parentType, parentName] as const,
+    queryFn: async () => {
+      const response = await client.listProjects({ organization, parentType, parentName })
+      return response.projects
+    },
+    enabled: isAuthenticated && !!organization,
+  })
+}
+
 export function useGetProject(name: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()

--- a/frontend/src/routes/_authenticated/folders/$folderName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName.tsx
@@ -1,9 +1,26 @@
+import { useEffect } from 'react'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { useOrg } from '@/lib/org-context'
+import { useGetFolder } from '@/queries/folders'
 
 export const Route = createFileRoute('/_authenticated/folders/$folderName')({
-  component: FolderLayout,
+  component: FolderLayoutRoute,
 })
 
-function FolderLayout() {
+function FolderLayoutRoute() {
+  const { folderName } = Route.useParams()
+  return <FolderLayout folderName={folderName} />
+}
+
+export function FolderLayout({ folderName }: { folderName: string }) {
+  const { selectedOrg, setSelectedOrg } = useOrg()
+  const { data: folder } = useGetFolder(folderName)
+
+  useEffect(() => {
+    if (folder?.organization && folder.organization !== selectedOrg) {
+      setSelectedOrg(folder.organization)
+    }
+  }, [folder?.organization, selectedOrg, setSelectedOrg])
+
   return <Outlet />
 }

--- a/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+
+const mockNavigate = vi.fn()
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -26,28 +27,33 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
         {children}
       </a>
     ),
-    Navigate: () => null,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
   }
 })
 
 vi.mock('@/queries/folders', () => ({
   useGetFolder: vi.fn(),
-  useGetFolderRaw: vi.fn(),
-  useUpdateFolder: vi.fn(),
   useListFolders: vi.fn(),
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useListProjectsByParent: vi.fn(),
 }))
 
 vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/components/create-folder-dialog', () => ({
+  CreateFolderDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-folder-dialog" /> : null,
+}))
 
-import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders } from '@/queries/folders'
+import { useGetFolder, useListFolders } from '@/queries/folders'
+import { useListProjectsByParent } from '@/queries/projects'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { FolderDetailPage } from '@/routes/_authenticated/folders/$folderName/settings/index'
+import { FolderIndexPage } from './index'
 
 const mockFolder = {
   name: 'payments',
@@ -55,21 +61,67 @@ const mockFolder = {
   description: 'Payment processing projects',
   organization: 'test-org',
   creatorEmail: 'admin@example.com',
-  createdAt: '',
+  createdAt: '2025-01-15T10:00:00Z',
   userRole: Role.OWNER,
   userGrants: [],
   roleGrants: [],
 }
 
-function setupMocks(userRole = Role.OWNER, folderOverride?: object) {
-  const folder = { ...mockFolder, ...folderOverride }
+function makeChildFolder(name: string, displayName: string, creatorEmail = 'admin@example.com') {
+  return {
+    name,
+    displayName,
+    description: '',
+    organization: 'test-org',
+    creatorEmail,
+    createdAt: '2025-02-01T08:00:00Z',
+    userRole: Role.OWNER,
+  }
+}
+
+function makeChildProject(name: string, displayName: string, creatorEmail = 'admin@example.com') {
+  return {
+    name,
+    displayName,
+    description: '',
+    organization: 'test-org',
+    creatorEmail,
+    createdAt: '2025-03-01T12:00:00Z',
+    userRole: Role.OWNER,
+  }
+}
+
+function setupMocks(
+  opts: {
+    folder?: typeof mockFolder
+    childFolders?: ReturnType<typeof makeChildFolder>[]
+    childProjects?: ReturnType<typeof makeChildProject>[]
+    userRole?: Role
+    folderLoading?: boolean
+    folderError?: Error | null
+  } = {},
+) {
+  const {
+    folder = mockFolder,
+    childFolders = [],
+    childProjects = [],
+    userRole = Role.OWNER,
+    folderLoading = false,
+    folderError = null,
+  } = opts
+
   ;(useGetFolder as Mock).mockReturnValue({
-    data: folder,
+    data: folderLoading ? undefined : folder,
+    isPending: folderLoading,
+    error: folderError,
+  })
+  ;(useListFolders as Mock).mockReturnValue({
+    data: childFolders,
     isPending: false,
     error: null,
   })
-  ;(useGetFolderRaw as Mock).mockReturnValue({
-    data: '{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"fld-payments"}}',
+  ;(useListProjectsByParent as Mock).mockReturnValue({
+    data: childProjects,
     isPending: false,
     error: null,
   })
@@ -78,189 +130,132 @@ function setupMocks(userRole = Role.OWNER, folderOverride?: object) {
     isPending: false,
     error: null,
   })
-  ;(useUpdateFolder as Mock).mockReturnValue({
-    mutateAsync: vi.fn().mockResolvedValue({}),
-    isPending: false,
-  })
-  ;(useListFolders as Mock).mockReturnValue({
-    data: [],
-    isPending: false,
-    error: null,
-  })
 }
 
-describe('FolderDetailPage', () => {
+describe('FolderIndexPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('renders folder display name', () => {
+  it('renders loading skeletons while folder is pending', () => {
+    setupMocks({ folderLoading: true })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders error alert when folder fetch fails', () => {
+    setupMocks({ folderError: new Error('folder not found') })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.getByText(/folder not found/i)).toBeInTheDocument()
+  })
+
+  it('renders empty state when folder has no children', () => {
     setupMocks()
-    render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-    // Display name appears in the h2 heading and in the display name field
-    const matches = screen.getAllByText('Payments Team')
-    expect(matches.length).toBeGreaterThanOrEqual(1)
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.getByText(/no items/i)).toBeInTheDocument()
   })
 
-  it('renders folder slug', () => {
+  it('renders data grid with combined folder and project rows', () => {
+    setupMocks({
+      childFolders: [makeChildFolder('billing', 'Billing')],
+      childProjects: [makeChildProject('checkout', 'Checkout')],
+    })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.getByText('Billing')).toBeInTheDocument()
+    expect(screen.getByText('Checkout')).toBeInTheDocument()
+  })
+
+  it('renders type badges for folders and projects', () => {
+    setupMocks({
+      childFolders: [makeChildFolder('billing', 'Billing')],
+      childProjects: [makeChildProject('checkout', 'Checkout')],
+    })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.getByText('Folder')).toBeInTheDocument()
+    expect(screen.getByText('Project')).toBeInTheDocument()
+  })
+
+  it('search filters rows by display name', () => {
+    setupMocks({
+      childFolders: [makeChildFolder('billing', 'Billing')],
+      childProjects: [makeChildProject('checkout', 'Checkout')],
+    })
+    render(<FolderIndexPage folderName="payments" />)
+    const searchInput = screen.getByPlaceholderText(/search/i)
+    fireEvent.change(searchInput, { target: { value: 'billing' } })
+    expect(screen.getByText('Billing')).toBeInTheDocument()
+    expect(screen.queryByText('Checkout')).not.toBeInTheDocument()
+  })
+
+  it('clicking a folder row navigates to /folders/$childFolderName', () => {
+    setupMocks({
+      childFolders: [makeChildFolder('billing', 'Billing')],
+    })
+    render(<FolderIndexPage folderName="payments" />)
+    const row = screen.getByText('Billing').closest('tr')!
+    fireEvent.click(row)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/folders/$folderName',
+      params: { folderName: 'billing' },
+    })
+  })
+
+  it('clicking a project row navigates to /projects/$projectName', () => {
+    setupMocks({
+      childProjects: [makeChildProject('checkout', 'Checkout')],
+    })
+    render(<FolderIndexPage folderName="payments" />)
+    const row = screen.getByText('Checkout').closest('tr')!
+    fireEvent.click(row)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/projects/$projectName',
+      params: { projectName: 'checkout' },
+    })
+  })
+
+  it('settings link points to /folders/$folderName/settings', () => {
     setupMocks()
-    render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-    // The slug appears in both the breadcrumb and the Name (slug) field
-    const matches = screen.getAllByText('payments')
-    expect(matches.length).toBeGreaterThanOrEqual(1)
+    render(<FolderIndexPage folderName="payments" />)
+    const settingsLink = screen.getByRole('link', { name: /settings/i })
+    expect(settingsLink).toBeInTheDocument()
+    expect(settingsLink).toHaveAttribute('href', '/folders/$folderName/settings')
   })
 
-  it('renders organization name', () => {
-    setupMocks()
-    render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-    // Multiple occurrences (breadcrumb + org field)
-    const matches = screen.getAllByText('test-org')
-    expect(matches.length).toBeGreaterThanOrEqual(1)
+  it('shows Create Folder button for OWNER', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<FolderIndexPage folderName="payments" />)
+    const buttons = screen.getAllByRole('button', { name: /create folder/i })
+    expect(buttons.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('renders creator email', () => {
-    setupMocks()
-    render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-    expect(screen.getByText('admin@example.com')).toBeInTheDocument()
+  it('shows Create Folder button for EDITOR', () => {
+    setupMocks({ userRole: Role.EDITOR })
+    render(<FolderIndexPage folderName="payments" />)
+    const buttons = screen.getAllByRole('button', { name: /create folder/i })
+    expect(buttons.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('renders folder description', () => {
-    setupMocks()
-    render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-    expect(screen.getByText('Payment processing projects')).toBeInTheDocument()
+  it('does not show Create Folder button for VIEWER', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.queryByRole('button', { name: /create folder/i })).not.toBeInTheDocument()
   })
 
-  it('shows loading skeletons while pending', () => {
-    ;(useGetFolder as Mock).mockReturnValue({ data: undefined, isPending: true, error: null })
-    ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole: Role.OWNER }, isPending: true, error: null })
-    ;(useUpdateFolder as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
-    ;(useListFolders as Mock).mockReturnValue({ data: [], isPending: false, error: null })
-    render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-    expect(screen.queryByText('Payments Team')).not.toBeInTheDocument()
+  it('clicking Create Folder button opens dialog', () => {
+    setupMocks({
+      userRole: Role.OWNER,
+      childFolders: [makeChildFolder('billing', 'Billing')],
+    })
+    render(<FolderIndexPage folderName="payments" />)
+    fireEvent.click(screen.getByRole('button', { name: /create folder/i }))
+    expect(screen.getByTestId('create-folder-dialog')).toBeInTheDocument()
   })
 
-  it('shows error alert when fetch fails', () => {
-    ;(useGetFolder as Mock).mockReturnValue({ data: undefined, isPending: false, error: new Error('not found') })
-    ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole: Role.OWNER }, isPending: false, error: null })
-    ;(useUpdateFolder as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
-    ;(useListFolders as Mock).mockReturnValue({ data: [], isPending: false, error: null })
-    render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-    expect(screen.getByText('not found')).toBeInTheDocument()
-  })
-
-  describe('display name editing', () => {
-    it('shows edit pencil button for OWNER', () => {
-      setupMocks(Role.OWNER)
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      expect(screen.getByRole('button', { name: /edit display name/i })).toBeInTheDocument()
+  it('renders creator email in the table', () => {
+    setupMocks({
+      childFolders: [makeChildFolder('billing', 'Billing', 'creator@example.com')],
     })
-
-    it('shows edit pencil button for EDITOR', () => {
-      setupMocks(Role.EDITOR)
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      expect(screen.getByRole('button', { name: /edit display name/i })).toBeInTheDocument()
-    })
-
-    it('does not show edit pencil button for VIEWER', () => {
-      setupMocks(Role.VIEWER)
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      expect(screen.queryByRole('button', { name: /edit display name/i })).not.toBeInTheDocument()
-    })
-
-    it('clicking edit display name shows input', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      await user.click(screen.getByRole('button', { name: /edit display name/i }))
-      expect(screen.getByRole('textbox', { name: /display name/i })).toBeInTheDocument()
-    })
-
-    it('saving display name calls updateFolder', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      await user.click(screen.getByRole('button', { name: /edit display name/i }))
-      const input = screen.getByRole('textbox', { name: /display name/i })
-      await user.clear(input)
-      await user.type(input, 'New Name')
-      await user.click(screen.getByRole('button', { name: /save display name/i }))
-      const mutateAsync = (useUpdateFolder as Mock).mock.results[0].value.mutateAsync
-      await waitFor(() => {
-        expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ displayName: 'New Name' }))
-      })
-    })
-
-    it('cancel restores view mode without saving', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      await user.click(screen.getByRole('button', { name: /edit display name/i }))
-      await user.click(screen.getByRole('button', { name: /cancel display name/i }))
-      expect(screen.queryByRole('textbox', { name: /display name/i })).not.toBeInTheDocument()
-      const mutateAsync = (useUpdateFolder as Mock).mock.results[0].value.mutateAsync
-      expect(mutateAsync).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('description editing', () => {
-    it('shows edit pencil button for OWNER', () => {
-      setupMocks(Role.OWNER)
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      expect(screen.getByRole('button', { name: /edit description/i })).toBeInTheDocument()
-    })
-
-    it('clicking edit description shows textarea', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      await user.click(screen.getByRole('button', { name: /edit description/i }))
-      expect(screen.getByRole('textbox', { name: /description/i })).toBeInTheDocument()
-    })
-  })
-
-  describe('breadcrumb navigation', () => {
-    it('renders org link in breadcrumb', () => {
-      setupMocks()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      const orgLink = screen.getByRole('link', { name: 'test-org' })
-      expect(orgLink).toBeInTheDocument()
-    })
-
-    it('renders Folders link in breadcrumb', () => {
-      setupMocks()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      expect(screen.getByRole('link', { name: 'Folders' })).toBeInTheDocument()
-    })
-  })
-
-  describe('delete dialog', () => {
-    it('shows Delete Folder button for OWNER', () => {
-      setupMocks(Role.OWNER)
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      expect(screen.getByRole('button', { name: /delete folder/i })).toBeInTheDocument()
-    })
-
-    it('does not show Delete Folder button for VIEWER', () => {
-      setupMocks(Role.VIEWER)
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      expect(screen.queryByRole('button', { name: /delete folder/i })).not.toBeInTheDocument()
-    })
-
-    it('clicking Delete Folder opens confirmation dialog', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      await user.click(screen.getByRole('button', { name: /delete folder/i }))
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
-    })
-
-    it('cancel closes dialog without deleting', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderDetailPage orgName="test-org" folderName="payments" />)
-      await user.click(screen.getByRole('button', { name: /delete folder/i }))
-      await user.click(screen.getByRole('button', { name: /cancel/i }))
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-    })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.getByText('creator@example.com')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -144,7 +144,6 @@ export function FolderIndexPage({ folderName: propFolderName }: { folderName?: s
           </Badge>
         )
       },
-      enableGlobalFilter: false,
     }),
     columnHelper.accessor('createdAt', {
       header: ({ column }) => {
@@ -240,6 +239,18 @@ export function FolderIndexPage({ folderName: propFolderName }: { folderName?: s
     }
   }
 
+  if (folderError) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{folderError.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
   const isLoading = folderPending || foldersLoading || projectsLoading
 
   if (isLoading) {
@@ -254,18 +265,6 @@ export function FolderIndexPage({ folderName: propFolderName }: { folderName?: s
               <Skeleton key={i} className="h-10 w-full" />
             ))}
           </div>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  if (folderError) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <Alert variant="destructive">
-            <AlertDescription>{folderError.message}</AlertDescription>
-          </Alert>
         </CardContent>
       </Card>
     )

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -1,16 +1,383 @@
-import { createFileRoute, Navigate } from '@tanstack/react-router'
+import { useState, useMemo } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  flexRender,
+  createColumnHelper,
+  type SortingState,
+} from '@tanstack/react-table'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Skeleton } from '@/components/ui/skeleton'
+import { ArrowUpDown, ArrowUp, ArrowDown, Plus, Settings } from 'lucide-react'
+import { useGetFolder, useListFolders } from '@/queries/folders'
+import { useListProjectsByParent } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
+import { ParentType } from '@/gen/holos/console/v1/folders_pb'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateFolderDialog } from '@/components/create-folder-dialog'
 
 export const Route = createFileRoute(
   '/_authenticated/folders/$folderName/',
 )({
-  component: FolderIndexRedirect,
+  component: FolderIndexRoute,
 })
 
-/**
- * Temporary redirect: bare /folders/$folderName routes to settings.
- * Phase 3 will replace this with the folder index page.
- */
-function FolderIndexRedirect() {
+function FolderIndexRoute() {
   const { folderName } = Route.useParams()
-  return <Navigate to="/folders/$folderName/settings" params={{ folderName }} replace />
+  return <FolderIndexPage folderName={folderName} />
+}
+
+/** Unified row type combining child folders and child projects. */
+type FolderChild = {
+  name: string
+  displayName: string
+  type: 'folder' | 'project'
+  createdAt: string
+  creatorEmail: string
+}
+
+const columnHelper = createColumnHelper<FolderChild>()
+
+export function FolderIndexPage({ folderName: propFolderName }: { folderName?: string } = {}) {
+  let routeParams: { folderName?: string } = {}
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeParams = Route.useParams()
+  } catch {
+    routeParams = {}
+  }
+  const folderName = propFolderName ?? routeParams.folderName ?? ''
+
+  let navigate: ReturnType<typeof useNavigate>
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    navigate = useNavigate()
+  } catch {
+    navigate = (() => {}) as unknown as ReturnType<typeof useNavigate>
+  }
+
+  const { data: folder, isPending: folderPending, error: folderError } = useGetFolder(folderName)
+  const orgName = folder?.organization ?? ''
+
+  const { data: org } = useGetOrganization(orgName)
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  const { data: childFolders, isPending: foldersLoading } = useListFolders(orgName, ParentType.FOLDER, folderName)
+  const { data: childProjects, isPending: projectsLoading } = useListProjectsByParent(orgName, ParentType.FOLDER, folderName)
+
+  const [globalFilter, setGlobalFilter] = useState('')
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'displayName', desc: false }])
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const data = useMemo<FolderChild[]>(() => {
+    const items: FolderChild[] = []
+    for (const f of childFolders ?? []) {
+      items.push({
+        name: f.name,
+        displayName: f.displayName || f.name,
+        type: 'folder',
+        createdAt: f.createdAt ?? '',
+        creatorEmail: f.creatorEmail ?? '',
+      })
+    }
+    for (const p of childProjects ?? []) {
+      items.push({
+        name: p.name,
+        displayName: p.displayName || p.name,
+        type: 'project',
+        createdAt: p.createdAt ?? '',
+        creatorEmail: p.creatorEmail ?? '',
+      })
+    }
+    return items
+  }, [childFolders, childProjects])
+
+  const columns = useMemo(() => [
+    columnHelper.accessor('displayName', {
+      header: ({ column }) => {
+        const sorted = column.getIsSorted()
+        return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="-ml-3 h-8 font-medium"
+            onClick={() => column.toggleSorting(sorted === 'asc')}
+          >
+            Display Name
+            {sorted === 'asc' ? (
+              <ArrowUp className="ml-1 h-3.5 w-3.5" />
+            ) : sorted === 'desc' ? (
+              <ArrowDown className="ml-1 h-3.5 w-3.5" />
+            ) : (
+              <ArrowUpDown className="ml-1 h-3.5 w-3.5 opacity-50" />
+            )}
+          </Button>
+        )
+      },
+      cell: ({ getValue }) => (
+        <span className="font-medium">{getValue()}</span>
+      ),
+    }),
+    columnHelper.accessor('type', {
+      header: 'Type',
+      cell: ({ getValue }) => {
+        const t = getValue()
+        return (
+          <Badge variant="outline">
+            {t === 'folder' ? 'Folder' : 'Project'}
+          </Badge>
+        )
+      },
+      enableGlobalFilter: false,
+    }),
+    columnHelper.accessor('createdAt', {
+      header: ({ column }) => {
+        const sorted = column.getIsSorted()
+        return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="-ml-3 h-8 font-medium"
+            onClick={() => column.toggleSorting(sorted === 'asc')}
+          >
+            Created
+            {sorted === 'asc' ? (
+              <ArrowUp className="ml-1 h-3.5 w-3.5" />
+            ) : sorted === 'desc' ? (
+              <ArrowDown className="ml-1 h-3.5 w-3.5" />
+            ) : (
+              <ArrowUpDown className="ml-1 h-3.5 w-3.5 opacity-50" />
+            )}
+          </Button>
+        )
+      },
+      cell: ({ getValue }) => {
+        const ts = getValue()
+        if (!ts) return <span className="text-muted-foreground">--</span>
+        try {
+          return (
+            <span className="text-muted-foreground text-sm">
+              {new Intl.DateTimeFormat(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              }).format(new Date(ts))}
+            </span>
+          )
+        } catch {
+          return <span className="text-muted-foreground text-sm">{ts}</span>
+        }
+      },
+    }),
+    columnHelper.accessor('creatorEmail', {
+      header: ({ column }) => {
+        const sorted = column.getIsSorted()
+        return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="-ml-3 h-8 font-medium"
+            onClick={() => column.toggleSorting(sorted === 'asc')}
+          >
+            Creator
+            {sorted === 'asc' ? (
+              <ArrowUp className="ml-1 h-3.5 w-3.5" />
+            ) : sorted === 'desc' ? (
+              <ArrowDown className="ml-1 h-3.5 w-3.5" />
+            ) : (
+              <ArrowUpDown className="ml-1 h-3.5 w-3.5 opacity-50" />
+            )}
+          </Button>
+        )
+      },
+      cell: ({ getValue }) => {
+        const email = getValue()
+        if (!email) return <span className="text-muted-foreground">--</span>
+        return <span className="text-muted-foreground text-sm">{email}</span>
+      },
+    }),
+  ], [])
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { globalFilter, sorting },
+    onGlobalFilterChange: setGlobalFilter,
+    onSortingChange: setSorting,
+    globalFilterFn: 'includesString',
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  })
+
+  const handleRowClick = (row: FolderChild) => {
+    if (row.type === 'folder') {
+      navigate({
+        to: '/folders/$folderName',
+        params: { folderName: row.name },
+      })
+    } else {
+      navigate({
+        to: '/projects/$projectName',
+        params: { projectName: row.name },
+      })
+    }
+  }
+
+  const isLoading = folderPending || foldersLoading || projectsLoading
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <CardTitle>Contents</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (folderError) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{folderError.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const displayName = folder?.displayName || folderName
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+                {orgName}
+              </Link>
+              {' / '}
+              <Link to="/orgs/$orgName/folders" params={{ orgName }} className="hover:underline">
+                Folders
+              </Link>
+              {' / '}
+              {folderName}
+            </p>
+            <CardTitle className="mt-1">{displayName}</CardTitle>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              to="/folders/$folderName/settings"
+              params={{ folderName }}
+              aria-label="Settings"
+            >
+              <Button variant="outline" size="sm">
+                <Settings className="h-4 w-4 mr-1" />
+                Settings
+              </Button>
+            </Link>
+            {canWrite && (
+              <Button size="sm" onClick={() => setCreateOpen(true)}>
+                <Plus className="h-4 w-4 mr-1" />
+                Create Folder
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {data.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <p className="text-muted-foreground">No items in this folder yet.</p>
+              {canWrite && (
+                <Button size="sm" onClick={() => setCreateOpen(true)}>
+                  Create Folder
+                </Button>
+              )}
+            </div>
+          ) : (
+            <>
+              <div className="mb-3">
+                <Input
+                  placeholder="Search items..."
+                  value={globalFilter}
+                  onChange={(e) => setGlobalFilter(e.target.value)}
+                  className="max-w-sm"
+                />
+              </div>
+              <Table>
+                <TableHeader>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <TableHead key={header.id}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(header.column.columnDef.header, header.getContext())}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.map((row) => (
+                    <TableRow
+                      key={row.id}
+                      className="cursor-pointer"
+                      onClick={() => handleRowClick(row.original)}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <CreateFolderDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        organization={orgName}
+        parentType={ParentType.FOLDER}
+        parentName={folderName}
+        onCreated={(name) => {
+          navigate({
+            to: '/folders/$folderName',
+            params: { folderName: name },
+          })
+        }}
+      />
+    </>
+  )
 }


### PR DESCRIPTION
## Summary
- Replace the temporary redirect at `/folders/$folderName` with a full index page showing child folders and projects in a unified data grid
- Add `useListProjectsByParent` query hook to `queries/projects.ts` (the proto already supported `parent_type`/`parent_name` fields; only the frontend hook was missing)
- Data grid columns: Display Name, Type (folder/project badge), Created (formatted timestamp), Creator (email)
- Default sort by Display Name ascending; Created and Creator columns are also sortable
- Global search filter across all columns
- Clicking a child folder navigates to `/folders/$childFolderName`; clicking a project navigates to `/projects/$projectName`
- Settings link and Create Folder button in the page header
- Loading skeleton, error alert, and empty state handling
- Update folder layout (`$folderName.tsx`) to fetch folder data and sync org context (matching the `projects/$projectName.tsx` pattern)

Closes #751

## Test plan
- [x] 14 new Vitest tests covering: data grid rendering, type badges, search filtering, folder row navigation, project row navigation, settings link, create button for OWNER/EDITOR, no create button for VIEWER, dialog opens on click, creator email display, loading/error/empty states
- [x] All 681 tests pass (`make test`)
- [x] `make generate` builds successfully
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent slot: `agent-2`