### PR TITLE
feat(folders): add folder sharing mutation query hooks

### DIFF
--- a/frontend/src/queries/folders.ts
+++ b/frontend/src/queries/folders.ts
@@ -94,3 +94,35 @@ export function useUpdateFolder(organization: string, name: string) {
   })
 }
 
+export function useUpdateFolderSharing(organization: string, name: string) {
+  const transport = useTransport()
+  const client = useMemo(() => createClient(FolderService, transport), [transport])
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      userGrants: ShareGrant[]
+      roleGrants: ShareGrant[]
+    }) => client.updateFolderSharing({ name, organization, ...params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
+      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
+    },
+  })
+}
+
+export function useUpdateFolderDefaultSharing(organization: string, name: string) {
+  const transport = useTransport()
+  const client = useMemo(() => createClient(FolderService, transport), [transport])
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      defaultUserGrants: ShareGrant[]
+      defaultRoleGrants: ShareGrant[]
+    }) => client.updateFolderDefaultSharing({ name, organization, ...params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
+      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
+    },
+  })
+}
+


### PR DESCRIPTION
## Summary

- Add `useUpdateFolderSharing` hook to `frontend/src/queries/folders.ts` that calls the existing `UpdateFolderSharing` RPC on the `FolderService`
- Add `useUpdateFolderDefaultSharing` hook to `frontend/src/queries/folders.ts` that calls the existing `UpdateFolderDefaultSharing` RPC on the `FolderService`
- Both hooks accept `organization` and `name` as constructor parameters, take `ShareGrant[]` arrays in the mutation params, and invalidate folder query caches on success matching the pattern used by `useUpdateFolder`

Closes #789

## Test plan

- [x] `make test-ui` passes (683 tests across 47 files)
- [x] `make test-go` passes (all packages)
- [ ] Hooks are integration-tested through the folder settings sharing UI in Phase 2 (#790)

> Local E2E was not run. These changes are frontend query hooks only (no routing, no component rendering), so E2E is not warranted per the relevance heuristic.

Generated with [Claude Code](https://claude.com/claude-code)

---

*Agent: agent-2*