### PR TITLE
feat(backend): implement populate_defaults org seeding

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -289,6 +289,10 @@ func (s *Server) Serve(ctx context.Context) error {
 		// org_templates.K8sClient from v1alpha1 — ADR 021 Decision 1).
 		templatesK8s := templates.NewK8sClient(k8sClientset, nsResolver)
 
+		// Wire defaults seeder for populate_defaults org creation flow.
+		projectPrefix := nsResolver.NamespacePrefix + nsResolver.ProjectPrefix
+		orgsHandler.WithDefaultsSeeder(templatesK8s, &projects.ProjectCreatorAdapter{K8s: projectsK8s}, projectPrefix)
+
 		// Mandatory template applier for project creation: walks the project's
 		// ancestor chain (org + folder ancestors) and applies all mandatory+enabled
 		// templates to the project namespace (ADR 021 Decision 3).

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -39,6 +39,21 @@ type FolderLister interface {
 	GetFolder(ctx context.Context, name string) (*corev1.Namespace, error)
 }
 
+// TemplateSeeder seeds default templates into a scope. Used by
+// CreateOrganization to seed example templates when populate_defaults is true.
+type TemplateSeeder interface {
+	SeedOrgTemplate(ctx context.Context, org string) error
+	SeedProjectTemplate(ctx context.Context, project string) error
+}
+
+// ProjectCreator creates a project namespace. Used by CreateOrganization to
+// create a default project when populate_defaults is true, following the same
+// pattern as FolderCreator.
+type ProjectCreator interface {
+	CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error
+	NamespaceExists(ctx context.Context, nsName string) (bool, error)
+}
+
 // Handler implements the OrganizationService.
 type Handler struct {
 	consolev1connect.UnimplementedOrganizationServiceHandler
@@ -47,6 +62,9 @@ type Handler struct {
 	folderCreator   FolderCreator
 	folderLister    FolderLister
 	folderPrefix    string // namespace prefix + folder prefix (e.g. "holos-fld-")
+	templateSeeder  TemplateSeeder
+	projectCreator  ProjectCreator
+	projectPrefix   string // namespace prefix + project prefix (e.g. "holos-prj-")
 	disableCreation bool
 	creatorUsers    []string
 	creatorRoles    []string
@@ -66,6 +84,15 @@ func (h *Handler) WithFolderCreator(fc FolderCreator, fl FolderLister, folderPre
 	h.folderCreator = fc
 	h.folderLister = fl
 	h.folderPrefix = folderPrefix
+	return h
+}
+
+// WithDefaultsSeeder sets the template seeder and project creator used to
+// populate example resources when populate_defaults is true on CreateOrganization.
+func (h *Handler) WithDefaultsSeeder(ts TemplateSeeder, pc ProjectCreator, projectPrefix string) *Handler {
+	h.templateSeeder = ts
+	h.projectCreator = pc
+	h.projectPrefix = projectPrefix
 	return h
 }
 
@@ -243,6 +270,23 @@ func (h *Handler) CreateOrganization(
 		}
 	}
 
+	// Seed example resources when populate_defaults is requested.
+	if req.Msg.GetPopulateDefaults() {
+		if err := h.seedDefaults(ctx, req.Msg.Name, claims.Email, shareUsers, shareRoles); err != nil {
+			slog.ErrorContext(ctx, "populate defaults failed, rolling back org",
+				slog.String("organization", req.Msg.Name),
+				slog.Any("error", err),
+			)
+			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
+				slog.ErrorContext(ctx, "org rollback after seed failure failed",
+					slog.String("organization", req.Msg.Name),
+					slog.Any("error", delErr),
+				)
+			}
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("seeding default resources: %w", err))
+		}
+	}
+
 	slog.InfoContext(ctx, "organization created",
 		slog.String("action", "organization_create"),
 		slog.String("resource_type", auditResourceType),
@@ -273,6 +317,57 @@ func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName,
 		return "", fmt.Errorf("creating folder namespace: %w", err)
 	}
 	return folderName, nil
