### PR TITLE
feat(templates): add linked template selection to create page

### DIFF
--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -82,6 +82,7 @@ export function useCreateTemplate(scope: TemplateScopeRef) {
       cueTemplate: string
       mandatory?: boolean
       enabled?: boolean
+      linkedTemplates?: LinkedTemplateRef[]
     }) =>
       client.createTemplate({
         scope,
@@ -93,7 +94,7 @@ export function useCreateTemplate(scope: TemplateScopeRef) {
           cueTemplate: params.cueTemplate,
           mandatory: params.mandatory ?? false,
           enabled: params.enabled ?? false,
-          linkedTemplates: [],
+          linkedTemplates: params.linkedTemplates ?? [],
         },
       }),
     onSuccess: () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
@@ -22,7 +23,13 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('@/queries/templates', () => ({
   useCreateTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
-  makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [] }),
+  makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
+  TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useGetProject: vi.fn(),
 }))
 
 vi.mock('@/hooks/use-debounced-value', () => ({
@@ -31,13 +38,16 @@ vi.mock('@/hooks/use-debounced-value', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useCreateTemplate, useRenderTemplate } from '@/queries/templates'
+import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates } from '@/queries/templates'
+import { useGetProject } from '@/queries/projects'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateTemplatePage } from './new'
 
 function setupMocks(
   mutateAsync = vi.fn().mockResolvedValue({}),
   renderData?: { renderedJson?: string },
   renderError?: Error,
+  userRole = Role.OWNER,
 ) {
   ;(useCreateTemplate as Mock).mockReturnValue({
     mutateAsync,
@@ -49,6 +59,10 @@ function setupMocks(
     error: renderError ?? null,
     isLoading: false,
     isError: !!renderError,
+  })
+  ;(useGetProject as Mock).mockReturnValue({
+    data: { name: 'test-project', userRole },
+    isLoading: false,
   })
 }
 
@@ -227,6 +241,125 @@ describe('CreateTemplatePage', () => {
       expect(cueEditor.value).toContain('ServiceAccount')
       expect(cueEditor.value).toContain('Deployment')
       expect(cueEditor.value).toContain('Service')
+    })
+  })
+
+  describe('linked platform templates on create page', () => {
+    const mockOrgTemplates = [
+      { name: 'reference-grant', displayName: 'Reference Grant', description: 'Default ReferenceGrant for cross-namespace gateway routing', mandatory: true, scopeRef: { scope: 1, scopeName: 'default' } },
+      { name: 'httpbin-platform', displayName: 'HTTPbin Platform', description: 'Platform HTTPRoute for go-httpbin', mandatory: false, scopeRef: { scope: 1, scopeName: 'default' } },
+    ]
+    const mockFolderTemplates = [
+      { name: 'team-network-policy', displayName: 'Team Network Policy', description: 'Standard NetworkPolicy for team namespaces', mandatory: false, scopeRef: { scope: 2, scopeName: 'team-a' } },
+    ]
+    const allLinkable = [...mockOrgTemplates, ...mockFolderTemplates]
+
+    it('hides linked templates section when no linkable templates exist', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [] })
+      setupMocks()
+      render(<CreateTemplatePage />)
+      expect(screen.queryByText(/linked platform templates/i)).not.toBeInTheDocument()
+    })
+
+    it('shows linked templates section when linkable templates exist for OWNER', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
+      render(<CreateTemplatePage />)
+      expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+    })
+
+    it('groups templates by scope with Organization and Folder headers', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
+      render(<CreateTemplatePage />)
+      expect(screen.getByText(/organization templates/i)).toBeInTheDocument()
+      expect(screen.getByText(/folder templates/i)).toBeInTheDocument()
+    })
+
+    it('shows checkboxes for linkable templates when user is OWNER', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
+      render(<CreateTemplatePage />)
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes.length).toBe(3)
+    })
+
+    it('mandatory template checkbox is checked and disabled', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
+      render(<CreateTemplatePage />)
+      const mandatoryCheckbox = screen.getByRole('checkbox', { name: /reference grant/i })
+      expect(mandatoryCheckbox).toBeChecked()
+      expect(mandatoryCheckbox).toBeDisabled()
+    })
+
+    it('non-mandatory template checkboxes are unchecked by default', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
+      render(<CreateTemplatePage />)
+      const httpbinCheckbox = screen.getByRole('checkbox', { name: /httpbin platform/i })
+      expect(httpbinCheckbox).not.toBeChecked()
+      expect(httpbinCheckbox).not.toBeDisabled()
+    })
+
+    it('shows read-only view for EDITOR with mandatory templates and permission note', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.EDITOR)
+      render(<CreateTemplatePage />)
+      expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      expect(screen.getByText(/reference grant/i)).toBeInTheDocument()
+      expect(screen.getByText(/only owners can link/i)).toBeInTheDocument()
+    })
+
+    it('shows read-only view for VIEWER with mandatory templates and permission note', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.VIEWER)
+      render(<CreateTemplatePage />)
+      expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      expect(screen.getByText(/only owners can link/i)).toBeInTheDocument()
+    })
+
+    it('selected linked templates are included in create mutation', async () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
+      const user = userEvent.setup()
+      render(<CreateTemplatePage />)
+
+      fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+
+      // Check a non-mandatory template
+      await user.click(screen.getByRole('checkbox', { name: /httpbin platform/i }))
+
+      fireEvent.click(screen.getByRole('button', { name: /create template/i }))
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            linkedTemplates: expect.arrayContaining([
+              expect.objectContaining({ name: 'httpbin-platform', scope: 1, scopeName: 'default' }),
+            ]),
+          }),
+        )
+      })
+    })
+
+    it('create mutation receives empty linkedTemplates when no optional templates selected', async () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
+      render(<CreateTemplatePage />)
+
+      fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+      fireEvent.click(screen.getByRole('button', { name: /create template/i }))
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            linkedTemplates: [],
+          }),
+        )
+      })
     })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -6,9 +6,13 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Info } from 'lucide-react'
