### PR TITLE
fix: surface child-list fetch errors on folder detail page

### DIFF
--- a/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
@@ -99,6 +99,8 @@ function setupMocks(
     userRole?: Role
     folderLoading?: boolean
     folderError?: Error | null
+    foldersError?: Error | null
+    projectsError?: Error | null
   } = {},
 ) {
   const {
@@ -108,6 +110,8 @@ function setupMocks(
     userRole = Role.OWNER,
     folderLoading = false,
     folderError = null,
+    foldersError = null,
+    projectsError = null,
   } = opts
 
   ;(useGetFolder as Mock).mockReturnValue({
@@ -116,14 +120,14 @@ function setupMocks(
     error: folderError,
   })
   ;(useListFolders as Mock).mockReturnValue({
-    data: childFolders,
+    data: foldersError ? undefined : childFolders,
     isPending: false,
-    error: null,
+    error: foldersError,
   })
   ;(useListProjectsByParent as Mock).mockReturnValue({
-    data: childProjects,
+    data: projectsError ? undefined : childProjects,
     isPending: false,
-    error: null,
+    error: projectsError,
   })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: 'test-org', userRole },
@@ -257,5 +261,17 @@ describe('FolderIndexPage', () => {
     })
     render(<FolderIndexPage folderName="payments" />)
     expect(screen.getByText('creator@example.com')).toBeInTheDocument()
+  })
+
+  it('renders error alert when child folders fetch fails', () => {
+    setupMocks({ foldersError: new Error('failed to load child folders') })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.getByText(/failed to load child folders/i)).toBeInTheDocument()
+  })
+
+  it('renders error alert when child projects fetch fails', () => {
+    setupMocks({ projectsError: new Error('failed to load child projects') })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(screen.getByText(/failed to load child projects/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -78,8 +78,8 @@ export function FolderIndexPage({ folderName: propFolderName }: { folderName?: s
   const userRole = org?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
-  const { data: childFolders, isPending: foldersLoading } = useListFolders(orgName, ParentType.FOLDER, folderName)
-  const { data: childProjects, isPending: projectsLoading } = useListProjectsByParent(orgName, ParentType.FOLDER, folderName)
+  const { data: childFolders, isPending: foldersLoading, error: foldersError } = useListFolders(orgName, ParentType.FOLDER, folderName)
+  const { data: childProjects, isPending: projectsLoading, error: projectsError } = useListProjectsByParent(orgName, ParentType.FOLDER, folderName)
 
   const [globalFilter, setGlobalFilter] = useState('')
   const [sorting, setSorting] = useState<SortingState>([{ id: 'displayName', desc: false }])
@@ -239,12 +239,13 @@ export function FolderIndexPage({ folderName: propFolderName }: { folderName?: s
     }
   }
 
-  if (folderError) {
+  const fetchError = folderError ?? foldersError ?? projectsError
+  if (fetchError) {
     return (
       <Card>
         <CardContent className="pt-6">
           <Alert variant="destructive">
-            <AlertDescription>{folderError.message}</AlertDescription>
+            <AlertDescription>{fetchError.message}</AlertDescription>
           </Alert>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Destructure `error` from `useListFolders` and `useListProjectsByParent` hooks in the folder detail page
- Coalesce all three query errors (`folderError`, `foldersError`, `projectsError`) into a single `fetchError` check
- Add two test cases verifying error alerts are shown when child-folder or child-project queries fail

Closes #782

## Test plan
- [x] New test: "renders error alert when child folders fetch fails" passes
- [x] New test: "renders error alert when child projects fetch fails" passes
- [x] All 16 tests in -index.test.tsx pass
- [x] All 683 UI tests pass (make test-ui)
- [ ] CI passes

> Local E2E was not run. This change is UI-only error handling (no proto, no Go, no route changes). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)