### PR TITLE
feat(templates): frontend release management UI

### DIFF
--- a/frontend/src/components/-template-releases.test.tsx
+++ b/frontend/src/components/-template-releases.test.tsx
@@ -1,0 +1,301 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@/queries/templates', () => ({
+  useListReleases: vi.fn(),
+  useCreateRelease: vi.fn(),
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement> & { children?: React.ReactNode }) => (
+    <label {...props}>{children}</label>
+  ),
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, type, disabled, ...rest }: {
+    children: React.ReactNode
+    onClick?: () => void
+    type?: string
+    disabled?: boolean
+    variant?: string
+    size?: string
+    className?: string
+  }) => (
+    <button onClick={onClick} type={type as 'button' | 'submit' | 'reset'} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...rest }: { children: React.ReactNode; variant?: string; className?: string }) => (
+    <span data-testid="badge">{children}</span>
+  ),
+}))
+
+vi.mock('@/components/ui/separator', () => ({
+  Separator: () => <hr />,
+}))
+
+vi.mock('@/components/ui/alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div role="alert">{children}</div>,
+  AlertDescription: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock('lucide-react', () => ({
+  Plus: () => <span data-testid="icon-plus" />,
+  Tag: () => <span data-testid="icon-tag" />,
+}))
+
+import { useListReleases, useCreateRelease } from '@/queries/templates'
+import { TemplateReleases } from './template-releases'
+import { TemplateScope } from '@/gen/holos/console/v1/templates_pb.js'
+
+const testScope = { scope: TemplateScope.ORGANIZATION, scopeName: 'test-org' } as any
+
+function makeRelease(version: string, changelog: string, upgradeAdvice = '', createdAt?: Date) {
+  return {
+    templateName: 'my-template',
+    scopeRef: testScope,
+    version,
+    changelog,
+    upgradeAdvice,
+    cueTemplate: '// cue',
+    defaults: undefined,
+    createdAt: createdAt ? { seconds: BigInt(Math.floor(createdAt.getTime() / 1000)), nanos: 0 } : undefined,
+  }
+}
+
+describe('TemplateReleases', () => {
+  const mockMutateAsync = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
+    ;(useCreateRelease as Mock).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    })
+  })
+
+  it('renders empty state when no releases exist', () => {
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    expect(screen.getByText(/no releases/i)).toBeInTheDocument()
+  })
+
+  it('renders release list in descending version order', () => {
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [
+        makeRelease('2.0.0', 'Breaking changes'),
+        makeRelease('1.1.0', 'Minor feature'),
+        makeRelease('1.0.0', 'Initial release'),
+      ],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    const versions = screen.getAllByText(/^\d+\.\d+\.\d+$/)
+    expect(versions[0]).toHaveTextContent('2.0.0')
+    expect(versions[1]).toHaveTextContent('1.1.0')
+    expect(versions[2]).toHaveTextContent('1.0.0')
+  })
+
+  it('highlights the latest release', () => {
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [
+        makeRelease('1.1.0', 'Latest feature'),
+        makeRelease('1.0.0', 'Initial release'),
+      ],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    expect(screen.getByText('Latest')).toBeInTheDocument()
+  })
+
+  it('shows truncated changelog text', () => {
+    const longChangelog = 'A'.repeat(200)
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [makeRelease('1.0.0', longChangelog)],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    // The truncated text should be present (first 120 chars + ellipsis)
+    const truncated = screen.getByText(new RegExp('^A{20,}'))
+    expect(truncated.textContent!.length).toBeLessThan(200)
+  })
+
+  it('shows Create Release button when canWrite is true', () => {
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    expect(screen.getByText(/create release/i)).toBeInTheDocument()
+  })
+
+  it('hides Create Release button when canWrite is false', () => {
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={false} />
+    )
+    expect(screen.queryByText(/create release/i)).toBeNull()
+  })
+
+  it('opens create dialog with suggested version when button is clicked', () => {
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [makeRelease('1.2.3', 'Last release')],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    expect(screen.getByTestId('dialog')).toBeInTheDocument()
+    // Version field should be pre-filled with suggested next patch version
+    const versionInput = screen.getByLabelText(/version/i) as HTMLInputElement
+    expect(versionInput.value).toBe('1.2.4')
+  })
+
+  it('validates invalid semver format', () => {
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    const versionInput = screen.getByLabelText(/version/i)
+    fireEvent.change(versionInput, { target: { value: 'not-semver' } })
+    fireEvent.click(screen.getByText(/^publish$/i))
+    expect(screen.getByText(/valid semver/i)).toBeInTheDocument()
+  })
+
+  it('validates duplicate version', () => {
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [makeRelease('1.0.0', 'Initial')],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    const versionInput = screen.getByLabelText(/version/i)
+    fireEvent.change(versionInput, { target: { value: '1.0.0' } })
+    fireEvent.click(screen.getByText(/^publish$/i))
+    expect(screen.getByText(/already exists/i)).toBeInTheDocument()
+  })
+
+  it('submits create release form successfully', async () => {
+    mockMutateAsync.mockResolvedValue({ release: makeRelease('1.0.0', 'First release') })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    const versionInput = screen.getByLabelText(/version/i)
+    fireEvent.change(versionInput, { target: { value: '1.0.0' } })
+    const changelogInput = screen.getByLabelText(/changelog/i)
+    fireEvent.change(changelogInput, { target: { value: 'First release' } })
+    fireEvent.click(screen.getByText(/^publish$/i))
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          version: '1.0.0',
+          changelog: 'First release',
+        })
+      )
+    })
+  })
+
+  it('shows upgrade advice field for major version bumps', () => {
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [makeRelease('1.2.3', 'Previous')],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    const versionInput = screen.getByLabelText(/version/i)
+    fireEvent.change(versionInput, { target: { value: '2.0.0' } })
+    // Upgrade advice textarea should now be visible
+    expect(screen.getByLabelText(/upgrade advice/i)).toBeInTheDocument()
+  })
+
+  it('hides upgrade advice field for non-major version bumps', () => {
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [makeRelease('1.2.3', 'Previous')],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    // Default suggested version is 1.2.4 (patch), so no upgrade advice
+    expect(screen.queryByLabelText(/upgrade advice/i)).toBeNull()
+  })
+
+  it('shows error when create release fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('release creation failed'))
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    const versionInput = screen.getByLabelText(/version/i)
+    fireEvent.change(versionInput, { target: { value: '1.0.0' } })
+    fireEvent.click(screen.getByText(/^publish$/i))
+
+    await waitFor(() => {
+      expect(screen.getByText(/release creation failed/i)).toBeInTheDocument()
+    })
+  })
+
+  it('suggests version options as radio buttons', () => {
+    ;(useListReleases as Mock).mockReturnValue({
+      data: [makeRelease('1.2.3', 'Previous')],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <TemplateReleases scope={testScope} templateName="my-template" canWrite={true} />
+    )
+    fireEvent.click(screen.getByText(/create release/i))
+    // Should show patch, minor, major radio options
+    expect(screen.getByLabelText(/1\.2\.4.*patch/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/1\.3\.0.*minor/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/2\.0\.0.*major/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/template-releases.tsx
+++ b/frontend/src/components/template-releases.tsx
@@ -1,0 +1,323 @@
+import { useState, useMemo } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Textarea } from '@/components/ui/textarea'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Plus, Tag } from 'lucide-react'
+import { useListReleases, useCreateRelease } from '@/queries/templates'
+import type { TemplateScopeRef, Release } from '@/queries/templates'
+
+// Semver validation regex: major.minor.patch
+const SEMVER_RE = /^\d+\.\d+\.\d+$/
+
+// parseSemver extracts major, minor, patch from a version string.
+function parseSemver(v: string): [number, number, number] | null {
+  const m = SEMVER_RE.exec(v)
+  if (!m) return null
+  const parts = v.split('.')
+  return [parseInt(parts[0], 10), parseInt(parts[1], 10), parseInt(parts[2], 10)]
+}
+
+// suggestVersions returns patch, minor, and major bump candidates from the latest version.
+function suggestVersions(latest: string): { patch: string; minor: string; major: string } {
+  const parsed = parseSemver(latest)
+  if (!parsed) return { patch: '0.0.1', minor: '0.1.0', major: '1.0.0' }
+  const [maj, min, pat] = parsed
+  return {
+    patch: `${maj}.${min}.${pat + 1}`,
+    minor: `${maj}.${min + 1}.0`,
+    major: `${maj + 1}.0.0`,
+  }
+}
+
+// isMajorBump returns true when the new version is a major bump relative to the latest.
+function isMajorBump(latest: string, next: string): boolean {
+  const lp = parseSemver(latest)
+  const np = parseSemver(next)
+  if (!lp || !np) return false
+  return np[0] > lp[0]
+}
+
+// truncateText truncates text to maxLen characters with ellipsis.
+function truncateText(text: string, maxLen = 120): string {
+  if (text.length <= maxLen) return text
+  return text.slice(0, maxLen) + '...'
+}
+
+// formatDate formats a protobuf Timestamp into a locale date string.
+function formatDate(ts: Release['createdAt']): string {
+  if (!ts) return ''
+  const ms = Number(ts.seconds) * 1000
+  return new Date(ms).toLocaleDateString()
+}
+
+interface TemplateReleasesProps {
+  scope: TemplateScopeRef
+  templateName: string
+  canWrite: boolean
+  /** Current CUE template source for creating a release from current state. */
+  currentCueTemplate?: string
+}
+
+export function TemplateReleases({ scope, templateName, canWrite, currentCueTemplate }: TemplateReleasesProps) {
+  const { data: releases, isPending, error } = useListReleases(scope, templateName)
+  const createMutation = useCreateRelease(scope, templateName)
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [version, setVersion] = useState('')
+  const [versionBump, setVersionBump] = useState<'patch' | 'minor' | 'major' | 'custom'>('patch')
+  const [changelog, setChangelog] = useState('')
+  const [upgradeAdvice, setUpgradeAdvice] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  // Sorted releases in descending version order (highest first).
+  const sortedReleases = useMemo(() => {
+    if (!releases) return []
+    return [...releases].sort((a, b) => {
+      const ap = parseSemver(a.version)
+      const bp = parseSemver(b.version)
+      if (!ap || !bp) return 0
+      if (ap[0] !== bp[0]) return bp[0] - ap[0]
+      if (ap[1] !== bp[1]) return bp[1] - ap[1]
+      return bp[2] - ap[2]
+    })
+  }, [releases])
+
+  const latestVersion = sortedReleases.length > 0 ? sortedReleases[0].version : ''
+  const suggestions = suggestVersions(latestVersion)
+  const existingVersions = new Set((releases ?? []).map((r) => r.version))
+
+  // Determine whether to show upgrade advice (major bump relative to latest).
+  const showUpgradeAdvice = latestVersion ? isMajorBump(latestVersion, version) : false
+
+  const handleOpenDialog = () => {
+    setVersion(suggestions.patch)
+    setVersionBump('patch')
+    setChangelog('')
+    setUpgradeAdvice('')
+    setValidationError(null)
+    setSubmitError(null)
+    setDialogOpen(true)
+  }
+
+  const handleBumpChange = (bump: 'patch' | 'minor' | 'major' | 'custom') => {
+    setVersionBump(bump)
+    if (bump === 'patch') setVersion(suggestions.patch)
+    else if (bump === 'minor') setVersion(suggestions.minor)
+    else if (bump === 'major') setVersion(suggestions.major)
+    setValidationError(null)
+  }
+
+  const handleVersionChange = (v: string) => {
+    setVersion(v)
+    // If the typed version matches one of the suggestions, select that radio
+    if (v === suggestions.patch) setVersionBump('patch')
+    else if (v === suggestions.minor) setVersionBump('minor')
+    else if (v === suggestions.major) setVersionBump('major')
+    else setVersionBump('custom')
+    setValidationError(null)
+  }
+
+  const handlePublish = async () => {
+    setValidationError(null)
+    setSubmitError(null)
+
+    if (!SEMVER_RE.test(version)) {
+      setValidationError('Version must be valid semver (e.g. 1.2.3)')
+      return
+    }
+    if (existingVersions.has(version)) {
+      setValidationError(`Version ${version} already exists`)
+      return
+    }
+
+    try {
+      await createMutation.mutateAsync({
+        version,
+        changelog,
+        upgradeAdvice: showUpgradeAdvice ? upgradeAdvice : '',
+        cueTemplate: currentCueTemplate ?? '',
+      })
+      setDialogOpen(false)
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Releases</h3>
+        {canWrite && (
+          <Button variant="outline" size="sm" onClick={handleOpenDialog}>
+            <Plus className="h-3.5 w-3.5 mr-1.5" />
+            Create Release
+          </Button>
+        )}
+      </div>
+      <Separator />
+
+      {isPending && <p className="text-sm text-muted-foreground">Loading releases...</p>}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {!isPending && !error && sortedReleases.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+          <Tag className="h-8 w-8 mb-2 opacity-50" />
+          <p className="text-sm">No releases published yet.</p>
+        </div>
+      )}
+
+      {sortedReleases.length > 0 && (
+        <ul className="space-y-2">
+          {sortedReleases.map((release, idx) => (
+            <li
+              key={release.version}
+              className={`flex items-start gap-3 p-3 rounded-md border ${idx === 0 ? 'border-primary/40 bg-primary/5' : 'border-border'}`}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium font-mono">{release.version}</span>
+                  {idx === 0 && (
+                    <Badge variant="secondary" className="text-xs">
+                      Latest
+                    </Badge>
+                  )}
+                  {release.createdAt && (
+                    <span className="text-xs text-muted-foreground">{formatDate(release.createdAt)}</span>
+                  )}
+                </div>
+                {release.changelog && (
+                  <p className="text-xs text-muted-foreground mt-1">{truncateText(release.changelog)}</p>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Create Release</DialogTitle>
+            <DialogDescription>
+              Publish a new versioned release of this template.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            {/* Version bump radio options */}
+            {latestVersion && (
+              <fieldset className="space-y-2">
+                <legend className="text-sm font-medium">Version bump</legend>
+                <div className="flex gap-4">
+                  <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                    <input
+                      type="radio"
+                      name="version-bump"
+                      value="patch"
+                      checked={versionBump === 'patch'}
+                      onChange={() => handleBumpChange('patch')}
+                    />
+                    {suggestions.patch} (patch)
+                  </label>
+                  <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                    <input
+                      type="radio"
+                      name="version-bump"
+                      value="minor"
+                      checked={versionBump === 'minor'}
+                      onChange={() => handleBumpChange('minor')}
+                    />
+                    {suggestions.minor} (minor)
+                  </label>
+                  <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                    <input
+                      type="radio"
+                      name="version-bump"
+                      value="major"
+                      checked={versionBump === 'major'}
+                      onChange={() => handleBumpChange('major')}
+                    />
+                    {suggestions.major} (major)
+                  </label>
+                </div>
+              </fieldset>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="release-version">Version</Label>
+              <Input
+                id="release-version"
+                aria-label="Version"
+                value={version}
+                onChange={(e) => handleVersionChange(e.target.value)}
+                placeholder="1.0.0"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="release-changelog">Changelog</Label>
+              <Textarea
+                id="release-changelog"
+                aria-label="Changelog"
+                value={changelog}
+                onChange={(e) => setChangelog(e.target.value)}
+                placeholder="Describe what changed in this release..."
+                rows={4}
+              />
+            </div>
+
+            {showUpgradeAdvice && (
+              <div className="space-y-2">
+                <Label htmlFor="release-upgrade-advice">Upgrade Advice</Label>
+                <Textarea
+                  id="release-upgrade-advice"
+                  aria-label="Upgrade Advice"
+                  value={upgradeAdvice}
+                  onChange={(e) => setUpgradeAdvice(e.target.value)}
+                  placeholder="Provide guidance for consumers upgrading to this major version..."
+                  rows={3}
+                />
+              </div>
+            )}
+
+            {validationError && (
+              <Alert variant="destructive">
+                <AlertDescription>{validationError}</AlertDescription>
+              </Alert>
+            )}
+            {submitError && (
+              <Alert variant="destructive">
+                <AlertDescription>{submitError}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handlePublish} disabled={createMutation.isPending}>
+              {createMutation.isPending ? 'Publishing...' : 'Publish'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/src/components/template-releases.tsx
+++ b/frontend/src/components/template-releases.tsx
@@ -68,9 +68,11 @@ interface TemplateReleasesProps {
   canWrite: boolean
   /** Current CUE template source for creating a release from current state. */
   currentCueTemplate?: string
+  /** Current template defaults for creating a release from current state. */
+  currentDefaults?: Release['defaults']
 }
 
-export function TemplateReleases({ scope, templateName, canWrite, currentCueTemplate }: TemplateReleasesProps) {
+export function TemplateReleases({ scope, templateName, canWrite, currentCueTemplate, currentDefaults }: TemplateReleasesProps) {
   const { data: releases, isPending, error } = useListReleases(scope, templateName)
   const createMutation = useCreateRelease(scope, templateName)
 
@@ -149,6 +151,7 @@ export function TemplateReleases({ scope, templateName, canWrite, currentCueTemp
         changelog,
         upgradeAdvice: showUpgradeAdvice ? upgradeAdvice : '',
         cueTemplate: currentCueTemplate ?? '',
+        defaults: currentDefaults,
       })
       setDialogOpen(false)
     } catch (err) {

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -7,12 +7,13 @@ import {
   TemplateService,
   TemplateScopeRefSchema,
   TemplateScope,
+  ReleaseSchema,
 } from '@/gen/holos/console/v1/templates_pb.js'
-import type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef } from '@/gen/holos/console/v1/templates_pb.js'
+import type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef, Release } from '@/gen/holos/console/v1/templates_pb.js'
 import { useAuth } from '@/lib/auth'
 
 // Re-export types used by consumers.
-export type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef }
+export type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef, Release }
 export { TemplateScope }
 
 // makeScope is a helper to build a TemplateScopeRef from scope and scopeName.
@@ -176,6 +177,74 @@ export function useListLinkableTemplates(scope: TemplateScopeRef) {
       return response.templates
     },
     enabled: isAuthenticated && !!scope.scopeName,
+  })
+}
+
+// --- Release hooks ---
+
+function releaseListKey(scope: TemplateScopeRef, templateName: string) {
+  return ['releases', 'list', scope.scope, scope.scopeName, templateName] as const
+}
+
+function releaseGetKey(scope: TemplateScopeRef, templateName: string, version: string) {
+  return ['releases', 'get', scope.scope, scope.scopeName, templateName, version] as const
+}
+
+export function useListReleases(scope: TemplateScopeRef, templateName: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  return useQuery({
+    queryKey: releaseListKey(scope, templateName),
+    queryFn: async () => {
+      const response = await client.listReleases({ scope, templateName })
+      return response.releases
+    },
+    enabled: isAuthenticated && !!scope.scopeName && !!templateName,
+  })
+}
+
+export function useGetRelease(scope: TemplateScopeRef, templateName: string, version: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  return useQuery({
+    queryKey: releaseGetKey(scope, templateName, version),
+    queryFn: async () => {
+      const response = await client.getRelease({ scope, templateName, version })
+      return response.release
+    },
+    enabled: isAuthenticated && !!scope.scopeName && !!templateName && !!version,
+  })
+}
+
+export function useCreateRelease(scope: TemplateScopeRef, templateName: string) {
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      version: string
+      changelog: string
+      upgradeAdvice?: string
+      cueTemplate: string
+      defaults?: Release['defaults']
+    }) =>
+      client.createRelease({
+        scope,
+        release: create(ReleaseSchema, {
+          templateName,
+          scopeRef: scope,
+          version: params.version,
+          changelog: params.changelog,
+          upgradeAdvice: params.upgradeAdvice ?? '',
+          cueTemplate: params.cueTemplate,
+          defaults: params.defaults,
+        }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: releaseListKey(scope, templateName) })
+    },
   })
 }
 

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -263,6 +263,7 @@ export function FolderTemplateDetailPage({
             templateName={templateName}
             canWrite={canWrite}
             currentCueTemplate={cueTemplate}
+            currentDefaults={template?.defaults}
           />
         </CardContent>
       </Card>

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -20,29 +20,37 @@ import {
 } from '@/components/ui/dialog'
 import { Lock, Copy } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useGetTemplate, useUpdateTemplate, useCloneTemplate, makeOrgScope } from '@/queries/templates'
-import { useGetOrganization } from '@/queries/organizations'
+import { TemplateScope } from '@/gen/holos/console/v1/templates_pb'
+import { create } from '@bufbuild/protobuf'
+import { TemplateScopeRefSchema } from '@/gen/holos/console/v1/templates_pb'
+import { useGetTemplate, useUpdateTemplate, useCloneTemplate } from '@/queries/templates'
+import { useGetFolder } from '@/queries/folders'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateReleases } from '@/components/template-releases'
 
-export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/org-templates/$templateName')({
-  component: OrgTemplateDetailRoute,
+export const Route = createFileRoute(
+  '/_authenticated/folders/$folderName/templates/$templateName',
+)({
+  component: FolderTemplateDetailRoute,
 })
 
-function OrgTemplateDetailRoute() {
-  const { orgName, templateName } = Route.useParams()
-  return <OrgTemplateDetailPage orgName={orgName} templateName={templateName} />
+function FolderTemplateDetailRoute() {
+  const { folderName, templateName } = Route.useParams()
+  return <FolderTemplateDetailPage folderName={folderName} templateName={templateName} />
 }
 
-export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: propTemplateName }: { orgName?: string; templateName?: string } = {}) {
-  let routeParams: { orgName?: string; templateName?: string } = {}
+export function FolderTemplateDetailPage({
+  folderName: propFolderName,
+  templateName: propTemplateName,
+}: { folderName?: string; templateName?: string } = {}) {
+  let routeParams: { folderName?: string; templateName?: string } = {}
   try {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     routeParams = Route.useParams()
   } catch {
     routeParams = {}
   }
-  const orgName = propOrgName ?? routeParams.orgName ?? ''
+  const folderName = propFolderName ?? routeParams.folderName ?? ''
   const templateName = propTemplateName ?? routeParams.templateName ?? ''
 
   let navigate: ReturnType<typeof useNavigate> | undefined
@@ -53,9 +61,14 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
     navigate = undefined
   }
 
-  const scope = makeOrgScope(orgName)
+  const { data: folder } = useGetFolder(folderName)
+  const orgName = folder?.organization ?? ''
+
+  const scope = create(TemplateScopeRefSchema, {
+    scope: TemplateScope.FOLDER,
+    scopeName: folderName,
+  })
   const { data: template, isPending, error } = useGetTemplate(scope, templateName)
-  const { data: org } = useGetOrganization(orgName)
   const updateMutation = useUpdateTemplate(scope, templateName)
   const cloneMutation = useCloneTemplate(scope)
 
@@ -71,9 +84,8 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
     }
   }, [template?.cueTemplate])
 
-  // Only org-level OWNERs can edit platform templates (backend enforces PERMISSION_TEMPLATES_WRITE).
-  // Frontend mirrors this: show Save only for OWNER.
-  const userRole = org?.userRole ?? Role.VIEWER
+  // Folder-level template editing requires OWNER role on the folder's org.
+  const userRole = folder?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER
 
   const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
@@ -120,8 +132,8 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
       setCloneOpen(false)
       if (navigate) {
         navigate({
-          to: '/orgs/$orgName/settings/org-templates/$templateName',
-          params: { orgName, templateName: response.name },
+          to: '/folders/$folderName/templates/$templateName',
+          params: { folderName, templateName: response.name },
         })
       }
     } catch (err) {
@@ -158,7 +170,25 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
       <Card>
         <CardContent className="pt-6 space-y-6">
           <div>
-            <p className="text-sm text-muted-foreground">{orgName} / Settings / Platform Templates / {templateName}</p>
+            <p className="text-sm text-muted-foreground">
+              <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+                {orgName}
+              </Link>
+              {' / '}
+              <Link to="/orgs/$orgName/folders" params={{ orgName }} className="hover:underline">
+                Folders
+              </Link>
+              {' / '}
+              <Link to="/folders/$folderName/settings" params={{ folderName }} className="hover:underline">
+                {folderName}
+              </Link>
+              {' / '}
+              <Link to="/folders/$folderName/templates" params={{ folderName }} className="hover:underline">
+                Platform Templates
+              </Link>
+              {' / '}
+              {templateName}
+            </p>
             <div className="flex items-center gap-2 mt-1">
               <h2 className="text-xl font-semibold">{template?.displayName || templateName}</h2>
               {template?.mandatory && (
@@ -212,7 +242,7 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
             {!canWrite && (
               <Alert>
                 <AlertDescription>
-                  You need org Owner permissions to edit platform templates.
+                  You need folder Owner permissions to edit platform templates.
                 </AlertDescription>
               </Alert>
             )}

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/index.tsx
@@ -12,7 +12,7 @@ import { create } from '@bufbuild/protobuf'
 import { TemplateScopeRefSchema } from '@/gen/holos/console/v1/templates_pb'
 
 export const Route = createFileRoute(
-  '/_authenticated/folders/$folderName/templates',
+  '/_authenticated/folders/$folderName/templates/',
 )({
   component: FolderTemplatesRoute,
 })
@@ -103,30 +103,36 @@ export function FolderTemplatesPage({
         {templates && templates.length > 0 ? (
           <ul className="space-y-2">
             {templates.map((tmpl) => (
-              <li key={tmpl.name} className="flex items-center gap-2 p-3 rounded-md border border-border">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium font-mono">{tmpl.name}</span>
-                    {tmpl.mandatory && (
-                      <Badge variant="secondary" className="flex items-center gap-1 text-xs">
-                        <Lock className="h-3 w-3" />
-                        Mandatory
-                      </Badge>
-                    )}
-                    {tmpl.enabled ? (
-                      <Badge variant="outline" className="text-xs text-green-500 border-green-500/30">
-                        Enabled
-                      </Badge>
-                    ) : (
-                      <Badge variant="outline" className="text-xs text-muted-foreground">
-                        Disabled
-                      </Badge>
+              <li key={tmpl.name}>
+                <Link
+                  to="/folders/$folderName/templates/$templateName"
+                  params={{ folderName, templateName: tmpl.name }}
+                  className="flex items-center gap-2 p-3 rounded-md border border-border hover:bg-accent/50 transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium font-mono">{tmpl.name}</span>
+                      {tmpl.mandatory && (
+                        <Badge variant="secondary" className="flex items-center gap-1 text-xs">
+                          <Lock className="h-3 w-3" />
+                          Mandatory
+                        </Badge>
+                      )}
+                      {tmpl.enabled ? (
+                        <Badge variant="outline" className="text-xs text-green-500 border-green-500/30">
+                          Enabled
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-xs text-muted-foreground">
+                          Disabled
+                        </Badge>
+                      )}
+                    </div>
+                    {tmpl.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">{tmpl.description}</p>
                     )}
                   </div>
-                  {tmpl.description && (
-                    <p className="text-xs text-muted-foreground truncate mt-0.5">{tmpl.description}</p>
-                  )}
-                </div>
+                </Link>
               </li>
             ))}
           </ul>

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/-org-templates.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/-org-templates.test.tsx
@@ -24,6 +24,8 @@ vi.mock('@/queries/templates', () => ({
   useUpdateTemplate: vi.fn(),
   useCloneTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
+  useListReleases: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  useCreateRelease: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
   makeOrgScope: vi.fn().mockReturnValue({ scope: 2, scopeName: 'test-org' }),
 }))
 

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
@@ -233,6 +233,7 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
             templateName={templateName}
             canWrite={canWrite}
             currentCueTemplate={cueTemplate}
+            currentDefaults={template?.defaults}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Add `useCreateRelease`, `useListReleases`, `useGetRelease` query hooks to `frontend/src/queries/templates.ts`
- Create shared `TemplateReleases` component (`frontend/src/components/template-releases.tsx`) with release list (descending version order, latest highlighted), Create Release dialog (semver validation, duplicate detection, suggested patch/minor/major radio buttons, upgrade advice for major bumps)
- Integrate releases section into org template detail page below the CUE editor
- Create folder template detail route (`/folders/$folderName/templates/$templateName`) with the same release management section, CUE editor, clone dialog, and general info
- Make folder template list items clickable to navigate to the new detail route
- 14 unit tests for the template releases component covering empty state, list rendering, version suggestions, validation, and mutation calls

Closes #777

## Test plan
- [x] `make test` passes (48 test files, 723 tests)
- [ ] Org template editor page shows Releases section below CUE editor
- [ ] Create Release dialog validates semver and duplicate versions
- [ ] Suggested version radio buttons appear when releases exist
- [ ] Upgrade advice field appears only for major version bumps
- [ ] Folder template list items link to new detail page
- [ ] Folder template detail page shows releases section

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
`agent-1`