### PR TITLE
feat(templates): populate releases in ListLinkableTemplates and support include_current in CheckUpdates

### DIFF
--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -539,6 +539,27 @@ func (h *Handler) ListLinkableTemplates(
 			)
 			continue
 		}
+		// Fetch releases for each linkable template and populate the Releases
+		// field, stripping cue_template and defaults to keep the payload small.
+		for _, lt := range infos {
+			cms, relErr := h.k8s.ListReleases(ctx, ancestorScope, ancestorName, lt.Name)
+			if relErr != nil {
+				slog.WarnContext(ctx, "failed to list releases for linkable template",
+					slog.String("template", lt.Name),
+					slog.Any("error", relErr),
+				)
+				continue
+			}
+			releases := make([]*consolev1.Release, 0, len(cms))
+			for _, cm := range cms {
+				r := configMapToRelease(&cm, ancestorScope, ancestorName)
+				// Strip heavy fields the linking UI does not need.
+				r.CueTemplate = ""
+				r.Defaults = nil
+				releases = append(releases, r)
+			}
+			lt.Releases = releases
+		}
 		result = append(result, infos...)
 	}
 
@@ -944,7 +965,7 @@ func (h *Handler) CheckUpdates(
 			continue
 		}
 		for _, ref := range refs {
-			update, err := h.checkLinkedUpdate(ctx, ref)
+			update, err := h.checkLinkedUpdate(ctx, ref, req.Msg.GetIncludeCurrent())
 			if err != nil {
 				slog.WarnContext(ctx, "failed to check update for linked template",
 					slog.String("name", ref.Name),
@@ -972,8 +993,11 @@ func (h *Handler) CheckUpdates(
 }
 
 // checkLinkedUpdate computes the update status for a single linked template
-// reference. Returns nil if no updates are available.
-func (h *Handler) checkLinkedUpdate(ctx context.Context, ref *consolev1.LinkedTemplateRef) (*consolev1.TemplateUpdate, error) {
+// reference. When includeCurrent is false (default), returns nil if no updates
+// are available. When includeCurrent is true, always returns a TemplateUpdate
+// with resolved version information even if the template is already at the
+// latest compatible version.
+func (h *Handler) checkLinkedUpdate(ctx context.Context, ref *consolev1.LinkedTemplateRef, includeCurrent bool) (*consolev1.TemplateUpdate, error) {
 	refScope := ref.GetScope()
 	refScopeName := ref.ScopeName
 	refName := ref.Name
@@ -1028,9 +1052,10 @@ func (h *Handler) checkLinkedUpdate(ctx context.Context, ref *consolev1.LinkedTe
 		}
 	}
 
-	// Only report an update if there is something new.
+	// Only report an update if there is something new, unless the caller
+	// requested all entries (include_current).
 	hasCompatibleUpdate := latestCompatibleStr != "" && latestCompatibleStr != currentStr
-	if !hasCompatibleUpdate && !breakingAvailable {
+	if !hasCompatibleUpdate && !breakingAvailable && !includeCurrent {
 		return nil, nil
 	}
 

--- a/console/templates/handler_linkable_test.go
+++ b/console/templates/handler_linkable_test.go
@@ -1,0 +1,239 @@
+package templates
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// stubAncestorWalker implements AncestorWalker for tests, returning a
+// predetermined list of ancestor namespaces.
+type stubAncestorWalker struct {
+	ancestors []*corev1.Namespace
+	err       error
+}
+
+func (s *stubAncestorWalker) WalkAncestors(_ context.Context, _ string) ([]*corev1.Namespace, error) {
+	return s.ancestors, s.err
+}
+
+// enabledTemplateCM creates an enabled template ConfigMap suitable for
+// ListLinkableTemplateInfos.
+func enabledTemplateCM(ns, name, displayName, description string, mandatory bool) *corev1.ConfigMap {
+	mandatoryStr := "false"
+	if mandatory {
+		mandatoryStr = "true"
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName: displayName,
+				v1alpha2.AnnotationDescription: description,
+				v1alpha2.AnnotationMandatory:   mandatoryStr,
+				v1alpha2.AnnotationEnabled:     "true",
+			},
+		},
+		Data: map[string]string{CueTemplateKey: validCue},
+	}
+}
+
+// makeReleaseCMWithData creates a release ConfigMap with CUE template and
+// defaults data so we can verify stripping behavior.
+func makeReleaseCMWithData(ns, templateName, version, cue, defaults string) *corev1.ConfigMap {
+	v, _ := ParseVersion(version)
+	data := map[string]string{
+		CueTemplateKey: cue,
+	}
+	if defaults != "" {
+		data[DefaultsKey] = defaults
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ReleaseConfigMapName(templateName, v),
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplateRelease,
+				v1alpha2.LabelReleaseOf:     templateName,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplateVersion: version,
+			},
+		},
+		Data: data,
+	}
+}
+
+// newLinkableTestHandler builds a Handler with an AncestorWalker wired up for
+// testing ListLinkableTemplates. Uses org-level grant resolver since linkable
+// templates come from ancestor (org/folder) scopes.
+func newLinkableTestHandler(fakeClient *fake.Clientset, shareUsers map[string]string, walker AncestorWalker) *Handler {
+	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+	k8s := NewK8sClient(fakeClient, r)
+	handler := NewHandler(k8s, r, &stubRenderer{})
+	handler.WithProjectGrantResolver(&stubProjectGrantResolver{users: shareUsers})
+	handler.WithAncestorWalker(walker)
+	return handler
+}
+
+func TestListLinkableTemplatesReleases(t *testing.T) {
+	const org = "acme"
+	const project = "my-project"
+	const ownerEmail = "platform@localhost"
+	const templateName = "httproute"
+
+	shareUsers := map[string]string{ownerEmail: "owner"}
+
+	t.Run("returns releases for each linkable template", func(t *testing.T) {
+		orgNsObj := orgNS(org)
+		projectNsObj := projectNS(project)
+		tmpl := enabledTemplateCM("org-"+org, templateName, "HTTPRoute", "Expose via gateway", false)
+		r1 := makeReleaseCMWithData("org-"+org, templateName, "1.0.0", validCue, `{"image":"nginx:1.0"}`)
+		r2 := makeReleaseCMWithData("org-"+org, templateName, "2.0.0", validCue, `{"image":"nginx:2.0"}`)
+
+		fakeClient := fake.NewClientset(orgNsObj, projectNsObj, tmpl, r1, r2)
+		walker := &stubAncestorWalker{
+			ancestors: []*corev1.Namespace{projectNsObj, orgNsObj},
+		}
+		handler := newLinkableTestHandler(fakeClient, shareUsers, walker)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.ListLinkableTemplatesRequest{
+			Scope: projectScopeRef(project),
+		})
+
+		resp, err := handler.ListLinkableTemplates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(resp.Msg.Templates) != 1 {
+			t.Fatalf("expected 1 linkable template, got %d", len(resp.Msg.Templates))
+		}
+		lt := resp.Msg.Templates[0]
+		if lt.Name != templateName {
+			t.Errorf("expected name %q, got %q", templateName, lt.Name)
+		}
+		if len(lt.Releases) != 2 {
+			t.Fatalf("expected 2 releases, got %d", len(lt.Releases))
+		}
+	})
+
+	t.Run("releases are sorted descending by version", func(t *testing.T) {
+		orgNsObj := orgNS(org)
+		projectNsObj := projectNS(project)
+		tmpl := enabledTemplateCM("org-"+org, templateName, "HTTPRoute", "Expose via gateway", false)
+		r1 := makeReleaseCMWithData("org-"+org, templateName, "1.0.0", validCue, "")
+		r2 := makeReleaseCMWithData("org-"+org, templateName, "1.5.0", validCue, "")
+		r3 := makeReleaseCMWithData("org-"+org, templateName, "2.0.0", validCue, "")
+
+		fakeClient := fake.NewClientset(orgNsObj, projectNsObj, tmpl, r1, r2, r3)
+		walker := &stubAncestorWalker{
+			ancestors: []*corev1.Namespace{projectNsObj, orgNsObj},
+		}
+		handler := newLinkableTestHandler(fakeClient, shareUsers, walker)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.ListLinkableTemplatesRequest{
+			Scope: projectScopeRef(project),
+		})
+
+		resp, err := handler.ListLinkableTemplates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		lt := resp.Msg.Templates[0]
+		if len(lt.Releases) != 3 {
+			t.Fatalf("expected 3 releases, got %d", len(lt.Releases))
+		}
+		expectedVersions := []string{"2.0.0", "1.5.0", "1.0.0"}
+		for i, r := range lt.Releases {
+			if r.Version != expectedVersions[i] {
+				t.Errorf("release %d: expected version %q, got %q", i, expectedVersions[i], r.Version)
+			}
+		}
+	})
+
+	t.Run("releases have cue_template and defaults stripped", func(t *testing.T) {
+		orgNsObj := orgNS(org)
+		projectNsObj := projectNS(project)
+		tmpl := enabledTemplateCM("org-"+org, templateName, "HTTPRoute", "Expose via gateway", false)
+		r1 := makeReleaseCMWithData("org-"+org, templateName, "1.0.0", validCue, `{"image":"nginx:1.0"}`)
+
+		fakeClient := fake.NewClientset(orgNsObj, projectNsObj, tmpl, r1)
+		walker := &stubAncestorWalker{
+			ancestors: []*corev1.Namespace{projectNsObj, orgNsObj},
+		}
+		handler := newLinkableTestHandler(fakeClient, shareUsers, walker)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.ListLinkableTemplatesRequest{
+			Scope: projectScopeRef(project),
+		})
+
+		resp, err := handler.ListLinkableTemplates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		lt := resp.Msg.Templates[0]
+		if len(lt.Releases) != 1 {
+			t.Fatalf("expected 1 release, got %d", len(lt.Releases))
+		}
+		release := lt.Releases[0]
+		if release.CueTemplate != "" {
+			t.Errorf("expected cue_template to be stripped, got %q", release.CueTemplate)
+		}
+		if release.Defaults != nil {
+			t.Errorf("expected defaults to be stripped, got %v", release.Defaults)
+		}
+		// Verify version and created_at are preserved.
+		if release.Version != "1.0.0" {
+			t.Errorf("expected version 1.0.0, got %q", release.Version)
+		}
+	})
+
+	t.Run("no releases for template returns empty releases slice", func(t *testing.T) {
+		orgNsObj := orgNS(org)
+		projectNsObj := projectNS(project)
+		tmpl := enabledTemplateCM("org-"+org, templateName, "HTTPRoute", "Expose via gateway", false)
+
+		fakeClient := fake.NewClientset(orgNsObj, projectNsObj, tmpl)
+		walker := &stubAncestorWalker{
+			ancestors: []*corev1.Namespace{projectNsObj, orgNsObj},
+		}
+		handler := newLinkableTestHandler(fakeClient, shareUsers, walker)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.ListLinkableTemplatesRequest{
+			Scope: projectScopeRef(project),
+		})
+
+		resp, err := handler.ListLinkableTemplates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		lt := resp.Msg.Templates[0]
+		if len(lt.Releases) != 0 {
+			t.Errorf("expected 0 releases, got %d", len(lt.Releases))
+		}
+	})
+}

