### PR TITLE
feat(ui): pass linked templates to preview render for unified output

### DIFF
--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 import { useRenderTemplate } from '@/queries/templates'
-import type { TemplateScopeRef } from '@/queries/templates'
+import type { TemplateScopeRef, LinkedTemplateRef } from '@/queries/templates'
 
 interface RenderStatusIndicatorProps {
   isStale: boolean
@@ -83,6 +83,8 @@ export interface CueTemplateEditorProps {
   defaultProjectInput?: string
   /** Scope used to resolve ancestor platform templates when rendering the preview */
   scope: TemplateScopeRef
+  /** Linked template refs to include in the render preview for unified output */
+  linkedTemplates?: LinkedTemplateRef[]
 }
 
 /**
@@ -99,6 +101,7 @@ export function CueTemplateEditor({
   defaultPlatformInput = '',
   defaultProjectInput = '',
   scope,
+  linkedTemplates = [],
 }: CueTemplateEditorProps) {
   const [activeTab, setActiveTab] = useState('editor')
   const [cuePlatformInput, setCuePlatformInput] = useState(defaultPlatformInput)
@@ -119,6 +122,7 @@ export function CueTemplateEditor({
     debouncedCueInput,
     activeTab === 'preview',
     debouncedCuePlatformInput,
+    linkedTemplates,
   )
 
   const renderedYaml = renderData?.renderedYaml

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -294,24 +294,31 @@ export function useCheckUpdates(scope: TemplateScopeRef, templateName = '', opti
 
 // useRenderTemplate renders a CUE template with the given inputs. The scope
 // parameter determines which ancestor platform templates are resolved.
+// linkedTemplates optionally passes explicit linked template refs to unify
+// with the project template for a combined preview.
 export function useRenderTemplate(
   scope: TemplateScopeRef,
   cueTemplate: string,
   cueInput = '',
   enabled = true,
   cuePlatformInput = '',
+  linkedTemplates: LinkedTemplateRef[] = [],
 ) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  // Serialize linked templates into the query key so the query refetches when
+  // the linked selection changes.
+  const linkedKey = linkedTemplates.map(t => `${t.scope}/${t.scopeName}/${t.name}`).join(',')
   return useQuery({
-    queryKey: ['templates', 'render', scope.scope, scope.scopeName, cueTemplate, cueInput, cuePlatformInput] as const,
+    queryKey: ['templates', 'render', scope.scope, scope.scopeName, cueTemplate, cueInput, cuePlatformInput, linkedKey] as const,
     queryFn: async () => {
       const response = await client.renderTemplate({
         scope,
         cueTemplate,
         cueProjectInput: cueInput,
         cuePlatformInput,
+        linkedTemplates,
       })
       return { renderedYaml: response.renderedYaml, renderedJson: response.renderedJson }
     },

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -309,7 +309,7 @@ export function useRenderTemplate(
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   // Serialize linked templates into the query key so the query refetches when
   // the linked selection changes.
-  const linkedKey = linkedTemplates.map(t => `${t.scope}/${t.scopeName}/${t.name}`).join(',')
+  const linkedKey = linkedTemplates.map(t => `${t.scope}/${t.scopeName}/${t.name}@${t.versionConstraint ?? ''}`).join(',')
   return useQuery({
     queryKey: ['templates', 'render', scope.scope, scope.scopeName, cueTemplate, cueInput, cuePlatformInput, linkedKey] as const,
     queryFn: async () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -329,6 +329,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
               defaultPlatformInput={defaultPlatformInput}
               defaultProjectInput={defaultProjectInput}
               scope={scope}
+              linkedTemplates={template?.linkedTemplates ?? []}
             />
           </div>
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -235,6 +235,7 @@ describe('DeploymentTemplateDetailPage', () => {
       expect.any(String),
       false,
       expect.any(String),
+      expect.any(Array), // linkedTemplates
     )
   })
 
@@ -249,6 +250,7 @@ describe('DeploymentTemplateDetailPage', () => {
       expect.any(String),
       true,
       expect.any(String),
+      expect.any(Array), // linkedTemplates
     )
   })
 
@@ -317,6 +319,7 @@ describe('DeploymentTemplateDetailPage', () => {
       'input: { name: "custom" }',
       true,
       expect.any(String),
+      expect.any(Array), // linkedTemplates
     )
   })
 
@@ -708,6 +711,32 @@ describe('DeploymentTemplateDetailPage', () => {
       await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
       const dialog = screen.getByRole('dialog')
       expect(within(dialog).queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
+    })
+
+    it('useRenderTemplate is called with template linked templates', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [
+        { name: 'httproute', scope: 1, scopeName: 'acme' },
+      ] })
+      render(<DeploymentTemplateDetailPage />)
+      const calls = (useRenderTemplate as Mock).mock.calls
+      const lastCall = calls[calls.length - 1]
+      // arg[5] is linkedTemplates
+      expect(lastCall[5]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'httproute', scope: 1, scopeName: 'acme' }),
+        ]),
+      )
+    })
+
+    it('useRenderTemplate receives empty linkedTemplates when template has none', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
+      render(<DeploymentTemplateDetailPage />)
+      const calls = (useRenderTemplate as Mock).mock.calls
+      const lastCall = calls[calls.length - 1]
+      // arg[5] is linkedTemplates
+      expect(lastCall[5]).toEqual([])
     })
 
     it('shows scope badge per template in read-only display', () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -408,5 +408,36 @@ describe('CreateTemplatePage', () => {
         )
       })
     })
+
+    it('useRenderTemplate is called with selected linked templates for preview', async () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
+      const user = userEvent.setup()
+      render(<CreateTemplatePage />)
+
+      // Select a non-mandatory template
+      await user.click(screen.getByRole('checkbox', { name: /httpbin platform/i }))
+
+      const calls = (useRenderTemplate as Mock).mock.calls
+      const lastCall = calls[calls.length - 1]
+      // arg[5] is linkedTemplates
+      expect(lastCall[5]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'httpbin-platform', scope: 1, scopeName: 'default' }),
+        ]),
+      )
+    })
+
+    it('useRenderTemplate receives empty linkedTemplates when none selected', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
+      render(<CreateTemplatePage />)
+
+      const calls = (useRenderTemplate as Mock).mock.calls
+      const lastCall = calls[calls.length - 1]
+      // arg[5] is linkedTemplates
+      expect(lastCall[5]).toEqual([])
+    })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -280,6 +280,13 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
 \tport:  8080
 }`
 
+  // Build LinkedTemplateRef objects from the currently selected keys for the
+  // preview render so the preview pane shows unified output.
+  const previewLinkedTemplates: LinkedTemplateRef[] = selectedLinkedKeys.map((key) => {
+    const parsed = parseLinkableKey(key)
+    return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name } as LinkedTemplateRef
+  })
+
   const debouncedCueTemplate = useDebouncedValue(cueTemplate, 500)
   const renderQuery = useRenderTemplate(
     scope,
@@ -287,6 +294,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
     previewCueInput,
     previewOpen,
     previewCuePlatformInput,
+    previewLinkedTemplates,
   )
 
   const handleLoadHttpbinExample = () => {


### PR DESCRIPTION
## Summary
- Add optional `linkedTemplates` parameter to `useRenderTemplate` hook and pass it to the `RenderTemplate` RPC
- Create page: build `LinkedTemplateRef[]` from selected checkbox keys and pass to `useRenderTemplate` so the preview pane shows unified output (project + linked platform templates)
- Detail page: pass `template.linkedTemplates` through `CueTemplateEditor` to `useRenderTemplate` for the preview
- Include linked templates in the render query key for proper cache invalidation when selections change
- Update `CueTemplateEditor` component with new `linkedTemplates` prop
- Add 4 new tests; update 3 existing tests for the new parameter

Closes #821

## Test plan
- [x] `make test` passes (792/792 tests)
- [ ] Create page: select linked template checkboxes, click Preview -- verify rendered output includes platform template resources
- [ ] Detail page: view a template with linked templates, click Preview tab -- verify rendered output includes linked platform template resources
- [ ] Create page: verify preview updates when linked template selection changes

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)