### PR TITLE
feat(templates): backend release CRUD, version resolution, and update checking

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -78,6 +78,20 @@ const (
 	// LabelTemplateScope identifies the hierarchy level of a template ConfigMap.
 	// Values: "organization", "folder", "project" (ADR 021 Decision 4).
 	LabelTemplateScope = "console.holos.run/template-scope"
+
+	// Release ConfigMap labels and annotations (ADR 024).
+
+	// ResourceTypeTemplateRelease is the resource type label value for release
+	// ConfigMaps, distinguishing them from live template ConfigMaps.
+	ResourceTypeTemplateRelease = "template-release"
+	// LabelReleaseOf identifies which template a release ConfigMap belongs to.
+	LabelReleaseOf = "console.holos.run/release-of"
+	// AnnotationTemplateVersion stores the semver version string of a release.
+	AnnotationTemplateVersion = "console.holos.run/template-version"
+	// ChangelogKey is the ConfigMap data key for the release changelog.
+	ChangelogKey = "changelog"
+	// UpgradeAdviceKey is the ConfigMap data key for upgrade advice text.
+	UpgradeAdviceKey = "upgrade-advice"
 	// TemplateScopeOrganization is the LabelTemplateScope value for org-level templates.
 	TemplateScopeOrganization = "organization"
 	// TemplateScopeFolder is the LabelTemplateScope value for folder-level templates.

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -88,6 +88,22 @@
 // Values: "organization", "folder", "project" (ADR 021 Decision 4).
 #LabelTemplateScope: "console.holos.run/template-scope"
 
+// ResourceTypeTemplateRelease is the resource type label value for release
+// ConfigMaps, distinguishing them from live template ConfigMaps.
+#ResourceTypeTemplateRelease: "template-release"
+
+// LabelReleaseOf identifies which template a release ConfigMap belongs to.
+#LabelReleaseOf: "console.holos.run/release-of"
+
+// AnnotationTemplateVersion stores the semver version string of a release.
+#AnnotationTemplateVersion: "console.holos.run/template-version"
+
+// ChangelogKey is the ConfigMap data key for the release changelog.
+#ChangelogKey: "changelog"
+
+// UpgradeAdviceKey is the ConfigMap data key for upgrade advice text.
+#UpgradeAdviceKey: "upgrade-advice"
+
 // TemplateScopeOrganization is the LabelTemplateScope value for org-level templates.
 #TemplateScopeOrganization: "organization"
 

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -735,6 +735,307 @@ func (h *Handler) checkProjectAccess(ctx context.Context, claims *rpc.Claims, pr
 	return rbac.CheckCascadeAccess(claims.Email, claims.Roles, users, roles, perm, rbac.TemplateCascadePerms)
 }
 
+// CreateRelease publishes a new immutable release of a template.
+func (h *Handler) CreateRelease(
+	ctx context.Context,
+	req *connect.Request[consolev1.CreateReleaseRequest],
+) (*connect.Response[consolev1.CreateReleaseResponse], error) {
+	scope, scopeName, err := extractScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	release := req.Msg.GetRelease()
+	if release == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("release is required"))
+	}
+	templateName := release.TemplateName
+	if templateName == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("release.template_name is required"))
+	}
+	if release.Version == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("release.version is required"))
+	}
+
+	version, err := ParseVersion(release.Version)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesWrite); err != nil {
+		return nil, err
+	}
+
+	// Create the release ConfigMap. K8s returns AlreadyExists if the version
+	// is duplicated (ConfigMap name is deterministic from template+version).
+	cm, err := h.k8s.CreateRelease(ctx, scope, scopeName, templateName, version, release.CueTemplate, release.Defaults, release.Changelog, release.UpgradeAdvice)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "release created",
+		slog.String("action", "release_create"),
+		slog.String("resource_type", "template-release"),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("templateName", templateName),
+		slog.String("version", version.String()),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.CreateReleaseResponse{
+		Release: configMapToRelease(cm, scope, scopeName),
+	}), nil
+}
+
+// ListReleases returns all releases for a template, sorted by version descending.
+func (h *Handler) ListReleases(
+	ctx context.Context,
+	req *connect.Request[consolev1.ListReleasesRequest],
+) (*connect.Response[consolev1.ListReleasesResponse], error) {
+	scope, scopeName, err := extractScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	templateName := req.Msg.TemplateName
+	if templateName == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template_name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesRead); err != nil {
+		return nil, err
+	}
+
+	cms, err := h.k8s.ListReleases(ctx, scope, scopeName, templateName)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	releases := make([]*consolev1.Release, 0, len(cms))
+	for _, cm := range cms {
+		releases = append(releases, configMapToRelease(&cm, scope, scopeName))
+	}
+
+	slog.InfoContext(ctx, "releases listed",
+		slog.String("action", "releases_list"),
+		slog.String("resource_type", "template-release"),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("templateName", templateName),
+		slog.String("sub", claims.Sub),
+		slog.Int("count", len(releases)),
+	)
+
+	return connect.NewResponse(&consolev1.ListReleasesResponse{
+		Releases: releases,
+	}), nil
+}
+
+// GetRelease retrieves a single release by template name, scope, and version.
+func (h *Handler) GetRelease(
+	ctx context.Context,
+	req *connect.Request[consolev1.GetReleaseRequest],
+) (*connect.Response[consolev1.GetReleaseResponse], error) {
+	scope, scopeName, err := extractScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	templateName := req.Msg.TemplateName
+	if templateName == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template_name is required"))
+	}
+	if req.Msg.Version == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("version is required"))
+	}
+
+	version, err := ParseVersion(req.Msg.Version)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesRead); err != nil {
+		return nil, err
+	}
+
+	cm, err := h.k8s.GetRelease(ctx, scope, scopeName, templateName, version)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "release read",
+		slog.String("action", "release_read"),
+		slog.String("resource_type", "template-release"),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("templateName", templateName),
+		slog.String("version", version.String()),
+		slog.String("sub", claims.Sub),
+	)
+
+	return connect.NewResponse(&consolev1.GetReleaseResponse{
+		Release: configMapToRelease(cm, scope, scopeName),
+	}), nil
+}
+
+// CheckUpdates computes available version updates for all linked templates
+// of a template (or all templates in a scope).
+func (h *Handler) CheckUpdates(
+	ctx context.Context,
+	req *connect.Request[consolev1.CheckUpdatesRequest],
+) (*connect.Response[consolev1.CheckUpdatesResponse], error) {
+	scope, scopeName, err := extractScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesRead); err != nil {
+		return nil, err
+	}
+
+	// Collect templates to check. If template_name is specified, check only
+	// that template's linked refs. Otherwise check all templates in scope.
+	var templates []corev1.ConfigMap
+	if req.Msg.TemplateName != "" {
+		cm, getErr := h.k8s.GetTemplate(ctx, scope, scopeName, req.Msg.TemplateName)
+		if getErr != nil {
+			return nil, mapK8sError(getErr)
+		}
+		templates = []corev1.ConfigMap{*cm}
+	} else {
+		cms, listErr := h.k8s.ListTemplates(ctx, scope, scopeName)
+		if listErr != nil {
+			return nil, mapK8sError(listErr)
+		}
+		templates = cms
+	}
+
+	var updates []*consolev1.TemplateUpdate
+	for _, tmpl := range templates {
+		raw, ok := tmpl.Annotations[v1alpha2.AnnotationLinkedTemplates]
+		if !ok || raw == "" {
+			continue
+		}
+		refs, err := unmarshalLinkedTemplates(raw)
+		if err != nil {
+			continue
+		}
+		for _, ref := range refs {
+			update, err := h.checkLinkedUpdate(ctx, ref)
+			if err != nil {
+				slog.WarnContext(ctx, "failed to check update for linked template",
+					slog.String("name", ref.Name),
+					slog.Any("error", err),
+				)
+				continue
+			}
+			if update != nil {
+				updates = append(updates, update)
+			}
+		}
+	}
+
+	slog.InfoContext(ctx, "updates checked",
+		slog.String("action", "check_updates"),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("sub", claims.Sub),
+		slog.Int("count", len(updates)),
+	)
+
+	return connect.NewResponse(&consolev1.CheckUpdatesResponse{
+		Updates: updates,
+	}), nil
+}
+
+// checkLinkedUpdate computes the update status for a single linked template
+// reference. Returns nil if no updates are available.
+func (h *Handler) checkLinkedUpdate(ctx context.Context, ref *consolev1.LinkedTemplateRef) (*consolev1.TemplateUpdate, error) {
+	refScope := ref.GetScope()
+	refScopeName := ref.ScopeName
+	refName := ref.Name
+	constraintStr := ref.VersionConstraint
+
+	// List all release versions for the linked template.
+	versions, err := h.k8s.ListReleaseVersions(ctx, refScope, refScopeName, refName)
+	if err != nil {
+		return nil, err
+	}
+	if len(versions) == 0 {
+		return nil, nil // no releases means no updates
+	}
+
+	// Parse the constraint from the linked ref.
+	constraint, err := ParseConstraint(constraintStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the current pinned version (the latest that matches the constraint).
+	currentVersion := LatestMatchingVersion(versions, constraint)
+	var currentStr string
+	if currentVersion != nil {
+		currentStr = currentVersion.String()
+	}
+
+	// Find the absolute latest version (no constraint).
+	latestVersion := LatestMatchingVersion(versions, nil)
+	var latestStr string
+	if latestVersion != nil {
+		latestStr = latestVersion.String()
+	}
+
+	// Find the latest compatible version (with constraint).
+	latestCompatible := LatestMatchingVersion(versions, constraint)
+	var latestCompatibleStr string
+	if latestCompatible != nil {
+		latestCompatibleStr = latestCompatible.String()
+	}
+
+	// Determine if a breaking update exists: there is a newer version outside
+	// the constraint range.
+	breakingAvailable := false
+	if latestVersion != nil && constraint != nil {
+		if !MatchesConstraint(latestVersion, constraint) {
+			breakingAvailable = true
+		}
+	}
+
+	// Only report an update if there is something new.
+	hasCompatibleUpdate := latestCompatibleStr != "" && latestCompatibleStr != currentStr
+	if !hasCompatibleUpdate && !breakingAvailable {
+		return nil, nil
+	}
+
+	update := &consolev1.TemplateUpdate{
+		Ref:                     ref,
+		CurrentVersion:          currentStr,
+		LatestCompatibleVersion: latestCompatibleStr,
+		LatestVersion:           latestStr,
+		BreakingUpdateAvailable: breakingAvailable,
+	}
+	return update, nil
+}
+
 // extractScope validates and extracts the scope and scope_name from a TemplateScopeRef.
 func extractScope(ref *consolev1.TemplateScopeRef) (consolev1.TemplateScope, string, error) {
 	if ref == nil {

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -990,8 +990,12 @@ func (h *Handler) checkLinkedUpdate(ctx context.Context, ref *consolev1.LinkedTe
 		return nil, err
 	}
 
-	// Find the current pinned version (the latest that matches the constraint).
-	currentVersion := LatestMatchingVersion(versions, constraint)
+	// Find the current pinned version. Without a stored resolved-version we
+	// approximate with the oldest matching release so that any newer compatible
+	// release is surfaced as an available update.
+	// TODO(versioning): track the actually-resolved version per deployment so
+	// currentVersion reflects the real pinned version, not an approximation.
+	currentVersion := OldestMatchingVersion(versions, constraint)
 	var currentStr string
 	if currentVersion != nil {
 		currentStr = currentVersion.String()

--- a/console/templates/handler_release_test.go
+++ b/console/templates/handler_release_test.go
@@ -1,0 +1,528 @@
+package templates
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// newOrgTestHandler builds a Handler wired to a fake K8s client with org grant
+// resolver for release tests. The grant resolver maps emails to roles.
+func newOrgTestHandler(fakeClient *fake.Clientset, shareUsers map[string]string) *Handler {
+	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+	k8s := NewK8sClient(fakeClient, r)
+	handler := NewHandler(k8s, r, &stubRenderer{})
+	handler.WithOrgGrantResolver(&stubOrgGrantResolver{users: shareUsers})
+	return handler
+}
+
+// stubOrgGrantResolver implements OrgGrantResolver for tests.
+type stubOrgGrantResolver struct {
+	users map[string]string
+	roles map[string]string
+	err   error
+}
+
+func (s *stubOrgGrantResolver) GetOrgGrants(_ context.Context, _ string) (map[string]string, map[string]string, error) {
+	return s.users, s.roles, s.err
+}
+
+func orgScopeRef(org string) *consolev1.TemplateScopeRef {
+	return &consolev1.TemplateScopeRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+		ScopeName: org,
+	}
+}
+
+func TestCreateRelease(t *testing.T) {
+	const org = "acme"
+	const ownerEmail = "platform@localhost"
+	const templateName = "my-template"
+
+	shareUsers := map[string]string{
+		ownerEmail: "owner",
+	}
+
+	t.Run("creates first release successfully", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName:  templateName,
+				Version:       "1.0.0",
+				CueTemplate:   validCue,
+				Changelog:     "Initial release",
+				UpgradeAdvice: "",
+			},
+		})
+
+		resp, err := handler.CreateRelease(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Release == nil {
+			t.Fatal("expected non-nil release in response")
+		}
+		if resp.Msg.Release.Version != "1.0.0" {
+			t.Errorf("expected version 1.0.0, got %q", resp.Msg.Release.Version)
+		}
+		if resp.Msg.Release.TemplateName != templateName {
+			t.Errorf("expected template_name %q, got %q", templateName, resp.Msg.Release.TemplateName)
+		}
+		if resp.Msg.Release.CueTemplate != validCue {
+			t.Errorf("expected CUE template to match")
+		}
+		if resp.Msg.Release.Changelog != "Initial release" {
+			t.Errorf("expected changelog 'Initial release', got %q", resp.Msg.Release.Changelog)
+		}
+
+		// Verify ConfigMap was persisted with correct labels.
+		cm, err := fakeClient.CoreV1().ConfigMaps("org-"+org).Get(context.Background(), "my-template--v1-0-0", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected release ConfigMap to exist, got %v", err)
+		}
+		if cm.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeTemplateRelease {
+			t.Errorf("expected resource-type %q, got %q", v1alpha2.ResourceTypeTemplateRelease, cm.Labels[v1alpha2.LabelResourceType])
+		}
+		if cm.Labels[v1alpha2.LabelReleaseOf] != templateName {
+			t.Errorf("expected release-of %q, got %q", templateName, cm.Labels[v1alpha2.LabelReleaseOf])
+		}
+		if cm.Annotations[v1alpha2.AnnotationTemplateVersion] != "1.0.0" {
+			t.Errorf("expected version annotation 1.0.0, got %q", cm.Annotations[v1alpha2.AnnotationTemplateVersion])
+		}
+	})
+
+	t.Run("rejects duplicate version", func(t *testing.T) {
+		ns := orgNS(org)
+		// Pre-seed a release ConfigMap.
+		existingRelease := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-template--v1-0-0",
+				Namespace: "org-" + org,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplateRelease,
+					v1alpha2.LabelReleaseOf:     templateName,
+					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+				},
+				Annotations: map[string]string{
+					v1alpha2.AnnotationTemplateVersion: "1.0.0",
+				},
+			},
+			Data: map[string]string{
+				CueTemplateKey: validCue,
+			},
+		}
+		fakeClient := fake.NewClientset(ns, existingRelease)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				Version:      "1.0.0",
+				CueTemplate:  validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected AlreadyExists error, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeAlreadyExists {
+			t.Errorf("expected code AlreadyExists, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("rejects invalid semver version", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				Version:      "not-a-version",
+				CueTemplate:  validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for invalid version, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("rejects missing template_name", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				Version:     "1.0.0",
+				CueTemplate: validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for missing template_name")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("rejects missing version", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				CueTemplate:  validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for missing version")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("VIEWER denied by PERMISSION_TEMPLATES_WRITE", func(t *testing.T) {
+		const viewerEmail = "sre@localhost"
+		ns := orgNS(org)
+		viewerShareUsers := map[string]string{
+			ownerEmail:  "owner",
+			viewerEmail: "viewer",
+		}
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, viewerShareUsers)
+
+		ctx := authedCtx(viewerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				Version:      "1.0.0",
+				CueTemplate:  validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected PermissionDenied error")
+		}
+		if connect.CodeOf(err) != connect.CodePermissionDenied {
+			t.Errorf("expected code PermissionDenied, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("creates release with defaults", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		defaults := &consolev1.TemplateDefaults{
+			Image: "ghcr.io/example/app",
+			Tag:   "1.0.0",
+		}
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				Version:      "1.0.0",
+				CueTemplate:  validCue,
+				Defaults:     defaults,
+			},
+		})
+
+		resp, err := handler.CreateRelease(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Release.Defaults == nil {
+			t.Fatal("expected non-nil defaults in response")
+		}
+		if resp.Msg.Release.Defaults.Image != "ghcr.io/example/app" {
+			t.Errorf("expected image 'ghcr.io/example/app', got %q", resp.Msg.Release.Defaults.Image)
+		}
+	})
+
+	t.Run("unauthenticated request rejected", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := context.Background() // no claims
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				Version:      "1.0.0",
+				CueTemplate:  validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected Unauthenticated error")
+		}
+		if connect.CodeOf(err) != connect.CodeUnauthenticated {
+			t.Errorf("expected code Unauthenticated, got %v", connect.CodeOf(err))
+		}
+	})
+}
+
+func TestListReleases(t *testing.T) {
+	const org = "acme"
+	const ownerEmail = "platform@localhost"
+	const templateName = "my-template"
+
+	shareUsers := map[string]string{ownerEmail: "owner"}
+
+	makeReleaseCM := func(version string) *corev1.ConfigMap {
+		v, _ := ParseVersion(version)
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ReleaseConfigMapName(templateName, v),
+				Namespace: "org-" + org,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplateRelease,
+					v1alpha2.LabelReleaseOf:     templateName,
+					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+				},
+				Annotations: map[string]string{
+					v1alpha2.AnnotationTemplateVersion: version,
+				},
+			},
+			Data: map[string]string{
+				CueTemplateKey: validCue,
+			},
+		}
+	}
+
+	t.Run("returns releases sorted by version descending", func(t *testing.T) {
+		ns := orgNS(org)
+		r1 := makeReleaseCM("1.0.0")
+		r2 := makeReleaseCM("2.0.0")
+		r3 := makeReleaseCM("1.5.0")
+		fakeClient := fake.NewClientset(ns, r1, r2, r3)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.ListReleasesRequest{
+			Scope:        orgScopeRef(org),
+			TemplateName: templateName,
+		})
+
+		resp, err := handler.ListReleases(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		releases := resp.Msg.Releases
+		if len(releases) != 3 {
+			t.Fatalf("expected 3 releases, got %d", len(releases))
+		}
+		// Should be sorted descending: 2.0.0, 1.5.0, 1.0.0
+		expectedVersions := []string{"2.0.0", "1.5.0", "1.0.0"}
+		for i, r := range releases {
+			if r.Version != expectedVersions[i] {
+				t.Errorf("release %d: expected version %q, got %q", i, expectedVersions[i], r.Version)
+			}
+		}
+	})
+
+	t.Run("returns empty list when no releases exist", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.ListReleasesRequest{
+			Scope:        orgScopeRef(org),
+			TemplateName: templateName,
+		})
+
+		resp, err := handler.ListReleases(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Msg.Releases) != 0 {
+			t.Errorf("expected 0 releases, got %d", len(resp.Msg.Releases))
+		}
+	})
+
+	t.Run("rejects missing template_name", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.ListReleasesRequest{
+			Scope: orgScopeRef(org),
+		})
+
+		_, err := handler.ListReleases(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for missing template_name")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+}
+
+func TestGetRelease(t *testing.T) {
+	const org = "acme"
+	const ownerEmail = "platform@localhost"
+	const templateName = "my-template"
+
+	shareUsers := map[string]string{ownerEmail: "owner"}
+
+	t.Run("returns existing release", func(t *testing.T) {
+		ns := orgNS(org)
+		release := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-template--v1-2-3",
+				Namespace: "org-" + org,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplateRelease,
+					v1alpha2.LabelReleaseOf:     templateName,
+					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+				},
+				Annotations: map[string]string{
+					v1alpha2.AnnotationTemplateVersion: "1.2.3",
+				},
+			},
+			Data: map[string]string{
+				CueTemplateKey:            validCue,
+				v1alpha2.ChangelogKey:     "Bug fixes",
+				v1alpha2.UpgradeAdviceKey: "No breaking changes",
+			},
+		}
+		fakeClient := fake.NewClientset(ns, release)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.GetReleaseRequest{
+			Scope:        orgScopeRef(org),
+			TemplateName: templateName,
+			Version:      "1.2.3",
+		})
+
+		resp, err := handler.GetRelease(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		r := resp.Msg.Release
+		if r.Version != "1.2.3" {
+			t.Errorf("expected version 1.2.3, got %q", r.Version)
+		}
+		if r.TemplateName != templateName {
+			t.Errorf("expected template_name %q, got %q", templateName, r.TemplateName)
+		}
+		if r.Changelog != "Bug fixes" {
+			t.Errorf("expected changelog 'Bug fixes', got %q", r.Changelog)
+		}
+		if r.UpgradeAdvice != "No breaking changes" {
+			t.Errorf("expected upgrade_advice 'No breaking changes', got %q", r.UpgradeAdvice)
+		}
+		if r.CueTemplate != validCue {
+			t.Errorf("expected CUE template to match")
+		}
+	})
+
+	t.Run("returns NotFound for nonexistent version", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.GetReleaseRequest{
+			Scope:        orgScopeRef(org),
+			TemplateName: templateName,
+			Version:      "9.9.9",
+		})
+
+		_, err := handler.GetRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected NotFound error")
+		}
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Errorf("expected code NotFound, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("rejects invalid version format", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.GetReleaseRequest{
+			Scope:        orgScopeRef(org),
+			TemplateName: templateName,
+			Version:      "bad",
+		})
+
+		_, err := handler.GetRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected InvalidArgument error")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("rejects missing version", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.GetReleaseRequest{
+			Scope:        orgScopeRef(org),
+			TemplateName: templateName,
+		})
+
+		_, err := handler.GetRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for missing version")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+}

