### PR TITLE
feat(templates): update detail page linked template editing with scoped permissions

### DIFF
--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -115,9 +115,11 @@ export function useUpdateTemplate(scope: TemplateScopeRef, name: string) {
       mandatory?: boolean
       enabled?: boolean
       linkedTemplates?: LinkedTemplateRef[]
+      updateLinkedTemplates?: boolean
     }) =>
       client.updateTemplate({
         scope,
+        updateLinkedTemplates: params.updateLinkedTemplates ?? false,
         template: {
           name,
           scopeRef: scope,

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -21,7 +21,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, makeProjectScope } from '@/queries/templates'
+import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope } from '@/queries/templates'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
@@ -78,6 +78,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const userRole = project?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
   const canDelete = userRole === Role.OWNER
+  const canEditLinks = userRole === Role.OWNER
 
   const defaultPlatformInput = `platform: {\n  project:          "${projectName}"\n  namespace:        "holos-prj-${projectName}"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
@@ -136,7 +137,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
           return { scope: lt.scopeRef.scope, scopeName: lt.scopeRef.scopeName, name } as LinkedTemplateRef
         })
         .filter((ref): ref is LinkedTemplateRef => ref !== null)
-      await updateMutation.mutateAsync({ linkedTemplates })
+      await updateMutation.mutateAsync({ linkedTemplates, updateLinkedTemplates: true })
       toast.success('Saved')
       setLinkedEditOpen(false)
     } catch (err) {
@@ -253,12 +254,16 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                       }
                       return (
                         <div className="flex flex-wrap gap-1">
-                          {dedupedLinked.map((t) => (
-                            <span key={t.name} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
-                              {t.displayName || t.name}
-                              {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
-                            </span>
-                          ))}
+                          {dedupedLinked.map((t) => {
+                            const scopeLabel = t.scopeRef?.scope === TemplateScope.ORGANIZATION ? 'Org' : t.scopeRef?.scope === TemplateScope.FOLDER ? 'Folder' : undefined
+                            return (
+                              <span key={t.name} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
+                                {t.displayName || t.name}
+                                {scopeLabel && <span className="text-xs text-muted-foreground">{scopeLabel}</span>}
+                                {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
+                              </span>
+                            )
+                          })}
                         </div>
                       )
                     })()}
@@ -369,45 +374,75 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
           <DialogHeader>
             <DialogTitle>Linked Platform Templates</DialogTitle>
             <DialogDescription>
-              Select org-level platform templates to unify with this deployment template at render time. Mandatory templates are always included.
+              Select platform templates to unify with this deployment template at render time. Mandatory templates are always included.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-2" aria-label="Linked platform templates">
-            {linkableTemplates.map((t) => (
-              <div key={t.name} className="flex items-start gap-2">
-                <Checkbox
-                  id={`linked-edit-${t.name}`}
-                  checked={t.mandatory || draftLinkedTemplateNames.includes(t.name)}
-                  disabled={t.mandatory}
-                  onCheckedChange={(checked) => {
-                    if (t.mandatory) return
-                    setDraftLinkedTemplateNames((prev) =>
-                      checked ? [...prev, t.name] : prev.filter((n) => n !== t.name),
-                    )
-                  }}
-                />
-                <div className="flex flex-col">
-                  <label htmlFor={`linked-edit-${t.name}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
-                    {t.displayName || t.name}
-                    {t.mandatory && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>This platform template is mandatory and always applied.</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    )}
-                  </label>
-                  {t.description && (
-                    <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+          {!canEditLinks && (
+            <Alert>
+              <AlertDescription>OWNER permission is required to modify linked templates.</AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-4" aria-label="Linked platform templates">
+            {(() => {
+              const orgTemplates = linkableTemplates.filter(
+                (t) => t.scopeRef?.scope === TemplateScope.ORGANIZATION,
+              )
+              const folderTemplates = linkableTemplates.filter(
+                (t) => t.scopeRef?.scope === TemplateScope.FOLDER,
+              )
+              const renderGroup = (templates: typeof linkableTemplates) =>
+                templates.map((t) => (
+                  <div key={t.name} className="flex items-start gap-2">
+                    <Checkbox
+                      id={`linked-edit-${t.name}`}
+                      checked={t.mandatory || draftLinkedTemplateNames.includes(t.name)}
+                      disabled={t.mandatory || !canEditLinks}
+                      onCheckedChange={(checked) => {
+                        if (t.mandatory || !canEditLinks) return
+                        setDraftLinkedTemplateNames((prev) =>
+                          checked ? [...prev, t.name] : prev.filter((n) => n !== t.name),
+                        )
+                      }}
+                    />
+                    <div className="flex flex-col">
+                      <label htmlFor={`linked-edit-${t.name}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                        {t.displayName || t.name}
+                        {t.mandatory && (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>This platform template is mandatory and always applied.</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        )}
+                      </label>
+                      {t.description && (
+                        <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                      )}
+                    </div>
+                  </div>
+                ))
+              return (
+                <>
+                  {orgTemplates.length > 0 && (
+                    <div className="space-y-2">
+                      <h4 className="text-sm font-medium text-muted-foreground">Organization Templates</h4>
+                      {renderGroup(orgTemplates)}
+                    </div>
                   )}
-                </div>
-              </div>
-            ))}
+                  {folderTemplates.length > 0 && (
+                    <div className="space-y-2">
+                      <h4 className="text-sm font-medium text-muted-foreground">Folder Templates</h4>
+                      {renderGroup(folderTemplates)}
+                    </div>
+                  )}
+                </>
+              )
+            })()}
           </div>
           {linkedEditError && (
             <Alert variant="destructive">
@@ -416,9 +451,11 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
           )}
           <DialogFooter>
             <Button variant="ghost" onClick={() => setLinkedEditOpen(false)}>Cancel</Button>
-            <Button onClick={handleSaveLinkedTemplates} disabled={updateMutation.isPending}>
-              {updateMutation.isPending ? 'Saving...' : 'Save'}
-            </Button>
+            {canEditLinks && (
+              <Button onClick={handleSaveLinkedTemplates} disabled={updateMutation.isPending}>
+                {updateMutation.isPending ? 'Saving...' : 'Save'}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -27,6 +27,17 @@ import { useGetProject } from '@/queries/projects'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { LinkifiedText } from '@/components/linkified-text'
 
+/** Build a composite key that uniquely identifies a linkable template across scopes. */
+function linkableKey(scope: number | undefined, scopeName: string | undefined, name: string): string {
+  return `${scope ?? 0}/${scopeName ?? ''}/${name}`
+}
+
+/** Parse a composite key back into its constituent parts. */
+function parseLinkableKey(key: string): { scope: number; scopeName: string; name: string } {
+  const parts = key.split('/')
+  return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
+}
+
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/$templateName')({
   component: DeploymentTemplateDetailRoute,
 })
@@ -66,7 +77,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const [cloneDisplayName, setCloneDisplayName] = useState('')
   const [cloneError, setCloneError] = useState<string | null>(null)
   const [linkedEditOpen, setLinkedEditOpen] = useState(false)
-  const [draftLinkedTemplateNames, setDraftLinkedTemplateNames] = useState<string[]>([])
+  const [draftLinkedTemplateKeys, setDraftLinkedTemplateKeys] = useState<string[]>([])
   const [linkedEditError, setLinkedEditError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -121,22 +132,19 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   }
 
   const handleOpenLinkedEdit = () => {
-    setDraftLinkedTemplateNames((template?.linkedTemplates ?? []).map(t => t.name))
+    setDraftLinkedTemplateKeys((template?.linkedTemplates ?? []).map(t => linkableKey(t.scope, t.scopeName, t.name)))
     setLinkedEditError(null)
     setLinkedEditOpen(true)
   }
 
   const handleSaveLinkedTemplates = async () => {
     try {
-      // Build LinkedTemplateRef objects from the selected names using scopeRef
-      // from the linkable template list returned by the server.
-      const linkedTemplates: LinkedTemplateRef[] = draftLinkedTemplateNames
-        .map((name) => {
-          const lt = linkableTemplates.find((t) => t.name === name)
-          if (!lt?.scopeRef) return null
-          return { scope: lt.scopeRef.scope, scopeName: lt.scopeRef.scopeName, name } as LinkedTemplateRef
+      // Parse composite keys back into LinkedTemplateRef objects.
+      const linkedTemplates: LinkedTemplateRef[] = draftLinkedTemplateKeys
+        .map((key) => {
+          const parsed = parseLinkableKey(key)
+          return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name } as LinkedTemplateRef
         })
-        .filter((ref): ref is LinkedTemplateRef => ref !== null)
       await updateMutation.mutateAsync({ linkedTemplates, updateLinkedTemplates: true })
       toast.success('Saved')
       setLinkedEditOpen(false)
@@ -240,14 +248,15 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                   <div className="flex-1">
                     {(() => {
                       // linkedTemplates (v1alpha2) replaces linkedOrgTemplates (v1alpha1).
-                      const linkedNames = (template?.linkedTemplates ?? []).map(t => t.name)
+                      const linkedKeys = (template?.linkedTemplates ?? []).map(t => linkableKey(t.scope, t.scopeName, t.name))
                       const mandatoryTemplates = linkableTemplates.filter((t) => t.mandatory)
+                      const keyOf = (t: (typeof linkableTemplates)[number]) => linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
                       const allLinked = [
-                        ...mandatoryTemplates.filter((t) => !linkedNames.includes(t.name)),
-                        ...linkableTemplates.filter((t) => linkedNames.includes(t.name) || t.mandatory),
+                        ...mandatoryTemplates.filter((t) => !linkedKeys.includes(keyOf(t))),
+                        ...linkableTemplates.filter((t) => linkedKeys.includes(keyOf(t)) || t.mandatory),
                       ]
                       const dedupedLinked = allLinked.filter(
-                        (t, i, arr) => arr.findIndex((x) => x.name === t.name) === i,
+                        (t, i, arr) => arr.findIndex((x) => keyOf(x) === keyOf(t)) === i,
                       )
                       if (dedupedLinked.length === 0) {
                         return <span className="text-sm text-muted-foreground">None linked</span>
@@ -257,7 +266,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                           {dedupedLinked.map((t) => {
                             const scopeLabel = t.scopeRef?.scope === TemplateScope.ORGANIZATION ? 'Org' : t.scopeRef?.scope === TemplateScope.FOLDER ? 'Folder' : undefined
                             return (
-                              <span key={t.name} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
+                              <span key={keyOf(t)} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
                                 {t.displayName || t.name}
                                 {scopeLabel && <span className="text-xs text-muted-foreground">{scopeLabel}</span>}
                                 {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
@@ -391,21 +400,23 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                 (t) => t.scopeRef?.scope === TemplateScope.FOLDER,
               )
               const renderGroup = (templates: typeof linkableTemplates) =>
-                templates.map((t) => (
-                  <div key={t.name} className="flex items-start gap-2">
+                templates.map((t) => {
+                  const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                  return (
+                  <div key={key} className="flex items-start gap-2">
                     <Checkbox
-                      id={`linked-edit-${t.name}`}
-                      checked={t.mandatory || draftLinkedTemplateNames.includes(t.name)}
+                      id={`linked-edit-${key}`}
+                      checked={t.mandatory || draftLinkedTemplateKeys.includes(key)}
                       disabled={t.mandatory || !canEditLinks}
                       onCheckedChange={(checked) => {
                         if (t.mandatory || !canEditLinks) return
-                        setDraftLinkedTemplateNames((prev) =>
-                          checked ? [...prev, t.name] : prev.filter((n) => n !== t.name),
+                        setDraftLinkedTemplateKeys((prev) =>
+                          checked ? [...prev, key] : prev.filter((k) => k !== key),
                         )
                       }}
                     />
                     <div className="flex flex-col">
-                      <label htmlFor={`linked-edit-${t.name}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                      <label htmlFor={`linked-edit-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
                         {t.displayName || t.name}
                         {t.mandatory && (
                           <TooltipProvider>
@@ -425,7 +436,8 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                       )}
                     </div>
                   </div>
-                ))
+                  )
+                })
               return (
                 <>
                   {orgTemplates.length > 0 && (

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
@@ -619,15 +619,16 @@ describe('DeploymentTemplateDetailPage', () => {
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
       await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+      const dialog = screen.getByRole('dialog')
       // Check the non-mandatory template
-      await user.click(screen.getByRole('checkbox', { name: /httproute gateway/i }))
-      await user.click(screen.getByRole('button', { name: /^save$/i }))
+      await user.click(within(dialog).getByRole('checkbox', { name: /httproute gateway/i }))
+      await user.click(within(dialog).getByRole('button', { name: /^save$/i }))
       const mutateAsync = (useUpdateTemplate as Mock).mock.results[0].value.mutateAsync
       await waitFor(() => {
         expect(mutateAsync).toHaveBeenCalledWith(
           expect.objectContaining({
             linkedTemplates: expect.arrayContaining([
-              expect.objectContaining({ name: 'httproute' }),
+              expect.objectContaining({ scope: 1, scopeName: 'acme', name: 'httproute' }),
             ]),
             updateLinkedTemplates: true,
           }),
@@ -692,7 +693,8 @@ describe('DeploymentTemplateDetailPage', () => {
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
       await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
-      expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
+      const dialog = screen.getByRole('dialog')
+      expect(within(dialog).queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
     })
 
     it('shows scope badge per template in read-only display', () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/queries/templates', () => ({
   useRenderTemplate: vi.fn(),
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [] }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
+  TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
 }))
 
 vi.mock('@/queries/projects', () => ({
@@ -527,8 +528,9 @@ describe('DeploymentTemplateDetailPage', () => {
 
   describe('linked platform templates', () => {
     const mockLinkable = [
-      { name: 'httproute', displayName: 'HTTPRoute Gateway', description: 'Adds an HTTPRoute', mandatory: false, scopeRef: { scope: 2, scopeName: 'acme' } },
-      { name: 'mandatory-labels', displayName: 'Mandatory Labels', description: 'Enforces labels', mandatory: true, scopeRef: { scope: 2, scopeName: 'acme' } },
+      { name: 'reference-grant', displayName: 'Reference Grant', description: 'Adds a ReferenceGrant', mandatory: true, scopeRef: { scope: 1, scopeName: 'acme' } },
+      { name: 'httproute', displayName: 'HTTPRoute Gateway', description: 'Adds an HTTPRoute', mandatory: false, scopeRef: { scope: 1, scopeName: 'acme' } },
+      { name: 'team-network-policy', displayName: 'Team Network Policy', description: 'Adds network policy', mandatory: false, scopeRef: { scope: 2, scopeName: 'platform' } },
     ]
 
     it('does not show linked templates row when no linkable templates exist', () => {
@@ -550,12 +552,12 @@ describe('DeploymentTemplateDetailPage', () => {
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       render(<DeploymentTemplateDetailPage />)
       // mandatory template is always shown even when linkedTemplates is empty
-      expect(screen.getByText('Mandatory Labels')).toBeInTheDocument()
+      expect(screen.getByText('Reference Grant')).toBeInTheDocument()
     })
 
     it('shows linked template names as badges', () => {
       ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
-      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 2, scopeName: 'acme' }] })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme' }] })
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByText('HTTPRoute Gateway')).toBeInTheDocument()
     })
@@ -563,6 +565,13 @@ describe('DeploymentTemplateDetailPage', () => {
     it('shows edit linked templates button for owners', () => {
       ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
       setupMocks(Role.OWNER)
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByRole('button', { name: /edit linked platform templates/i })).toBeInTheDocument()
+    })
+
+    it('shows edit linked templates button for editors', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      setupMocks(Role.EDITOR)
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByRole('button', { name: /edit linked platform templates/i })).toBeInTheDocument()
     })
@@ -576,7 +585,7 @@ describe('DeploymentTemplateDetailPage', () => {
 
     it('clicking edit linked templates button opens dialog', async () => {
       ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
-      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 2, scopeName: 'acme' }] })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme' }] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
       await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
@@ -590,7 +599,7 @@ describe('DeploymentTemplateDetailPage', () => {
       render(<DeploymentTemplateDetailPage />)
       await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
       const checkboxes = screen.getAllByRole('checkbox')
-      expect(checkboxes.length).toBeGreaterThanOrEqual(2)
+      expect(checkboxes.length).toBeGreaterThanOrEqual(3)
     })
 
     it('mandatory template checkbox is checked and disabled in dialog', async () => {
@@ -599,12 +608,12 @@ describe('DeploymentTemplateDetailPage', () => {
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
       await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
-      const mandatoryCheckbox = screen.getByRole('checkbox', { name: /mandatory labels/i })
+      const mandatoryCheckbox = screen.getByRole('checkbox', { name: /reference grant/i })
       expect(mandatoryCheckbox).toBeChecked()
       expect(mandatoryCheckbox).toBeDisabled()
     })
 
-    it('saving calls updateMutation with selected linkedTemplates', async () => {
+    it('saving calls updateMutation with selected linkedTemplates and updateLinkedTemplates: true', async () => {
       ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
@@ -620,9 +629,85 @@ describe('DeploymentTemplateDetailPage', () => {
             linkedTemplates: expect.arrayContaining([
               expect.objectContaining({ name: 'httproute' }),
             ]),
+            updateLinkedTemplates: true,
           }),
         )
       })
+    })
+
+    it('saving CUE template does NOT include updateLinkedTemplates: true', async () => {
+      setupMocks(Role.OWNER)
+      render(<DeploymentTemplateDetailPage />)
+      const editor = screen.getByRole('textbox', { name: /cue template/i })
+      fireEvent.change(editor, { target: { value: '// updated cue' } })
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+      const mutateAsync = (useUpdateTemplate as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.not.objectContaining({ updateLinkedTemplates: true }),
+        )
+      })
+    })
+
+    it('dialog groups templates by scope with Organization and Folder headers', async () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
+      const user = userEvent.setup()
+      render(<DeploymentTemplateDetailPage />)
+      await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+      expect(screen.getByText('Organization Templates')).toBeInTheDocument()
+      expect(screen.getByText('Folder Templates')).toBeInTheDocument()
+    })
+
+    it('OWNER can toggle non-mandatory checkboxes in dialog', async () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
+      const user = userEvent.setup()
+      render(<DeploymentTemplateDetailPage />)
+      await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+      const httpCheckbox = screen.getByRole('checkbox', { name: /httproute gateway/i })
+      expect(httpCheckbox).not.toBeDisabled()
+      const folderCheckbox = screen.getByRole('checkbox', { name: /team network policy/i })
+      expect(folderCheckbox).not.toBeDisabled()
+    })
+
+    it('EDITOR sees all checkboxes disabled with permission message', async () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      setupMocks(Role.EDITOR, { ...mockTemplate, linkedTemplates: [] })
+      const user = userEvent.setup()
+      render(<DeploymentTemplateDetailPage />)
+      await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+      // All checkboxes should be disabled for EDITOR
+      const checkboxes = screen.getAllByRole('checkbox')
+      checkboxes.forEach((cb) => {
+        expect(cb).toBeDisabled()
+      })
+      // Permission message should be visible
+      expect(screen.getByText(/owner permission is required/i)).toBeInTheDocument()
+    })
+
+    it('EDITOR does not see Save button in linked templates dialog', async () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      setupMocks(Role.EDITOR, { ...mockTemplate, linkedTemplates: [] })
+      const user = userEvent.setup()
+      render(<DeploymentTemplateDetailPage />)
+      await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+      expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
+    })
+
+    it('shows scope badge per template in read-only display', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [
+        { name: 'httproute', scope: 1, scopeName: 'acme' },
+        { name: 'team-network-policy', scope: 2, scopeName: 'platform' },
+      ] })
+      render(<DeploymentTemplateDetailPage />)
+      // Org badge for httproute and reference-grant (mandatory)
+      const orgBadges = screen.getAllByText('Org')
+      expect(orgBadges.length).toBeGreaterThanOrEqual(1)
+      // Folder badge for team-network-policy
+      const folderBadges = screen.getAllByText('Folder')
+      expect(folderBadges.length).toBeGreaterThanOrEqual(1)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add `updateLinkedTemplates` flag to `useUpdateTemplate` mutation; only linked template saves set it to `true`, preventing accidental link overwrites during CUE/description saves
- Group linkable templates in the edit dialog by scope with "Organization Templates" and "Folder Templates" section headers
- Restrict linked template editing to OWNER role; EDITORs see the dialog as read-only with all checkboxes disabled and a permission message
- Add scope badges ("Org" / "Folder") to the read-only linked template badge display
- Add unit tests verifying scope grouping, OWNER editability, EDITOR disabled state, update flag inclusion/exclusion, and scope badge rendering

Closes #769

## Test plan
- [x] `make test` passes (700 tests, 47 files)
- [ ] Verify OWNER can toggle linked template checkboxes and save
- [ ] Verify EDITOR opens dialog and sees disabled checkboxes with permission message
- [ ] Verify CUE template save does not include `updateLinkedTemplates: true`
- [ ] Verify scope headers appear in dialog when both org and folder templates exist
- [ ] Verify scope badges appear in read-only badge display

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)