### PR TITLE
fix: use isPending instead of isSuccess for linkable templates loading state

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -52,7 +52,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const scope = makeProjectScope(projectName)
   const { data: template, isPending, error } = useGetTemplate(scope, templateName)
   const { data: project } = useGetProject(projectName)
-  const { data: linkableTemplates = [], isSuccess: linkableReady } = useListLinkableTemplates(scope)
+  const { data: linkableTemplates = [], isPending: linkablePending } = useListLinkableTemplates(scope)
   const updateMutation = useUpdateTemplate(scope, templateName)
   const deleteMutation = useDeleteTemplate(scope)
   const cloneMutation = useCloneTemplate(scope)
@@ -240,7 +240,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
               <div className="flex items-start gap-1 flex-1">
                 <div className="flex-1">
                   {(() => {
-                    if (!linkableReady) {
+                    if (linkablePending) {
                       return <span className="text-sm text-muted-foreground">Loading...</span>
                     }
                     if (linkableTemplates.length === 0) {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/queries/templates', () => ({
   useDeleteTemplate: vi.fn(),
   useCloneTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
-  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isSuccess: true }),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
   useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
@@ -548,7 +548,7 @@ describe('DeploymentTemplateDetailPage', () => {
     ]
 
     it('shows linked templates section with empty state when no linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false })
       setupMocks()
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -557,14 +557,14 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('shows linked templates row when linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks()
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
     })
 
     it('shows None linked when no templates are linked', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       render(<DeploymentTemplateDetailPage />)
       // mandatory template is always shown even when linkedTemplates is empty
@@ -572,35 +572,35 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('shows linked template names as badges', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme' }] })
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByText('HTTPRoute Gateway')).toBeInTheDocument()
     })
 
     it('shows edit linked templates button for owners', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER)
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByRole('button', { name: /edit linked platform templates/i })).toBeInTheDocument()
     })
 
     it('shows edit linked templates button for editors', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.EDITOR)
       render(<DeploymentTemplateDetailPage />)
       expect(screen.getByRole('button', { name: /edit linked platform templates/i })).toBeInTheDocument()
     })
 
     it('does not show edit linked templates button for viewers', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.VIEWER)
       render(<DeploymentTemplateDetailPage />)
       expect(screen.queryByRole('button', { name: /edit linked platform templates/i })).not.toBeInTheDocument()
     })
 
     it('clicking edit linked templates button opens dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme' }] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -609,7 +609,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('dialog shows checkboxes for each linkable template', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -619,7 +619,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('mandatory template checkbox is checked and disabled in dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -630,7 +630,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('saving calls updateMutation with selected linkedTemplates and updateLinkedTemplates: true', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -667,7 +667,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('dialog groups templates by scope with Organization and Folder headers', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -677,7 +677,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('OWNER can toggle non-mandatory checkboxes in dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -689,7 +689,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('EDITOR sees all checkboxes disabled with permission message', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.EDITOR, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -704,7 +704,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('EDITOR does not see Save button in linked templates dialog', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.EDITOR, { ...mockTemplate, linkedTemplates: [] })
       const user = userEvent.setup()
       render(<DeploymentTemplateDetailPage />)
@@ -714,7 +714,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('useRenderTemplate is called with template linked templates', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [
         { name: 'httproute', scope: 1, scopeName: 'acme' },
       ] })
@@ -730,7 +730,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('useRenderTemplate receives empty linkedTemplates when template has none', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [] })
       render(<DeploymentTemplateDetailPage />)
       const calls = (useRenderTemplate as Mock).mock.calls
@@ -740,7 +740,7 @@ describe('DeploymentTemplateDetailPage', () => {
     })
 
     it('shows scope badge per template in read-only display', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
       setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [
         { name: 'httproute', scope: 1, scopeName: 'acme' },
         { name: 'team-network-policy', scope: 2, scopeName: 'platform' },
@@ -752,6 +752,21 @@ describe('DeploymentTemplateDetailPage', () => {
       // Folder badge for team-network-policy
       const folderBadges = screen.getAllByText('Folder')
       expect(folderBadges.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('shows loading state when query is pending', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: true, isSuccess: false })
+      setupMocks()
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByText('Loading...')).toBeInTheDocument()
+    })
+
+    it('does not show loading state when query errors (falls through to empty state)', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false, isSuccess: false })
+      setupMocks()
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+      expect(screen.getByText(/none linked/i)).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@/queries/templates', () => ({
   useDeleteTemplate: vi.fn(),
   useCloneTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
-  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isSuccess: true }),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
   useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
