### PR TITLE
chore: remove dead SeedDefaultOrgTemplates and update template-service docs

### DIFF
--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -417,26 +417,6 @@ func (k *K8sClient) ListLinkableTemplateInfos(ctx context.Context, scope console
 	return result, nil
 }
 
-// SeedDefaultOrgTemplates seeds the built-in HTTPRoute platform template into
-// the org namespace if no templates exist. Called on first List to avoid a
-// separate migration step. The template is seeded as disabled.
-func (k *K8sClient) SeedDefaultOrgTemplates(ctx context.Context, org string) error {
-	_, err := k.CreateTemplate(
-		ctx,
-		consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
-		org,
-		DefaultReferenceGrantName,
-		"HTTPRoute",
-		"Exposes a deployment's Service via an HTTPRoute through the gateway. Requires a ReferenceGrant in the project namespace (provided by the default deployment template).",
-		DefaultReferenceGrantTemplate,
-		nil,
-		false, // not mandatory
-		false, // disabled: configure the Gateway name before enabling
-		nil,
-	)
-	return err
-}
-
 // SeedOrgTemplate seeds the built-in HTTPRoute platform template as enabled into
 // the org namespace. Used by the populate_defaults flow during org creation.
 func (k *K8sClient) SeedOrgTemplate(ctx context.Context, org string) error {

--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -45,7 +45,7 @@ The render set formula is: `(mandatory AND enabled) UNION (enabled AND ref IN li
 
 ## Folder Template Management
 
-The folder templates page (`/folders/$folderName/templates`) provides a read-only list of platform templates at folder scope. Full CRUD (create, edit, clone, delete) for folder-scoped templates is available through the same UI patterns as org and project templates, with create and detail routes under the folder settings area.
+The folder templates page (`/folders/$folderName/templates`) provides a read-only list of platform templates at folder scope. Mandatory templates are marked with a lock badge.
 
 ## Permissions
 

--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -21,6 +21,16 @@ The `RenderDeploymentTemplate` RPC returns rendered resources as both YAML (`ren
 
 The default template adds a `console.holos.run/deployer-email` annotation to all resources from `platform.claims.email`. The default template includes a `ReferenceGrant` (using `platform.gatewayNamespace`, default "istio-ingress") that allows HTTPRoute resources from the gateway namespace to reference Services in the project namespace.
 
+## Org Seeding via `populate_defaults`
+
+When `CreateOrganization` is called with `populate_defaults: true`, the backend seeds example resources into the new org:
+
+1. An org-level platform template (HTTPRoute ReferenceGrant, enabled) via `SeedOrgTemplate`
+2. A default project in the org's default folder
+3. An example project-level deployment template (go-httpbin) via `SeedProjectTemplate`
+
+The frontend exposes this as a "Populate with example resources" checkbox in the Create Organization dialog.
+
 ## Mandatory and Enabled Flags
 
 Platform templates (org-scoped or folder-scoped) can be marked `mandatory` (applied to project namespaces at creation time; always unified at render time) and/or `enabled` (available for linking and render-time unification).
@@ -32,6 +42,10 @@ ADR 019, extended to cross-level refs: each deployment template ConfigMap may ca
 The render set formula is: `(mandatory AND enabled) UNION (enabled AND ref IN linked_list)`.
 
 `MandatoryTemplateApplier` walks the full ancestor hierarchy (org + folder ancestors) applying mandatory+enabled templates at project creation.
+
+## Folder Template Management
+
+The folder templates page (`/folders/$folderName/templates`) provides a read-only list of platform templates at folder scope. Full CRUD (create, edit, clone, delete) for folder-scoped templates is available through the same UI patterns as org and project templates, with create and detail routes under the folder settings area.
 
 ## Permissions
 


### PR DESCRIPTION
## Summary
- Remove dead `SeedDefaultOrgTemplates` function from `console/templates/k8s.go` -- it was superseded by the `populate_defaults` flow (`SeedOrgTemplate` + `SeedProjectTemplate`) in #758 and had zero callers
- Update `docs/agents/template-service.md` to document the `populate_defaults` org seeding flow and folder template management UI added in prior phases
- Verified the flat `folders/$folderName/templates.tsx` route file is still the canonical folder template list page (no directory-based replacement exists), so it is retained

Closes #763

## Test plan
- [x] `go vet ./console/...` passes
- [x] `make test` passes (all Go packages + 714 UI tests)
- [x] `make generate` produces no diff
- [x] `grep -r SeedDefaultOrgTemplates` returns no results after removal
- [ ] CI passes

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent slot: `agent-3`