### PR TITLE
docs(agents): add guardrail for Template-first field ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Before making changes, review `CONTRIBUTING.md` for commit message requirements.
 - [URL Scheme](docs/agents/guardrail-url-scheme.md) — Top-level resources get dedicated URL prefixes; never nest one top-level resource under another.
 - [Collection Index Pages](docs/agents/guardrail-collection-index.md) — Every resource collection must have an index/listing page at the root URL; settings live at a `/settings` subroute.
 - [Searchable Collections](docs/agents/guardrail-searchable-collections.md) — All index pages and dynamic-collection combo boxes must include a search/filter input using TanStack Table `globalFilterFn: 'includesString'`.
+- [Template-First Field Ordering](docs/agents/guardrail-template-first-field.md) — Template must be the first form field in Create Deployment; selecting it auto-populates all other fields.
 
 ## Planning & Execution
 

--- a/docs/agents/guardrail-template-first-field.md
+++ b/docs/agents/guardrail-template-first-field.md
@@ -1,0 +1,45 @@
+# Guardrail: Template-First Field Ordering
+
+**The Template field must be the first form field in the Create Deployment form (`new.tsx`), before Display Name, Name (slug), and Description.** When no templates are available, the "No templates available" fallback occupies the same first position.
+
+## Rationale
+
+Selecting a template auto-populates all other fields (name, description, image, tag, port, command, args, env) via `handleTemplateChange`. If Template is not first, users fill in details manually before discovering the template overwrites them -- wasting effort and causing confusion. This ordering was established by PR #785 / issue #772.
+
+## Enforcement
+
+A unit test in `-new.test.tsx` asserts that the Template label appears as the first form field in DOM order:
+
+```tsx
+it('renders Template as the first form field, before Display Name', () => {
+  // ...
+  expect(templateIndex).toBe(0) // Template is the very first field
+})
+```
+
+CI will fail if the ordering regresses. The test covers both the Combobox path (templates exist) and the "No templates available" fallback path (empty template list).
+
+## Common Failure Mode
+
+Branches forked before the Template-first reorder carry `new.tsx` with Template in position 4. When these branches merge, Git's 3-way merge can silently revert the ordering. The unit test catches this -- a merge that reverts the field order will fail CI.
+
+## Triggers
+
+Apply this rule when:
+- Editing `frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx`
+- Adding, removing, or reordering form fields in the Create Deployment form
+- Resolving merge conflicts in `new.tsx`
+
+## Incorrect Patterns
+
+| Pattern | Why it is wrong |
+|---------|-----------------|
+| Template field after Display Name | Users type a name, then template overwrites it |
+| Template field after any other form field | Same auto-populate confusion applies to all fields |
+| Removing the field-ordering test | The regression guard must stay in place |
+
+## Related
+
+- [Selection Components](selection-components.md) -- Combobox for dynamic collections, Select for static enumerations
+- [Deployment Service](deployment-service.md) -- Kubernetes Deployment CRUD and CUE rendering
+- [Guardrail: Template Fields](guardrail-template-fields.md) -- New proto fields must propagate through the render pipeline


### PR DESCRIPTION
## Summary
- Add `docs/agents/guardrail-template-first-field.md` documenting the rule that the Template field must be the first form field in the Create Deployment form
- Document rationale (auto-populate via `handleTemplateChange`), enforcement (unit test from #796), common merge-conflict failure mode, and triggers
- Update `AGENTS.md` Guardrails section with a link to the new document
- Cross-links to `selection-components.md`, `deployment-service.md`, and `guardrail-template-fields.md`

Closes #797

## Test plan
- [x] `make test-ui` passes (696/696 tests)
- [ ] Verify guardrail doc renders correctly on GitHub
- [ ] Verify AGENTS.md link resolves to the new document

> Local E2E was not run (docs-only change, no E2E-relevant files modified).

Generated with [Claude Code](https://claude.com/claude-code)