+}
+
+// seedDefaults creates example resources for the new organization:
+//  1. An org-level platform template (HTTPRoute, enabled)
+//  2. A default project in the default folder
+//  3. An example project-level deployment template in the new project
+//
+// If any step fails, the caller is responsible for rolling back the org.
+func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
+	if h.templateSeeder == nil || h.projectCreator == nil {
+		return fmt.Errorf("defaults seeder not configured")
+	}
+
+	// Step 1: Seed org-level platform template (enabled).
+	if err := h.templateSeeder.SeedOrgTemplate(ctx, orgName); err != nil {
+		return fmt.Errorf("seeding org template: %w", err)
+	}
+
+	// Step 2: Create default project in the default folder.
+	// Resolve the default folder namespace from the org's annotation.
+	orgNs, err := h.k8s.GetOrganization(ctx, orgName)
+	if err != nil {
+		return fmt.Errorf("looking up org for default folder: %w", err)
+	}
+	defaultFolder := orgNs.Annotations[v1alpha2.AnnotationDefaultFolder]
+	if defaultFolder == "" {
+		return fmt.Errorf("organization %q has no default folder set", orgName)
+	}
+
+	// Derive the parent namespace from the default folder.
+	parentNs := h.k8s.resolver.FolderNamespace(defaultFolder)
+
+	projectDisplayName := "Default"
+	exists := func(ctx context.Context, nsName string) (bool, error) {
+		return h.projectCreator.NamespaceExists(ctx, nsName)
+	}
+	projectName, err := v1alpha2.GenerateIdentifier(ctx, projectDisplayName, h.projectPrefix, exists)
+	if err != nil {
+		return fmt.Errorf("generating project identifier: %w", err)
+	}
+
+	if err := h.projectCreator.CreateProject(ctx, projectName, projectDisplayName, "", orgName, parentNs, creatorEmail, shareUsers, shareRoles); err != nil {
+		return fmt.Errorf("creating default project: %w", err)
+	}
+
+	// Step 3: Seed project-level example deployment template.
+	if err := h.templateSeeder.SeedProjectTemplate(ctx, projectName); err != nil {
+		return fmt.Errorf("seeding project template: %w", err)
+	}
+
+	return nil
 }
 
 // UpdateOrganization updates organization metadata.

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -27,10 +27,12 @@ type ProjectLister interface {
 	ListProjects(ctx context.Context, org, parentNs string) ([]*corev1.Namespace, error)
 }
 
-// FolderCreator creates a folder namespace. Used by CreateOrganization to
+// FolderCreator creates and deletes a folder namespace. Used by CreateOrganization to
 // auto-create the default folder without importing the folders package directly.
+// DeleteFolder is needed for rollback when later steps of org creation fail.
 type FolderCreator interface {
 	CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
+	DeleteFolder(ctx context.Context, name string) error
 	NamespaceExists(ctx context.Context, nsName string) (bool, error)
 }
 
@@ -46,11 +48,13 @@ type TemplateSeeder interface {
 	SeedProjectTemplate(ctx context.Context, project string) error
 }
 
-// ProjectCreator creates a project namespace. Used by CreateOrganization to
+// ProjectCreator creates and deletes a project namespace. Used by CreateOrganization to
 // create a default project when populate_defaults is true, following the same
-// pattern as FolderCreator.
+// pattern as FolderCreator. DeleteProject is needed for rollback when later
+// seeding steps fail.
 type ProjectCreator interface {
 	CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error
+	DeleteProject(ctx context.Context, name string) error
 	NamespaceExists(ctx context.Context, nsName string) (bool, error)
 }
 
@@ -230,15 +234,22 @@ func (h *Handler) CreateOrganization(
 	}
 
 	// Auto-create the default folder as an immediate child of the org.