--- a/console/templates/handler_release_test.go
+++ b/console/templates/handler_release_test.go
@@ -102,6 +102,57 @@ func TestCreateRelease(t *testing.T) {
 		if cm.Annotations[v1alpha2.AnnotationTemplateVersion] != "1.0.0" {
 			t.Errorf("expected version annotation 1.0.0, got %q", cm.Annotations[v1alpha2.AnnotationTemplateVersion])
 		}
+		if cm.Immutable == nil || !*cm.Immutable {
+			t.Error("expected ConfigMap to be immutable")
+		}
+	})
+
+	t.Run("rejects prerelease version", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				Version:      "1.0.0-beta.1",
+				CueTemplate:  validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for prerelease version, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("rejects build metadata version", func(t *testing.T) {
+		ns := orgNS(org)
+		fakeClient := fake.NewClientset(ns)
+		handler := newOrgTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CreateReleaseRequest{
+			Scope: orgScopeRef(org),
+			Release: &consolev1.Release{
+				TemplateName: templateName,
+				Version:      "1.0.0+build.123",
+				CueTemplate:  validCue,
+			},
+		})
+
+		_, err := handler.CreateRelease(ctx, req)
+		if err == nil {
+			t.Fatal("expected error for build metadata version, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected code InvalidArgument, got %v", connect.CodeOf(err))
+		}
 	})
 
 	t.Run("rejects duplicate version", func(t *testing.T) {

--- a/console/templates/handler_updates_test.go
+++ b/console/templates/handler_updates_test.go
@@ -139,12 +139,21 @@ func TestCheckUpdates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		// With constraint >=1.0.0 <2.0.0, the current version is the latest
-		// matching = 1.1.0. The latest compatible is also 1.1.0. Since there
-		// is no breaking version outside the range, no update is reported.
-		// This tests the "already at latest" case.
-		if len(resp.Msg.Updates) != 0 {
-			t.Errorf("expected 0 updates (already at latest compatible), got %d", len(resp.Msg.Updates))
+		// With constraint >=1.0.0 <2.0.0 and releases 1.0.0 + 1.1.0,
+		// the current (oldest matching) is 1.0.0 and the latest compatible
+		// is 1.1.0, so a compatible update should be reported.
+		if len(resp.Msg.Updates) != 1 {
+			t.Fatalf("expected 1 update (compatible), got %d", len(resp.Msg.Updates))
+		}
+		update := resp.Msg.Updates[0]
+		if update.CurrentVersion != "1.0.0" {
+			t.Errorf("expected current_version 1.0.0, got %q", update.CurrentVersion)
+		}
+		if update.LatestCompatibleVersion != "1.1.0" {
+			t.Errorf("expected latest_compatible_version 1.1.0, got %q", update.LatestCompatibleVersion)
+		}
+		if update.BreakingUpdateAvailable {
+			t.Error("expected breaking_update_available=false")
 		}
 	})
 
@@ -188,12 +197,12 @@ func TestCheckUpdates(t *testing.T) {
 		if update.LatestCompatibleVersion != "1.5.0" {
 			t.Errorf("expected latest_compatible_version 1.5.0, got %q", update.LatestCompatibleVersion)
 		}
-		if update.CurrentVersion != "1.5.0" {
-			t.Errorf("expected current_version 1.5.0, got %q", update.CurrentVersion)
+		if update.CurrentVersion != "1.0.0" {
+			t.Errorf("expected current_version 1.0.0, got %q", update.CurrentVersion)
 		}
 	})
 
-	t.Run("no constraint means all versions match", func(t *testing.T) {
+	t.Run("no constraint reports compatible update when multiple releases exist", func(t *testing.T) {
 		projectNs := projectNS(project)
 		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
 			{
@@ -219,9 +228,50 @@ func TestCheckUpdates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		// No constraint: current=latest=2.0.0. No update.
+		// No constraint: current (oldest) = 1.0.0, latest compatible = 2.0.0.
+		// A compatible update is reported.
+		if len(resp.Msg.Updates) != 1 {
+			t.Fatalf("expected 1 update, got %d", len(resp.Msg.Updates))
+		}
+		update := resp.Msg.Updates[0]
+		if update.CurrentVersion != "1.0.0" {
+			t.Errorf("expected current_version 1.0.0, got %q", update.CurrentVersion)
+		}
+		if update.LatestCompatibleVersion != "2.0.0" {
+			t.Errorf("expected latest_compatible_version 2.0.0, got %q", update.LatestCompatibleVersion)
+		}
+		if update.BreakingUpdateAvailable {
+			t.Error("expected breaking_update_available=false")
+		}
+	})
+
+	t.Run("no constraint single release means no update", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName: org,
+				Name:      linkedTemplateName,
+				// No version constraint
+			},
+		})
+		// Single release: current == latest, no update.
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl, r1)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:        projectScopeRef(project),
+			TemplateName: "web-app",
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 		if len(resp.Msg.Updates) != 0 {
-			t.Errorf("expected 0 updates when no constraint and at latest, got %d", len(resp.Msg.Updates))
+			t.Errorf("expected 0 updates when single release, got %d", len(resp.Msg.Updates))
 		}
 	})
 

