### PR TITLE
chore(templates): clean up dead code and verify guardrails

### DIFF
--- a/docs/agents/guardrail-template-fields.md
+++ b/docs/agents/guardrail-template-fields.md
@@ -9,6 +9,8 @@
 
 This ensures template authors always see new fields in the preview, that the CUE schema stays in sync with the proto interface, and that the `defaults` block extraction covers all form fields. See `docs/cue-template-guide.md` for the full template interface.
 
+**Note:** Request-level flags (e.g., `update_linked_templates` on `UpdateTemplateRequest`) that control *how* the backend processes a request are not template fields. They do not need to propagate through CUE types, the render pipeline, frontend preview, or defaults extraction. They only need handler logic and tests.
+
 ## Related
 
 - [Template Service](template-service.md) — The service these fields belong to

--- a/docs/agents/guardrail-template-linking.md
+++ b/docs/agents/guardrail-template-linking.md
@@ -8,6 +8,17 @@
 
 When adding new fields that affect template linking, update `docs/cue-template-guide.md` and the AGENTS.md context map.
 
+## Scoped Link Permissions
+
+Modifying linked template references requires scoped link permissions in addition to `PERMISSION_TEMPLATES_WRITE`:
+
+- `PERMISSION_TEMPLATES_LINK_ORG_WRITE` — required when any linked ref targets an organization-scope template.
+- `PERMISSION_TEMPLATES_LINK_FOLDER_WRITE` — required when any linked ref targets a folder-scope template.
+
+Both permissions are checked at the template's owning scope (not the linked template's scope). Only OWNERs have these permissions via the `TemplateCascadePerms` cascade table. EDITORs can create and update templates but cannot modify linked template references.
+
+The `update_linked_templates` flag on `UpdateTemplateRequest` controls whether the backend processes the `linked_templates` field. When false (default), existing links are preserved regardless of the request payload. When true, the handler enforces scoped link permissions against both the existing linked refs (being removed) and the new linked refs (being added), then replaces the stored links.
+
 ## Related
 
 - [Template Service](template-service.md) — Explicit linking model and render set formula

--- a/docs/agents/rbac.md
+++ b/docs/agents/rbac.md
@@ -41,6 +41,10 @@ Roles: VIEWER (1), EDITOR (2), OWNER (3) defined in `proto/holos/console/v1/rbac
 
 `PERMISSION_REPARENT` is required to move a folder or project to a different parent. It is granted only to OWNERs via the `ReparentCascadePerms` cascade table. The caller must hold this permission on both the source parent and the destination parent. This is deliberately more restrictive than WRITE because reparenting changes RBAC inheritance chains (ADR 022 Decision 6).
 
+`PERMISSION_TEMPLATES_LINK_ORG_WRITE` is required to add or remove organization-level linked template references on a template. It is checked at the template's owning scope (e.g., the project that owns the template being edited). Granted only to OWNERs via the `TemplateCascadePerms` cascade table in `console/rbac/rbac.go`.
+
+`PERMISSION_TEMPLATES_LINK_FOLDER_WRITE` is required to add or remove folder-level linked template references on a template. Same scope and cascade rules as the org variant. Both permissions are enforced by the `checkLinkPermissions` helper in `console/templates/handler.go` when `update_linked_templates` is true on an `UpdateTemplateRequest`, or when `linked_templates` is non-empty on a `CreateTemplateRequest`.
+
 ## Related
 
 - [Authentication](authentication.md) — OIDC flow that produces the identity claims RBAC evaluates


### PR DESCRIPTION
## Summary
- Verified no dead code, unused imports, or stale references across all Go and TypeScript files modified in phases 1-4 (#766, #767, #768, #769)
- Updated `docs/agents/rbac.md` to document `PERMISSION_TEMPLATES_LINK_ORG_WRITE` and `PERMISSION_TEMPLATES_LINK_FOLDER_WRITE` with scope, cascade table, and enforcement details
- Updated `docs/agents/guardrail-template-linking.md` with a new "Scoped Link Permissions" section covering the permission model and `update_linked_templates` flag semantics
- Updated `docs/agents/guardrail-template-fields.md` with a note clarifying that request-level flags like `update_linked_templates` are not template fields and don't require pipeline propagation
- Verified `docs/cue-template-guide.md` remains complete: "Writing a Custom Template" section has ServiceAccount, Deployment, Service, port flow, and HTTPRoute guidance
- Confirmed `make generate` is a no-op (all generated files up to date)
- Confirmed `make test` passes (709 tests, 0 failures)
- Confirmed `go vet ./console/...` and `tsc --noEmit` are clean

Closes #770

## Test plan
- [x] `make generate` produces no diff
- [x] `make test` passes (709 tests)
- [x] `go vet ./console/...` clean
- [x] `tsc --noEmit` clean
- [x] No `-k`, `--insecure`, or `-plaintext` in any new examples
- [ ] Review guardrail doc updates for accuracy

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)