### PR TITLE
chore(templates): cleanup dead code and stale docs after linking UI fix

### DIFF
--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -45,7 +45,7 @@ The render set formula is: `(mandatory AND enabled) UNION (enabled AND ref IN li
 
 ## Folder Template Management
 
-The folder templates page (`/folders/$folderName/templates`) provides a read-only list of platform templates at folder scope. Mandatory templates are marked with a lock badge.
+The folder templates page (`/folders/$folderName/templates`) lists platform templates at folder scope with full CRUD (create, edit, delete) for authorized users. Mandatory templates are marked with a lock badge.
 
 ## Versioning, Releases, and Version Constraints
 

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -588,11 +588,11 @@ multiple non-overlapping archetypes to coexist in the same organization.
 **How to link templates in the editor**
 
 When creating or editing a deployment template, the form shows a
-"Linked Platform Templates" section listing all enabled platform templates for
-the organization. Each non-mandatory template has a checkbox — check it to
-include that template in every render of this deployment template. Mandatory
-templates appear pre-checked with a lock icon; they are always included and
-cannot be deselected.
+"Linked Platform Templates" section listing all enabled ancestor platform
+templates (organization and folder scopes), grouped by scope. Each non-mandatory
+template has a checkbox — check it to include that template in every render of
+this deployment template. Mandatory templates appear pre-checked with a lock
+icon; they are always included and cannot be deselected.
 
 **Render set formula**
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -251,7 +251,6 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                         </div>
                       )
                     }
-                    // linkedTemplates (v1alpha2) replaces linkedOrgTemplates (v1alpha1).
                     const linkedKeys = (template?.linkedTemplates ?? []).map(t => linkableKey(t.scope, t.scopeName, t.name))
                     const mandatoryTemplates = linkableTemplates.filter((t) => t.mandatory)
                     const keyOf = (t: (typeof linkableTemplates)[number]) => linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)


### PR DESCRIPTION
## Summary

- Removed stale v1alpha1 migration comment from the template detail page (`$templateName.tsx` line 254)
- Updated `docs/cue-template-guide.md` "Linking Platform Templates" section to reference both organization and folder scopes (previously only mentioned organization)
- Corrected `docs/agents/template-service.md` folder template management description from "read-only list" to "full CRUD" to reflect changes from PR #800

No unused imports were found in the template files (`new.tsx`, `$templateName.tsx`, `templates.ts`). All exports from `templates.ts` are consumed by other modules. The `guardrail-template-linking.md` doc is accurate as-is.

Closes #823

## Test plan

- [x] `make generate` produces no diff
- [x] `make test` passes (814 UI tests, all Go tests)
- [x] TypeScript compiler (`tsc --noEmit`) reports no errors
- [x] ESLint reports no errors on modified files

> Local E2E was not run (documentation-only and comment-removal changes, no runtime behavior affected).

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent slot: `agent-2`