### PR TITLE
feat(folders): wire SharingPanel into folder settings page

### DIFF
--- a/frontend/src/queries/folders.ts
+++ b/frontend/src/queries/folders.ts
@@ -3,7 +3,6 @@ import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { FolderService } from '@/gen/holos/console/v1/folders_pb.js'
-import type { ShareGrant } from '@/gen/holos/console/v1/secrets_pb.js'
 import type { ParentType } from '@/gen/holos/console/v1/folders_pb.js'
 import { useAuth } from '@/lib/auth'
 
@@ -70,8 +69,8 @@ export function useCreateFolder(organization: string) {
       description: string
       parentType: ParentType
       parentName: string
-      userGrants?: ShareGrant[]
-      roleGrants?: ShareGrant[]
+      userGrants?: { principal: string; role: number }[]
+      roleGrants?: { principal: string; role: number }[]
     }) =>
       client.createFolder({ organization, ...params }),
     onSuccess: () => {
@@ -100,8 +99,8 @@ export function useUpdateFolderSharing(organization: string, name: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (params: {
-      userGrants: ShareGrant[]
-      roleGrants: ShareGrant[]
+      userGrants: { principal: string; role: number }[]
+      roleGrants: { principal: string; role: number }[]
     }) => client.updateFolderSharing({ name, organization, ...params }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
@@ -116,8 +115,8 @@ export function useUpdateFolderDefaultSharing(organization: string, name: string
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (params: {
-      defaultUserGrants: ShareGrant[]
-      defaultRoleGrants: ShareGrant[]
+      defaultUserGrants: { principal: string; role: number }[]
+      defaultRoleGrants: { principal: string; role: number }[]
     }) => client.updateFolderDefaultSharing({ name, organization, ...params }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: folderListKey(organization) })

--- a/frontend/src/routes/_authenticated/folders/$folderName/-folder-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-folder-detail.test.tsx
@@ -22,6 +22,8 @@ vi.mock('@/queries/folders', () => ({
   useGetFolderRaw: vi.fn(),
   useUpdateFolder: vi.fn(),
   useListFolders: vi.fn(),
+  useUpdateFolderSharing: vi.fn(),
+  useUpdateFolderDefaultSharing: vi.fn(),
 }))
 
 vi.mock('@/queries/organizations', () => ({
@@ -30,7 +32,7 @@ vi.mock('@/queries/organizations', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders } from '@/queries/folders'
+import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders, useUpdateFolderSharing, useUpdateFolderDefaultSharing } from '@/queries/folders'
 import { useGetOrganization } from '@/queries/organizations'
 import { FolderDetailPage } from '@/routes/_authenticated/folders/$folderName/settings/index'
 
@@ -43,6 +45,10 @@ const mockFolder = {
   parentType: 1, // ORGANIZATION
   parentName: 'test-org',
   userRole: 3, // OWNER
+  userGrants: [{ principal: 'alice@example.com', role: 3 }],
+  roleGrants: [],
+  defaultUserGrants: [{ principal: 'bob@example.com', role: 1 }],
+  defaultRoleGrants: [],
 }
 
 const mockOrg = {
@@ -85,6 +91,14 @@ function setupMocks(overrides: { folder?: Partial<typeof mockFolder>; org?: Part
     data: folders,
     isPending: false,
     error: null,
+  })
+  ;(useUpdateFolderSharing as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useUpdateFolderDefaultSharing as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
   })
 }
 
@@ -227,6 +241,63 @@ describe('FolderDetailPage', () => {
         // level3 is a descendant of level2, excluded by depth (3+2=5 > 3)
         expect(screen.queryByText('Level 3')).not.toBeInTheDocument()
       })
+    })
+  })
+
+  describe('Sharing section', () => {
+    it('renders SharingPanel with user grants', () => {
+      setupMocks()
+      render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    })
+
+    it('saving sharing calls useUpdateFolderSharing', async () => {
+      setupMocks()
+      render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
+      // First Edit button is the Sharing section (index 0), second is Default Sharing (index 1)
+      const editButtons = screen.getAllByRole('button', { name: /^edit$/i })
+      fireEvent.click(editButtons[0])
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+      const mutateAsync = (useUpdateFolderSharing as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Default Sharing section', () => {
+    it('renders default grants from folder data', () => {
+      setupMocks()
+      render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
+      expect(screen.getByText('Default Sharing')).toBeInTheDocument()
+      expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+    })
+
+    it('shows explanatory description text', () => {
+      setupMocks()
+      render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
+      expect(screen.getByText(/automatically applied to every new secret created in projects within this folder/i)).toBeInTheDocument()
+    })
+
+    it('save calls useUpdateFolderDefaultSharing mutation', async () => {
+      setupMocks()
+      render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
+      // Second Edit button is the Default Sharing section (index 1)
+      const editButtons = screen.getAllByRole('button', { name: /^edit$/i })
+      fireEvent.click(editButtons[1])
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+      const mutateAsync = (useUpdateFolderDefaultSharing as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalled()
+      })
+    })
+
+    it('non-owners cannot edit sharing grants', () => {
+      setupMocks({ folder: { userRole: 1 }, org: { userRole: 1 } }) // VIEWER
+      render(<FolderDetailPage orgName="test-org" folderName="test-folder" />)
+      // With userRole=VIEWER (not owner), there should be no Edit buttons for sharing
+      const editButtons = screen.queryAllByRole('button', { name: /^edit$/i })
+      expect(editButtons.length).toBe(0)
     })
   })
 })