--- a/console/templates/handler_updates_test.go
+++ b/console/templates/handler_updates_test.go
@@ -1,0 +1,311 @@
+package templates
+
+import (
+	"encoding/json"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// makeReleaseCMInNS creates a release ConfigMap in the given namespace.
+func makeReleaseCMInNS(ns, templateName, version string) *corev1.ConfigMap {
+	v, _ := ParseVersion(version)
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ReleaseConfigMapName(templateName, v),
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplateRelease,
+				v1alpha2.LabelReleaseOf:     templateName,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplateVersion: version,
+			},
+		},
+		Data: map[string]string{
+			CueTemplateKey: validCue,
+		},
+	}
+}
+
+// makeTemplateWithLinks creates a template ConfigMap with linked template refs.
+func makeTemplateWithLinks(ns, name string, links []*consolev1.LinkedTemplateRef) *corev1.ConfigMap {
+	type storedRef struct {
+		Scope             string `json:"scope"`
+		ScopeName         string `json:"scope_name"`
+		Name              string `json:"name"`
+		VersionConstraint string `json:"version_constraint,omitempty"`
+	}
+	stored := make([]storedRef, 0, len(links))
+	for _, ref := range links {
+		stored = append(stored, storedRef{
+			Scope:             scopeLabelValue(ref.Scope),
+			ScopeName:         ref.ScopeName,
+			Name:              ref.Name,
+			VersionConstraint: ref.VersionConstraint,
+		})
+	}
+	linkedJSON, _ := json.Marshal(stored)
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:     name,
+				v1alpha2.AnnotationDescription:     "test template",
+				v1alpha2.AnnotationMandatory:       "false",
+				v1alpha2.AnnotationEnabled:         "true",
+				v1alpha2.AnnotationLinkedTemplates: string(linkedJSON),
+			},
+		},
+		Data: map[string]string{
+			CueTemplateKey: validCue,
+		},
+	}
+}
+
+func TestCheckUpdates(t *testing.T) {
+	const org = "acme"
+	const project = "my-project"
+	const ownerEmail = "platform@localhost"
+	const linkedTemplateName = "httproute"
+
+	shareUsers := map[string]string{ownerEmail: "owner"}
+
+	t.Run("no updates when no releases exist", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName: org,
+				Name:      linkedTemplateName,
+			},
+		})
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:        projectScopeRef(project),
+			TemplateName: "web-app",
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Msg.Updates) != 0 {
+			t.Errorf("expected 0 updates, got %d", len(resp.Msg.Updates))
+		}
+	})
+
+	t.Run("minor update available within constraint", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:             consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:         org,
+				Name:              linkedTemplateName,
+				VersionConstraint: ">=1.0.0 <2.0.0",
+			},
+		})
+		// Create releases: 1.0.0 and 1.1.0
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		r2 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.1.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl, r1, r2)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:        projectScopeRef(project),
+			TemplateName: "web-app",
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// With constraint >=1.0.0 <2.0.0, the current version is the latest
+		// matching = 1.1.0. The latest compatible is also 1.1.0. Since there
+		// is no breaking version outside the range, no update is reported.
+		// This tests the "already at latest" case.
+		if len(resp.Msg.Updates) != 0 {
+			t.Errorf("expected 0 updates (already at latest compatible), got %d", len(resp.Msg.Updates))
+		}
+	})
+
+	t.Run("breaking update available", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:             consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:         org,
+				Name:              linkedTemplateName,
+				VersionConstraint: ">=1.0.0 <2.0.0",
+			},
+		})
+		// Create releases: 1.0.0, 1.5.0, 2.0.0
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		r2 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.5.0")
+		r3 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "2.0.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl, r1, r2, r3)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:        projectScopeRef(project),
+			TemplateName: "web-app",
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Msg.Updates) != 1 {
+			t.Fatalf("expected 1 update, got %d", len(resp.Msg.Updates))
+		}
+		update := resp.Msg.Updates[0]
+		if !update.BreakingUpdateAvailable {
+			t.Error("expected breaking_update_available=true")
+		}
+		if update.LatestVersion != "2.0.0" {
+			t.Errorf("expected latest_version 2.0.0, got %q", update.LatestVersion)
+		}
+		if update.LatestCompatibleVersion != "1.5.0" {
+			t.Errorf("expected latest_compatible_version 1.5.0, got %q", update.LatestCompatibleVersion)
+		}
+		if update.CurrentVersion != "1.5.0" {
+			t.Errorf("expected current_version 1.5.0, got %q", update.CurrentVersion)
+		}
+	})
+
+	t.Run("no constraint means all versions match", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName: org,
+				Name:      linkedTemplateName,
+				// No version constraint
+			},
+		})
+		// Create releases: 1.0.0, 2.0.0
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		r2 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "2.0.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl, r1, r2)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:        projectScopeRef(project),
+			TemplateName: "web-app",
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// No constraint: current=latest=2.0.0. No update.
+		if len(resp.Msg.Updates) != 0 {
+			t.Errorf("expected 0 updates when no constraint and at latest, got %d", len(resp.Msg.Updates))
+		}
+	})
+
+	t.Run("no linked templates means no updates", func(t *testing.T) {
+		projectNs := projectNS(project)
+		// Template with no linked templates.
+		tmpl := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "standalone",
+				Namespace: "prj-" + project,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+				},
+				Annotations: map[string]string{
+					v1alpha2.AnnotationDisplayName: "standalone",
+					v1alpha2.AnnotationDescription: "no links",
+					v1alpha2.AnnotationMandatory:   "false",
+					v1alpha2.AnnotationEnabled:     "true",
+				},
+			},
+			Data: map[string]string{CueTemplateKey: validCue},
+		}
+		fakeClient := fake.NewClientset(projectNs, tmpl)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:        projectScopeRef(project),
+			TemplateName: "standalone",
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Msg.Updates) != 0 {
+			t.Errorf("expected 0 updates, got %d", len(resp.Msg.Updates))
+		}
+	})
+
+	t.Run("checks all templates when template_name omitted", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl1 := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:             consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:         org,
+				Name:              linkedTemplateName,
+				VersionConstraint: ">=1.0.0 <2.0.0",
+			},
+		})
+		tmpl2 := makeTemplateWithLinks("prj-"+project, "api-svc", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:             consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:         org,
+				Name:              "gateway",
+				VersionConstraint: ">=1.0.0 <2.0.0",
+			},
+		})
+		// httproute: has breaking update (2.0.0)
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		r2 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "2.0.0")
+		// gateway: has no updates
+		r3 := makeReleaseCMInNS("org-"+org, "gateway", "1.0.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl1, tmpl2, r1, r2, r3)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope: projectScopeRef(project),
+			// template_name omitted -- check all
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// Only httproute should have an update (breaking).
+		if len(resp.Msg.Updates) != 1 {
+			t.Fatalf("expected 1 update, got %d", len(resp.Msg.Updates))
+		}
+		if resp.Msg.Updates[0].Ref.Name != linkedTemplateName {
+			t.Errorf("expected update for %q, got %q", linkedTemplateName, resp.Msg.Updates[0].Ref.Name)
+		}
+	})
+}

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -777,9 +777,10 @@ func linkedRefFromProto(ref *consolev1.LinkedTemplateRef) linkedRef {
 // marshalLinkedTemplates serializes LinkedTemplateRef slice to JSON for annotation storage.
 func marshalLinkedTemplates(refs []*consolev1.LinkedTemplateRef) ([]byte, error) {
 	type storedRef struct {
-		Scope     string `json:"scope"`
-		ScopeName string `json:"scope_name"`
-		Name      string `json:"name"`
+		Scope             string `json:"scope"`
+		ScopeName         string `json:"scope_name"`
+		Name              string `json:"name"`
+		VersionConstraint string `json:"version_constraint,omitempty"`
 	}
 	stored := make([]storedRef, 0, len(refs))
 	for _, r := range refs {
@@ -787,9 +788,10 @@ func marshalLinkedTemplates(refs []*consolev1.LinkedTemplateRef) ([]byte, error)
 			continue
 		}
 		stored = append(stored, storedRef{
-			Scope:     scopeLabelValue(r.Scope),
-			ScopeName: r.ScopeName,
-			Name:      r.Name,
+			Scope:             scopeLabelValue(r.Scope),
+			ScopeName:         r.ScopeName,
+			Name:              r.Name,
+			VersionConstraint: r.VersionConstraint,
 		})
 	}
 	b, err := json.Marshal(stored)
@@ -802,9 +804,10 @@ func marshalLinkedTemplates(refs []*consolev1.LinkedTemplateRef) ([]byte, error)
 // unmarshalLinkedTemplates parses the AnnotationLinkedTemplates JSON into proto refs.
 func unmarshalLinkedTemplates(raw string) ([]*consolev1.LinkedTemplateRef, error) {
 	type storedRef struct {
-		Scope     string `json:"scope"`
-		ScopeName string `json:"scope_name"`
-		Name      string `json:"name"`
+		Scope             string `json:"scope"`
+		ScopeName         string `json:"scope_name"`
+		Name              string `json:"name"`
+		VersionConstraint string `json:"version_constraint,omitempty"`
 	}
 	var stored []storedRef
 	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
@@ -813,9 +816,10 @@ func unmarshalLinkedTemplates(raw string) ([]*consolev1.LinkedTemplateRef, error
 	refs := make([]*consolev1.LinkedTemplateRef, 0, len(stored))
 	for _, s := range stored {
 		refs = append(refs, &consolev1.LinkedTemplateRef{
-			Scope:     scopeFromLabel(s.Scope),
-			ScopeName: s.ScopeName,
-			Name:      s.Name,
+			Scope:             scopeFromLabel(s.Scope),
+			ScopeName:         s.ScopeName,
+			Name:              s.Name,
+			VersionConstraint: s.VersionConstraint,
 		})
 	}
 	return refs, nil

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -507,6 +507,7 @@ func (k *K8sClient) CreateRelease(ctx context.Context, scope consolev1.TemplateS
 		data[DefaultsKey] = string(b)
 	}
 
+	immutable := true
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
@@ -521,7 +522,8 @@ func (k *K8sClient) CreateRelease(ctx context.Context, scope consolev1.TemplateS
 				v1alpha2.AnnotationTemplateVersion: version.String(),
 			},
 		},
-		Data: data,
+		Immutable: &immutable,
+		Data:      data,
 	}
 	return k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 }

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -7,11 +7,13 @@ import (
 	"log/slog"
 	"strconv"
 
+	"github.com/Masterminds/semver/v3"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -471,6 +473,223 @@ func (k *K8sClient) SeedProjectTemplate(ctx context.Context, project string) err
 		nil,
 	)
 	return err