+	// folderName is hoisted so the seed-defaults rollback can also delete
+	// the folder namespace (Kubernetes namespaces are flat — deleting the
+	// org does not cascade to the folder or project namespaces).
+	var folderName string
 	if h.folderCreator != nil {
 		folderDisplayName := "Default"
 		if req.Msg.DefaultFolder != nil && *req.Msg.DefaultFolder != "" {
 			folderDisplayName = *req.Msg.DefaultFolder
 		}
 
-		folderName, err := h.createDefaultFolder(ctx, req.Msg.Name, folderDisplayName, claims.Email, shareUsers, shareRoles)
+		var err error
+		folderName, err = h.createDefaultFolder(ctx, req.Msg.Name, folderDisplayName, claims.Email, shareUsers, shareRoles)
 		if err != nil {
 			// Rollback: delete the org namespace on default folder failure.
+			// The folder namespace does not exist yet (creation failed), so
+			// only the org needs cleanup.
 			slog.ErrorContext(ctx, "default folder creation failed, rolling back org",
 				slog.String("organization", req.Msg.Name),
 				slog.Any("error", err),
@@ -259,7 +270,9 @@ func (h *Handler) CreateOrganization(
 				slog.String("folder", folderName),
 				slog.Any("error", err),
 			)
-			// Roll back: the org contract requires default_folder to be set.
+			// Roll back folder then org: the folder was already created but the
+			// annotation write failed, so we must explicitly remove it.
+			h.rollbackFolder(ctx, folderName)
 			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
 				slog.ErrorContext(ctx, "org rollback after annotation failure failed",
 					slog.String("organization", req.Msg.Name),
@@ -277,6 +290,10 @@ func (h *Handler) CreateOrganization(
 				slog.String("organization", req.Msg.Name),
 				slog.Any("error", err),
 			)
+			// seedDefaults performs incremental rollback for resources it
+			// created (e.g. project namespace). Here we clean up the folder
+			// and org namespaces which were created before seeding began.
+			h.rollbackFolder(ctx, folderName)
 			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
 				slog.ErrorContext(ctx, "org rollback after seed failure failed",
 					slog.String("organization", req.Msg.Name),
@@ -319,12 +336,27 @@ func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName,
 	return folderName, nil
 }
 
+// rollbackFolder deletes the folder namespace as part of org creation rollback.
+// Errors are logged but not propagated since this is best-effort cleanup.
+func (h *Handler) rollbackFolder(ctx context.Context, folderName string) {
+	if folderName == "" || h.folderCreator == nil {
+		return
+	}
+	if delErr := h.folderCreator.DeleteFolder(ctx, folderName); delErr != nil {
+		slog.ErrorContext(ctx, "folder rollback failed",
+			slog.String("folder", folderName),
+			slog.Any("error", delErr),
+		)
+	}
+}
+
 // seedDefaults creates example resources for the new organization:
 //  1. An org-level platform template (HTTPRoute, enabled)
 //  2. A default project in the default folder
 //  3. An example project-level deployment template in the new project
 //
-// If any step fails, the caller is responsible for rolling back the org.
+// Each step performs incremental rollback of resources it created on failure.
+// The caller is responsible for rolling back the org and folder namespaces.
 func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
 	if h.templateSeeder == nil || h.projectCreator == nil {
 		return fmt.Errorf("defaults seeder not configured")
@@ -364,6 +396,17 @@ func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail string
 
 	// Step 3: Seed project-level example deployment template.
 	if err := h.templateSeeder.SeedProjectTemplate(ctx, projectName); err != nil {
+		// Rollback: delete the project namespace created in step 2.
+		slog.ErrorContext(ctx, "project template seeding failed, rolling back project",
+			slog.String("project", projectName),
+			slog.Any("error", err),
+		)
+		if delErr := h.projectCreator.DeleteProject(ctx, projectName); delErr != nil {
+			slog.ErrorContext(ctx, "project rollback within seedDefaults failed",
+				slog.String("project", projectName),
+				slog.Any("error", delErr),
+			)
+		}
 		return fmt.Errorf("seeding project template: %w", err)
 	}
 

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -141,6 +141,11 @@ func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, 
 	return f.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 }
 
+func (f *k8sFolderCreator) DeleteFolder(ctx context.Context, name string) error {
+	nsName := f.resolver.FolderNamespace(name)
+	return f.client.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+}
+
 func (f *k8sFolderCreator) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
 	_, err := f.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
 	if err != nil {
@@ -1270,6 +1275,11 @@ func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName
 	return err
 }
 
+func (p *k8sProjectCreator) DeleteProject(ctx context.Context, name string) error {
+	nsName := p.resolver.ProjectNamespace(name)
+	return p.client.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+}
+
 func (p *k8sProjectCreator) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
 	_, err := p.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
 	if err != nil {
@@ -1402,11 +1412,21 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 
-		// Verify the org namespace was cleaned up.
 		fc := handler.folderCreator.(*k8sFolderCreator)
+
+		// Verify the org namespace was cleaned up.
 		_, getErr := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-seed-org", metav1.GetOptions{})
 		if !k8serrors.IsNotFound(getErr) {
 			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
+		}
+
+		// Verify the folder namespace was also cleaned up (namespaces are flat,
+		// deleting the org does not cascade to the folder).
+		nsList, _ := fc.client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+		for _, ns := range nsList.Items {
+			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeFolder {
+				t.Errorf("expected folder namespace %q to be deleted after rollback", ns.Name)
+			}
 		}
 	})
 
@@ -1447,6 +1467,14 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 		if !k8serrors.IsNotFound(getErr) {
 			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
 		}
+
+		// Verify the folder namespace was also cleaned up.
+		nsList, _ := fakeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+		for _, ns := range nsList.Items {
+			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeFolder {
+				t.Errorf("expected folder namespace %q to be deleted after rollback", ns.Name)
+			}
+		}
 	})
 
 	t.Run("rollback on project template seed failure", func(t *testing.T) {
@@ -1468,11 +1496,28 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 
-		// Verify the org namespace was cleaned up.
 		fc := handler.folderCreator.(*k8sFolderCreator)
+
+		// Verify the org namespace was cleaned up.
 		_, getErr := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-ptmpl-org", metav1.GetOptions{})
 		if !k8serrors.IsNotFound(getErr) {
 			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
+		}
+
+		// Verify the folder namespace was cleaned up.
+		nsList, _ := fc.client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+		for _, ns := range nsList.Items {
+			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeFolder {
+				t.Errorf("expected folder namespace %q to be deleted after rollback", ns.Name)
+			}
+		}
+
+		// Verify the project namespace was cleaned up by seedDefaults'
+		// incremental rollback (project was created in step 2, then step 3 failed).
+		for _, ns := range nsList.Items {
+			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeProject {
+				t.Errorf("expected project namespace %q to be deleted after rollback", ns.Name)
+			}
 		}
 	})
 }

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -60,6 +60,9 @@ type testHandlerOpts struct {
 	creatorRoles       []string
 	projectLister      ProjectLister
 	withFolderCreator  bool
+	withDefaultsSeeder bool
+	templateSeeder     TemplateSeeder
+	projectCreator     ProjectCreator
 }
 
 func newTestHandler(namespaces ...*corev1.Namespace) *Handler {
@@ -80,6 +83,19 @@ func newTestHandlerWithOpts(opts testHandlerOpts, namespaces ...*corev1.Namespac
 		fc := &k8sFolderCreator{client: fakeClient, resolver: r}
 		folderPrefix := r.NamespacePrefix + r.FolderPrefix
 		handler.WithFolderCreator(fc, fc, folderPrefix)
+	}
+
+	if opts.withDefaultsSeeder {
+		ts := opts.templateSeeder
+		if ts == nil {
+			ts = &mockTemplateSeeder{}
+		}
+		pc := opts.projectCreator
+		if pc == nil {
+			pc = &k8sProjectCreator{client: fakeClient, resolver: r}
+		}
+		projectPrefix := r.NamespacePrefix + r.ProjectPrefix
+		handler.WithDefaultsSeeder(ts, pc, projectPrefix)
 	}
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
@@ -1183,6 +1199,282 @@ func TestUpdateOrganization_UpdateDefaultFolder_EmptyValue(t *testing.T) {
 		DefaultFolder: &empty,
 	}))
 	assertInvalidArgument(t, err)
