### PR TITLE
fix(ui): shorten httpbin tooltip to 12 words

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -358,7 +358,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                       <Info className="h-4 w-4 text-muted-foreground cursor-default" />
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>This example deploys go-httpbin with a ServiceAccount, Deployment, and Service. When an org-level platform template is enabled, it is unified with this template at render time — the platform template can inject platform resources (like HTTPRoute) and constrain which resource kinds this template may produce.</p>
+                      <p>Deploys go-httpbin with a ServiceAccount, Deployment, and Service as an example.</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>


### PR DESCRIPTION
## Summary
- Replaced ~40-word paragraph in the httpbin example tooltip with a concise 12-word summary
- New text: "Deploys go-httpbin with a ServiceAccount, Deployment, and Service as an example."
- No test changes needed — no existing tests assert on tooltip content

Closes #759

## Test plan
- [x] `make test-ui` passes (47 files, 688 tests, 0 failures)
- [ ] Visual check: tooltip next to "Load httpbin Example" button on project template creation page shows shortened text

> Local E2E was not run — this is a copy-only change with no functional impact. Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) from agent slot `agent-1`