--- a/console/templates/handler_updates_test.go
+++ b/console/templates/handler_updates_test.go
@@ -340,4 +340,149 @@ func TestCheckUpdates(t *testing.T) {
 			t.Errorf("expected update for %q, got %q", linkedTemplateName, resp.Msg.Updates[0].Ref.Name)
 		}
 	})
+
+	t.Run("include_current returns entries for up-to-date linked templates", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:             consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:         org,
+				Name:              linkedTemplateName,
+				VersionConstraint: ">=1.0.0 <2.0.0",
+			},
+		})
+		// Releases: 1.0.0 and 1.1.0 — already on latest compatible.
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		r2 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.1.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl, r1, r2)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:          projectScopeRef(project),
+			TemplateName:   "web-app",
+			IncludeCurrent: true,
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// include_current=true should return 1 entry even though already up-to-date.
+		if len(resp.Msg.Updates) != 1 {
+			t.Fatalf("expected 1 update (include_current=true), got %d", len(resp.Msg.Updates))
+		}
+		update := resp.Msg.Updates[0]
+		if update.CurrentVersion != "1.1.0" {
+			t.Errorf("expected current_version 1.1.0, got %q", update.CurrentVersion)
+		}
+		if update.LatestCompatibleVersion != "1.1.0" {
+			t.Errorf("expected latest_compatible_version 1.1.0, got %q", update.LatestCompatibleVersion)
+		}
+		if update.BreakingUpdateAvailable {
+			t.Error("expected breaking_update_available=false")
+		}
+	})
+
+	t.Run("include_current false preserves existing behavior", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:             consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:         org,
+				Name:              linkedTemplateName,
+				VersionConstraint: ">=1.0.0 <2.0.0",
+			},
+		})
+		// Releases: 1.0.0 and 1.1.0 — already on latest compatible.
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		r2 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.1.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl, r1, r2)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:          projectScopeRef(project),
+			TemplateName:   "web-app",
+			IncludeCurrent: false,
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// include_current=false (default): no updates when already on latest.
+		if len(resp.Msg.Updates) != 0 {
+			t.Fatalf("expected 0 updates (include_current=false), got %d", len(resp.Msg.Updates))
+		}
+	})
+
+	t.Run("include_current with no releases returns no entries", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName: org,
+				Name:      linkedTemplateName,
+			},
+		})
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:          projectScopeRef(project),
+			TemplateName:   "web-app",
+			IncludeCurrent: true,
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// No releases exist, so even include_current should produce nothing.
+		if len(resp.Msg.Updates) != 0 {
+			t.Errorf("expected 0 updates, got %d", len(resp.Msg.Updates))
+		}
+	})
+
+	t.Run("include_current with breaking update still reports breaking", func(t *testing.T) {
+		projectNs := projectNS(project)
+		tmpl := makeTemplateWithLinks("prj-"+project, "web-app", []*consolev1.LinkedTemplateRef{
+			{
+				Scope:             consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:         org,
+				Name:              linkedTemplateName,
+				VersionConstraint: ">=1.0.0 <2.0.0",
+			},
+		})
+		// Releases: 1.0.0, 1.5.0, 2.0.0 — breaking update exists.
+		r1 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.0.0")
+		r2 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "1.5.0")
+		r3 := makeReleaseCMInNS("org-"+org, linkedTemplateName, "2.0.0")
+		fakeClient := fake.NewClientset(projectNs, orgNS(org), tmpl, r1, r2, r3)
+		handler := newTestHandler(fakeClient, shareUsers)
+
+		ctx := authedCtx(ownerEmail, nil)
+		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
+			Scope:          projectScopeRef(project),
+			TemplateName:   "web-app",
+			IncludeCurrent: true,
+		})
+
+		resp, err := handler.CheckUpdates(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(resp.Msg.Updates) != 1 {
+			t.Fatalf("expected 1 update, got %d", len(resp.Msg.Updates))
+		}
+		update := resp.Msg.Updates[0]
+		if !update.BreakingUpdateAvailable {
+			t.Error("expected breaking_update_available=true")
+		}
+		if update.LatestVersion != "2.0.0" {
+			t.Errorf("expected latest_version 2.0.0, got %q", update.LatestVersion)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- ListLinkableTemplates handler now populates `releases` on each LinkableTemplate with all published releases for that template, sorted descending by version. Releases have `cue_template` and `defaults` stripped to keep the payload lightweight.
- CheckUpdates handler now supports the `include_current` flag: when true, returns a TemplateUpdate entry for every linked template even if already at the latest compatible version.
- When `include_current` is false (default), behavior is unchanged from current implementation.
- Added table-driven Go unit tests covering both new behaviors.

Closes #838

## Test plan
- [x] `make test` passes (829 tests)
- [x] New tests verify ListLinkableTemplates returns releases sorted descending
- [x] New tests verify releases have cue_template and defaults stripped
- [x] New tests verify include_current=true returns entries for up-to-date templates
- [x] New tests verify include_current=false preserves existing behavior
- [ ] CI: Unit Tests pass
- [ ] CI: Lint passes

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)