### PR TITLE
fix: use scope-qualified keys for linked template selection

### DIFF
--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -15,6 +15,17 @@ import { useAuth } from '@/lib/auth'
 export type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef }
 export { TemplateScope }
 
+/** Build a composite key that uniquely identifies a linkable template across scopes. */
+export function linkableKey(scope: number | undefined, scopeName: string | undefined, name: string): string {
+  return `${scope ?? 0}/${scopeName ?? ''}/${name}`
+}
+
+/** Parse a composite key back into its constituent parts. */
+export function parseLinkableKey(key: string): { scope: number; scopeName: string; name: string } {
+  const parts = key.split('/')
+  return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
+}
+
 // makeScope is a helper to build a TemplateScopeRef from scope and scopeName.
 export function makeScope(scope: TemplateScope, scopeName: string): TemplateScopeRef {
   return create(TemplateScopeRefSchema, { scope, scopeName })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -21,22 +21,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope } from '@/queries/templates'
+import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { LinkifiedText } from '@/components/linkified-text'
-
-/** Build a composite key that uniquely identifies a linkable template across scopes. */
-function linkableKey(scope: number | undefined, scopeName: string | undefined, name: string): string {
-  return `${scope ?? 0}/${scopeName ?? ''}/${name}`
-}
-
-/** Parse a composite key back into its constituent parts. */
-function parseLinkableKey(key: string): { scope: number; scopeName: string; name: string } {
-  const parts = key.split('/')
-  return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
-}
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/$templateName')({
   component: DeploymentTemplateDetailRoute,

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -24,6 +24,12 @@ vi.mock('@/queries/templates', () => ({
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [] }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
+  linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
+    `${scope ?? 0}/${scopeName ?? ''}/${name}`,
+  parseLinkableKey: (key: string) => {
+    const parts = key.split('/')
+    return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
+  },
 }))
 
 vi.mock('@/queries/projects', () => ({

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -26,6 +26,12 @@ vi.mock('@/queries/templates', () => ({
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [] }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
+  linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
+    `${scope ?? 0}/${scopeName ?? ''}/${name}`,
+  parseLinkableKey: (key: string) => {
+    const parts = key.split('/')
+    return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
+  },
 }))
 
 vi.mock('@/queries/projects', () => ({
@@ -339,6 +345,38 @@ describe('CreateTemplatePage', () => {
             linkedTemplates: expect.arrayContaining([
               expect.objectContaining({ name: 'httpbin-platform', scope: 1, scopeName: 'default' }),
             ]),
+          }),
+        )
+      })
+    })
+
+    it('disambiguates same-name templates across org and folder scopes', async () => {
+      // When an org and folder template share the same name, selecting one
+      // must not affect the other and the mutation must carry the correct scope.
+      const sameName = [
+        { name: 'shared-policy', displayName: 'Shared Policy (Org)', description: '', mandatory: false, scopeRef: { scope: 1, scopeName: 'default' } },
+        { name: 'shared-policy', displayName: 'Shared Policy (Folder)', description: '', mandatory: false, scopeRef: { scope: 2, scopeName: 'team-a' } },
+      ]
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: sameName })
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
+      const user = userEvent.setup()
+      render(<CreateTemplatePage />)
+
+      fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+
+      // Select only the folder-scoped template (second checkbox)
+      const checkboxes = screen.getAllByRole('checkbox')
+      await user.click(checkboxes[1])
+
+      fireEvent.click(screen.getByRole('button', { name: /create template/i }))
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            linkedTemplates: [
+              expect.objectContaining({ name: 'shared-policy', scope: 2, scopeName: 'team-a' }),
+            ],
           }),
         )
       })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -10,7 +10,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Info, Lock } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope } from '@/queries/templates'
+import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
@@ -249,7 +249,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const [cueTemplate, setCueTemplate] = useState(DEFAULT_CUE_TEMPLATE)
   const [error, setError] = useState<string | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