-import { useCreateTemplate, useRenderTemplate, makeProjectScope } from '@/queries/templates'
+import { Info, Lock } from 'lucide-react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope } from '@/queries/templates'
+import type { LinkedTemplateRef } from '@/queries/templates'
+import { useGetProject } from '@/queries/projects'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 
 const DEFAULT_CUE_TEMPLATE = `// Use generated type definitions from api/v1alpha2 (prepended by renderer).
@@ -233,6 +237,11 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const navigate = useNavigate()
   const scope = makeProjectScope(projectName)
   const createMutation = useCreateTemplate(scope)
+  const { data: project } = useGetProject(projectName)
+  const { data: linkableTemplates = [] } = useListLinkableTemplates(scope)
+
+  const userRole = project?.userRole ?? Role.VIEWER
+  const canLink = userRole === Role.OWNER
 
   const [displayName, setDisplayName] = useState('')
   const [name, setName] = useState('')
@@ -240,6 +249,15 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const [cueTemplate, setCueTemplate] = useState(DEFAULT_CUE_TEMPLATE)
   const [error, setError] = useState<string | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
+  const [selectedLinkedNames, setSelectedLinkedNames] = useState<string[]>([])
+
+  // Group linkable templates by scope for display.
+  const orgTemplates = linkableTemplates.filter(
+    (t) => t.scopeRef?.scope === TemplateScope.ORGANIZATION,
+  )
+  const folderTemplates = linkableTemplates.filter(
+    (t) => t.scopeRef?.scope === TemplateScope.FOLDER,
+  )
 
   const previewCuePlatformInput = `platform: {
 \tproject:          "${projectName}"
@@ -290,11 +308,22 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
     }
     setError(null)
     try {
+      // Build LinkedTemplateRef objects from selected names using scopeRef
+      // from the linkable template list returned by the server.
+      const linkedTemplates: LinkedTemplateRef[] = selectedLinkedNames
+        .map((n) => {
+          const lt = linkableTemplates.find((t) => t.name === n)
+          if (!lt?.scopeRef) return null
+          return { scope: lt.scopeRef.scope, scopeName: lt.scopeRef.scopeName, name: n } as LinkedTemplateRef
+        })
+        .filter((ref): ref is LinkedTemplateRef => ref !== null)
+
       await createMutation.mutateAsync({
         name: name.trim(),
         displayName: displayName.trim(),
         description: description.trim(),
         cueTemplate,
+        linkedTemplates,
       })
       await navigate({
         to: '/projects/$projectName/templates/$templateName',
@@ -373,6 +402,106 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
               className="font-mono text-sm field-sizing-normal max-h-[600px] overflow-y-auto"
             />
           </div>
+          {linkableTemplates.length > 0 && (
+            <div className="space-y-3">
+              <Label>Linked Platform Templates</Label>
+              {canLink ? (
+                <div className="space-y-4">
+                  {orgTemplates.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Organization Templates</p>
+                      {orgTemplates.map((t) => (
+                        <div key={t.name} className="flex items-start gap-2">
+                          <Checkbox
+                            id={`linked-create-${t.name}`}
+                            checked={t.mandatory || selectedLinkedNames.includes(t.name)}
+                            disabled={t.mandatory}
+                            onCheckedChange={(checked) => {
+                              if (t.mandatory) return
+                              setSelectedLinkedNames((prev) =>
+                                checked ? [...prev, t.name] : prev.filter((n) => n !== t.name),
+                              )
+                            }}
+                          />
+                          <div className="flex flex-col">
+                            <label htmlFor={`linked-create-${t.name}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                              {t.displayName || t.name}
+                              {t.mandatory && (
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>This platform template is mandatory and always applied.</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              )}
+                            </label>
+                            {t.description && (
+                              <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {folderTemplates.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Folder Templates</p>
+                      {folderTemplates.map((t) => (
+                        <div key={t.name} className="flex items-start gap-2">
+                          <Checkbox
+                            id={`linked-create-${t.name}`}
+                            checked={t.mandatory || selectedLinkedNames.includes(t.name)}
+                            disabled={t.mandatory}
+                            onCheckedChange={(checked) => {
+                              if (t.mandatory) return
+                              setSelectedLinkedNames((prev) =>
+                                checked ? [...prev, t.name] : prev.filter((n) => n !== t.name),
+                              )
+                            }}
+                          />
+                          <div className="flex flex-col">
+                            <label htmlFor={`linked-create-${t.name}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                              {t.displayName || t.name}
+                              {t.mandatory && (
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>This platform template is mandatory and always applied.</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              )}
+                            </label>
+                            {t.description && (
+                              <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {linkableTemplates.filter((t) => t.mandatory).map((t) => (
+                    <div key={t.name} className="flex items-center gap-1 text-sm">
+                      <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
+                      <span>{t.displayName || t.name}</span>
+                      <span className="text-muted-foreground">(mandatory, auto-applied)</span>
+                    </div>
+                  ))}
+                  <p className="text-xs text-muted-foreground">Only owners can link additional platform templates.</p>
+                </div>
+              )}
+            </div>
+          )}
           <div>
             <Button variant="outline" type="button" onClick={() => setPreviewOpen((v) => !v)}>
               {previewOpen ? 'Hide Preview' : 'Preview'}


### PR DESCRIPTION
## Summary
- Add a "Linked Platform Templates" section to the create template page that lets users select linked org and folder templates at creation time
- Templates are grouped by scope (Organization, Folder) with section headers
- Mandatory templates are shown as always-checked and disabled with Lock icon
- Non-mandatory templates are selectable checkboxes for OWNER role users
- EDITOR/VIEWER users see a read-only view with mandatory templates listed and a note that only owners can link additional templates
- Section hidden entirely when no linkable templates exist
- Update `useCreateTemplate` to accept optional `linkedTemplates` parameter
- 9 new unit tests covering all linked template behaviors

Closes #768

## Test plan
- [x] `make test` passes (693 UI tests + all Go tests pass)
- [ ] Verify linked template section renders correctly with org and folder templates
- [ ] Verify mandatory templates are checked and disabled
- [ ] Verify EDITOR/VIEWER see read-only view with permission note
- [ ] Verify section hidden when no linkable templates exist
- [ ] Verify selected linked templates passed in create mutation

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) from agent slot `agent-4`