### PR TITLE
fix(deployments): reorder Create Deployment form -- template first

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
@@ -129,6 +129,32 @@ export function CreateDeploymentPage({ projectName: propProjectName }: { project
       <CardContent>
         <div className="space-y-4">
           <div>
+            <Label>Template</Label>
+            {templates.length === 0 ? (
+              <p className="text-sm text-muted-foreground mt-1">
+                No templates available.{' '}
+                <Link
+                  to="/projects/$projectName/templates/new"
+                  params={{ projectName }}
+                  className="underline"
+                >
+                  Create a template
+                </Link>{' '}
+                first.
+              </p>
+            ) : (
+              <Combobox
+                aria-label="Template"
+                items={templates.map((t) => ({ value: t.name, label: t.name }))}
+                value={template}
+                onValueChange={handleTemplateChange}
+                placeholder="Select a template..."
+                searchPlaceholder="Search templates..."
+                emptyMessage="No templates found."
+              />
+            )}
+          </div>
+          <div>
             <Label htmlFor="deployment-display-name">Display Name</Label>
             <Input
               id="deployment-display-name"
@@ -160,32 +186,6 @@ export function CreateDeploymentPage({ projectName: propProjectName }: { project
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What does this deployment serve?"
             />
-          </div>
-          <div>
-            <Label>Template</Label>
-            {templates.length === 0 ? (
-              <p className="text-sm text-muted-foreground mt-1">
-                No templates available.{' '}
-                <Link
-                  to="/projects/$projectName/templates/new"
-                  params={{ projectName }}
-                  className="underline"
-                >
-                  Create a template
-                </Link>{' '}
-                first.
-              </p>
-            ) : (
-              <Combobox
-                aria-label="Template"
-                items={templates.map((t) => ({ value: t.name, label: t.name }))}
-                value={template}
-                onValueChange={handleTemplateChange}
-                placeholder="Select a template..."
-                searchPlaceholder="Search templates..."
-                emptyMessage="No templates found."
-              />
-            )}
           </div>
           <div>
             <Label htmlFor="deployment-image">Image</Label>


### PR DESCRIPTION
## Summary

- Move the Template selector from position 4 to position 1 in the Create Deployment form
- Users are now guided to select a template first, which auto-populates all downstream fields (Display Name, Name slug, Description, Image, Tag, Port, Command, Args, Env)
- `autoFocus` remains on the Display Name input (first text input after selecting a template via the Combobox popover)
- No changes to `handleTemplateChange` logic, backend, or proto files

Closes #772

## Test plan

- [x] All 681 UI tests pass (`make test-ui`), including all 34 tests in `-new.test.tsx`
- [ ] Template selector renders as the first field in the form, above Display Name
- [ ] Selecting a template still auto-populates all fields
- [ ] "No templates available" fallback with link renders when no templates exist
- [ ] `autoFocus` is on the Display Name input

> Local E2E was not run (frontend-only change with no routing or backend impact). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent: agent-1