### PR TITLE
chore(folders): remove dead ParentType re-export from folder queries

### DIFF
--- a/frontend/src/queries/folders.ts
+++ b/frontend/src/queries/folders.ts
@@ -6,8 +6,6 @@ import { FolderService } from '@/gen/holos/console/v1/folders_pb.js'
 import type { ParentType } from '@/gen/holos/console/v1/folders_pb.js'
 import { useAuth } from '@/lib/auth'
 
-export type { ParentType }
-
 function folderListKey(organization: string, parentType?: number, parentName?: string) {
   return ['folders', 'list', organization, parentType, parentName] as const
 }
@@ -124,4 +122,3 @@ export function useUpdateFolderDefaultSharing(organization: string, name: string
     },
   })
 }
-


### PR DESCRIPTION
## Summary
- Remove unused `export type { ParentType }` re-export from `frontend/src/queries/folders.ts` — all consumers import `ParentType` directly from the generated proto file, so this re-export was dead code flagged by `knip`
- Remove trailing blank line at end of file

Closes #791

## Test plan
- [x] `make test` passes (702 UI tests, all Go tests)
- [x] `tsc --noEmit` compiles cleanly
- [x] `knip --no-progress` no longer reports `ParentType` in `src/queries/folders.ts`
- [x] Verified `Role` import in folder settings page is still used (lines 86-89)
- [x] No stale TODO/FIXME comments found in folder routes or queries

Generated with [Claude Code](https://claude.com/claude-code) from ${AGENT_SLOT}