+}
+
+// CreateRelease creates an immutable Release ConfigMap for a template at a
+// specific semver version. The ConfigMap name follows the pattern
+// {template-name}--v{major}-{minor}-{patch}. Returns AlreadyExists if the
+// version has already been published.
+func (k *K8sClient) CreateRelease(ctx context.Context, scope consolev1.TemplateScope, scopeName, templateName string, version *semver.Version, cueTemplate string, defaults *consolev1.TemplateDefaults, changelog, upgradeAdvice string) (*corev1.ConfigMap, error) {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+	cmName := ReleaseConfigMapName(templateName, version)
+	slog.DebugContext(ctx, "creating release in kubernetes",
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("namespace", ns),
+		slog.String("templateName", templateName),
+		slog.String("version", version.String()),
+		slog.String("configMapName", cmName),
+	)
+
+	data := map[string]string{
+		CueTemplateKey:         cueTemplate,
+		v1alpha2.ChangelogKey:  changelog,
+		v1alpha2.UpgradeAdviceKey: upgradeAdvice,
+	}
+	if defaults != nil {
+		b, err := json.Marshal(defaults)
+		if err != nil {
+			return nil, fmt.Errorf("serializing release defaults: %w", err)
+		}
+		data[DefaultsKey] = string(b)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplateRelease,
+				v1alpha2.LabelReleaseOf:     templateName,
+				v1alpha2.LabelTemplateScope: scopeLabelValue(scope),
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplateVersion: version.String(),
+			},
+		},
+		Data: data,
+	}
+	return k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+}
+
+// ListReleases returns all release ConfigMaps for a template, sorted by version
+// descending (newest first).
+func (k *K8sClient) ListReleases(ctx context.Context, scope consolev1.TemplateScope, scopeName, templateName string) ([]corev1.ConfigMap, error) {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		v1alpha2.LabelResourceType, v1alpha2.ResourceTypeTemplateRelease,
+		v1alpha2.LabelReleaseOf, templateName,
+	)
+	slog.DebugContext(ctx, "listing releases from kubernetes",
+		slog.String("namespace", ns),
+		slog.String("templateName", templateName),
+		slog.String("labelSelector", labelSelector),
+	)
+	list, err := k.client.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing releases: %w", err)
+	}
+
+	// Sort by version descending.
+	items := list.Items
+	sortReleaseConfigMapsDesc(items)
+	return items, nil
+}
+
+// GetRelease retrieves a specific release ConfigMap by template name and version.
+func (k *K8sClient) GetRelease(ctx context.Context, scope consolev1.TemplateScope, scopeName, templateName string, version *semver.Version) (*corev1.ConfigMap, error) {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+	cmName := ReleaseConfigMapName(templateName, version)
+	slog.DebugContext(ctx, "getting release from kubernetes",
+		slog.String("namespace", ns),
+		slog.String("templateName", templateName),
+		slog.String("version", version.String()),
+		slog.String("configMapName", cmName),
+	)
+	return k.client.CoreV1().ConfigMaps(ns).Get(ctx, cmName, metav1.GetOptions{})
+}
+
+// sortReleaseConfigMapsDesc sorts release ConfigMaps by their version annotation
+// in descending order (newest first). ConfigMaps with invalid or missing version
+// annotations sort to the end.
+func sortReleaseConfigMapsDesc(items []corev1.ConfigMap) {
+	type versioned struct {
+		idx int
+		ver *semver.Version
+	}
+	entries := make([]versioned, len(items))
+	for i, cm := range items {
+		raw := cm.Annotations[v1alpha2.AnnotationTemplateVersion]
+		v, _ := ParseVersion(raw)
+		entries[i] = versioned{idx: i, ver: v}
+	}
+	// Sort: valid versions descending, then invalid/missing at end.
+	sorted := make([]corev1.ConfigMap, len(items))
+	copy(sorted, items)
+	for i := 0; i < len(entries); i++ {
+		for j := i + 1; j < len(entries); j++ {
+			vi, vj := entries[i].ver, entries[j].ver
+			swap := false
+			if vi == nil && vj != nil {
+				swap = true
+			} else if vi != nil && vj != nil && vj.GreaterThan(vi) {
+				swap = true
+			}
+			if swap {
+				entries[i], entries[j] = entries[j], entries[i]
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+	copy(items, sorted)
+}
+
+// configMapToRelease converts a Kubernetes ConfigMap to a Release protobuf message.
+func configMapToRelease(cm *corev1.ConfigMap, scope consolev1.TemplateScope, scopeName string) *consolev1.Release {
+	release := &consolev1.Release{
+		TemplateName: cm.Labels[v1alpha2.LabelReleaseOf],
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     scope,
+			ScopeName: scopeName,
+		},
+		Version:       cm.Annotations[v1alpha2.AnnotationTemplateVersion],
+		Changelog:     cm.Data[v1alpha2.ChangelogKey],
+		UpgradeAdvice: cm.Data[v1alpha2.UpgradeAdviceKey],
+		CueTemplate:   cm.Data[CueTemplateKey],
+		CreatedAt:     timestamppb.New(cm.CreationTimestamp.Time),
+	}
+
+	// Parse defaults from JSON if present.
+	if rawJSON, ok := cm.Data[DefaultsKey]; ok && rawJSON != "" {
+		var defaults consolev1.TemplateDefaults
+		if err := json.Unmarshal([]byte(rawJSON), &defaults); err == nil {
+			release.Defaults = &defaults
+		}
+	}
+
+	return release
+}
+
+// ListReleaseVersions returns all parsed semver versions for a template's
+// releases. Releases with invalid version annotations are skipped.
+func (k *K8sClient) ListReleaseVersions(ctx context.Context, scope consolev1.TemplateScope, scopeName, templateName string) ([]*semver.Version, error) {
+	cms, err := k.ListReleases(ctx, scope, scopeName, templateName)
+	if err != nil {
+		return nil, err
+	}
+	var versions []*semver.Version
+	for _, cm := range cms {
+		raw := cm.Annotations[v1alpha2.AnnotationTemplateVersion]
+		v, err := ParseVersion(raw)
+		if err != nil {
+			continue
+		}
+		versions = append(versions, v)
+	}
+	return versions, nil
+}
+
+// ResolveVersionedSource resolves the CUE source for a linked template. If
+// releases exist and a version constraint is provided, it returns the CUE
+// source from the latest matching release. If no releases exist (pre-versioning
+// backwards compatibility), it falls back to the live template ConfigMap's CUE
+// source.
+func (k *K8sClient) ResolveVersionedSource(ctx context.Context, scope consolev1.TemplateScope, scopeName, templateName, versionConstraint string) (string, error) {
+	versions, err := k.ListReleaseVersions(ctx, scope, scopeName, templateName)
+	if err != nil {
+		return "", fmt.Errorf("listing release versions for %s: %w", templateName, err)
+	}
+
+	// No releases exist: fall back to live template ConfigMap.
+	if len(versions) == 0 {
+		cm, err := k.GetTemplate(ctx, scope, scopeName, templateName)
+		if err != nil {
+			return "", fmt.Errorf("getting live template %s: %w", templateName, err)
+		}
+		return cm.Data[CueTemplateKey], nil
+	}
+
+	// Parse the version constraint.
+	constraint, err := ParseConstraint(versionConstraint)
+	if err != nil {
+		return "", err
+	}
+
+	// Find the latest matching version.
+	best := LatestMatchingVersion(versions, constraint)
+	if best == nil {
+		return "", fmt.Errorf("no release of %q matches constraint %q", templateName, versionConstraint)
+	}
+
+	// Fetch the release ConfigMap.
+	cm, err := k.GetRelease(ctx, scope, scopeName, templateName, best)
+	if err != nil {
+		return "", fmt.Errorf("getting release %s@%s: %w", templateName, best.String(), err)
+	}
+
+	return cm.Data[CueTemplateKey], nil
 }
 
 // configMapToTemplate converts a Kubernetes ConfigMap to a Template protobuf message.

--- a/console/templates/semver.go
+++ b/console/templates/semver.go
@@ -1,0 +1,75 @@
+package templates
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// ParseVersion parses and validates a semver version string. It accepts
+// versions with or without a "v" prefix (e.g. "1.2.3" or "v1.2.3").
+// The version must be a strict MAJOR.MINOR.PATCH triple.
+func ParseVersion(version string) (*semver.Version, error) {
+	raw := strings.TrimPrefix(version, "v")
+	v, err := semver.StrictNewVersion(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid semver version %q: %w", version, err)
+	}
+	return v, nil
+}
+
+// ParseConstraint parses a semver constraint string (e.g. ">=1.0.0 <2.0.0").
+// An empty constraint matches all versions.
+func ParseConstraint(constraint string) (*semver.Constraints, error) {
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" {
+		return nil, nil // nil constraint matches everything
+	}
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version constraint %q: %w", constraint, err)
+	}
+	return c, nil
+}
+
+// MatchesConstraint checks whether a version satisfies a constraint. A nil
+// constraint matches all versions.
+func MatchesConstraint(v *semver.Version, c *semver.Constraints) bool {
+	if c == nil {
+		return true
+	}
+	return c.Check(v)
+}
+
+// SortVersionsDesc sorts a slice of semver versions in descending order
+// (newest first).
+func SortVersionsDesc(versions []*semver.Version) {
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].GreaterThan(versions[j])
+	})
+}
+
+// ReleaseConfigMapName returns the DNS-label-safe ConfigMap name for a release:
+// {template-name}--v{major}-{minor}-{patch}
+func ReleaseConfigMapName(templateName string, version *semver.Version) string {
+	return fmt.Sprintf("%s--v%d-%d-%d", templateName, version.Major(), version.Minor(), version.Patch())
+}
+
+// LatestMatchingVersion returns the highest version from the given list that
+// satisfies the constraint. Returns nil if no version matches. The input slice
+// is not modified.
+func LatestMatchingVersion(versions []*semver.Version, c *semver.Constraints) *semver.Version {
+	// Make a copy to avoid mutating the caller's slice.
+	sorted := make([]*semver.Version, len(versions))
+	copy(sorted, versions)
+	SortVersionsDesc(sorted)
+
+	for _, v := range sorted {
+		if MatchesConstraint(v, c) {
+			return v
+		}
+	}
+	return nil
+}

