### PR TITLE
feat(frontend): migrate folder template creation from modal to dedicated page

### DIFF
--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/-index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
@@ -13,26 +13,25 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     }),
     Link: ({
       children,
+      to,
+      params,
       ...props
-    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children: React.ReactNode }) => (
-      <a {...props}>{children}</a>
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children: React.ReactNode; to?: string; params?: Record<string, string> }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>{children}</a>
     ),
   }
 })
 
 vi.mock('@/queries/templates', () => ({
   useListTemplates: vi.fn(),
-  useCreateTemplate: vi.fn(),
-  makeFolderScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-folder' }),
+  makeFolderScope: vi.fn().mockReturnValue({ scope: 2, scopeName: 'test-folder' }),
 }))
 
 vi.mock('@/queries/folders', () => ({
   useGetFolder: vi.fn(),
 }))
 
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-
-import { useListTemplates, useCreateTemplate } from '@/queries/templates'
+import { useListTemplates } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { FolderTemplatesIndexPage } from './index'
@@ -66,10 +65,6 @@ function setupMocks(userRole = Role.OWNER) {
     data: { name: 'test-folder', organization: 'test-org', userRole },
     isPending: false,
     error: null,
-  })
-  ;(useCreateTemplate as Mock).mockReturnValue({
-    mutateAsync: vi.fn().mockResolvedValue({}),
-    isPending: false,
   })
 }
 
@@ -114,10 +109,6 @@ describe('FolderTemplatesIndexPage', () => {
       isPending: false,
       error: null,
     })
-    ;(useCreateTemplate as Mock).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    })
     render(<FolderTemplatesIndexPage folderName="test-folder" />)
     expect(screen.queryByText('httproute-ingress')).not.toBeInTheDocument()
   })
@@ -133,10 +124,6 @@ describe('FolderTemplatesIndexPage', () => {
       isPending: false,
       error: null,
     })
-    ;(useCreateTemplate as Mock).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    })
     render(<FolderTemplatesIndexPage folderName="test-folder" />)
     expect(screen.getByText('Failed to load templates')).toBeInTheDocument()
   })