@@ -153,7 +153,7 @@ describe('Linking UI regression — CreateTemplatePage', () => {
   ] as const)('role=%s', (_label, role) => {
     describe('empty linkable templates', () => {
       beforeEach(() => {
-        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false })
         setupCreateMocks(role)
       })
 
@@ -170,7 +170,7 @@ describe('Linking UI regression — CreateTemplatePage', () => {
 
     describe('populated linkable templates', () => {
       beforeEach(() => {
-        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
         setupCreateMocks(role)
       })
 
@@ -183,7 +183,7 @@ describe('Linking UI regression — CreateTemplatePage', () => {
 
   describe('OWNER with populated linkable templates', () => {
     beforeEach(() => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupCreateMocks(Role.OWNER)
     })
 
@@ -228,7 +228,7 @@ describe('Linking UI regression — DeploymentTemplateDetailPage', () => {
   ] as const)('role=%s', (_label, role) => {
     describe('empty linkable templates', () => {
       beforeEach(() => {
-        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false })
         setupDetailMocks(role)
       })
 
@@ -245,7 +245,7 @@ describe('Linking UI regression — DeploymentTemplateDetailPage', () => {
 
     describe('populated linkable templates', () => {
       beforeEach(() => {
-        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+        ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
         setupDetailMocks(role)
       })
 
@@ -258,7 +258,7 @@ describe('Linking UI regression — DeploymentTemplateDetailPage', () => {
 
   describe('OWNER with populated linkable templates', () => {
     beforeEach(() => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupDetailMocks(Role.OWNER)
     })
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('@/queries/templates', () => ({
   useCreateTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
-  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isSuccess: true }),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
   linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
@@ -261,7 +261,7 @@ describe('CreateTemplatePage', () => {
     const allLinkable = [...mockOrgTemplates, ...mockFolderTemplates]
 
     it('shows linked templates section with empty state when no linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false })
       setupMocks()
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -269,7 +269,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows empty state message for EDITOR when no linkable templates exist', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.EDITOR)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -277,14 +277,14 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows linked templates section when linkable templates exist for OWNER', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
     })
 
     it('groups templates by scope with Organization and Folder headers', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/organization templates/i)).toBeInTheDocument()
@@ -292,7 +292,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows checkboxes for linkable templates when user is OWNER', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       const checkboxes = screen.getAllByRole('checkbox')
@@ -300,7 +300,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('mandatory template checkbox is checked and disabled', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       const mandatoryCheckbox = screen.getByRole('checkbox', { name: /reference grant/i })
@@ -309,7 +309,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('non-mandatory template checkboxes are unchecked by default', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
       const httpbinCheckbox = screen.getByRole('checkbox', { name: /httpbin platform/i })
@@ -318,7 +318,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows read-only view for EDITOR with mandatory templates and permission note', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.EDITOR)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -327,7 +327,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('shows read-only view for VIEWER with mandatory templates and permission note', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.VIEWER)
       render(<CreateTemplatePage />)
       expect(screen.getByText(/linked platform templates/i)).toBeInTheDocument()
@@ -335,7 +335,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('selected linked templates are included in create mutation', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
       const user = userEvent.setup()
@@ -366,7 +366,7 @@ describe('CreateTemplatePage', () => {
         { name: 'shared-policy', displayName: 'Shared Policy (Org)', description: '', mandatory: false, scopeRef: { scope: 1, scopeName: 'default' } },
         { name: 'shared-policy', displayName: 'Shared Policy (Folder)', description: '', mandatory: false, scopeRef: { scope: 2, scopeName: 'team-a' } },
       ]
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: sameName, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: sameName, isPending: false })
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
       const user = userEvent.setup()
@@ -392,7 +392,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('create mutation receives empty linkedTemplates when no optional templates selected', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
@@ -410,7 +410,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('useRenderTemplate is called with selected linked templates for preview', async () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync, undefined, undefined, Role.OWNER)
       const user = userEvent.setup()
@@ -430,7 +430,7 @@ describe('CreateTemplatePage', () => {
     })
 
     it('useRenderTemplate receives empty linkedTemplates when none selected', () => {
-      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isSuccess: true })
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
       setupMocks(vi.fn().mockResolvedValue({}), undefined, undefined, Role.OWNER)
       render(<CreateTemplatePage />)
 
@@ -438,6 +438,21 @@ describe('CreateTemplatePage', () => {
       const lastCall = calls[calls.length - 1]
       // arg[5] is linkedTemplates
       expect(lastCall[5]).toEqual([])
+    })
+
+    it('shows loading state when query is pending', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: true, isSuccess: false })
+      setupMocks()
+      render(<CreateTemplatePage />)
+      expect(screen.getByText(/loading platform templates/i)).toBeInTheDocument()
+    })
+
+    it('does not show loading state when query errors (falls through to empty state)', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false, isSuccess: false })
+      setupMocks()
+      render(<CreateTemplatePage />)
+      expect(screen.queryByText(/loading platform templates/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/no platform templates available to link/i)).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -238,7 +238,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const scope = makeProjectScope(projectName)
   const createMutation = useCreateTemplate(scope)
   const { data: project } = useGetProject(projectName)
-  const { data: linkableTemplates = [], isSuccess: linkableReady } = useListLinkableTemplates(scope)
+  const { data: linkableTemplates = [], isPending: linkablePending } = useListLinkableTemplates(scope)
 
   const userRole = project?.userRole ?? Role.VIEWER
   const canLink = userRole === Role.OWNER
@@ -409,7 +409,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
           </div>
           <div className="space-y-3">
             <Label>Linked Platform Templates</Label>
-            {!linkableReady ? (
+            {linkablePending ? (
               <p className="text-sm text-muted-foreground">Loading platform templates...</p>
             ) : linkableTemplates.length === 0 ? (
               <p className="text-sm text-muted-foreground">No platform templates available to link. Create organization or folder templates to enable linking.</p>


### PR DESCRIPTION
## Summary
- Changed the loading guard for linkable templates from `isSuccess` to `isPending` in both the Create Template page (`new.tsx`) and the Template Detail page (`$templateName.tsx`)
- When the query errors (including background refetch failures), the UI now falls through to the empty state instead of showing "Loading..." indefinitely
- Added regression tests for both components covering the pending and error states
- Updated all test mocks across 3 test files to use `isPending: false` instead of `isSuccess: true`

Closes #825

## Test plan
- [x] All 818 UI tests pass (`make test-ui`)
- [x] New tests verify pending state shows loading indicator
- [x] New tests verify error state does NOT show loading indicator (falls through to empty state)
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)