--- a/console/templates/semver.go
+++ b/console/templates/semver.go
@@ -10,12 +10,19 @@ import (
 
 // ParseVersion parses and validates a semver version string. It accepts
 // versions with or without a "v" prefix (e.g. "1.2.3" or "v1.2.3").
-// The version must be a strict MAJOR.MINOR.PATCH triple.
+// The version must be a strict MAJOR.MINOR.PATCH triple with no prerelease
+// or build metadata (e.g. "1.2.3-beta.1" and "1.2.3+meta" are rejected).
 func ParseVersion(version string) (*semver.Version, error) {
 	raw := strings.TrimPrefix(version, "v")
 	v, err := semver.StrictNewVersion(raw)
 	if err != nil {
 		return nil, fmt.Errorf("invalid semver version %q: %w", version, err)
+	}
+	if v.Prerelease() != "" {
+		return nil, fmt.Errorf("invalid semver version %q: prerelease versions are not supported", version)
+	}
+	if v.Metadata() != "" {
+		return nil, fmt.Errorf("invalid semver version %q: build metadata is not supported", version)
 	}
 	return v, nil
 }
@@ -72,4 +79,22 @@ func LatestMatchingVersion(versions []*semver.Version, c *semver.Constraints) *s
 		}
 	}
 	return nil
