### PR TITLE
feat(ui): always render linked templates section on create and edit pages

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -235,71 +235,77 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
               </div>
             </div>
 
-            {linkableTemplates.length > 0 && (
-              <div className="flex items-start gap-2">
-                <span className="w-32 text-sm text-muted-foreground shrink-0 pt-0.5">Linked Platform Templates</span>
-                <div className="flex items-start gap-1 flex-1">
-                  <div className="flex-1">
-                    {(() => {
-                      // linkedTemplates (v1alpha2) replaces linkedOrgTemplates (v1alpha1).
-                      const linkedKeys = (template?.linkedTemplates ?? []).map(t => linkableKey(t.scope, t.scopeName, t.name))
-                      const mandatoryTemplates = linkableTemplates.filter((t) => t.mandatory)
-                      const keyOf = (t: (typeof linkableTemplates)[number]) => linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
-                      const allLinked = [
-                        ...mandatoryTemplates.filter((t) => !linkedKeys.includes(keyOf(t))),
-                        ...linkableTemplates.filter((t) => linkedKeys.includes(keyOf(t)) || t.mandatory),
-                      ]
-                      const dedupedLinked = allLinked.filter(
-                        (t, i, arr) => arr.findIndex((x) => keyOf(x) === keyOf(t)) === i,
-                      )
-                      if (dedupedLinked.length === 0) {
-                        return <span className="text-sm text-muted-foreground">None linked</span>
-                      }
+            <div className="flex items-start gap-2">
+              <span className="w-32 text-sm text-muted-foreground shrink-0 pt-0.5">Linked Platform Templates</span>
+              <div className="flex items-start gap-1 flex-1">
+                <div className="flex-1">
+                  {(() => {
+                    if (linkableTemplates.length === 0) {
                       return (
-                        <div className="flex flex-col gap-2">
-                          <div className="flex flex-wrap gap-1">
-                            {dedupedLinked.map((t) => {
-                              const scopeLbl = t.scopeRef?.scope === TemplateScope.ORGANIZATION ? 'Org' : t.scopeRef?.scope === TemplateScope.FOLDER ? 'Folder' : undefined
-                              // Look up the version constraint from the template's linkedTemplates.
-                              const linkedRef = (template?.linkedTemplates ?? []).find(
-                                (lt) => lt.scope === t.scopeRef?.scope && lt.scopeName === t.scopeRef?.scopeName && lt.name === t.name
-                              )
-                              const constraint = linkedRef?.versionConstraint
-                              return (
-                                <span key={keyOf(t)} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
-                                  {t.displayName || t.name}
-                                  {scopeLbl && <span className="text-xs text-muted-foreground">{scopeLbl}</span>}
-                                  {constraint && <span className="text-xs font-mono text-muted-foreground">{constraint}</span>}
-                                  {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
-                                </span>
-                              )
-                            })}
-                          </div>
-                          {templateUpdates.length > 0 && (
-                            <button
-                              onClick={() => setUpgradeOpen(true)}
-                              className="inline-flex items-center gap-1 text-xs text-primary hover:underline cursor-pointer w-fit"
-                            >
-                              <ArrowUpCircle className="h-3 w-3" />
-                              {templateUpdates.length === 1 ? '1 update available' : `${templateUpdates.length} updates available`}
-                            </button>
-                          )}
+                        <div className="space-y-1">
+                          <span className="text-sm text-muted-foreground">None linked</span>
+                          <p className="text-xs text-muted-foreground">No platform templates available to link. Create organization or folder templates to enable linking.</p>
                         </div>
                       )
-                    })()}
-                  </div>
-                  {canWrite && (
-                    <button
-                      aria-label="edit linked platform templates"
-                      onClick={handleOpenLinkedEdit}
-                      className="ml-1 p-0.5 text-muted-foreground hover:text-foreground shrink-0"
-                    >
-                      <Pencil className="size-3.5" />
-                    </button>
-                  )}
+                    }
+                    // linkedTemplates (v1alpha2) replaces linkedOrgTemplates (v1alpha1).
+                    const linkedKeys = (template?.linkedTemplates ?? []).map(t => linkableKey(t.scope, t.scopeName, t.name))
+                    const mandatoryTemplates = linkableTemplates.filter((t) => t.mandatory)
+                    const keyOf = (t: (typeof linkableTemplates)[number]) => linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                    const allLinked = [
+                      ...mandatoryTemplates.filter((t) => !linkedKeys.includes(keyOf(t))),
+                      ...linkableTemplates.filter((t) => linkedKeys.includes(keyOf(t)) || t.mandatory),
+                    ]
+                    const dedupedLinked = allLinked.filter(
+                      (t, i, arr) => arr.findIndex((x) => keyOf(x) === keyOf(t)) === i,
+                    )
+                    if (dedupedLinked.length === 0) {
+                      return <span className="text-sm text-muted-foreground">None linked</span>
+                    }
+                    return (
+                      <div className="flex flex-col gap-2">
+                        <div className="flex flex-wrap gap-1">
+                          {dedupedLinked.map((t) => {
+                            const scopeLbl = t.scopeRef?.scope === TemplateScope.ORGANIZATION ? 'Org' : t.scopeRef?.scope === TemplateScope.FOLDER ? 'Folder' : undefined
+                            // Look up the version constraint from the template's linkedTemplates.
+                            const linkedRef = (template?.linkedTemplates ?? []).find(
+                              (lt) => lt.scope === t.scopeRef?.scope && lt.scopeName === t.scopeRef?.scopeName && lt.name === t.name
+                            )
+                            const constraint = linkedRef?.versionConstraint
+                            return (
+                              <span key={keyOf(t)} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
+                                {t.displayName || t.name}
+                                {scopeLbl && <span className="text-xs text-muted-foreground">{scopeLbl}</span>}
+                                {constraint && <span className="text-xs font-mono text-muted-foreground">{constraint}</span>}
+                                {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
+                              </span>
+                            )
+                          })}
+                        </div>
+                        {templateUpdates.length > 0 && (
+                          <button
+                            onClick={() => setUpgradeOpen(true)}
+                            className="inline-flex items-center gap-1 text-xs text-primary hover:underline cursor-pointer w-fit"
+                          >
+                            <ArrowUpCircle className="h-3 w-3" />
+                            {templateUpdates.length === 1 ? '1 update available' : `${templateUpdates.length} updates available`}
+                          </button>
+                        )}
+                      </div>
+                    )
+                  })()}
                 </div>
+                {canWrite && linkableTemplates.length > 0 && (
+                  <button
+                    aria-label="edit linked platform templates"
+                    onClick={handleOpenLinkedEdit}
+                    className="ml-1 p-0.5 text-muted-foreground hover:text-foreground shrink-0"
+                  >
+                    <Pencil className="size-3.5" />
+                  </button>
+                )}
               </div>
-            )}
+            </div>
           </div>
 
           <div className="space-y-4">

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -52,7 +52,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const scope = makeProjectScope(projectName)
   const { data: template, isPending, error } = useGetTemplate(scope, templateName)
   const { data: project } = useGetProject(projectName)
-  const { data: linkableTemplates = [] } = useListLinkableTemplates(scope)
+  const { data: linkableTemplates = [], isSuccess: linkableReady } = useListLinkableTemplates(scope)
   const updateMutation = useUpdateTemplate(scope, templateName)
   const deleteMutation = useDeleteTemplate(scope)
   const cloneMutation = useCloneTemplate(scope)
@@ -240,6 +240,9 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
               <div className="flex items-start gap-1 flex-1">
                 <div className="flex-1">
                   {(() => {
+                    if (!linkableReady) {
+                      return <span className="text-sm text-muted-foreground">Loading...</span>
+                    }
                     if (linkableTemplates.length === 0) {
                       return (
                         <div className="space-y-1">

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -544,11 +544,13 @@ describe('DeploymentTemplateDetailPage', () => {
       { name: 'team-network-policy', displayName: 'Team Network Policy', description: 'Adds network policy', mandatory: false, scopeRef: { scope: 2, scopeName: 'platform' } },
     ]
 
-    it('does not show linked templates row when no linkable templates exist', () => {
+    it('shows linked templates section with empty state when no linkable templates exist', () => {
       ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [] })
       setupMocks()
       render(<DeploymentTemplateDetailPage />)
-      expect(screen.queryByText(/linked platform templates/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      expect(screen.getByText(/none linked/i)).toBeInTheDocument()
+      expect(screen.getByText(/no platform templates available to link/i)).toBeInTheDocument()
     })
 
     it('shows linked templates row when linkable templates exist', () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/queries/templates', () => ({
   useDeleteTemplate: vi.fn(),
   useCloneTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
-  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [] }),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isSuccess: true }),
   useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
@@ -545,7 +545,7 @@ describe('DeploymentTemplateDetailPage', () => {
     ]
 
     it('shows linked templates section with empty state when no linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [] })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
       setupMocks()
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -554,14 +554,14 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('shows linked templates row when linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks()
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
     })
 
     it('shows None linked when no templates are linked', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       render(<DeploymentTemplateDetailPage />)
       // mandatory template is always shown even when linkedTemplates is empty
@@ -569,35 +569,35 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('shows linked template names as badges', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme' }] })
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByText('HTTPRoute Gateway')).toBeInTheDocument()
     })
 
     it('shows edit linked templates button for owners', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER)
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByRole('button', { name: /edit linked platform templates/i })).toBeInTheDocument()
     })
 
     it('shows edit linked templates button for editors', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.EDITOR)
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByRole('button', { name: /edit linked platform templates/i })).toBeInTheDocument()
     })
 
     it('does not show edit linked templates button for viewers', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.VIEWER)
       render(<DeploymentTemplateDetailPage />)
       expect(screen.queryByRole('button', { name: /edit linked platform templates/i })).not.toBeInTheDocument()
     })
 
     it('clicking edit linked templates button opens dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme' }] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -606,7 +606,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('dialog shows checkboxes for each linkable template', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -616,7 +616,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('mandatory template checkbox is checked and disabled in dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -627,7 +627,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('saving calls updateMutation with selected linkedTemplates and updateLinkedTemplates: true', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -664,7 +664,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('dialog groups templates by scope with Organization and Folder headers', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -674,7 +674,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('OWNER can toggle non-mandatory checkboxes in dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -686,7 +686,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('EDITOR sees all checkboxes disabled with permission message', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.EDITOR, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -701,7 +701,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('EDITOR does not see Save button in linked templates dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.EDITOR, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -711,7 +711,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('shows scope badge per template in read-only display', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [
         { name: 'httproute', scope: 1, scopeName: 'acme' },
         { name: 'team-network-policy', scope: 2, scopeName: 'platform' },

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('@/queries/templates', () => ({
   useCreateTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
-  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [] }),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isSuccess: true }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
   linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
@@ -261,7 +261,7 @@ describe('CreateTemplatePage', () => {
     const allLinkable = [...mockOrgTemplates, ...mockFolderTemplates]
 
     it('shows linked templates section with empty state when no linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [] })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
       setupMocks()
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -269,7 +269,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows empty state message for EDITOR when no linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [] })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.EDITOR)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -277,14 +277,14 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows linked templates section when linkable templates exist for OWNER', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
     })
 
     it('groups templates by scope with Organization and Folder headers', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/organization templates/i)).toBeInTheDocument()
@@ -292,7 +292,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows checkboxes for linkable templates when user is OWNER', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       const checkboxes = screen.getAllByRole('checkbox')
@@ -300,7 +300,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('mandatory template checkbox is checked and disabled', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       const mandatoryCheckbox = screen.getByRole('checkbox', { name: /reference grant/i })
@@ -309,7 +309,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('non-mandatory template checkboxes are unchecked by default', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       const httpbinCheckbox = screen.getByRole('checkbox', { name: /httpbin platform/i })
@@ -318,7 +318,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows read-only view for EDITOR with mandatory templates and permission note', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.EDITOR)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -327,7 +327,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows read-only view for VIEWER with mandatory templates and permission note', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.VIEWER)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -335,7 +335,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('selected linked templates are included in create mutation', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
       const user = userEvent.setup()
@@ -366,7 +366,7 @@ describe('CreateTemplatePage', () => {
         { name: 'shared-policy', displayName: 'Shared Policy (Org)', description: '', mandatory: false, scopeRef: { scope: 1, scopeName: 'default' } },
         { name: 'shared-policy', displayName: 'Shared Policy (Folder)', description: '', mandatory: false, scopeRef: { scope: 2, scopeName: 'team-a' } },
       ]
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: sameName })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: sameName, isSuccess: true })
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
       const user = userEvent.setup()