@@ -151,10 +138,6 @@ describe('FolderTemplatesIndexPage', () => {
       data: { name: 'test-folder', organization: 'test-org', userRole: Role.OWNER },
       isPending: false,
       error: null,
-    })
-    ;(useCreateTemplate as Mock).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
     })
     render(<FolderTemplatesIndexPage folderName="test-folder" />)
     expect(
@@ -178,156 +161,35 @@ describe('FolderTemplatesIndexPage', () => {
     expect(screen.queryByText('httproute-ingress')).not.toBeInTheDocument()
   })
 
-  describe('create template button and dialog', () => {
-    it('shows Create Template button for folder OWNER', () => {
+  describe('create template button', () => {
+    it('shows Create Template link for folder OWNER', () => {
       setupMocks(Role.OWNER)
       render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      expect(
-        screen.getByRole('button', { name: /create template/i }),
-      ).toBeInTheDocument()
+      const link = screen.getByRole('link', { name: /create template/i })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/folders/$folderName/templates/new')
     })
 
-    it('does not show Create Template button for folder VIEWER', () => {
+    it('does not show Create Template link for folder VIEWER', () => {
       setupMocks(Role.VIEWER)
       render(<FolderTemplatesIndexPage folderName="test-folder" />)
       expect(
-        screen.queryByRole('button', { name: /create template/i }),
+        screen.queryByRole('link', { name: /create template/i }),
       ).not.toBeInTheDocument()
     })
 
-    it('does not show Create Template button for folder EDITOR', () => {
+    it('does not show Create Template link for folder EDITOR', () => {
       setupMocks(Role.EDITOR)
       render(<FolderTemplatesIndexPage folderName="test-folder" />)
       expect(
-        screen.queryByRole('button', { name: /create template/i }),
+        screen.queryByRole('link', { name: /create template/i }),
       ).not.toBeInTheDocument()
     })
 
-    it('clicking Create Template opens dialog', async () => {
+    it('does not render a dialog', () => {
       setupMocks(Role.OWNER)
-      const user = userEvent.setup()
       render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
-    })
-
-    it('create dialog has enabled toggle defaulting to disabled', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const toggle = screen.getByRole('switch', { name: /enabled/i })
-      expect(toggle).toBeInTheDocument()
-      expect(toggle).toHaveAttribute('data-state', 'unchecked')
-    })
-
-    it('confirming create calls createTemplate with enabled state', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const nameInput = screen.getByRole('textbox', { name: /^name$/i })
-      await user.type(nameInput, 'my-template')
-      await user.click(screen.getByRole('switch', { name: /enabled/i }))
-      await user.click(screen.getByRole('button', { name: /^create$/i }))
-      const mutateAsync = (useCreateTemplate as Mock).mock.results[0].value
-        .mutateAsync
-      await waitFor(() => {
-        expect(mutateAsync).toHaveBeenCalledWith(
-          expect.objectContaining({
-            name: 'my-template',
-            enabled: true,
-          }),
-        )
-      })
-    })
-
-    it('create with enabled defaulting to false passes disabled', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const nameInput = screen.getByRole('textbox', { name: /^name$/i })
-      await user.type(nameInput, 'my-template')
-      await user.click(screen.getByRole('button', { name: /^create$/i }))
-      const mutateAsync = (useCreateTemplate as Mock).mock.results[0].value
-        .mutateAsync
-      await waitFor(() => {
-        expect(mutateAsync).toHaveBeenCalledWith(
-          expect.objectContaining({
-            name: 'my-template',
-            enabled: false,
-          }),
-        )
-      })
-    })
-
-    it('cancel closes create dialog without saving', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      await user.click(screen.getByRole('button', { name: /cancel/i }))
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-      const mutateAsync = (useCreateTemplate as Mock).mock.results[0].value
-        .mutateAsync
-      expect(mutateAsync).not.toHaveBeenCalled()
-    })
-
-    it('disables Create button when name is empty', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const createBtn = screen.getByRole('button', { name: /^create$/i })
-      expect(createBtn).toBeDisabled()
-    })
-
-    it('shows validation error when name is whitespace only', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const nameInput = screen.getByRole('textbox', { name: /^name$/i })
-      await user.type(nameInput, '   ')
-      await user.click(screen.getByRole('button', { name: /^create$/i }))
-      await waitFor(() => {
-        expect(screen.getByText('Name is required')).toBeInTheDocument()
-      })
-      const mutateAsync = (useCreateTemplate as Mock).mock.results[0].value
-        .mutateAsync
-      expect(mutateAsync).not.toHaveBeenCalled()
-    })
-
-    it('shows error alert when create mutation fails', async () => {
-      setupMocks(Role.OWNER)
-      ;(useCreateTemplate as Mock).mockReturnValue({
-        mutateAsync: vi.fn().mockRejectedValue(new Error('Template already exists')),
-        isPending: false,
-      })
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const nameInput = screen.getByRole('textbox', { name: /^name$/i })
-      await user.type(nameInput, 'existing-template')
-      await user.click(screen.getByRole('button', { name: /^create$/i }))
-      await waitFor(() => {
-        expect(screen.getByText('Template already exists')).toBeInTheDocument()
-      })
-      // Dialog should remain open on error
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
-    })
-
-    it('Load Example populates fields', async () => {
-      setupMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<FolderTemplatesIndexPage folderName="test-folder" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      await user.click(screen.getByRole('button', { name: /load example/i }))
-      const nameInput = screen.getByRole('textbox', {
-        name: /^name$/i,
-      }) as HTMLInputElement
-      expect(nameInput.value).toBe('httproute-ingress')
     })
   })
 })

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
@@ -1,0 +1,246 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ folderName: 'test-folder' }),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({ children, className, to, params }: { children: React.ReactNode; className?: string; to?: string; params?: Record<string, string> }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>{children}</a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templates', () => ({
+  useCreateTemplate: vi.fn(),
+  makeFolderScope: vi.fn().mockReturnValue({ scope: 2, scopeName: 'test-folder' }),
+}))
+
+vi.mock('@/queries/folders', () => ({
+  useGetFolder: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { useCreateTemplate } from '@/queries/templates'
+import { useGetFolder } from '@/queries/folders'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateFolderTemplatePage } from './new'
+
+function setupMocks(
+  mutateAsync = vi.fn().mockResolvedValue({}),
+  userRole = Role.OWNER,
+) {
+  ;(useCreateTemplate as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+    reset: vi.fn(),
+  })
+  ;(useGetFolder as Mock).mockReturnValue({
+    data: { name: 'test-folder', organization: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('CreateFolderTemplatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page heading', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByText(/create platform template/i)).toBeInTheDocument()
+  })
+
+  it('renders Display Name field', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+  })
+
+  it('renders Name (slug) field', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByLabelText(/name slug/i)).toBeInTheDocument()
+  })
+
+  it('renders Description field', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders CUE Template textarea', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByRole('textbox', { name: /cue template/i })).toBeInTheDocument()
+  })
+
+  it('renders Enabled switch defaulting to unchecked', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    const toggle = screen.getByRole('switch', { name: /enabled/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders Create submit button', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeInTheDocument()
+  })
+
+  it('renders a Cancel link back to the templates list', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByRole('link', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('auto-derives slug from display name', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    const displayNameInput = screen.getByLabelText(/display name/i)
+    fireEvent.change(displayNameInput, { target: { value: 'My Web App' } })
+    const slugInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
+    expect(slugInput.value).toBe('my-web-app')
+  })
+
+  it('shows validation error when name is empty', async () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/template name is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('calls createMutation with form values on submit', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(mutateAsync)
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'A description' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'my-template',
+          displayName: 'My Template',
+          description: 'A description',
+          mandatory: false,
+          enabled: false,
+        }),
+      )
+    })
+  })
+
+  it('navigates to template detail page after successful creation', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(mutateAsync)
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '/folders/$folderName/templates/$templateName',
+          params: expect.objectContaining({ folderName: 'test-folder', templateName: 'my-template' }),
+        }),
+      )
+    })
+  })
+
+  it('shows error message when creation fails', async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(new Error('server error'))
+    setupMocks(mutateAsync)
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/server error/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders breadcrumb navigation', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    expect(screen.getByText('Platform Templates')).toBeInTheDocument()
+    expect(screen.getByText('test-folder')).toBeInTheDocument()
+  })
+
+  describe('Load Example button', () => {
+    it('renders Load Example button', () => {
+      render(<CreateFolderTemplatePage folderName="test-folder" />)
+      expect(screen.getByRole('button', { name: /load example/i })).toBeInTheDocument()
+    })
+
+    it('clicking Load Example populates all form fields', () => {
+      render(<CreateFolderTemplatePage folderName="test-folder" />)
+      fireEvent.click(screen.getByRole('button', { name: /load example/i }))
+
+      const nameInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
+      expect(nameInput.value).toBe('httproute-ingress')
+
+      const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement
+      expect(displayNameInput.value).toBe('HTTPRoute Ingress')
+
+      const descriptionInput = screen.getByLabelText(/description/i) as HTMLInputElement
+      expect(descriptionInput.value).toContain('HTTPRoute')
+
+      const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
+      expect(cueEditor.value).toContain('HTTPRoute')
+      expect(cueEditor.value).toContain('istio-ingress')
+    })
+  })
+
+  describe('Enabled switch', () => {
+    it('passes enabled: true when toggle is switched on', async () => {
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks(mutateAsync)
+      render(<CreateFolderTemplatePage folderName="test-folder" />)
+
+      fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+      fireEvent.click(screen.getByRole('switch', { name: /enabled/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            enabled: true,
+          }),
+        )
+      })
+    })
+  })
+
+  describe('permissions', () => {
+    it('disables form fields for non-OWNER users', () => {
+      setupMocks(vi.fn().mockResolvedValue({}), Role.VIEWER)
+      render(<CreateFolderTemplatePage folderName="test-folder" />)
+
+      expect(screen.getByLabelText(/display name/i)).toBeDisabled()
+      expect(screen.getByLabelText(/name slug/i)).toBeDisabled()
+      expect(screen.getByLabelText(/description/i)).toBeDisabled()
+      expect(screen.getByRole('textbox', { name: /cue template/i })).toBeDisabled()
+      expect(screen.getByRole('switch', { name: /enabled/i })).toBeDisabled()
+      expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+    })
+
+    it('enables form fields for OWNER users', () => {
+      setupMocks(vi.fn().mockResolvedValue({}), Role.OWNER)
+      render(<CreateFolderTemplatePage folderName="test-folder" />)
+
+      expect(screen.getByLabelText(/display name/i)).not.toBeDisabled()
+      expect(screen.getByLabelText(/name slug/i)).not.toBeDisabled()
+      expect(screen.getByLabelText(/description/i)).not.toBeDisabled()
+      expect(screen.getByRole('textbox', { name: /cue template/i })).not.toBeDisabled()
+      expect(screen.getByRole('button', { name: /^create$/i })).not.toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/index.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { toast } from 'sonner'
 import {
   useReactTable,
   getCoreRowModel,
@@ -11,9 +10,6 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
-import { Switch } from '@/components/ui/switch'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
@@ -26,56 +22,10 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Lock, Info } from 'lucide-react'
+import { Lock } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useListTemplates, useCreateTemplate, makeFolderScope } from '@/queries/templates'
+import { useListTemplates, makeFolderScope } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-
-// EXAMPLE_FOLDER_PLATFORM_TEMPLATE is the example folder-level platform template CUE content.
-// It provides an HTTPRoute into the istio-ingress namespace using platformResources.
-const EXAMPLE_FOLDER_PLATFORM_TEMPLATE = `// Folder-level platform template — HTTPRoute for istio-ingress gateway.
-// Applied to projects within this folder hierarchy.
-platformResources: {
-    namespacedResources: ("istio-ingress"): {
-        HTTPRoute: (input.name): {
-            apiVersion: "gateway.networking.k8s.io/v1"
-            kind:       "HTTPRoute"
-            metadata: {
-                name:      input.name
-                namespace: "istio-ingress"
-                labels: {
-                    "app.kubernetes.io/managed-by": "console.holos.run"
-                    "app.kubernetes.io/name":       input.name
-                }
-            }
-            spec: {
-                parentRefs: [{
-                    group:     "gateway.networking.k8s.io"
-                    kind:      "Gateway"
-                    namespace: platform.gatewayNamespace
-                    name:      "default"
-                }]
-                rules: [{
-                    backendRefs: [{
-                        name: input.name
-                        port: 80
-                    }]
-                }]
-            }
-        }
-    }
-    clusterResources: {}
-}
-`
 
 /** Row type for the template table. */
 type TemplateRow = {
@@ -117,19 +67,11 @@ export function FolderTemplatesIndexPage({
 
   const scope = makeFolderScope(folderName)
   const { data: templates, isPending, error } = useListTemplates(scope)
-  const createMutation = useCreateTemplate(scope)
 
   const userRole = folder?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER
 
   const [globalFilter, setGlobalFilter] = useState('')
-  const [createOpen, setCreateOpen] = useState(false)
-  const [createName, setCreateName] = useState('')
-  const [createDisplayName, setCreateDisplayName] = useState('')
-  const [createDescription, setCreateDescription] = useState('')
-  const [createCueTemplate, setCreateCueTemplate] = useState('')
-  const [createEnabled, setCreateEnabled] = useState(false)
-  const [createError, setCreateError] = useState<string | null>(null)
 
   const data = useMemo<TemplateRow[]>(() => {
     if (!templates) return []
@@ -198,47 +140,6 @@ export function FolderTemplatesIndexPage({
     getFilteredRowModel: getFilteredRowModel(),
   })
 
-  const handleOpenCreate = () => {
-    setCreateName('')
-    setCreateDisplayName('')
-    setCreateDescription('')
-    setCreateCueTemplate('')
-    setCreateEnabled(false)
-    setCreateError(null)
-    setCreateOpen(true)
-  }
-
-  const handleLoadExample = () => {
-    setCreateName('httproute-ingress')
-    setCreateDisplayName('HTTPRoute Ingress')
-    setCreateDescription(
-      'Provides an HTTPRoute for the istio-ingress gateway, routing traffic to project services.',
-    )
-    setCreateCueTemplate(EXAMPLE_FOLDER_PLATFORM_TEMPLATE)
-  }
-
-  const handleCreateConfirm = async () => {
-    if (!createName.trim()) {
-      setCreateError('Name is required')
-      return
-    }
-    setCreateError(null)
-    try {
-      await createMutation.mutateAsync({
-        name: createName.trim(),
-        displayName: createDisplayName.trim(),
-        description: createDescription.trim(),
-        cueTemplate: createCueTemplate,
-        mandatory: false,
-        enabled: createEnabled,
-      })
-      toast.success(`Created platform template "${createName}"`)
-      setCreateOpen(false)
-    } catch (err) {
-      setCreateError(err instanceof Error ? err.message : String(err))
-    }
-  }
-
   if (isPending) {
     return (
       <Card>
@@ -264,8 +165,7 @@ export function FolderTemplatesIndexPage({
   }
 
   return (
-    <>
-      <Card>
+    <Card>
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
           <div>
             <p className="text-sm text-muted-foreground">
@@ -289,9 +189,11 @@ export function FolderTemplatesIndexPage({
             <CardTitle className="mt-1">Platform Templates</CardTitle>
           </div>
           {canWrite && (
-            <Button size="sm" onClick={handleOpenCreate}>
-              Create Template
-            </Button>
+            <Link to="/folders/$folderName/templates/new" params={{ folderName }}>
+              <Button size="sm">
+                Create Template
+              </Button>
+            </Link>
           )}
         </CardHeader>
         <CardContent className="space-y-4">
@@ -352,107 +254,6 @@ export function FolderTemplatesIndexPage({
             </p>
           )}
         </CardContent>
-      </Card>
-
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Create Platform Template</DialogTitle>
-            <DialogDescription>
-              Create a new platform template for folder &quot;{folderName}&quot;.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={handleLoadExample}>
-                Load Example
-              </Button>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="h-4 w-4 text-muted-foreground cursor-default" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>
-                      Platform templates are unified with project deployment templates at render
-                      time via CUE. This example provides an HTTPRoute for the istio-ingress
-                      gateway.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="create-name">Name</Label>
-              <Input
-                id="create-name"
-                aria-label="Name"
-                value={createName}
-                onChange={(e) => setCreateName(e.target.value)}
-                placeholder="my-template"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="create-display-name">Display Name</Label>
-              <Input
-                id="create-display-name"
-                aria-label="Display Name"
-                value={createDisplayName}
-                onChange={(e) => setCreateDisplayName(e.target.value)}
-                placeholder="My Template"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="create-description">Description</Label>
-              <Input
-                id="create-description"
-                aria-label="Description"
-                value={createDescription}
-                onChange={(e) => setCreateDescription(e.target.value)}
-                placeholder="What does this template produce?"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="create-cue-template">CUE Template</Label>
-              <Textarea
-                id="create-cue-template"
-                aria-label="CUE Template"
-                value={createCueTemplate}
-                onChange={(e) => setCreateCueTemplate(e.target.value)}
-                placeholder="// CUE template content"
-                className="font-mono text-xs min-h-[120px]"
-              />
-            </div>
-            <div className="flex items-center gap-3">
-              <Switch
-                id="create-enabled"
-                aria-label="Enabled"
-                checked={createEnabled}
-                onCheckedChange={setCreateEnabled}
-              />
-              <Label htmlFor="create-enabled" className="text-sm cursor-pointer">
-                Enabled (apply to projects in this folder)
-              </Label>
-            </div>
-          </div>
-          {createError && (
-            <Alert variant="destructive">
-              <AlertDescription>{createError}</AlertDescription>
-            </Alert>
-          )}
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setCreateOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleCreateConfirm}
-              disabled={createMutation.isPending || !createName}
-            >
-              {createMutation.isPending ? 'Creating...' : 'Create'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+    </Card>
   )
 }

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/new.tsx
@@ -1,0 +1,267 @@
+import { useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Info } from 'lucide-react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplate, makeFolderScope } from '@/queries/templates'
+import { useGetFolder } from '@/queries/folders'
+
+// EXAMPLE_FOLDER_PLATFORM_TEMPLATE is the example folder-level platform template CUE content.
+// It provides an HTTPRoute into the istio-ingress namespace using platformResources.
+const EXAMPLE_FOLDER_PLATFORM_TEMPLATE = `// Folder-level platform template — HTTPRoute for istio-ingress gateway.
+// Applied to projects within this folder hierarchy.
+platformResources: {
+    namespacedResources: ("istio-ingress"): {
+        HTTPRoute: (input.name): {
+            apiVersion: "gateway.networking.k8s.io/v1"
+            kind:       "HTTPRoute"
+            metadata: {
+                name:      input.name
+                namespace: "istio-ingress"
+                labels: {
+                    "app.kubernetes.io/managed-by": "console.holos.run"
+                    "app.kubernetes.io/name":       input.name
+                }
+            }
+            spec: {
+                parentRefs: [{
+                    group:     "gateway.networking.k8s.io"
+                    kind:      "Gateway"
+                    namespace: platform.gatewayNamespace
+                    name:      "default"
+                }]
+                rules: [{
+                    backendRefs: [{
+                        name: input.name
+                        port: 80
+                    }]
+                }]
+            }
+        }
+    }
+    clusterResources: {}
+}
+`
+
+export const Route = createFileRoute('/_authenticated/folders/$folderName/templates/new')({
+  component: CreateFolderTemplateRoute,
+})
+
+function CreateFolderTemplateRoute() {
+  const { folderName } = Route.useParams()
+  return <CreateFolderTemplatePage folderName={folderName} />
+}
+
+export function CreateFolderTemplatePage({ folderName: propFolderName }: { folderName?: string } = {}) {
+  let routeFolderName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeFolderName = Route.useParams().folderName
+  } catch {
+    routeFolderName = undefined
+  }
+  const folderName = propFolderName ?? routeFolderName ?? ''
+
+  const navigate = useNavigate()
+  const scope = makeFolderScope(folderName)
+  const createMutation = useCreateTemplate(scope)
+  const { data: folder } = useGetFolder(folderName)
+
+  const orgName = folder?.organization ?? ''
+  const userRole = folder?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER
+
+  const [displayName, setDisplayName] = useState('')
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [cueTemplate, setCueTemplate] = useState('')
+  const [enabled, setEnabled] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const slugify = (val: string) =>
+    val.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+
+  const handleDisplayNameChange = (val: string) => {
+    setDisplayName(val)
+    setName(slugify(val))
+  }
+
+  const handleLoadExample = () => {
+    setName('httproute-ingress')
+    setDisplayName('HTTPRoute Ingress')
+    setDescription(
+      'Provides an HTTPRoute for the istio-ingress gateway, routing traffic to project services.',
+    )
+    setCueTemplate(EXAMPLE_FOLDER_PLATFORM_TEMPLATE)
+  }
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      setError('Template name is required')
+      return
+    }
+    setError(null)
+    try {
+      await createMutation.mutateAsync({
+        name: name.trim(),
+        displayName: displayName.trim(),
+        description: description.trim(),
+        cueTemplate,
+        mandatory: false,
+        enabled,
+      })
+      await navigate({
+        to: '/folders/$folderName/templates/$templateName',
+        params: { folderName, templateName: name.trim() },
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+              {orgName}
+            </Link>
+            {' / '}
+            <Link to="/orgs/$orgName/folders" params={{ orgName }} className="hover:underline">
+              Folders
+            </Link>
+            {' / '}
+            <Link
+              to="/folders/$folderName/settings"
+              params={{ folderName }}
+              className="hover:underline"
+            >
+              {folderName}
+            </Link>
+            {' / '}
+            <Link
+              to="/folders/$folderName/templates"
+              params={{ folderName }}
+              className="hover:underline"
+            >
+              Platform Templates
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">Create Platform Template</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="template-display-name">Display Name</Label>
+            <Input
+              id="template-display-name"
+              aria-label="Display Name"
+              autoFocus
+              value={displayName}
+              onChange={(e) => handleDisplayNameChange(e.target.value)}
+              placeholder="My Template"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <Label>Name (slug)</Label>
+            <Input
+              aria-label="Name slug"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-template"
+              disabled={!canWrite}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Auto-derived from display name. Lowercase alphanumeric and hyphens only.
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="template-description">Description</Label>
+            <Input
+              id="template-description"
+              aria-label="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this template produce?"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <Label htmlFor="template-cue-template">CUE Template</Label>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" type="button" onClick={handleLoadExample} disabled={!canWrite}>
+                  Load Example
+                </Button>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info className="h-4 w-4 text-muted-foreground cursor-default" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>
+                        Platform templates are unified with project deployment templates at render
+                        time via CUE. This example provides an HTTPRoute for the istio-ingress
+                        gateway.
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            </div>
+            <Textarea
+              id="template-cue-template"
+              aria-label="CUE Template"
+              value={cueTemplate}
+              onChange={(e) => setCueTemplate(e.target.value)}
+              rows={20}
+              className="font-mono text-sm field-sizing-normal max-h-[600px] overflow-y-auto"
+              disabled={!canWrite}
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="template-enabled"
+              aria-label="Enabled"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+              disabled={!canWrite}
+            />
+            <Label htmlFor="template-enabled" className="text-sm cursor-pointer">
+              Enabled (apply to projects in this folder)
+            </Label>
+          </div>
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="flex items-center gap-3 pt-2">
+            <Button onClick={handleCreate} disabled={createMutation.isPending || !canWrite}>
+              {createMutation.isPending ? 'Creating...' : 'Create'}
+            </Button>
+            <Link
+              to="/folders/$folderName/templates"
+              params={{ folderName }}
+            >
+              <Button variant="ghost" type="button" aria-label="Cancel">
+                Cancel
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- Added a dedicated `/folders/$folderName/templates/new` page with a Card-based layout matching the project template creation page pattern
- Removed the modal dialog from the folder templates index page (`index.tsx`) including all Dialog imports, state variables, handlers, and JSX
- Changed the "Create Template" button on the index page to a `<Link>` navigating to the new page
- Added comprehensive Vitest + RTL tests for the new page: form rendering, auto-slug, validation, create mutation, navigation, error display, Load Example, enabled switch, and OWNER permission gating
- Updated index page tests to verify the modal is gone and the Create Template button is now a link

Closes #833

## Test plan
- [ ] `make test` passes (829 UI tests, all Go tests)
- [ ] New page renders at `/folders/$folderName/templates/new` with breadcrumb, form fields, and Load Example button
- [ ] Load Example pre-fills all fields including CUE textarea with `EXAMPLE_FOLDER_PLATFORM_TEMPLATE`
- [ ] Create button calls `useCreateTemplate(makeFolderScope(folderName))` and navigates to the template detail page
- [ ] Cancel button links back to `/folders/$folderName/templates`
- [ ] Enabled switch defaults to unchecked and passes `enabled: true/false` to the mutation
- [ ] Non-OWNER users see disabled form fields and Create button
- [ ] Index page "Create Template" button navigates to the new page instead of opening a dialog
- [ ] No Dialog renders on the index page

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent: `agent-3`