### PR TITLE
feat(ui): add populate defaults checkbox to org creation dialog

### DIFF
--- a/frontend/src/components/create-org-dialog.test.tsx
+++ b/frontend/src/components/create-org-dialog.test.tsx
@@ -229,9 +229,9 @@ describe('CreateOrgDialog', () => {
       fireEvent.submit(screen.getByRole('form'))
 
       await waitFor(() => {
-        expect(mockMutateAsync).toHaveBeenCalledWith(
-          expect.not.objectContaining({ populateDefaults: true })
-        )
+        expect(mockMutateAsync).toHaveBeenCalled()
+        const args = mockMutateAsync.mock.calls[0][0]
+        expect(args).not.toHaveProperty('populateDefaults')
       })
     })
   })

--- a/frontend/src/components/create-org-dialog.test.tsx
+++ b/frontend/src/components/create-org-dialog.test.tsx
@@ -49,6 +49,31 @@ vi.mock('@/components/ui/alert', () => ({
   AlertDescription: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
 }))
 
+vi.mock('@/components/ui/checkbox', () => ({
+  Checkbox: ({ id, checked, onCheckedChange, ...props }: {
+    id?: string
+    checked?: boolean
+    onCheckedChange?: (checked: boolean) => void
+    [key: string]: unknown
+  }) => (
+    <input
+      type="checkbox"
+      id={id}
+      checked={checked ?? false}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+      role="checkbox"
+      {...props}
+    />
+  ),
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div data-testid="tooltip-content">{children}</div>,
+}))
+
 import { useCreateOrganization } from '@/queries/organizations'
 import { CreateOrgDialog } from './create-org-dialog'
 
@@ -158,6 +183,56 @@ describe('CreateOrgDialog', () => {
 
     await waitFor(() => {
       expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('populate defaults checkbox', () => {
+    it('renders checkbox unchecked by default', () => {
+      render(<CreateOrgDialog open={true} onOpenChange={onOpenChange} />)
+      const checkbox = screen.getByRole('checkbox')
+      expect(checkbox).toBeDefined()
+      expect((checkbox as HTMLInputElement).checked).toBe(false)
+    })
+
+    it('renders label text for the checkbox', () => {
+      render(<CreateOrgDialog open={true} onOpenChange={onOpenChange} />)
+      expect(screen.getByText('Populate with example resources')).toBeDefined()
+    })
+
+    it('renders tooltip with expected content', () => {
+      render(<CreateOrgDialog open={true} onOpenChange={onOpenChange} />)
+      expect(
+        screen.getByText(/Creates a default folder and project structure with example templates/)
+      ).toBeDefined()
+    })
+
+    it('passes populateDefaults: true when checkbox is checked', async () => {
+      mockMutateAsync.mockResolvedValue({ name: 'new-org' })
+      render(<CreateOrgDialog open={true} onOpenChange={onOpenChange} />)
+
+      fireEvent.change(screen.getByPlaceholderText(/my organization/i), { target: { value: 'New Org' } })
+      fireEvent.click(screen.getByRole('checkbox'))
+      fireEvent.submit(screen.getByRole('form'))
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({ populateDefaults: true })
+        )
+      })
+    })
+
+    it('does not send populateDefaults when checkbox is unchecked', async () => {
+      mockMutateAsync.mockResolvedValue({ name: 'new-org' })
+      render(<CreateOrgDialog open={true} onOpenChange={onOpenChange} />)
+
+      fireEvent.change(screen.getByPlaceholderText(/my organization/i), { target: { value: 'New Org' } })
+      fireEvent.submit(screen.getByRole('form'))
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.not.objectContaining({ populateDefaults: true })
+        )
+      })
     })
   })
 })

--- a/frontend/src/components/create-org-dialog.tsx
+++ b/frontend/src/components/create-org-dialog.tsx
@@ -11,6 +11,9 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Info } from 'lucide-react'
 import { useCreateOrganization } from '@/queries/organizations'
 import { toSlug } from '@/lib/slug'
 
@@ -25,6 +28,7 @@ export function CreateOrgDialog({ open, onOpenChange, onCreated }: CreateOrgDial
   const [name, setName] = useState('')
   const [nameEdited, setNameEdited] = useState(false)
   const [description, setDescription] = useState('')
+  const [populateDefaults, setPopulateDefaults] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const { mutateAsync, isPending } = useCreateOrganization()
@@ -51,10 +55,16 @@ export function CreateOrgDialog({ open, onOpenChange, onCreated }: CreateOrgDial
     e.preventDefault()
     setError(null)
     try {
-      const response = await mutateAsync({ name, displayName, description })
+      const response = await mutateAsync({
+        name,
+        displayName,
+        description,
+        ...(populateDefaults ? { populateDefaults: true } : {}),
+      })
       setName('')
       setDisplayName('')
       setDescription('')
+      setPopulateDefaults(false)
       setNameEdited(false)
       onCreated?.(response.name)
       onOpenChange(false)
@@ -118,6 +128,26 @@ export function CreateOrgDialog({ open, onOpenChange, onCreated }: CreateOrgDial
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Optional description"
               />
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="populate-defaults"
+                checked={populateDefaults}
+                onCheckedChange={(checked) => setPopulateDefaults(checked === true)}
+              />
+              <Label htmlFor="populate-defaults" className="text-sm cursor-pointer">
+                Populate with example resources
+              </Label>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-4 w-4 text-muted-foreground cursor-default" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Creates a default folder and project structure with example templates at each level, including an org-level HTTPRoute platform template and a project-level deployment template.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           </div>
           <DialogFooter>

--- a/frontend/src/queries/organizations.ts
+++ b/frontend/src/queries/organizations.ts
@@ -49,7 +49,7 @@ export function useCreateOrganization() {
   const client = useMemo(() => createClient(OrganizationService, transport), [transport])
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (params: { name: string; displayName?: string; description?: string }) =>
+    mutationFn: (params: { name: string; displayName?: string; description?: string; populateDefaults?: boolean }) =>
       client.createOrganization(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['connect-query'] })


### PR DESCRIPTION
## Summary
- Add a "Populate with example resources" checkbox to the org creation dialog below the description field
- When checked, passes `populateDefaults: true` to the `CreateOrganization` RPC
- When unchecked (default), `populateDefaults` is not sent, preserving existing behavior
- Include Info icon tooltip explaining what gets created (default folder/project structure with example templates)
- Add `populateDefaults?: boolean` parameter to `useCreateOrganization` mutation
- Add 5 Vitest tests covering checkbox rendering, label, tooltip content, checked submission, and unchecked submission

Closes #761

## Test plan
- [x] Checkbox renders unchecked by default
- [x] Checking the box and submitting passes `populateDefaults: true` to the mutation
- [x] Tooltip content matches acceptance criteria
- [x] Submitting without checking the box does not send `populateDefaults`
- [x] All 707 existing tests continue to pass (`make test`)
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)