### PR TITLE
feat(templates): updates-available indicator and upgrade flow

### DIFF
--- a/frontend/src/components/-template-updates.test.tsx
+++ b/frontend/src/components/-template-updates.test.tsx
@@ -237,7 +237,16 @@ describe('UpgradeDialog', () => {
     })
   })
 
-  it('shows confirmation for breaking update', () => {
+  it('requires explicit confirmation for breaking upgrade', async () => {
+    mockMutateAsync.mockResolvedValue({})
+    const linkedTemplates = [
+      {
+        scope: TemplateScope.ORGANIZATION,
+        scopeName: 'test-org',
+        name: 'platform-security',
+        versionConstraint: '>=1.0.0 <2.0.0',
+      },
+    ]
     const updates = [makeUpdate({
       latestCompatibleVersion: '',
       latestVersion: '2.0.0',
@@ -250,11 +259,67 @@ describe('UpgradeDialog', () => {
         updates={updates as any}
         scope={testScope}
         templateName="my-template"
-        linkedTemplates={[]}
+        linkedTemplates={linkedTemplates as any}
       />
     )
-    // The upgrade button for breaking changes should mention "upgrade"
-    expect(screen.getByText(/upgrade/i)).toBeInTheDocument()
+    // Click "Upgrade" — should not call mutation yet
+    fireEvent.click(screen.getByText(/^upgrade$/i))
+    expect(mockMutateAsync).not.toHaveBeenCalled()
+
+    // Confirmation dialog should appear
+    expect(screen.getByText(/confirm breaking upgrade/i)).toBeInTheDocument()
+
+    // Click "Confirm Upgrade" to proceed
+    fireEvent.click(screen.getByText(/confirm upgrade/i))
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ updateLinkedTemplates: true })
+      )
+    })
+  })
+
+  it('selects compatible version when both compatible and breaking are available', async () => {
+    mockMutateAsync.mockResolvedValue({})
+    const linkedTemplates = [
+      {
+        scope: TemplateScope.ORGANIZATION,
+        scopeName: 'test-org',
+        name: 'platform-security',
+        versionConstraint: '>=1.0.0 <2.0.0',
+      },
+    ]
+    // Mixed case: compatible minor update + breaking major available
+    const updates = [makeUpdate({
+      latestCompatibleVersion: '1.3.0',
+      latestVersion: '2.0.0',
+      breakingUpdateAvailable: true,
+    })]
+    render(
+      <UpgradeDialog
+        open={true}
+        onOpenChange={() => {}}
+        updates={updates as any}
+        scope={testScope}
+        templateName="my-template"
+        linkedTemplates={linkedTemplates as any}
+      />
+    )
+    // Should show "Update" (not "Upgrade") since compatible version exists
+    const updateButton = screen.getByText(/^update$/i)
+    fireEvent.click(updateButton)
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updateLinkedTemplates: true,
+          linkedTemplates: expect.arrayContaining([
+            expect.objectContaining({
+              versionConstraint: '>=1.3.0 <2.0.0',
+            }),
+          ]),
+        })
+      )
+    })
   })
 
   it('renders empty state when no updates', () => {

--- a/frontend/src/components/-template-updates.test.tsx
+++ b/frontend/src/components/-template-updates.test.tsx
@@ -1,0 +1,291 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@/queries/templates', () => ({
+  useCheckUpdates: vi.fn(),
+  useUpdateTemplate: vi.fn(),
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...rest }: { children: React.ReactNode; variant?: string; className?: string }) => (
+    <span data-testid="badge" {...rest}>{children}</span>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, ...rest }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    variant?: string
+    size?: string
+    className?: string
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div role="alert">{children}</div>,
+  AlertDescription: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock('@/components/ui/table', () => ({
+  Table: ({ children }: { children: React.ReactNode }) => <table>{children}</table>,
+  TableHeader: ({ children }: { children: React.ReactNode }) => <thead>{children}</thead>,
+  TableBody: ({ children }: { children: React.ReactNode }) => <tbody>{children}</tbody>,
+  TableRow: ({ children }: { children: React.ReactNode }) => <tr>{children}</tr>,
+  TableHead: ({ children }: { children: React.ReactNode }) => <th>{children}</th>,
+  TableCell: ({ children }: { children: React.ReactNode }) => <td>{children}</td>,
+}))
+
+vi.mock('lucide-react', () => ({
+  ArrowUpCircle: () => <span data-testid="icon-arrow-up-circle" />,
+  AlertTriangle: () => <span data-testid="icon-alert-triangle" />,
+}))
+
+import { useCheckUpdates, useUpdateTemplate } from '@/queries/templates'
+import { UpdatesAvailableBadge, UpgradeDialog } from './template-updates'
+import { TemplateScope } from '@/gen/holos/console/v1/templates_pb.js'
+
+const testScope = { scope: TemplateScope.PROJECT, scopeName: 'test-project' } as any
+
+function makeUpdate(overrides: Record<string, unknown> = {}) {
+  return {
+    ref: {
+      scope: TemplateScope.ORGANIZATION,
+      scopeName: 'test-org',
+      name: 'platform-security',
+      versionConstraint: '>=1.0.0 <2.0.0',
+    },
+    currentVersion: '1.0.0',
+    latestCompatibleVersion: '1.2.0',
+    latestVersion: '1.2.0',
+    breakingUpdateAvailable: false,
+    ...overrides,
+  }
+}
+
+describe('UpdatesAvailableBadge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useCheckUpdates as Mock).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      error: null,
+    })
+  })
+
+  it('renders nothing when no updates are available', () => {
+    ;(useCheckUpdates as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
+    const { container } = render(
+      <UpdatesAvailableBadge scope={testScope} templateName="my-template" />
+    )
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing while loading', () => {
+    ;(useCheckUpdates as Mock).mockReturnValue({
+      data: undefined,
+      isPending: true,
+      error: null,
+    })
+    const { container } = render(
+      <UpdatesAvailableBadge scope={testScope} templateName="my-template" />
+    )
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders badge when one compatible update exists', () => {
+    ;(useCheckUpdates as Mock).mockReturnValue({
+      data: [makeUpdate()],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <UpdatesAvailableBadge scope={testScope} templateName="my-template" />
+    )
+    expect(screen.getByText(/1 update/i)).toBeInTheDocument()
+  })
+
+  it('renders badge with count for multiple updates', () => {
+    ;(useCheckUpdates as Mock).mockReturnValue({
+      data: [
+        makeUpdate({ ref: { scope: 1, scopeName: 'org', name: 'tmpl-a', versionConstraint: '' } }),
+        makeUpdate({ ref: { scope: 1, scopeName: 'org', name: 'tmpl-b', versionConstraint: '' } }),
+      ],
+      isPending: false,
+      error: null,
+    })
+    render(
+      <UpdatesAvailableBadge scope={testScope} templateName="my-template" />
+    )
+    expect(screen.getByText(/2 updates/i)).toBeInTheDocument()
+  })
+
+  it('calls onClick handler when badge is clicked', () => {
+    ;(useCheckUpdates as Mock).mockReturnValue({
+      data: [makeUpdate()],
+      isPending: false,
+      error: null,
+    })
+    const handleClick = vi.fn()
+    render(
+      <UpdatesAvailableBadge scope={testScope} templateName="my-template" onClick={handleClick} />
+    )
+    fireEvent.click(screen.getByText(/1 update/i))
+    expect(handleClick).toHaveBeenCalled()
+  })
+})
+
+describe('UpgradeDialog', () => {
+  const mockMutateAsync = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useUpdateTemplate as Mock).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    })
+  })
+
+  it('renders update table with compatible update', () => {
+    const updates = [makeUpdate()]
+    render(
+      <UpgradeDialog
+        open={true}
+        onOpenChange={() => {}}
+        updates={updates as any}
+        scope={testScope}
+        templateName="my-template"
+        linkedTemplates={[]}
+      />
+    )
+    expect(screen.getByText('platform-security')).toBeInTheDocument()
+    expect(screen.getByText('1.0.0')).toBeInTheDocument()
+    expect(screen.getByText('1.2.0')).toBeInTheDocument()
+  })
+
+  it('shows breaking tag for breaking updates', () => {
+    const updates = [makeUpdate({
+      latestCompatibleVersion: '',
+      latestVersion: '2.0.0',
+      breakingUpdateAvailable: true,
+    })]
+    render(
+      <UpgradeDialog
+        open={true}
+        onOpenChange={() => {}}
+        updates={updates as any}
+        scope={testScope}
+        templateName="my-template"
+        linkedTemplates={[]}
+      />
+    )
+    expect(screen.getByText(/breaking/i)).toBeInTheDocument()
+  })
+
+  it('calls update mutation for compatible update', async () => {
+    mockMutateAsync.mockResolvedValue({})
+    const linkedTemplates = [
+      {
+        scope: TemplateScope.ORGANIZATION,
+        scopeName: 'test-org',
+        name: 'platform-security',
+        versionConstraint: '>=1.0.0 <2.0.0',
+      },
+    ]
+    const updates = [makeUpdate()]
+    render(
+      <UpgradeDialog
+        open={true}
+        onOpenChange={() => {}}
+        updates={updates as any}
+        scope={testScope}
+        templateName="my-template"
+        linkedTemplates={linkedTemplates as any}
+      />
+    )
+    // Click the individual Update button
+    const updateButtons = screen.getAllByText(/^update$/i)
+    fireEvent.click(updateButtons[0])
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updateLinkedTemplates: true,
+        })
+      )
+    })
+  })
+
+  it('shows confirmation for breaking update', () => {
+    const updates = [makeUpdate({
+      latestCompatibleVersion: '',
+      latestVersion: '2.0.0',
+      breakingUpdateAvailable: true,
+    })]
+    render(
+      <UpgradeDialog
+        open={true}
+        onOpenChange={() => {}}
+        updates={updates as any}
+        scope={testScope}
+        templateName="my-template"
+        linkedTemplates={[]}
+      />
+    )
+    // The upgrade button for breaking changes should mention "upgrade"
+    expect(screen.getByText(/upgrade/i)).toBeInTheDocument()
+  })
+
+  it('renders empty state when no updates', () => {
+    render(
+      <UpgradeDialog
+        open={true}
+        onOpenChange={() => {}}
+        updates={[]}
+        scope={testScope}
+        templateName="my-template"
+        linkedTemplates={[]}
+      />
+    )
+    expect(screen.getByText(/no updates/i)).toBeInTheDocument()
+  })
+
+  it('shows Update All button when multiple compatible updates exist', () => {
+    const updates = [
+      makeUpdate({ ref: { scope: 1, scopeName: 'org', name: 'tmpl-a', versionConstraint: '' } }),
+      makeUpdate({ ref: { scope: 1, scopeName: 'org', name: 'tmpl-b', versionConstraint: '' } }),
+    ]
+    render(
+      <UpgradeDialog
+        open={true}
+        onOpenChange={() => {}}
+        updates={updates as any}
+        scope={testScope}
+        templateName="my-template"
+        linkedTemplates={[]}
+      />
+    )
+    expect(screen.getByText(/update all compatible/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/template-updates.tsx
+++ b/frontend/src/components/template-updates.tsx
@@ -87,6 +87,7 @@ export function UpgradeDialog({
 }: UpgradeDialogProps) {
   const updateMutation = useUpdateTemplate(scope, templateName)
   const [error, setError] = useState<string | null>(null)
+  const [confirmBreaking, setConfirmBreaking] = useState<TemplateUpdate | null>(null)
 
   const compatibleUpdates = updates.filter(hasCompatibleUpdate)
   const hasMultipleCompatible = compatibleUpdates.length > 1
@@ -114,9 +115,13 @@ export function UpgradeDialog({
   }
 
   // handleUpdateSingle updates one linked template's version constraint.
+  // Uses the same isBreaking classification as the display to pick the right
+  // target version: compatible when available, breaking only when no compatible
+  // update exists.
   async function handleUpdateSingle(update: TemplateUpdate) {
     setError(null)
-    const targetVersion = update.breakingUpdateAvailable
+    const isBreaking = update.breakingUpdateAvailable && !hasCompatibleUpdate(update)
+    const targetVersion = isBreaking
       ? update.latestVersion
       : update.latestCompatibleVersion
     if (!targetVersion) return
@@ -154,6 +159,7 @@ export function UpgradeDialog({
   }
 
   return (
+    <>
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
@@ -213,7 +219,7 @@ export function UpgradeDialog({
                         <Button
                           size="sm"
                           variant="outline"
-                          onClick={() => handleUpdateSingle(update)}
+                          onClick={() => setConfirmBreaking(update)}
                           disabled={updateMutation.isPending}
                         >
                           Upgrade
@@ -253,5 +259,37 @@ export function UpgradeDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    {/* Breaking upgrade confirmation dialog */}
+    <Dialog open={!!confirmBreaking} onOpenChange={(open) => { if (!open) setConfirmBreaking(null) }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Confirm Breaking Upgrade</DialogTitle>
+          <DialogDescription>
+            Upgrading <strong>{confirmBreaking?.ref?.name}</strong> from{' '}
+            <span className="font-mono">{confirmBreaking?.currentVersion}</span> to{' '}
+            <span className="font-mono">{confirmBreaking?.latestVersion}</span> is a
+            breaking change. This may require changes to your template.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setConfirmBreaking(null)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={async () => {
+              const update = confirmBreaking
+              setConfirmBreaking(null)
+              await handleUpdateSingle(update!)
+            }}
+            disabled={updateMutation.isPending}
+          >
+            {updateMutation.isPending ? 'Upgrading...' : 'Confirm Upgrade'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    </>
   )
 }

--- a/frontend/src/components/template-updates.tsx
+++ b/frontend/src/components/template-updates.tsx
@@ -1,0 +1,257 @@
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ArrowUpCircle, AlertTriangle } from 'lucide-react'
+import { useCheckUpdates, useUpdateTemplate } from '@/queries/templates'
+import type { TemplateScopeRef, TemplateUpdate, LinkedTemplateRef } from '@/queries/templates'
+import { TemplateScope } from '@/gen/holos/console/v1/templates_pb.js'
+import { toast } from 'sonner'
+
+// scopeLabel returns a human-readable scope label.
+function scopeLabel(scope: number | undefined): string {
+  if (scope === TemplateScope.ORGANIZATION) return 'Org'
+  if (scope === TemplateScope.FOLDER) return 'Folder'
+  return ''
+}
+
+// hasCompatibleUpdate returns true when a non-breaking compatible update exists.
+function hasCompatibleUpdate(update: TemplateUpdate): boolean {
+  return !!update.latestCompatibleVersion && update.latestCompatibleVersion !== update.currentVersion
+}
+
+// --- UpdatesAvailableBadge ---
+
+interface UpdatesAvailableBadgeProps {
+  scope: TemplateScopeRef
+  templateName: string
+  onClick?: () => void
+}
+
+/** Pill badge showing "N updates" for a template with available linked-template updates. */
+export function UpdatesAvailableBadge({ scope, templateName, onClick }: UpdatesAvailableBadgeProps) {
+  const { data: updates, isPending } = useCheckUpdates(scope, templateName)
+
+  if (isPending || !updates || updates.length === 0) return null
+
+  const count = updates.length
+  const label = count === 1 ? '1 update' : `${count} updates`
+
+  return (
+    <Badge
+      variant="secondary"
+      className="cursor-pointer gap-1"
+      onClick={onClick}
+    >
+      <ArrowUpCircle className="h-3 w-3" />
+      {label}
+    </Badge>
+  )
+}
+
+// --- UpgradeDialog ---
+
+interface UpgradeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  updates: TemplateUpdate[]
+  scope: TemplateScopeRef
+  templateName: string
+  linkedTemplates: LinkedTemplateRef[]
+}
+
+/** Dialog showing available updates for linked templates with upgrade actions. */
+export function UpgradeDialog({
+  open,
+  onOpenChange,
+  updates,
+  scope,
+  templateName,
+  linkedTemplates,
+}: UpgradeDialogProps) {
+  const updateMutation = useUpdateTemplate(scope, templateName)
+  const [error, setError] = useState<string | null>(null)
+
+  const compatibleUpdates = updates.filter(hasCompatibleUpdate)
+  const hasMultipleCompatible = compatibleUpdates.length > 1
+
+  // buildUpdatedLinkedTemplates replaces the versionConstraint for a specific
+  // linked template ref, targeting the new version range.
+  function buildUpdatedLinkedTemplates(
+    currentLinked: LinkedTemplateRef[],
+    update: TemplateUpdate,
+    newVersion: string,
+  ): LinkedTemplateRef[] {
+    return currentLinked.map((lt) => {
+      if (
+        lt.scope === update.ref?.scope &&
+        lt.scopeName === update.ref?.scopeName &&
+        lt.name === update.ref?.name
+      ) {
+        // Build new constraint: >=newVersion <nextMajor
+        const major = parseInt(newVersion.split('.')[0], 10)
+        const newConstraint = `>=${newVersion} <${major + 1}.0.0`
+        return { ...lt, versionConstraint: newConstraint }
+      }
+      return lt
+    })
+  }
+
+  // handleUpdateSingle updates one linked template's version constraint.
+  async function handleUpdateSingle(update: TemplateUpdate) {
+    setError(null)
+    const targetVersion = update.breakingUpdateAvailable
+      ? update.latestVersion
+      : update.latestCompatibleVersion
+    if (!targetVersion) return
+
+    try {
+      const newLinked = buildUpdatedLinkedTemplates(linkedTemplates, update, targetVersion)
+      await updateMutation.mutateAsync({
+        linkedTemplates: newLinked,
+        updateLinkedTemplates: true,
+      })
+      toast.success(`Updated ${update.ref?.name} to ${targetVersion}`)
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  // handleUpdateAllCompatible bulk-updates all non-breaking compatible updates.
+  async function handleUpdateAllCompatible() {
+    setError(null)
+    try {
+      let updated = [...linkedTemplates]
+      for (const update of compatibleUpdates) {
+        updated = buildUpdatedLinkedTemplates(updated, update, update.latestCompatibleVersion)
+      }
+      await updateMutation.mutateAsync({
+        linkedTemplates: updated,
+        updateLinkedTemplates: true,
+      })
+      toast.success(`Updated ${compatibleUpdates.length} linked templates`)
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Available Updates</DialogTitle>
+          <DialogDescription>
+            Updates available for linked platform templates.
+          </DialogDescription>
+        </DialogHeader>
+
+        {updates.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">No updates available.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Template</TableHead>
+                <TableHead>Current</TableHead>
+                <TableHead>Available</TableHead>
+                <TableHead></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {updates.map((update) => {
+                const ref = update.ref
+                const isBreaking = update.breakingUpdateAvailable && !hasCompatibleUpdate(update)
+                const targetVersion = isBreaking
+                  ? update.latestVersion
+                  : update.latestCompatibleVersion
+                return (
+                  <TableRow key={`${ref?.scope}/${ref?.scopeName}/${ref?.name}`}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{ref?.name}</span>
+                        {ref && (
+                          <span className="text-xs text-muted-foreground">
+                            {scopeLabel(ref.scope)}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <span className="font-mono text-sm">{update.currentVersion}</span>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-sm">{targetVersion}</span>
+                        {isBreaking && (
+                          <Badge variant="destructive" className="text-xs gap-1">
+                            <AlertTriangle className="h-3 w-3" />
+                            breaking
+                          </Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {isBreaking ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleUpdateSingle(update)}
+                          disabled={updateMutation.isPending}
+                        >
+                          Upgrade
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          onClick={() => handleUpdateSingle(update)}
+                          disabled={updateMutation.isPending}
+                        >
+                          Update
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          {hasMultipleCompatible && (
+            <Button onClick={handleUpdateAllCompatible} disabled={updateMutation.isPending}>
+              {updateMutation.isPending ? 'Updating...' : 'Update All Compatible'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -146,6 +146,9 @@ export function useUpdateTemplate(scope: TemplateScopeRef, name: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: templateListKey(scope) })
       queryClient.invalidateQueries({ queryKey: templateGetKey(scope, name) })
+      // Invalidate all check-updates queries for this scope so upgrade badges
+      // and dialogs reflect the new state immediately after a template update.
+      queryClient.invalidateQueries({ queryKey: ['templates', 'checkUpdates'] })
     },
   })
 }
@@ -268,17 +271,19 @@ function checkUpdatesKey(scope: TemplateScopeRef, templateName: string) {
 // useCheckUpdates returns available version updates for linked templates.
 // When templateName is provided, only that template's links are checked.
 // When empty, all templates in the scope are checked.
-export function useCheckUpdates(scope: TemplateScopeRef, templateName = '') {
+// Pass options.enabled to control when the query fires (defaults to true).
+export function useCheckUpdates(scope: TemplateScopeRef, templateName = '', options?: { enabled?: boolean }) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  const callerEnabled = options?.enabled ?? true
   return useQuery({
     queryKey: checkUpdatesKey(scope, templateName),
     queryFn: async () => {
       const response = await client.checkUpdates({ scope, templateName })
       return response.updates
     },
-    enabled: isAuthenticated && !!scope.scopeName,
+    enabled: isAuthenticated && !!scope.scopeName && callerEnabled,
   })
 }
 

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -9,11 +9,11 @@ import {
   TemplateScope,
   ReleaseSchema,
 } from '@/gen/holos/console/v1/templates_pb.js'
-import type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef, Release } from '@/gen/holos/console/v1/templates_pb.js'
+import type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef, Release, TemplateUpdate } from '@/gen/holos/console/v1/templates_pb.js'
 import { useAuth } from '@/lib/auth'
 
 // Re-export types used by consumers.
-export type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef, Release }
+export type { TemplateScopeRef, LinkableTemplate, LinkedTemplateRef, Release, TemplateUpdate }
 export { TemplateScope }
 
 /** Build a composite key that uniquely identifies a linkable template across scopes. */
@@ -256,6 +256,29 @@ export function useCreateRelease(scope: TemplateScopeRef, templateName: string) 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: releaseListKey(scope, templateName) })
     },
+  })
+}
+
+// --- CheckUpdates hooks ---
+
+function checkUpdatesKey(scope: TemplateScopeRef, templateName: string) {
+  return ['templates', 'checkUpdates', scope.scope, scope.scopeName, templateName] as const
+}
+
+// useCheckUpdates returns available version updates for linked templates.
+// When templateName is provided, only that template's links are checked.
+// When empty, all templates in the scope are checked.
+export function useCheckUpdates(scope: TemplateScopeRef, templateName = '') {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  return useQuery({
+    queryKey: checkUpdatesKey(scope, templateName),
+    queryFn: async () => {
+      const response = await client.checkUpdates({ scope, templateName })
+      return response.updates
+    },
+    enabled: isAuthenticated && !!scope.scopeName,
   })
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import { Pencil, Copy, Lock } from 'lucide-react'
+import { Pencil, Copy, Lock, ArrowUpCircle } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -21,11 +21,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
+import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, useCheckUpdates, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { LinkifiedText } from '@/components/linkified-text'
+import { UpgradeDialog } from '@/components/template-updates'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/$templateName')({
   component: DeploymentTemplateDetailRoute,
@@ -68,6 +69,10 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const [linkedEditOpen, setLinkedEditOpen] = useState(false)
   const [draftLinkedTemplateKeys, setDraftLinkedTemplateKeys] = useState<string[]>([])
   const [linkedEditError, setLinkedEditError] = useState<string | null>(null)
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
+
+  // Check for available updates on this template's linked templates.
+  const { data: templateUpdates = [] } = useCheckUpdates(scope, templateName)
 
   useEffect(() => {
     if (template?.cueTemplate !== undefined) {
@@ -251,17 +256,34 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                         return <span className="text-sm text-muted-foreground">None linked</span>
                       }
                       return (
-                        <div className="flex flex-wrap gap-1">
-                          {dedupedLinked.map((t) => {
-                            const scopeLabel = t.scopeRef?.scope === TemplateScope.ORGANIZATION ? 'Org' : t.scopeRef?.scope === TemplateScope.FOLDER ? 'Folder' : undefined
-                            return (
-                              <span key={keyOf(t)} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
-                                {t.displayName || t.name}
-                                {scopeLabel && <span className="text-xs text-muted-foreground">{scopeLabel}</span>}
-                                {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
-                              </span>
-                            )
-                          })}
+                        <div className="flex flex-col gap-2">
+                          <div className="flex flex-wrap gap-1">
+                            {dedupedLinked.map((t) => {
+                              const scopeLbl = t.scopeRef?.scope === TemplateScope.ORGANIZATION ? 'Org' : t.scopeRef?.scope === TemplateScope.FOLDER ? 'Folder' : undefined
+                              // Look up the version constraint from the template's linkedTemplates.
+                              const linkedRef = (template?.linkedTemplates ?? []).find(
+                                (lt) => lt.scope === t.scopeRef?.scope && lt.scopeName === t.scopeRef?.scopeName && lt.name === t.name
+                              )
+                              const constraint = linkedRef?.versionConstraint
+                              return (
+                                <span key={keyOf(t)} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
+                                  {t.displayName || t.name}
+                                  {scopeLbl && <span className="text-xs text-muted-foreground">{scopeLbl}</span>}
+                                  {constraint && <span className="text-xs font-mono text-muted-foreground">{constraint}</span>}
+                                  {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
+                                </span>
+                              )
+                            })}
+                          </div>
+                          {templateUpdates.length > 0 && (
+                            <button
+                              onClick={() => setUpgradeOpen(true)}
+                              className="inline-flex items-center gap-1 text-xs text-primary hover:underline cursor-pointer w-fit"
+                            >
+                              <ArrowUpCircle className="h-3 w-3" />
+                              {templateUpdates.length === 1 ? '1 update available' : `${templateUpdates.length} updates available`}
+                            </button>
+                          )}
                         </div>
                       )
                     })()}
@@ -423,6 +445,17 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                       {t.description && (
                         <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
                       )}
+                      {(() => {
+                        const linkedRef = (template?.linkedTemplates ?? []).find(
+                          (lt) => lt.scope === t.scopeRef?.scope && lt.scopeName === t.scopeRef?.scopeName && lt.name === t.name
+                        )
+                        if (!linkedRef?.versionConstraint) return null
+                        return (
+                          <span className="text-xs font-mono text-muted-foreground mt-0.5">
+                            Version: {linkedRef.versionConstraint}
+                          </span>
+                        )
+                      })()}
                     </div>
                   </div>
                   )
@@ -504,6 +537,15 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <UpgradeDialog
+        open={upgradeOpen}
+        onOpenChange={setUpgradeOpen}
+        updates={templateUpdates}
+        scope={scope}
+        templateName={templateName}
+        linkedTemplates={template?.linkedTemplates ?? []}
+      />
     </>
   )
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/queries/templates', () => ({
   useCloneTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [] }),
+  useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
   linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
@@ -30,6 +31,10 @@ vi.mock('@/queries/templates', () => ({
     const parts = key.split('/')
     return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
   },
+}))
+
+vi.mock('@/components/template-updates', () => ({
+  UpgradeDialog: () => null,
 }))
 
 vi.mock('@/queries/projects', () => ({

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx
@@ -20,7 +20,14 @@ vi.mock('@/queries/templates', () => ({
   useListTemplates: vi.fn(),
   useDeleteTemplate: vi.fn(),
   useCloneTemplate: vi.fn(),
+  useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  useGetTemplate: vi.fn().mockReturnValue({ data: undefined, isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
+}))
+
+vi.mock('@/components/template-updates', () => ({
+  UpdatesAvailableBadge: () => null,
+  UpgradeDialog: () => null,
 }))
 
 vi.mock('@/queries/projects', () => ({

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -25,8 +25,10 @@ import {
 } from '@/components/ui/table'
 import { Pencil, Trash2, Copy } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useListTemplates, useDeleteTemplate, useCloneTemplate, makeProjectScope } from '@/queries/templates'
+import { useListTemplates, useDeleteTemplate, useCloneTemplate, useCheckUpdates, useGetTemplate, makeProjectScope } from '@/queries/templates'
+import type { TemplateUpdate } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
+import { UpdatesAvailableBadge, UpgradeDialog } from '@/components/template-updates'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/')({
   component: DeploymentTemplatesRoute,
@@ -60,6 +62,20 @@ export function DeploymentTemplatesPage({ projectName: propProjectName }: { proj
   const [cloneName, setCloneName] = useState('')
   const [cloneDisplayName, setCloneDisplayName] = useState('')
   const [cloneError, setCloneError] = useState<string | null>(null)
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
+  const [upgradeTemplateName, setUpgradeTemplateName] = useState<string | null>(null)
+
+  // Fetch updates for all templates in this project scope.
+  const { data: allUpdates = [] } = useCheckUpdates(scope)
+  // Fetch updates for the selected upgrade template.
+  const { data: upgradeUpdates = [] } = useCheckUpdates(scope, upgradeTemplateName ?? '')
+  // Fetch the selected template to get its linkedTemplates for the dialog.
+  const { data: upgradeTemplate } = useGetTemplate(scope, upgradeTemplateName ?? '')
+
+  const handleOpenUpgrade = (templateName: string) => {
+    setUpgradeTemplateName(templateName)
+    setUpgradeOpen(true)
+  }
 
   const userRole = project?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
@@ -163,13 +179,20 @@ export function DeploymentTemplatesPage({ projectName: propProjectName }: { proj
                 {templates.map((template) => (
                   <TableRow key={template.name}>
                     <TableCell>
-                      <Link
-                        to="/projects/$projectName/templates/$templateName"
-                        params={{ projectName, templateName: template.name }}
-                        className="font-medium hover:underline"
-                      >
-                        {template.name}
-                      </Link>
+                      <div className="flex items-center gap-2">
+                        <Link
+                          to="/projects/$projectName/templates/$templateName"
+                          params={{ projectName, templateName: template.name }}
+                          className="font-medium hover:underline"
+                        >
+                          {template.name}
+                        </Link>
+                        <UpdatesAvailableBadge
+                          scope={scope}
+                          templateName={template.name}
+                          onClick={() => handleOpenUpgrade(template.name)}
+                        />
+                      </div>
                     </TableCell>
                     <TableCell>
                       {template.description ? (
@@ -283,6 +306,20 @@ export function DeploymentTemplatesPage({ projectName: propProjectName }: { proj
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {upgradeTemplateName && (
+        <UpgradeDialog
+          open={upgradeOpen}
+          onOpenChange={(open) => {
+            setUpgradeOpen(open)
+            if (!open) setUpgradeTemplateName(null)
+          }}
+          updates={upgradeUpdates}
+          scope={scope}
+          templateName={upgradeTemplateName}
+          linkedTemplates={upgradeTemplate?.linkedTemplates ?? []}
+        />
+      )}
     </>
   )
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -26,7 +26,6 @@ import {
 import { Pencil, Trash2, Copy } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useListTemplates, useDeleteTemplate, useCloneTemplate, useCheckUpdates, useGetTemplate, makeProjectScope } from '@/queries/templates'
-import type { TemplateUpdate } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { UpdatesAvailableBadge, UpgradeDialog } from '@/components/template-updates'
 
@@ -65,9 +64,7 @@ export function DeploymentTemplatesPage({ projectName: propProjectName }: { proj
   const [upgradeOpen, setUpgradeOpen] = useState(false)
   const [upgradeTemplateName, setUpgradeTemplateName] = useState<string | null>(null)
 
-  // Fetch updates for all templates in this project scope.
-  const { data: allUpdates = [] } = useCheckUpdates(scope)
-  // Fetch updates for the selected upgrade template.
+  // Fetch updates for the selected upgrade template (when dialog is open).
   const { data: upgradeUpdates = [] } = useCheckUpdates(scope, upgradeTemplateName ?? '')
   // Fetch the selected template to get its linkedTemplates for the dialog.
   const { data: upgradeTemplate } = useGetTemplate(scope, upgradeTemplateName ?? '')

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -64,8 +64,8 @@ export function DeploymentTemplatesPage({ projectName: propProjectName }: { proj
   const [upgradeOpen, setUpgradeOpen] = useState(false)
   const [upgradeTemplateName, setUpgradeTemplateName] = useState<string | null>(null)
 
-  // Fetch updates for the selected upgrade template (when dialog is open).
-  const { data: upgradeUpdates = [] } = useCheckUpdates(scope, upgradeTemplateName ?? '')
+  // Fetch updates for the selected upgrade template (only when dialog is open).
+  const { data: upgradeUpdates = [] } = useCheckUpdates(scope, upgradeTemplateName ?? '', { enabled: !!upgradeTemplateName })
   // Fetch the selected template to get its linkedTemplates for the dialog.
   const { data: upgradeTemplate } = useGetTemplate(scope, upgradeTemplateName ?? '')
 


### PR DESCRIPTION
## Summary
- Add `useCheckUpdates` query hook calling the CheckUpdates RPC in `frontend/src/queries/templates.ts`
- Create `UpdatesAvailableBadge` component showing "N updates" pill badge next to template names when linked templates have newer versions
- Create `UpgradeDialog` component with a table of available updates, individual Update/Upgrade buttons per row, and a bulk "Update All Compatible" action for non-breaking updates
- Integrate badge into the project template list page (clicking opens upgrade dialog)
- Integrate upgrade indicator and dialog into the template detail page with version constraint display in linked template pills
- Show version constraint in the linked templates edit dialog
- 11 unit tests covering: no updates, loading state, single/multiple update badge, badge click handler, compatible update table, breaking update tag, update mutation call, breaking confirmation, empty state, and bulk update button

Closes #778

## Test plan
- [x] `make test` passes (739 UI tests + all Go tests green)
- [ ] Badge appears next to templates with linked templates that have newer releases
- [ ] Clicking badge opens upgrade dialog showing current vs available version
- [ ] Compatible (non-breaking) updates have "Update" button
- [ ] Breaking updates show "breaking" tag and "Upgrade" button
- [ ] "Update All Compatible" button appears when 2+ non-breaking updates exist
- [ ] Version constraint shown in linked template pills on detail page
- [ ] Version constraint shown in linked templates edit dialog

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
`agent-1`