### PR TITLE
feat(docs): add guardrail for linked templates UI regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Before making changes, review `CONTRIBUTING.md` for commit message requirements.
 - [Collection Index Pages](docs/agents/guardrail-collection-index.md) — Every resource collection must have an index/listing page at the root URL; settings live at a `/settings` subroute.
 - [Searchable Collections](docs/agents/guardrail-searchable-collections.md) — All index pages and dynamic-collection combo boxes must include a search/filter input using TanStack Table `globalFilterFn: 'includesString'`.
 - [Template-First Field Ordering](docs/agents/guardrail-template-first-field.md) — Template must be the first form field in Create Deployment; selecting it auto-populates all other fields.
+- [Linking UI](docs/agents/guardrail-linking-ui.md) — Linked templates section must always render on create and edit pages.
 - [CI Check Names](docs/agents/guardrail-ci-check-names.md) — Use actual GitHub Actions names: "Unit Tests", "Lint", "E2E Tests" — not lowercase shorthand.
 
 ## Planning & Execution

--- a/docs/agents/guardrail-linking-ui.md
+++ b/docs/agents/guardrail-linking-ui.md
@@ -1,0 +1,22 @@
+# Guardrail: Linked Templates UI
+
+The "Linked Platform Templates" section must always render on project template
+create and edit pages, regardless of whether linkable ancestor templates exist.
+
+## Rules
+
+1. Never conditionally hide the section based on `linkableTemplates.length`.
+2. When no linkable templates exist, show an empty state message.
+3. The preview pane must pass linked templates to `useRenderTemplate` for unified output.
+4. Regression tests in `-linking-regression.test.tsx` must pass.
+
+## Why
+
+This feature has been lost multiple times because conditional rendering made it
+invisible in environments without pre-existing platform templates. The guardrail
+tests and this document prevent that regression.
+
+## Related
+
+- [Guardrail: Template Linking](guardrail-template-linking.md) -- Backend linking model
+- [Template Service](template-service.md) -- Render set formula

--- a/docs/agents/guardrail-template-linking.md
+++ b/docs/agents/guardrail-template-linking.md
@@ -31,3 +31,4 @@ The `update_linked_templates` flag on `UpdateTemplateRequest` controls whether t
 - [Guardrail: Template Fields](guardrail-template-fields.md) — New fields must be added across the pipeline
 - [Guardrail: Template Docs](guardrail-template-docs.md) — Keep cue-template-guide.md current
 - [ADR 024](../adrs/024-template-versioning.md) — Version constraints on LinkedTemplateRef