+}
+
+// OldestMatchingVersion returns the lowest version from the given list that
+// satisfies the constraint. Returns nil if no version matches. The input slice
+// is not modified.
+func OldestMatchingVersion(versions []*semver.Version, c *semver.Constraints) *semver.Version {
+	// Make a copy to avoid mutating the caller's slice.
+	sorted := make([]*semver.Version, len(versions))
+	copy(sorted, versions)
+	SortVersionsDesc(sorted)
+
+	var oldest *semver.Version
+	for _, v := range sorted {
+		if MatchesConstraint(v, c) {
+			oldest = v
+		}
+	}
+	return oldest
 }

--- a/console/templates/semver_test.go
+++ b/console/templates/semver_test.go
@@ -1,0 +1,229 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		wantStr string
+	}{
+		{name: "valid basic", input: "1.2.3", wantStr: "1.2.3"},
+		{name: "valid with v prefix", input: "v1.2.3", wantStr: "1.2.3"},
+		{name: "valid zero", input: "0.0.0", wantStr: "0.0.0"},
+		{name: "valid high numbers", input: "100.200.300", wantStr: "100.200.300"},
+		{name: "invalid empty", input: "", wantErr: true},
+		{name: "invalid letters", input: "abc", wantErr: true},
+		{name: "invalid partial", input: "1.2", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := ParseVersion(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v.Original() != tt.input {
+				// Compare the normalized version string.
+			}
+			if v.String() != tt.wantStr {
+				t.Errorf("expected version %q, got %q", tt.wantStr, v.String())
+			}
+		})
+	}
+}
+
+func TestParseConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		wantErr    bool
+		wantNil    bool
+	}{
+		{name: "empty returns nil", constraint: "", wantNil: true},
+		{name: "whitespace returns nil", constraint: "   ", wantNil: true},
+		{name: "valid range", constraint: ">=1.0.0 <2.0.0"},
+		{name: "valid caret", constraint: "^1.2.3"},
+		{name: "valid tilde", constraint: "~1.2.3"},
+		{name: "valid exact", constraint: "1.2.3"},
+		{name: "valid wildcard", constraint: ">=1.0.0"},
+		{name: "invalid", constraint: "not-a-constraint", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := ParseConstraint(tt.constraint)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for constraint %q", tt.constraint)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil && c != nil {
+				t.Fatalf("expected nil constraint, got %v", c)
+			}
+			if !tt.wantNil && c == nil {
+				t.Fatal("expected non-nil constraint")
+			}
+		})
+	}
+}
+
+func TestMatchesConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		constraint string
+		want       bool
+	}{
+		{name: "nil constraint matches all", version: "1.2.3", constraint: "", want: true},
+		{name: "exact match", version: "1.2.3", constraint: "1.2.3", want: true},
+		{name: "range match lower bound", version: "1.0.0", constraint: ">=1.0.0 <2.0.0", want: true},
+		{name: "range match mid", version: "1.5.0", constraint: ">=1.0.0 <2.0.0", want: true},
+		{name: "range no match upper bound", version: "2.0.0", constraint: ">=1.0.0 <2.0.0", want: false},
+		{name: "range no match below", version: "0.9.0", constraint: ">=1.0.0 <2.0.0", want: false},
+		{name: "caret match", version: "1.2.5", constraint: "^1.2.3", want: true},
+		{name: "caret no match major", version: "2.0.0", constraint: "^1.2.3", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := ParseVersion(tt.version)
+			if err != nil {
+				t.Fatalf("failed to parse version: %v", err)
+			}
+			c, err := ParseConstraint(tt.constraint)
+			if err != nil {
+				t.Fatalf("failed to parse constraint: %v", err)
+			}
+			got := MatchesConstraint(v, c)
+			if got != tt.want {
+				t.Errorf("MatchesConstraint(%q, %q) = %v, want %v", tt.version, tt.constraint, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortVersionsDesc(t *testing.T) {
+	versions := make([]*semver.Version, 0)
+	for _, s := range []string{"1.0.0", "3.0.0", "2.0.0", "2.1.0", "1.0.1"} {
+		v, _ := ParseVersion(s)
+		versions = append(versions, v)
+	}
+	SortVersionsDesc(versions)
+
+	expected := []string{"3.0.0", "2.1.0", "2.0.0", "1.0.1", "1.0.0"}
+	for i, v := range versions {
+		if v.String() != expected[i] {
+			t.Errorf("index %d: expected %q, got %q", i, expected[i], v.String())
+		}
+	}
+}
+
+func TestReleaseConfigMapName(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateName string
+		version      string
+		want         string
+	}{
+		{name: "basic", templateName: "my-template", version: "1.2.3", want: "my-template--v1-2-3"},
+		{name: "zero version", templateName: "base", version: "0.0.0", want: "base--v0-0-0"},
+		{name: "large numbers", templateName: "svc", version: "10.20.30", want: "svc--v10-20-30"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, _ := ParseVersion(tt.version)
+			got := ReleaseConfigMapName(tt.templateName, v)
+			if got != tt.want {
+				t.Errorf("ReleaseConfigMapName(%q, %q) = %q, want %q", tt.templateName, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLatestMatchingVersion(t *testing.T) {
+	mkVersions := func(strs ...string) []*semver.Version {
+		var result []*semver.Version
+		for _, s := range strs {
+			v, _ := ParseVersion(s)
+			result = append(result, v)
+		}
+		return result
+	}
+
+	tests := []struct {
+		name       string
+		versions   []*semver.Version
+		constraint string
+		want       string // empty means nil
+	}{
+		{
+			name:       "nil constraint returns latest",
+			versions:   mkVersions("1.0.0", "2.0.0", "1.5.0"),
+			constraint: "",
+			want:       "2.0.0",
+		},
+		{
+			name:       "constraint filters to compatible",
+			versions:   mkVersions("1.0.0", "2.0.0", "1.5.0", "1.9.0"),
+			constraint: ">=1.0.0 <2.0.0",
+			want:       "1.9.0",
+		},
+		{
+			name:       "no matching version",
+			versions:   mkVersions("3.0.0", "4.0.0"),
+			constraint: ">=1.0.0 <2.0.0",
+			want:       "",
+		},
+		{
+			name:       "empty versions list",
+			versions:   nil,
+			constraint: "",
+			want:       "",
+		},
+		{
+			name:       "single matching version",
+			versions:   mkVersions("1.2.3"),
+			constraint: "^1.0.0",
+			want:       "1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := ParseConstraint(tt.constraint)
+			if err != nil {
+				t.Fatalf("failed to parse constraint: %v", err)
+			}
+			got := LatestMatchingVersion(tt.versions, c)
+			if tt.want == "" {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", tt.want)
+			}
+			if got.String() != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got.String())
+			}
+		})
+	}
+}

--- a/console/templates/semver_test.go
+++ b/console/templates/semver_test.go
@@ -17,6 +17,9 @@ func TestParseVersion(t *testing.T) {
 		{name: "valid with v prefix", input: "v1.2.3", wantStr: "1.2.3"},
 		{name: "valid zero", input: "0.0.0", wantStr: "0.0.0"},
 		{name: "valid high numbers", input: "100.200.300", wantStr: "100.200.300"},
+		{name: "invalid prerelease", input: "1.2.3-beta.1", wantErr: true},
+		{name: "invalid build metadata", input: "1.2.3+meta", wantErr: true},
+		{name: "invalid prerelease with v", input: "v1.0.0-rc1", wantErr: true},
 		{name: "invalid empty", input: "", wantErr: true},
 		{name: "invalid letters", input: "abc", wantErr: true},
 		{name: "invalid partial", input: "1.2", wantErr: true},
@@ -212,6 +215,77 @@ func TestLatestMatchingVersion(t *testing.T) {
 				t.Fatalf("failed to parse constraint: %v", err)
 			}
 			got := LatestMatchingVersion(tt.versions, c)
+			if tt.want == "" {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", tt.want)
+			}
+			if got.String() != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got.String())
+			}
+		})
+	}
+}
+
+func TestOldestMatchingVersion(t *testing.T) {
+	mkVersions := func(strs ...string) []*semver.Version {
+		var result []*semver.Version
+		for _, s := range strs {
+			v, _ := ParseVersion(s)
+			result = append(result, v)
+		}
+		return result
+	}
+
+	tests := []struct {
+		name       string
+		versions   []*semver.Version
+		constraint string
+		want       string // empty means nil
+	}{
+		{
+			name:       "nil constraint returns oldest",
+			versions:   mkVersions("1.0.0", "2.0.0", "1.5.0"),
+			constraint: "",
+			want:       "1.0.0",
+		},
+		{
+			name:       "constraint filters to oldest compatible",
+			versions:   mkVersions("1.0.0", "2.0.0", "1.5.0", "1.9.0"),
+			constraint: ">=1.0.0 <2.0.0",
+			want:       "1.0.0",
+		},
+		{
+			name:       "no matching version",
+			versions:   mkVersions("3.0.0", "4.0.0"),
+			constraint: ">=1.0.0 <2.0.0",
+			want:       "",
+		},
+		{
+			name:       "empty versions list",
+			versions:   nil,
+			constraint: "",
+			want:       "",
+		},
+		{
+			name:       "single matching version",
+			versions:   mkVersions("1.2.3"),
+			constraint: "^1.0.0",
+			want:       "1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := ParseConstraint(tt.constraint)
+			if err != nil {
+				t.Fatalf("failed to parse constraint: %v", err)
+			}
+			got := OldestMatchingVersion(tt.versions, c)
 			if tt.want == "" {
 				if got != nil {
 					t.Errorf("expected nil, got %v", got)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	connectrpc.com/grpcreflect v1.3.0
 	cuelang.org/go v0.16.0
 	filippo.io/mkcert v1.4.4
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bufbuild/buf v1.62.1
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dexidp/dex v0.0.0-20251209162832-8ab38ebb7920
@@ -49,7 +50,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect


### PR DESCRIPTION
## Summary

- Add semver parsing, constraint matching, and version comparison helpers (`console/templates/semver.go`) using `Masterminds/semver/v3`
- Implement release ConfigMap CRUD in `console/templates/k8s.go`: `CreateRelease`, `ListReleases`, `GetRelease`, `ListReleaseVersions`, `ResolveVersionedSource`
- Add handler methods for `CreateRelease`, `ListReleases`, `GetRelease`, and `CheckUpdates` RPCs in `console/templates/handler.go`
- Add release ConfigMap annotations/labels to `api/v1alpha2/annotations.go`: `ResourceTypeTemplateRelease`, `LabelReleaseOf`, `AnnotationTemplateVersion`, `ChangelogKey`, `UpgradeAdviceKey`
- Extend `marshalLinkedTemplates`/`unmarshalLinkedTemplates` to persist the `version_constraint` field
- Release ConfigMaps use naming convention `{template-name}--v{major}-{minor}-{patch}` and are labeled with `console.holos.run/resource-type: template-release`
- Version resolution falls back to live template ConfigMap when no releases exist (backwards compatibility)

Closes #776

## Test plan

- [x] `make test-go` passes (all packages, race detection enabled)
- [x] `make test-ui` passes (683 tests)
- [x] Table-driven tests for semver parsing, constraint matching, version sorting, ConfigMap naming
- [x] Table-driven tests for CreateRelease: first release, duplicate rejection, invalid semver, RBAC (viewer denied), defaults, unauthenticated
- [x] Table-driven tests for ListReleases: version-sorted output, empty list, missing template_name
- [x] Table-driven tests for GetRelease: existing release, not-found, invalid version format
- [x] Table-driven tests for CheckUpdates: no releases, minor update, breaking update, no constraint, no linked templates, all-templates scan
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent slot: `agent-1`