### PR TITLE
docs: add guardrail for pages over modals in create/update UIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Before making changes, review `CONTRIBUTING.md` for commit message requirements.
 - [Template-First Field Ordering](docs/agents/guardrail-template-first-field.md) — Template must be the first form field in Create Deployment; selecting it auto-populates all other fields.
 - [Linking UI](docs/agents/guardrail-linking-ui.md) — Linked templates section must always render on create and edit pages.
 - [CI Check Names](docs/agents/guardrail-ci-check-names.md) — Use actual GitHub Actions names: "Unit Tests", "Lint", "E2E Tests" — not lowercase shorthand.
+- [Pages Over Modals](docs/agents/guardrail-pages-over-modals.md) — Create and update UIs use dedicated route pages, not modals; modals only for brief confirmations and lightweight actions.
 
 ## Planning & Execution
 

--- a/docs/agents/guardrail-pages-over-modals.md
+++ b/docs/agents/guardrail-pages-over-modals.md
@@ -1,0 +1,42 @@
+# Guardrail: Pages Over Modals
+
+**Create and update UIs use dedicated route pages, not modal dialogs.** Modals
+are reserved for brief confirmations (delete, discard) and lightweight actions
+that require only a name field (clone).
+
+## Rules
+
+1. Resource creation goes to a `/new` page (e.g., `/templates/new`).
+2. Resource editing goes to a `/$name/edit` page (e.g., `/templates/$name/edit`).
+3. Both pages use the standard Card layout with full viewport width.
+4. Modals are acceptable only for actions with no textarea fields and at most one
+   or two short inputs (name, confirmation checkbox).
+
+## Why
+
+Modals have fixed viewport constraints that break when content grows -- CUE
+template textareas, example loading, and multi-field forms overflow or require
+internal scrolling that fights the browser. Dedicated pages provide full
+viewport space, browser back-button navigation, bookmarkable URLs, and natural
+content flow.
+
+## Triggers
+
+Apply this rule when:
+- Adding a new resource creation or editing UI
+- Creating route files under `frontend/src/routes/`
+- Adding forms with textareas or multi-field layouts
+
+## Incorrect Patterns
+
+| Pattern | Why it is wrong |
+|---------|-----------------|
+| Dialog/modal for a create form with textarea fields | Content overflows fixed modal viewport; use a `/new` page |
+| Dialog/modal for an edit form | Edit forms grow with the resource; use an `/$name/edit` page |
+| Sheet/drawer for multi-field creation | Same viewport constraints as modals; use a dedicated page |
+
+## Related
+
+- [Collection Index Pages](guardrail-collection-index.md) -- URL structure for resource collections
+- [URL Scheme](guardrail-url-scheme.md) -- Top-level resource URL conventions
+- [UI Architecture](ui-architecture.md) -- TanStack Router and component library


### PR DESCRIPTION
## Summary
- Add new guardrail document `docs/agents/guardrail-pages-over-modals.md` establishing the convention that create and update UIs use dedicated route pages, not modal dialogs
- Modals are reserved for brief confirmations (delete, discard) and lightweight actions (clone with just a name field)
- Add reference to the new guardrail in the Guardrails section of `AGENTS.md`

Closes #832

## Test plan
- [x] `make test` passes (818 tests, 52 test files)
- [ ] New guardrail file exists at `docs/agents/guardrail-pages-over-modals.md`
- [ ] AGENTS.md Guardrails section includes the new entry
- [ ] Guardrail follows established format: title, rule statement, rules list, why, triggers, incorrect patterns table, related links
- [ ] Document is under 50 lines (42 lines)

> Local E2E was not run (docs-only change, no UI or backend modifications).

Generated with [Claude Code](https://claude.com/claude-code)
`agent-3`