@@ -392,7 +392,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('create mutation receives empty linkedTemplates when no optional templates selected', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -260,11 +260,20 @@ describe('CreateTemplatePage', () => {
     ]
     const allLinkable = [...mockOrgTemplates, ...mockFolderTemplates]
 
-    it('hides linked templates section when no linkable templates exist', () => {
+    it('shows linked templates section with empty state when no linkable templates exist', () => {
       ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [] })
       setupMocks()
       render(<CreateTemplatePage />)
-      expect(screen.queryByText(/linked platform templates/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      expect(screen.getByText(/no platform templates available to link/i)).toBeInTheDocument()
+    })
+
+    it('shows empty state message for EDITOR when no linkable templates exist', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [] })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.EDITOR)
+      render(<CreateTemplatePage />)
+      expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      expect(screen.getByText(/no platform templates available to link/i)).toBeInTheDocument()
     })
 
     it('shows linked templates section when linkable templates exist for OWNER', () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -238,7 +238,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const scope = makeProjectScope(projectName)
   const createMutation = useCreateTemplate(scope)
   const { data: project } = useGetProject(projectName)
-  const { data: linkableTemplates = [] } = useListLinkableTemplates(scope)
+  const { data: linkableTemplates = [], isSuccess: linkableReady } = useListLinkableTemplates(scope)
 
   const userRole = project?.userRole ?? Role.VIEWER
   const canLink = userRole === Role.OWNER
@@ -401,7 +401,9 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
           </div>
           <div className="space-y-3">
             <Label>Linked Platform Templates</Label>
-            {linkableTemplates.length === 0 ? (
+            {!linkableReady ? (
+              <p className="text-sm text-muted-foreground">Loading platform templates...</p>
+            ) : linkableTemplates.length === 0 ? (
               <p className="text-sm text-muted-foreground">No platform templates available to link. Create organization or folder templates to enable linking.</p>
             ) : canLink ? (
               <div className="space-y-4">

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -399,112 +399,112 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
               className="font-mono text-sm field-sizing-normal max-h-[600px] overflow-y-auto"
             />
           </div>
-          {linkableTemplates.length > 0 && (
-            <div className="space-y-3">
-              <Label>Linked Platform Templates</Label>
-              {canLink ? (
-                <div className="space-y-4">
-                  {orgTemplates.length > 0 && (
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Organization Templates</p>
-                      {orgTemplates.map((t) => {
-                        const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
-                        return (
-                        <div key={key} className="flex items-start gap-2">
-                          <Checkbox
-                            id={`linked-create-${key}`}
-                            checked={t.mandatory || selectedLinkedKeys.includes(key)}
-                            disabled={t.mandatory}
-                            onCheckedChange={(checked) => {
-                              if (t.mandatory) return
-                              setSelectedLinkedKeys((prev) =>
-                                checked ? [...prev, key] : prev.filter((k) => k !== key),
-                              )
-                            }}
-                          />
-                          <div className="flex flex-col">
-                            <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
-                              {t.displayName || t.name}
-                              {t.mandatory && (
-                                <TooltipProvider>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>This platform template is mandatory and always applied.</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
-                              )}
-                            </label>
-                            {t.description && (
-                              <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+          <div className="space-y-3">
+            <Label>Linked Platform Templates</Label>
+            {linkableTemplates.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No platform templates available to link. Create organization or folder templates to enable linking.</p>
+            ) : canLink ? (
+              <div className="space-y-4">
+                {orgTemplates.length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Organization Templates</p>
+                    {orgTemplates.map((t) => {
+                      const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                      return (
+                      <div key={key} className="flex items-start gap-2">
+                        <Checkbox
+                          id={`linked-create-${key}`}
+                          checked={t.mandatory || selectedLinkedKeys.includes(key)}
+                          disabled={t.mandatory}
+                          onCheckedChange={(checked) => {
+                            if (t.mandatory) return
+                            setSelectedLinkedKeys((prev) =>
+                              checked ? [...prev, key] : prev.filter((k) => k !== key),
+                            )
+                          }}
+                        />
+                        <div className="flex flex-col">
+                          <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                            {t.displayName || t.name}
+                            {t.mandatory && (
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    <p>This platform template is mandatory and always applied.</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
                             )}
-                          </div>
+                          </label>
+                          {t.description && (
+                            <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                          )}
                         </div>
-                        )
-                      })}
-                    </div>
-                  )}
-                  {folderTemplates.length > 0 && (
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Folder Templates</p>
-                      {folderTemplates.map((t) => {
-                        const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
-                        return (
-                        <div key={key} className="flex items-start gap-2">
-                          <Checkbox
-                            id={`linked-create-${key}`}
-                            checked={t.mandatory || selectedLinkedKeys.includes(key)}
-                            disabled={t.mandatory}
-                            onCheckedChange={(checked) => {
-                              if (t.mandatory) return
-                              setSelectedLinkedKeys((prev) =>
-                                checked ? [...prev, key] : prev.filter((k) => k !== key),
-                              )
-                            }}
-                          />
-                          <div className="flex flex-col">
-                            <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
-                              {t.displayName || t.name}
-                              {t.mandatory && (
-                                <TooltipProvider>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>This platform template is mandatory and always applied.</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
-                              )}
-                            </label>
-                            {t.description && (
-                              <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                      </div>
+                      )
+                    })}
+                  </div>
+                )}
+                {folderTemplates.length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Folder Templates</p>
+                    {folderTemplates.map((t) => {
+                      const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                      return (
+                      <div key={key} className="flex items-start gap-2">
+                        <Checkbox
+                          id={`linked-create-${key}`}
+                          checked={t.mandatory || selectedLinkedKeys.includes(key)}
+                          disabled={t.mandatory}
+                          onCheckedChange={(checked) => {
+                            if (t.mandatory) return
+                            setSelectedLinkedKeys((prev) =>
+                              checked ? [...prev, key] : prev.filter((k) => k !== key),
+                            )
+                          }}
+                        />
+                        <div className="flex flex-col">
+                          <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
+                            {t.displayName || t.name}
+                            {t.mandatory && (
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    <p>This platform template is mandatory and always applied.</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
                             )}
-                          </div>
+                          </label>
+                          {t.description && (
+                            <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                          )}
                         </div>
-                        )
-                      })}
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  {linkableTemplates.filter((t) => t.mandatory).map((t) => (
-                    <div key={linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)} className="flex items-center gap-1 text-sm">
-                      <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
-                      <span>{t.displayName || t.name}</span>
-                      <span className="text-muted-foreground">(mandatory, auto-applied)</span>
-                    </div>
-                  ))}
-                  <p className="text-xs text-muted-foreground">Only owners can link additional platform templates.</p>
-                </div>
-              )}
-            </div>
-          )}
+                      </div>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {linkableTemplates.filter((t) => t.mandatory).map((t) => (
+                  <div key={linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)} className="flex items-center gap-1 text-sm">
+                    <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />
+                    <span>{t.displayName || t.name}</span>
+                    <span className="text-muted-foreground">(mandatory, auto-applied)</span>
+                  </div>
+                ))}
+                <p className="text-xs text-muted-foreground">Only owners can link additional platform templates.</p>
+              </div>
+            )}
+          </div>
           <div>
             <Button variant="outline" type="button" onClick={() => setPreviewOpen((v) => !v)}>
               {previewOpen ? 'Hide Preview' : 'Preview'}


### PR DESCRIPTION
## Summary
- Remove the `linkableTemplates.length > 0` conditional guard that hid the "Linked Platform Templates" section on project template create and detail pages
- Add an empty state message when no linkable templates exist, guiding users to create org or folder templates
- Create page shows: "No platform templates available to link. Create organization or folder templates to enable linking."
- Detail page shows: "None linked" with the same guidance text
- Hide the edit pencil button on the detail page when there are no linkable templates (nothing to edit)
- Update tests: change the "hides section" assertions to "shows section with empty state" and add new empty state tests for EDITOR role

Closes #820

## Test plan
- [x] `make test` passes (788 tests, 51 files, 0 failures)
- [ ] Create page: "Linked Platform Templates" section renders even when no linkable templates exist
- [ ] Create page: empty state shows guidance message
- [ ] Detail page: "Linked Platform Templates" section renders even when no linkable templates exist
- [ ] Detail page: empty state shows "None linked" and guidance message
- [ ] Existing linking behavior (checkboxes, mandatory lock icon, OWNER-only editing) preserved when templates exist

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent slot: `agent-2`