+}
+
+// ---- PopulateDefaults tests ----
+
+// mockTemplateSeeder implements TemplateSeeder for tests.
+type mockTemplateSeeder struct {
+	orgTemplateSeeded     bool
+	projectTemplateSeeded bool
+	seedOrgErr            error
+	seedProjectErr        error
+	// Track the project name for verification.
+	seededProjectName string
+}
+
+func (m *mockTemplateSeeder) SeedOrgTemplate(_ context.Context, _ string) error {
+	if m.seedOrgErr != nil {
+		return m.seedOrgErr
+	}
+	m.orgTemplateSeeded = true
+	return nil
+}
+
+func (m *mockTemplateSeeder) SeedProjectTemplate(_ context.Context, project string) error {
+	if m.seedProjectErr != nil {
+		return m.seedProjectErr
+	}
+	m.projectTemplateSeeded = true
+	m.seededProjectName = project
+	return nil
+}
+
+// k8sProjectCreator implements ProjectCreator for tests.
+type k8sProjectCreator struct {
+	client    *fake.Clientset
+	resolver  *resolver.Resolver
+	createErr error
+}
+
+func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
+	if p.createErr != nil {
+		return p.createErr
+	}
+	usersJSON, _ := json.Marshal(shareUsers)
+	rolesJSON, _ := json.Marshal(shareRoles)
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareUsers: string(usersJSON),
+		v1alpha2.AnnotationShareRoles: string(rolesJSON),
+	}
+	if displayName != "" {
+		annotations[v1alpha2.AnnotationDisplayName] = displayName
+	}
+	if creatorEmail != "" {
+		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: p.resolver.ProjectNamespace(name),
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelProject:      name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+	_, err := p.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	return err
+}
+
+func (p *k8sProjectCreator) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
+	_, err := p.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func TestCreateOrganization_PopulateDefaults(t *testing.T) {
+	t.Run("true creates all expected resources", func(t *testing.T) {
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := true
+
+		resp, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "seed-org",
+			DisplayName:      "Seed Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Name != "seed-org" {
+			t.Errorf("expected name 'seed-org', got %q", resp.Msg.Name)
+		}
+
+		// Verify org-level template was seeded.
+		if !ts.orgTemplateSeeded {
+			t.Error("expected org-level template to be seeded")
+		}
+
+		// Verify project-level template was seeded.
+		if !ts.projectTemplateSeeded {
+			t.Error("expected project-level template to be seeded")
+		}
+
+		// Verify the default project was created (check that at least one project namespace exists).
+		pc := handler.projectCreator.(*k8sProjectCreator)
+		projectNsName := pc.resolver.ProjectNamespace(ts.seededProjectName)
+		_, err = pc.client.CoreV1().Namespaces().Get(context.Background(), projectNsName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected default project namespace %q to exist, got %v", projectNsName, err)
+		}
+	})
+
+	t.Run("false behaves as before", func(t *testing.T) {
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := false
+
+		resp, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "no-seed-org",
+			DisplayName:      "No Seed Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Name != "no-seed-org" {
+			t.Errorf("expected name 'no-seed-org', got %q", resp.Msg.Name)
+		}
+
+		// Verify no seeding occurred.
+		if ts.orgTemplateSeeded {
+			t.Error("expected org-level template NOT to be seeded")
+		}
+		if ts.projectTemplateSeeded {
+			t.Error("expected project-level template NOT to be seeded")
+		}
+	})
+
+	t.Run("unset behaves as before", func(t *testing.T) {
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+
+		resp, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:        "unset-org",
+			DisplayName: "Unset Org",
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Name != "unset-org" {
+			t.Errorf("expected name 'unset-org', got %q", resp.Msg.Name)
+		}
+
+		// Verify no seeding occurred.
+		if ts.orgTemplateSeeded {
+			t.Error("expected org-level template NOT to be seeded")
+		}
+		if ts.projectTemplateSeeded {
+			t.Error("expected project-level template NOT to be seeded")
+		}
+	})
+
+	t.Run("rollback on org template seed failure", func(t *testing.T) {
+		ts := &mockTemplateSeeder{seedOrgErr: fmt.Errorf("simulated org template failure")}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := true
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "fail-seed-org",
+			DisplayName:      "Fail Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		// Verify the org namespace was cleaned up.
+		fc := handler.folderCreator.(*k8sFolderCreator)
+		_, getErr := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-seed-org", metav1.GetOptions{})
+		if !k8serrors.IsNotFound(getErr) {
+			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
+		}
+	})
+
+	t.Run("rollback on project creation failure", func(t *testing.T) {
+		ts := &mockTemplateSeeder{}
+		pc := &k8sProjectCreator{
+			client:    nil, // will be set below
+			resolver:  testResolver(),
+			createErr: fmt.Errorf("simulated project creation failure"),
+		}
+		objs := []runtime.Object{}
+		fakeClient := fake.NewClientset(objs...)
+		r := testResolver()
+		k8s := NewK8sClient(fakeClient, r)
+		handler := NewHandler(k8s, nil, false, nil, nil)
+		fc := &k8sFolderCreator{client: fakeClient, resolver: r}
+		folderPrefix := r.NamespacePrefix + r.FolderPrefix
+		handler.WithFolderCreator(fc, fc, folderPrefix)
+		pc.client = fakeClient
+		projectPrefix := r.NamespacePrefix + r.ProjectPrefix
+		handler.WithDefaultsSeeder(ts, pc, projectPrefix)
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := true
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "fail-proj-org",
+			DisplayName:      "Fail Project Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		// Verify the org namespace was cleaned up.
+		_, getErr := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-proj-org", metav1.GetOptions{})
+		if !k8serrors.IsNotFound(getErr) {
+			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
+		}
+	})
+
+	t.Run("rollback on project template seed failure", func(t *testing.T) {
+		ts := &mockTemplateSeeder{seedProjectErr: fmt.Errorf("simulated project template failure")}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := true
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "fail-ptmpl-org",
+			DisplayName:      "Fail Project Template Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		// Verify the org namespace was cleaned up.
+		fc := handler.folderCreator.(*k8sFolderCreator)
+		_, getErr := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-ptmpl-org", metav1.GetOptions{})
+		if !k8serrors.IsNotFound(getErr) {
+			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
+		}
+	})
 }
 
 // ---- Helpers ----

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -372,6 +372,25 @@ func (c *K8sClient) UpdateProjectDefaultSharing(ctx context.Context, name string
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 
+// ProjectCreatorAdapter adapts the projects K8sClient to satisfy the
+// organizations.ProjectCreator interface. The adapter drops the
+// defaultShareUsers/defaultShareRoles parameters that are not needed for
+// the populate_defaults seeding flow.
+type ProjectCreatorAdapter struct {
+	K8s *K8sClient
+}
+
+// CreateProject creates a project namespace without default sharing grants.
+func (a *ProjectCreatorAdapter) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
+	_, err := a.K8s.CreateProject(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, nil, nil)
+	return err
+}
+
+// NamespaceExists delegates to the K8sClient.
+func (a *ProjectCreatorAdapter) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
+	return a.K8s.NamespaceExists(ctx, nsName)
+}
+
 func parseGrantAnnotation(ns *corev1.Namespace, key string) ([]secrets.AnnotationGrant, error) {
 	if ns.Annotations == nil {
 		return nil, nil

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -386,6 +386,11 @@ func (a *ProjectCreatorAdapter) CreateProject(ctx context.Context, name, display
 	return err
 }
 
+// DeleteProject delegates to the K8sClient.
+func (a *ProjectCreatorAdapter) DeleteProject(ctx context.Context, name string) error {
+	return a.K8s.DeleteProject(ctx, name)
+}
+
 // NamespaceExists delegates to the K8sClient.
 func (a *ProjectCreatorAdapter) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
 	return a.K8s.NamespaceExists(ctx, nsName)

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -435,6 +435,44 @@ func (k *K8sClient) SeedDefaultOrgTemplates(ctx context.Context, org string) err
 	return err
 }
 
+// SeedOrgTemplate seeds the built-in HTTPRoute platform template as enabled into
+// the org namespace. Used by the populate_defaults flow during org creation.
+func (k *K8sClient) SeedOrgTemplate(ctx context.Context, org string) error {
+	_, err := k.CreateTemplate(
+		ctx,
+		consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+		org,
+		DefaultReferenceGrantName,
+		"HTTPRoute",
+		"Exposes a deployment's Service via an HTTPRoute through the gateway. Requires a ReferenceGrant in the project namespace (provided by the default deployment template).",
+		DefaultReferenceGrantTemplate,
+		nil,
+		false, // not mandatory
+		true,  // enabled for populate_defaults flow
+		nil,
+	)
+	return err
+}
+
+// SeedProjectTemplate seeds the example httpbin deployment template into the
+// project namespace. Used by the populate_defaults flow during org creation.
+func (k *K8sClient) SeedProjectTemplate(ctx context.Context, project string) error {
+	_, err := k.CreateTemplate(
+		ctx,
+		consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+		project,
+		"example-httpbin",
+		"Example Httpbin",
+		"Example go-httpbin project-level deployment template. Produces ServiceAccount, Deployment, and Service resources.",
+		ExampleHttpbinTemplate,
+		nil,
+		false, // not mandatory
+		true,  // enabled for populate_defaults flow
+		nil,
+	)
+	return err
+}
+
 // configMapToTemplate converts a Kubernetes ConfigMap to a Template protobuf message.
 // The scope and scopeName must be provided by the caller since they are encoded
 // in the namespace (which the ConfigMap stores but the proto carries explicitly).


### PR DESCRIPTION
## Summary
- Implements the `populate_defaults` flag on `CreateOrganizationRequest` so that when true, the backend seeds example resources into the new org
- When `populate_defaults=true`, `CreateOrganization` now additionally creates: (1) an org-level HTTPRoute platform template (enabled), (2) a default project in the default folder, (3) an example httpbin project-level deployment template
- When `populate_defaults=false` or unset, behavior is unchanged (org + default folder only)
- Rollback: if any seeding step fails, the org namespace is cleaned up
- Follows existing dependency injection patterns (`FolderCreator` → `TemplateSeeder` + `ProjectCreator`)

Closes #758

## Test plan
- [x] `make test` passes (all Go and UI tests)
- [x] Table-driven tests cover `populate_defaults=true` (all resources created)
- [x] Table-driven tests cover `populate_defaults=false` (no seeding)
- [x] Table-driven tests cover `populate_defaults` unset (no seeding)
- [x] Table-driven tests cover rollback on org template seed failure
- [x] Table-driven tests cover rollback on project creation failure
- [x] Table-driven tests cover rollback on project template seed failure
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent:agent-3 -->