-  const [selectedLinkedNames, setSelectedLinkedNames] = useState<string[]>([])
+  const [selectedLinkedKeys, setSelectedLinkedKeys] = useState<string[]>([])
 
   // Group linkable templates by scope for display.
   const orgTemplates = linkableTemplates.filter(
@@ -308,15 +308,12 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
     }
     setError(null)
     try {
-      // Build LinkedTemplateRef objects from selected names using scopeRef
-      // from the linkable template list returned by the server.
-      const linkedTemplates: LinkedTemplateRef[] = selectedLinkedNames
-        .map((n) => {
-          const lt = linkableTemplates.find((t) => t.name === n)
-          if (!lt?.scopeRef) return null
-          return { scope: lt.scopeRef.scope, scopeName: lt.scopeRef.scopeName, name: n } as LinkedTemplateRef
+      // Build LinkedTemplateRef objects from scope-qualified keys.
+      const linkedTemplates: LinkedTemplateRef[] = selectedLinkedKeys
+        .map((key) => {
+          const parsed = parseLinkableKey(key)
+          return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name } as LinkedTemplateRef
         })
-        .filter((ref): ref is LinkedTemplateRef => ref !== null)
 
       await createMutation.mutateAsync({
         name: name.trim(),
@@ -410,21 +407,23 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                   {orgTemplates.length > 0 && (
                     <div className="space-y-2">
                       <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Organization Templates</p>
-                      {orgTemplates.map((t) => (
-                        <div key={t.name} className="flex items-start gap-2">
+                      {orgTemplates.map((t) => {
+                        const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                        return (
+                        <div key={key} className="flex items-start gap-2">
                           <Checkbox
-                            id={`linked-create-${t.name}`}
-                            checked={t.mandatory || selectedLinkedNames.includes(t.name)}
+                            id={`linked-create-${key}`}
+                            checked={t.mandatory || selectedLinkedKeys.includes(key)}
                             disabled={t.mandatory}
                             onCheckedChange={(checked) => {
                               if (t.mandatory) return
-                              setSelectedLinkedNames((prev) =>
-                                checked ? [...prev, t.name] : prev.filter((n) => n !== t.name),
+                              setSelectedLinkedKeys((prev) =>
+                                checked ? [...prev, key] : prev.filter((k) => k !== key),
                               )
                             }}
                           />
                           <div className="flex flex-col">
-                            <label htmlFor={`linked-create-${t.name}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                            <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
                               {t.displayName || t.name}
                               {t.mandatory && (
                                 <TooltipProvider>
@@ -444,27 +443,30 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                             )}
                           </div>
                         </div>
-                      ))}
+                        )
+                      })}
                     </div>
                   )}
                   {folderTemplates.length > 0 && (
                     <div className="space-y-2">
                       <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Folder Templates</p>
-                      {folderTemplates.map((t) => (
-                        <div key={t.name} className="flex items-start gap-2">
+                      {folderTemplates.map((t) => {
+                        const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                        return (
+                        <div key={key} className="flex items-start gap-2">
                           <Checkbox
-                            id={`linked-create-${t.name}`}
-                            checked={t.mandatory || selectedLinkedNames.includes(t.name)}
+                            id={`linked-create-${key}`}
+                            checked={t.mandatory || selectedLinkedKeys.includes(key)}
                             disabled={t.mandatory}
                             onCheckedChange={(checked) => {
                               if (t.mandatory) return
-                              setSelectedLinkedNames((prev) =>
-                                checked ? [...prev, t.name] : prev.filter((n) => n !== t.name),
+                              setSelectedLinkedKeys((prev) =>
+                                checked ? [...prev, key] : prev.filter((k) => k !== key),
                               )
                             }}
                           />
                           <div className="flex flex-col">
-                            <label htmlFor={`linked-create-${t.name}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                            <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
                               {t.displayName || t.name}
                               {t.mandatory && (
                                 <TooltipProvider>
@@ -484,14 +486,15 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                             )}
                           </div>
                         </div>
-                      ))}
+                        )
+                      })}
                     </div>
                   )}
                 </div>
               ) : (
                 <div className="space-y-2">
                   {linkableTemplates.filter((t) => t.mandatory).map((t) => (
-                    <div key={t.name} className="flex items-center gap-1 text-sm">
+                    <div key={linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)} className="flex items-center gap-1 text-sm">
                       <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
                       <span>{t.displayName || t.name}</span>
                       <span className="text-muted-foreground">(mandatory, auto-applied)</span>


### PR DESCRIPTION
## Summary
- Extracted `linkableKey()` and `parseLinkableKey()` from the template detail page into the shared `queries/templates.ts` module so both pages use the same scope-qualified key format
- Updated the create template page to use scope-qualified composite keys (`scope/scopeName/name`) instead of name-only keys for linked template checkbox selection state
- This prevents collisions when org and folder templates share the same name -- previously checking one would affect both, and the create mutation would resolve to the wrong scope

Closes #804

## Test plan
- [x] New test: "disambiguates same-name templates across org and folder scopes" -- sets up two templates with the same name in different scopes and verifies only the selected scope is sent in the mutation
- [x] All 31 create page tests pass
- [x] All 64 detail page tests pass
- [x] All 715 UI tests pass (47 test files)
- [x] All Go tests pass
- [x] TypeScript compiles cleanly (no type errors)
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)