### PR TITLE
chore(folders): cleanup stale docs after folder route restructure

### DIFF
--- a/docs/adrs/023-top-level-url-scheme.md
+++ b/docs/adrs/023-top-level-url-scheme.md
@@ -91,7 +91,8 @@ users time to update bookmarks. After that period, they may be removed.
 | Org templates | `/orgs/$org/settings/org-templates/$tpl` | Org sub-page |
 | Org folder list | `/orgs/$org/folders` | Org-scoped navigation |
 | Org project list | `/orgs/$org/projects` | Org-scoped navigation |
-| Folder detail | `/folders/$folder` | Global namespace — top-level |
+| Folder index | `/folders/$folder` | Global namespace — top-level; shows folder contents (child folders and projects) |
+| Folder settings | `/folders/$folder/settings` | Folder sub-page; display name, parent, description, danger zone |
 | Folder templates | `/folders/$folder/templates` | Folder sub-page |
 | Project secrets | `/projects/$project/secrets` | Project sub-page |
 | Project deployments | `/projects/$project/deployments` | Project sub-page |

--- a/docs/agents/guardrail-collection-index.md
+++ b/docs/agents/guardrail-collection-index.md
@@ -7,9 +7,12 @@
 | URL | Purpose |
 |-----|---------|
 | `/orgs/$orgName/projects` | **Index page** -- lists all projects in the org |
+| `/orgs/$orgName/folders` | **Index page** -- lists top-level folders in the org |
+| `/folders/$folderName` | **Index page** -- lists child folders and projects in the folder |
+| `/folders/$folderName/settings` | **Settings page** -- folder configuration |
+| `/folders/$folderName/templates` | **Index page** -- lists folder-scoped templates |
 | `/projects/$projectName/secrets` | **Index page** -- lists all secrets in the project |
 | `/projects/$projectName/settings` | **Settings page** -- project configuration |
-| `/folders/$folderName/templates` | **Index page** -- lists folder-scoped templates |
 
 The index page is the default view when navigating to a resource collection. Settings always live at a dedicated `/settings` subroute, never at the collection root.
 

--- a/docs/agents/guardrail-url-scheme.md
+++ b/docs/agents/guardrail-url-scheme.md
@@ -5,14 +5,16 @@
 | Resource type | URL pattern | Example |
 |---------------|-------------|---------|
 | Organization | `/orgs/$orgName/...` | `/orgs/acme/settings` |
-| Folder | `/folders/$folderName/...` | `/folders/engineering/templates` |
+| Folder | `/folders/$folderName/...` | `/folders/engineering/settings` |
 | Project | `/projects/$projectName/...` | `/projects/frontend/secrets` |
+
+Folders use an index-and-subroute pattern: `/folders/$folderName` shows the folder contents (child folders and projects in a data grid), while `/folders/$folderName/settings` shows the folder settings (display name, parent, description, danger zone). `/folders/$folderName/templates` shows platform templates scoped to the folder.
 
 **Sub-resources** (secrets, deployments, project-scoped templates) are scoped under their parent project: `/projects/$projectName/secrets/$secretName`.
 
 **Org-scoped navigation** views (folder list, project list) live under `/orgs/$orgName/...` because they filter by organization context: `/orgs/$orgName/folders`, `/orgs/$orgName/projects`.
 
-**Rule**: Never nest a top-level resource under another top-level resource in the URL. A folder detail page is `/folders/$folderName`, not `/orgs/$orgName/folders/$folderName`.
+**Rule**: Never nest a top-level resource under another top-level resource in the URL. A folder page is `/folders/$folderName`, not `/orgs/$orgName/folders/$folderName`.
 
 **Triggers**: Apply this rule when adding new route files to `frontend/src/routes/` or modifying navigation links.
 


### PR DESCRIPTION
## Summary
- Updated `docs/agents/guardrail-url-scheme.md` to reflect that folders now have an index page (showing contents at `/folders/$folderName`) and a settings subroute (`/folders/$folderName/settings`), replacing the old single "detail page" description
- Updated ADR 023 URL pattern table to split "Folder detail" into "Folder index" and "Folder settings" rows with rationale
- Updated `docs/agents/guardrail-collection-index.md` to include the folder index page, org folder listing, and folder settings subroute in the URL table
- Verified all navigation links, redirect routes, imports, and test files are consistent with the new folder route structure introduced in #750 and #751 -- no stale code references found

Closes #752

## Test plan
- [x] `make test` -- all 681 UI tests and Go tests pass
- [x] No remaining navigation links point to `/folders/$folderName` expecting settings (all correctly land on the new index page)
- [x] Org-scoped redirects (`/orgs/$orgName/folders/$folderName/`) redirect to `/folders/$folderName`
- [x] No dead imports or unused components from the route restructure
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) from slot `agent-2`