--- a/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
@@ -28,9 +28,10 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Combobox, type ComboboxItem } from '@/components/ui/combobox'
 import { Check, Pencil, X, Table2, Braces } from 'lucide-react'
+import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { ViewModeToggle } from '@/components/view-mode-toggle'
 import { RawView } from '@/components/raw-view'
-import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders } from '@/queries/folders'
+import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders, useUpdateFolderSharing, useUpdateFolderDefaultSharing } from '@/queries/folders'
 import { useGetOrganization } from '@/queries/organizations'
 import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -74,6 +75,8 @@ export function FolderDetailPage({
   const { data: org } = useGetOrganization(orgName)
   const updateMutation = useUpdateFolder(orgName, folderName)
   const { data: allFolders } = useListFolders(orgName)
+  const updateFolderSharing = useUpdateFolderSharing(orgName, folderName)
+  const updateFolderDefaultSharing = useUpdateFolderDefaultSharing(orgName, folderName)
 
   // View mode: data or raw
   const [viewMode, setViewMode] = useState<'data' | 'raw'>('data')
@@ -235,6 +238,14 @@ export function FolderDetailPage({
     }
   }
 
+  const handleSaveSharing = async (userGrants: Grant[], roleGrants: Grant[]) => {
+    await updateFolderSharing.mutateAsync({ userGrants, roleGrants })
+  }
+
+  const handleSaveDefaultSharing = async (defaultUserGrants: Grant[], defaultRoleGrants: Grant[]) => {
+    await updateFolderDefaultSharing.mutateAsync({ defaultUserGrants, defaultRoleGrants })
+  }
+
   if (isPending) {
     return (
       <Card>
@@ -262,6 +273,10 @@ export function FolderDetailPage({
   const displayName = folder?.displayName ?? ''
   const description = folder?.description ?? ''
   const creatorEmail = folder?.creatorEmail ?? ''
+  const userGrants = (folder?.userGrants ?? []) as Grant[]
+  const roleGrants = (folder?.roleGrants ?? []) as Grant[]
+  const defaultUserGrants = (folder?.defaultUserGrants ?? []) as Grant[]
+  const defaultRoleGrants = (folder?.defaultRoleGrants ?? []) as Grant[]
 
   return (
     <>
@@ -482,6 +497,26 @@ export function FolderDetailPage({
               )}
             </div>
           </div>
+
+          {/* Sharing section */}
+          <SharingPanel
+            userGrants={userGrants}
+            roleGrants={roleGrants}
+            isOwner={isOwner}
+            onSave={handleSaveSharing}
+            isSaving={updateFolderSharing.isPending}
+          />
+
+          {/* Default Sharing section */}
+          <SharingPanel
+            title="Default Sharing"
+            description="These grants are automatically applied to every new secret created in projects within this folder."
+            userGrants={defaultUserGrants}
+            roleGrants={defaultRoleGrants}
+            isOwner={isOwner}
+            onSave={handleSaveDefaultSharing}
+            isSaving={updateFolderDefaultSharing.isPending}
+          />
 
           {/* Platform Templates section */}
           <div className="space-y-4">


### PR DESCRIPTION
## Summary
- Wire `SharingPanel` component into folder settings page for both direct and default sharing grants
- Add `handleSaveSharing` / `handleSaveDefaultSharing` handlers calling the mutation hooks from #789
- Extract `userGrants`, `roleGrants`, `defaultUserGrants`, `defaultRoleGrants` from folder data
- Gate Edit button on `isOwner` (folder-level owner role)
- Place sharing panels between General and Platform Templates sections, matching org/project layout
- Add 5 tests covering grant rendering, save mutations, description text, and RBAC gating

Closes #790

## Test plan
- [x] `make test` passes (689 UI tests, all Go tests)
- [x] Sharing panel renders with folder user grants
- [x] Default Sharing panel renders with default grants and description text
- [x] Save calls correct mutation hooks
- [x] Non-owners cannot see Edit buttons on sharing panels

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

agent-2