+- [Guardrail: Linking UI](guardrail-linking-ui.md) — UI must always show linking section

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * Regression tests for the "Linked Platform Templates" UI section.
+ *
+ * This file exists solely to prevent the linking section from being removed or
+ * conditionally hidden on the create and edit pages.  It covers:
+ *   - Empty linkable state (no ancestor templates)
+ *   - Populated linkable state (org + folder templates)
+ *   - OWNER / EDITOR / VIEWER roles
+ *   - Preview integration (linked templates passed to useRenderTemplate)
+ *
+ * See docs/agents/guardrail-linking-ui.md for the guardrail this enforces.
+ */
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project', templateName: 'web-app' }),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({ children, className, to, params }: { children: React.ReactNode; className?: string; to?: string; params?: Record<string, string> }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>{children}</a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templates', () => ({
+  useCreateTemplate: vi.fn(),
+  useGetTemplate: vi.fn(),
+  useUpdateTemplate: vi.fn(),
+  useDeleteTemplate: vi.fn(),
+  useCloneTemplate: vi.fn(),
+  useRenderTemplate: vi.fn(),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isSuccess: true }),
+  useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
+  TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
+  linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
+    `${scope ?? 0}/${scopeName ?? ''}/${name}`,
+  parseLinkableKey: (key: string) => {
+    const parts = key.split('/')
+    return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
+  },
+}))
+
+vi.mock('@/components/template-updates', () => ({
+  UpgradeDialog: () => null,
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useGetProject: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-debounced-value', () => ({
+  useDebouncedValue: vi.fn((value: unknown) => value),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import {
+  useCreateTemplate,
+  useGetTemplate,
+  useUpdateTemplate,
+  useDeleteTemplate,
+  useCloneTemplate,
+  useRenderTemplate,
+  useListLinkableTemplates,
+} from '@/queries/templates'
+import { useGetProject } from '@/queries/projects'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateTemplatePage } from './new'
+import { DeploymentTemplateDetailPage } from './$templateName'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockOrgTemplates = [
+  { name: 'reference-grant', displayName: 'Reference Grant', description: 'Default ReferenceGrant for cross-namespace gateway routing', mandatory: true, scopeRef: { scope: 1, scopeName: 'default' } },
+  { name: 'httpbin-platform', displayName: 'HTTPbin Platform', description: 'Platform HTTPRoute for go-httpbin', mandatory: false, scopeRef: { scope: 1, scopeName: 'default' } },
+]
+const mockFolderTemplates = [
+  { name: 'team-network-policy', displayName: 'Team Network Policy', description: 'Standard NetworkPolicy for team namespaces', mandatory: false, scopeRef: { scope: 2, scopeName: 'team-a' } },
+]
+const allLinkable = [...mockOrgTemplates, ...mockFolderTemplates]
+
+const mockTemplate = {
+  name: 'web-app',
+  project: 'test-project',
+  displayName: 'Web App',
+  description: 'Standard web application',
+  cueTemplate: '// cue template content',
+  linkedTemplates: [] as Array<{ name: string; scope: number; scopeName: string }>,
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+function setupCreateMocks(userRole = Role.OWNER) {
+  ;(useCreateTemplate as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+    reset: vi.fn(),
+  })
+  ;(useRenderTemplate as Mock).mockReturnValue({
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isError: false,
+  })
+  ;(useGetProject as Mock).mockReturnValue({
+    data: { name: 'test-project', userRole },
+    isLoading: false,
+  })
+}
+
+function setupDetailMocks(userRole = Role.OWNER, templateOverrides?: Partial<typeof mockTemplate>) {
+  const template = { ...mockTemplate, ...templateOverrides }
+  ;(useGetTemplate as Mock).mockReturnValue({ data: template, isPending: false, error: null })
+  ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
+  ;(useDeleteTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+  ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'new-template' }), isPending: false })
+  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole }, isLoading: false })
+  ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+}
+
+// ---------------------------------------------------------------------------
+// Create page regression tests
+// ---------------------------------------------------------------------------
+
+describe('Linking UI regression — CreateTemplatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe.each([
+    ['OWNER', Role.OWNER],
+    ['EDITOR', Role.EDITOR],
+    ['VIEWER', Role.VIEWER],
+  ] as const)('role=%s', (_label, role) => {
+    describe('empty linkable templates', () => {
+      beforeEach(() => {
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
+        setupCreateMocks(role)
+      })
+
+      it('always renders the "Linked Platform Templates" section', () => {
+        render(<CreateTemplatePage />)
+        expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      })
+
+      it('shows empty state message when no linkable templates exist', () => {
+        render(<CreateTemplatePage />)
+        expect(screen.getByText(/no platform templates available to link/i)).toBeInTheDocument()
+      })
+    })
+
+    describe('populated linkable templates', () => {
+      beforeEach(() => {
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+        setupCreateMocks(role)
+      })
+
+      it('always renders the "Linked Platform Templates" section', () => {
+        render(<CreateTemplatePage />)
+        expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('OWNER with populated linkable templates', () => {
+    beforeEach(() => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      setupCreateMocks(Role.OWNER)
+    })
+
+    it('renders checkboxes for linkable templates', () => {
+      render(<CreateTemplatePage />)
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes.length).toBe(allLinkable.length)
+    })
+
+    it('passes selected linked templates to useRenderTemplate for preview', async () => {
+      const user = userEvent.setup()
+      render(<CreateTemplatePage />)
+
+      // Select a non-mandatory template
+      await user.click(screen.getByRole('checkbox', { name: /httpbin platform/i }))
+
+      const calls = (useRenderTemplate as Mock).mock.calls
+      const lastCall = calls[calls.length - 1]
+      // arg[5] is linkedTemplates
+      expect(lastCall[5]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'httpbin-platform', scope: 1, scopeName: 'default' }),
+        ]),
+      )
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Detail / edit page regression tests
+// ---------------------------------------------------------------------------
+
+describe('Linking UI regression — DeploymentTemplateDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe.each([
+    ['OWNER', Role.OWNER],
+    ['EDITOR', Role.EDITOR],
+    ['VIEWER', Role.VIEWER],
+  ] as const)('role=%s', (_label, role) => {
+    describe('empty linkable templates', () => {
+      beforeEach(() => {
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
+        setupDetailMocks(role)
+      })
+
+      it('always renders the "Linked Platform Templates" section', () => {
+        render(<DeploymentTemplateDetailPage />)
+        expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      })
+
+      it('shows empty state message when no linkable templates exist', () => {
+        render(<DeploymentTemplateDetailPage />)
+        expect(screen.getByText(/no platform templates available to link/i)).toBeInTheDocument()
+      })
+    })
+
+    describe('populated linkable templates', () => {
+      beforeEach(() => {
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+        setupDetailMocks(role)
+      })
+
+      it('always renders the "Linked Platform Templates" section', () => {
+        render(<DeploymentTemplateDetailPage />)
+        expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('OWNER with populated linkable templates', () => {
+    beforeEach(() => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      setupDetailMocks(Role.OWNER)
+    })
+
+    it('renders checkboxes when edit linked templates dialog is opened', async () => {
+      const user = userEvent.setup()
+      render(<DeploymentTemplateDetailPage />)
+      await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+      const dialog = screen.getByRole('dialog')
+      const checkboxes = within(dialog).getAllByRole('checkbox')
+      expect(checkboxes.length).toBeGreaterThanOrEqual(allLinkable.length)
+    })
+
+    it('preview receives linked templates argument via useRenderTemplate', () => {
+      setupDetailMocks(Role.OWNER, { linkedTemplates: [{ name: 'reference-grant', scope: 1, scopeName: 'default' }] })
+      render(<DeploymentTemplateDetailPage />)
+
+      const calls = (useRenderTemplate as Mock).mock.calls
+      const lastCall = calls[calls.length - 1]
+      // arg[5] is linkedTemplates
+      expect(lastCall[5]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'reference-grant', scope: 1, scopeName: 'default' }),
+        ]),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `docs/agents/guardrail-linking-ui.md` documenting that the "Linked Platform Templates" section must always render on create and edit pages
- Update `AGENTS.md` Guardrails section with a link to the new guardrail document
- Add cross-reference from `docs/agents/guardrail-template-linking.md` to the new UI guardrail
- Add dedicated regression test file (`-linking-regression.test.tsx`) with 22 tests covering both `CreateTemplatePage` and `DeploymentTemplateDetailPage` across OWNER/EDITOR/VIEWER roles in empty and populated linkable states

Closes #822

## Test plan
- [x] 22 regression tests pass: `npx vitest run src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx`
- [x] Full test suite passes: `make test` (814 tests, 52 files)
- [ ] CI Unit Tests pass
- [ ] CI Lint passes

> Local E2E was not run (docs and UI test changes only — no E2E-relevant paths affected). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code) from agent-2