### PR TITLE
feat(frontend): migrate org template creation from modal to dedicated page

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/-org-templates.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/-org-templates.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
@@ -42,7 +42,6 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 import {
   useListTemplates,
   useGetTemplate,
-  useCreateTemplate,
   useUpdateTemplate,
   useCloneTemplate,
   useRenderTemplate,
@@ -83,10 +82,6 @@ function setupListMocks(userRole = Role.OWNER) {
     data: { name: 'test-org', userRole },
     isPending: false,
     error: null,
-  })
-  ;(useCreateTemplate as Mock).mockReturnValue({
-    mutateAsync: vi.fn().mockResolvedValue({}),
-    isPending: false,
   })
 }
 
@@ -148,7 +143,6 @@ describe('OrgTemplatesListPage', () => {
       error: null,
     })
     ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole: Role.OWNER }, isPending: false, error: null })
-    ;(useCreateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     render(<OrgTemplatesListPage orgName="test-org" />)
     expect(screen.queryByText('Mandatory')).not.toBeInTheDocument()
   })
@@ -172,7 +166,6 @@ describe('OrgTemplatesListPage', () => {
       error: null,
     })
     ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole: Role.OWNER }, isPending: false, error: null })
-    ;(useCreateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     render(<OrgTemplatesListPage orgName="test-org" />)
     // Should not crash; skeleton elements rendered
     expect(screen.queryByText('reference-grant')).not.toBeInTheDocument()
@@ -185,7 +178,6 @@ describe('OrgTemplatesListPage', () => {
       error: new Error('Failed to load templates'),
     })
     ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole: Role.OWNER }, isPending: false, error: null })
-    ;(useCreateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     render(<OrgTemplatesListPage orgName="test-org" />)
     expect(screen.getByText('Failed to load templates')).toBeInTheDocument()
   })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/-org-templates.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/-org-templates.test.tsx
@@ -190,82 +190,25 @@ describe('OrgTemplatesListPage', () => {
     expect(screen.getByText('Failed to load templates')).toBeInTheDocument()
   })
 
-  describe('create template button and dialog', () => {
-    it('shows Create Template button for org OWNER', () => {
+  describe('create template link', () => {
+    it('shows Create Template link for org OWNER', () => {
       setupListMocks(Role.OWNER)
       render(<OrgTemplatesListPage orgName="test-org" />)
       expect(screen.getByRole('button', { name: /create template/i })).toBeInTheDocument()
     })
 
-    it('does not show Create Template button for org VIEWER', () => {
+    it('does not show Create Template link for org VIEWER', () => {
       setupListMocks(Role.VIEWER)
       render(<OrgTemplatesListPage orgName="test-org" />)
       expect(screen.queryByRole('button', { name: /create template/i })).not.toBeInTheDocument()
     })
 
-    it('clicking Create Template opens dialog', async () => {
+    it('Create Template button is wrapped in a link to the new page', () => {
       setupListMocks(Role.OWNER)
-      const user = userEvent.setup()
       render(<OrgTemplatesListPage orgName="test-org" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      expect(screen.getByRole('dialog')).toBeInTheDocument()
-    })
-
-    it('create dialog has enabled toggle defaulting to disabled', async () => {
-      setupListMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<OrgTemplatesListPage orgName="test-org" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const toggle = screen.getByRole('switch', { name: /enabled/i })
-      expect(toggle).toBeInTheDocument()
-      expect(toggle).toHaveAttribute('data-state', 'unchecked')
-    })
-
-    it('confirming create calls createOrgTemplate with enabled state', async () => {
-      setupListMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<OrgTemplatesListPage orgName="test-org" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const nameInput = screen.getByRole('textbox', { name: /^name$/i })
-      await user.type(nameInput, 'my-template')
-      // Toggle enabled on
-      await user.click(screen.getByRole('switch', { name: /enabled/i }))
-      await user.click(screen.getByRole('button', { name: /^create$/i }))
-      const mutateAsync = (useCreateTemplate as Mock).mock.results[0].value.mutateAsync
-      await waitFor(() => {
-        expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({
-          name: 'my-template',
-          enabled: true,
-        }))
-      })
-    })
-
-    it('create with enabled defaulting to false passes disabled to createOrgTemplate', async () => {
-      setupListMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<OrgTemplatesListPage orgName="test-org" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      const nameInput = screen.getByRole('textbox', { name: /^name$/i })
-      await user.type(nameInput, 'my-template')
-      await user.click(screen.getByRole('button', { name: /^create$/i }))
-      const mutateAsync = (useCreateTemplate as Mock).mock.results[0].value.mutateAsync
-      await waitFor(() => {
-        expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({
-          name: 'my-template',
-          enabled: false,
-        }))
-      })
-    })
-
-    it('cancel closes create dialog without saving', async () => {
-      setupListMocks(Role.OWNER)
-      const user = userEvent.setup()
-      render(<OrgTemplatesListPage orgName="test-org" />)
-      await user.click(screen.getByRole('button', { name: /create template/i }))
-      await user.click(screen.getByRole('button', { name: /cancel/i }))
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-      const mutateAsync = (useCreateTemplate as Mock).mock.results[0].value.mutateAsync
-      expect(mutateAsync).not.toHaveBeenCalled()
+      const button = screen.getByRole('button', { name: /create template/i })
+      const link = button.closest('a')
+      expect(link).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
@@ -18,7 +18,6 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 
 vi.mock('@/queries/templates', () => ({
   useListTemplates: vi.fn(),
-  useCreateTemplate: vi.fn(),
   makeOrgScope: vi.fn().mockReturnValue({ scope: 2, scopeName: 'test-org' }),
 }))
 
@@ -26,76 +25,73 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-
-import { useListTemplates, useCreateTemplate } from '@/queries/templates'
+import { useListTemplates } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { OrgTemplatesListPage } from './index'
 
-function setupMocks(userRole = Role.OWNER) {
-  ;(useListTemplates as Mock).mockReturnValue({ data: [], isPending: false, error: null })
+function setupMocks(userRole = Role.OWNER, templates: Array<{ name: string; description?: string; mandatory?: boolean; enabled?: boolean }> = []) {
+  ;(useListTemplates as Mock).mockReturnValue({ data: templates, isPending: false, error: null })
   ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole } })
-  ;(useCreateTemplate as Mock).mockReturnValue({
-    mutateAsync: vi.fn().mockResolvedValue({}),
-    isPending: false,
-  })
 }
 
-describe('OrgTemplatesListPage - Load httpbin Example button', () => {
+describe('OrgTemplatesListPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('renders Load httpbin Example button for ORG_OWNER after opening create dialog', async () => {
+  it('renders Create Template link button for OWNER', () => {
     setupMocks(Role.OWNER)
     render(<OrgTemplatesListPage orgName="test-org" />)
-    fireEvent.click(screen.getByRole('button', { name: /create template/i }))
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /load httpbin example/i })).toBeInTheDocument()
-    })
+    const link = screen.getByRole('link', { name: /create template/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/orgs/$orgName/settings/org-templates/new')
   })
 
-  it('does NOT render Load httpbin Example button for VIEWER (create button not shown)', () => {
+  it('does NOT render Create Template link for VIEWER', () => {
     setupMocks(Role.VIEWER)
     render(<OrgTemplatesListPage orgName="test-org" />)
-    expect(screen.queryByRole('button', { name: /create template/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /load httpbin example/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /create template/i })).not.toBeInTheDocument()
   })
 
-  it('clicking Load httpbin Example populates the name field', async () => {
+  it('renders the empty state when no templates exist', () => {
     setupMocks(Role.OWNER)
     render(<OrgTemplatesListPage orgName="test-org" />)
-    fireEvent.click(screen.getByRole('button', { name: /create template/i }))
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /load httpbin example/i })).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByRole('button', { name: /load httpbin example/i }))
-    const nameInput = screen.getByRole('textbox', { name: /^name$/i }) as HTMLInputElement
-    expect(nameInput.value).toBe('httpbin-platform')
+    expect(screen.getByText(/no platform templates found/i)).toBeInTheDocument()
   })
 
-  it('clicking Load httpbin Example populates the display name field', async () => {
-    setupMocks(Role.OWNER)
+  it('renders template list items', () => {
+    setupMocks(Role.OWNER, [
+      { name: 'httpbin-platform', description: 'HTTPRoute for gateway', mandatory: false, enabled: true },
+      { name: 'lockdown', description: 'Restrict kinds', mandatory: true, enabled: false },
+    ])
     render(<OrgTemplatesListPage orgName="test-org" />)
-    fireEvent.click(screen.getByRole('button', { name: /create template/i }))
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /load httpbin example/i })).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByRole('button', { name: /load httpbin example/i }))
-    const displayNameInput = screen.getByRole('textbox', { name: /display name/i }) as HTMLInputElement
-    expect(displayNameInput.value).toBe('httpbin Platform')
+    expect(screen.getByText('httpbin-platform')).toBeInTheDocument()
+    expect(screen.getByText('lockdown')).toBeInTheDocument()
+    expect(screen.getByText('Mandatory')).toBeInTheDocument()
+    expect(screen.getByText('Enabled')).toBeInTheDocument()
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
   })
 
-  it('clicking Load httpbin Example populates the description field', async () => {
+  it('renders loading skeleton when isPending', () => {
+    ;(useListTemplates as Mock).mockReturnValue({ data: undefined, isPending: true, error: null })
+    ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole: Role.OWNER } })
+    render(<OrgTemplatesListPage orgName="test-org" />)
+    // Skeleton elements do not have accessible names, but the Create Template button should not be visible
+    expect(screen.queryByRole('link', { name: /create template/i })).not.toBeInTheDocument()
+  })
+
+  it('renders error alert when query fails', () => {
+    ;(useListTemplates as Mock).mockReturnValue({ data: undefined, isPending: false, error: new Error('fetch failed') })
+    ;(useGetOrganization as Mock).mockReturnValue({ data: { userRole: Role.OWNER } })
+    render(<OrgTemplatesListPage orgName="test-org" />)
+    expect(screen.getByText(/fetch failed/i)).toBeInTheDocument()
+  })
+
+  it('renders breadcrumb path with org name', () => {
     setupMocks(Role.OWNER)
     render(<OrgTemplatesListPage orgName="test-org" />)
-    fireEvent.click(screen.getByRole('button', { name: /create template/i }))
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /load httpbin example/i })).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByRole('button', { name: /load httpbin example/i }))
-    const descInput = screen.getByRole('textbox', { name: /description/i }) as HTMLInputElement
-    expect(descInput.value).toContain('HTTPRoute')
+    // The breadcrumb line contains the orgName and "Platform Templates" text
+    expect(screen.getByText(/test-org/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-new.test.tsx
@@ -170,8 +170,9 @@ describe('CreateOrgTemplatePage', () => {
 
   it('renders breadcrumb navigation', () => {
     render(<CreateOrgTemplatePage orgName="test-org" />)
-    expect(screen.getByText('Platform Templates')).toBeInTheDocument()
     expect(screen.getByText('test-org')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.getByText('Platform Templates')).toBeInTheDocument()
   })
 
   describe('Load httpbin Example button', () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-new.test.tsx
@@ -1,0 +1,246 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org' }),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({ children, className, to, params }: { children: React.ReactNode; className?: string; to?: string; params?: Record<string, string> }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>{children}</a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templates', () => ({
+  useCreateTemplate: vi.fn(),
+  makeOrgScope: vi.fn().mockReturnValue({ scope: 2, scopeName: 'test-org' }),
+}))
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { useCreateTemplate } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateOrgTemplatePage } from './new'
+
+function setupMocks(
+  mutateAsync = vi.fn().mockResolvedValue({}),
+  userRole = Role.OWNER,
+) {
+  ;(useCreateTemplate as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+    reset: vi.fn(),
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('CreateOrgTemplatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page heading', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByText(/create platform template/i)).toBeInTheDocument()
+  })
+
+  it('renders Display Name field', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+  })
+
+  it('renders Name (slug) field', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByLabelText(/name slug/i)).toBeInTheDocument()
+  })
+
+  it('renders Description field', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders CUE Template textarea', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByRole('textbox', { name: /cue template/i })).toBeInTheDocument()
+  })
+
+  it('renders Enabled switch defaulting to unchecked', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    const toggle = screen.getByRole('switch', { name: /enabled/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders Create submit button', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeInTheDocument()
+  })
+
+  it('renders a Cancel link back to the templates list', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByRole('link', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('auto-derives slug from display name', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    const displayNameInput = screen.getByLabelText(/display name/i)
+    fireEvent.change(displayNameInput, { target: { value: 'My Web App' } })
+    const slugInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
+    expect(slugInput.value).toBe('my-web-app')
+  })
+
+  it('shows validation error when name is empty', async () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/template name is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('calls createMutation with form values on submit', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(mutateAsync)
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'A description' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'my-template',
+          displayName: 'My Template',
+          description: 'A description',
+          mandatory: false,
+          enabled: false,
+        }),
+      )
+    })
+  })
+
+  it('navigates to template detail page after successful creation', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(mutateAsync)
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '/orgs/$orgName/settings/org-templates/$templateName',
+          params: expect.objectContaining({ orgName: 'test-org', templateName: 'my-template' }),
+        }),
+      )
+    })
+  })
+
+  it('shows error message when creation fails', async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(new Error('server error'))
+    setupMocks(mutateAsync)
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/server error/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders breadcrumb navigation', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByText('Platform Templates')).toBeInTheDocument()
+    expect(screen.getByText('test-org')).toBeInTheDocument()
+  })
+
+  describe('Load httpbin Example button', () => {
+    it('renders Load httpbin Example button', () => {
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+      expect(screen.getByRole('button', { name: /load httpbin example/i })).toBeInTheDocument()
+    })
+
+    it('clicking Load httpbin Example populates all form fields', () => {
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+      fireEvent.click(screen.getByRole('button', { name: /load httpbin example/i }))
+
+      const nameInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
+      expect(nameInput.value).toBe('httpbin-platform')
+
+      const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement
+      expect(displayNameInput.value).toBe('httpbin Platform')
+
+      const descriptionInput = screen.getByLabelText(/description/i) as HTMLInputElement
+      expect(descriptionInput.value).toContain('HTTPRoute')
+
+      const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
+      expect(cueEditor.value).toContain('HTTPRoute')
+      expect(cueEditor.value).toContain('platformResources')
+    })
+  })
+
+  describe('Enabled switch', () => {
+    it('passes enabled: true when toggle is switched on', async () => {
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks(mutateAsync)
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+
+      fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+      fireEvent.click(screen.getByRole('switch', { name: /enabled/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            enabled: true,
+          }),
+        )
+      })
+    })
+  })
+
+  describe('permissions', () => {
+    it('disables form fields for non-OWNER users', () => {
+      setupMocks(vi.fn().mockResolvedValue({}), Role.VIEWER)
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+
+      expect(screen.getByLabelText(/display name/i)).toBeDisabled()
+      expect(screen.getByLabelText(/name slug/i)).toBeDisabled()
+      expect(screen.getByLabelText(/description/i)).toBeDisabled()
+      expect(screen.getByRole('textbox', { name: /cue template/i })).toBeDisabled()
+      expect(screen.getByRole('switch', { name: /enabled/i })).toBeDisabled()
+      expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+    })
+
+    it('enables form fields for OWNER users', () => {
+      setupMocks(vi.fn().mockResolvedValue({}), Role.OWNER)
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+
+      expect(screen.getByLabelText(/display name/i)).not.toBeDisabled()
+      expect(screen.getByLabelText(/name slug/i)).not.toBeDisabled()
+      expect(screen.getByLabelText(/description/i)).not.toBeDisabled()
+      expect(screen.getByRole('textbox', { name: /cue template/i })).not.toBeDisabled()
+      expect(screen.getByRole('button', { name: /^create$/i })).not.toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/index.tsx
@@ -1,105 +1,14 @@
-import { useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { toast } from 'sonner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
 import { Badge } from '@/components/ui/badge'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Lock, Info } from 'lucide-react'
+import { Lock } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useListTemplates, useCreateTemplate, makeOrgScope } from '@/queries/templates'
+import { useListTemplates, makeOrgScope } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-
-// EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE is the example org-level platform template CUE content.
-// It matches console/org_templates/example_httpbin_platform.cue.
-const EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE = `// Org-level platform template — evaluated at organization scope.
-// Any changes here affect every project in the org.
-//
-// This template does two things:
-//  1. Provides an HTTPRoute in platformResources so the gateway routes
-//     traffic to the deployment's Service.
-//  2. Closes projectResources.namespacedResources to Deployment, Service,
-//     and ServiceAccount (ADR 016 Decision 9) so project templates cannot
-//     produce any other resource kind.
-//
-// Pair with console/templates/example_httpbin.cue for the project-level template.
-
-// input and platform are available because platform templates are unified with
-// the deployment template before evaluation (ADR 016 Decision 8).
-input: #ProjectInput & {
-	port: >0 & <=65535 | *8080
-}
-platform: #PlatformInput
-
-// ── Platform resources (managed by the platform team) ───────────────────────
-
-// platformResources holds resources the platform team manages. The renderer
-// reads these only from organization/folder-level templates — project templates
-// that define platformResources are silently ignored (ADR 016 Decision 8).
-platformResources: {
-	namespacedResources: (platform.namespace): {
-		// HTTPRoute exposes the deployment's Service via the gateway.
-		// It routes all traffic from the gateway to the Service named input.name
-		// on port 80 (the Service port, which forwards to containerPort input.port).
-		HTTPRoute: (input.name): {
-			apiVersion: "gateway.networking.k8s.io/v1"
-			kind:       "HTTPRoute"
-			metadata: {
-				name:      input.name
-				namespace: platform.namespace
-				labels: {
-					"app.kubernetes.io/managed-by": "console.holos.run"
-					"app.kubernetes.io/name":       input.name
-				}
-			}
-			spec: {
-				parentRefs: [{
-					group:     "gateway.networking.k8s.io"
-					kind:      "Gateway"
-					namespace: platform.gatewayNamespace
-					name:      "default"
-				}]
-				rules: [{
-					backendRefs: [{
-						name: input.name
-						port: 80
-					}]
-				}]
-			}
-		}
-	}
-	clusterResources: {}
-}
-
-// ── Project resource constraints (enforced by the platform team) ─────────────
-
-// Close projectResources.namespacedResources so that every namespace bucket
-// may only contain Deployment, Service, or ServiceAccount. Using close() with
-// optional fields is the correct CUE pattern: the close() call marks the struct
-// as closed (no additional fields allowed), and the ? marks each listed field
-// as optional (a namespace bucket need not contain all three). Any unlisted
-// Kind key — such as RoleBinding — is a CUE constraint violation at evaluation
-// time, before any Kubernetes API call (ADR 016 Decision 9).
-projectResources: namespacedResources: [_]: close({
-	Deployment?:     _
-	Service?:        _
-	ServiceAccount?: _
-})
-`
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/org-templates/')({
   component: OrgTemplatesListRoute,
@@ -123,57 +32,9 @@ export function OrgTemplatesListPage({ orgName: propOrgName }: { orgName?: strin
   const scope = makeOrgScope(orgName)
   const { data: templates, isPending, error } = useListTemplates(scope)
   const { data: org } = useGetOrganization(orgName)
-  const createMutation = useCreateTemplate(scope)
-
-  const [createOpen, setCreateOpen] = useState(false)
-  const [createName, setCreateName] = useState('')
-  const [createDisplayName, setCreateDisplayName] = useState('')
-  const [createDescription, setCreateDescription] = useState('')
-  const [createCueTemplate, setCreateCueTemplate] = useState('')
-  const [createEnabled, setCreateEnabled] = useState(false)
-  const [createError, setCreateError] = useState<string | null>(null)
 
   const userRole = org?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER
-
-  const handleOpenCreate = () => {
-    setCreateName('')
-    setCreateDisplayName('')
-    setCreateDescription('')
-    setCreateCueTemplate('')
-    setCreateEnabled(false)
-    setCreateError(null)
-    setCreateOpen(true)
-  }
-
-  const handleLoadHttpbinExample = () => {
-    setCreateName('httpbin-platform')
-    setCreateDisplayName('httpbin Platform')
-    setCreateDescription('Provides an HTTPRoute for gateway access and constrains project templates to Deployment, Service, and ServiceAccount only.')
-    setCreateCueTemplate(EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE)
-  }
-
-  const handleCreateConfirm = async () => {
-    if (!createName.trim()) {
-      setCreateError('Name is required')
-      return
-    }
-    setCreateError(null)
-    try {
-      await createMutation.mutateAsync({
-        name: createName.trim(),
-        displayName: createDisplayName.trim(),
-        description: createDescription.trim(),
-        cueTemplate: createCueTemplate,
-        mandatory: false,
-        enabled: createEnabled,
-      })
-      toast.success(`Created platform template "${createName}"`)
-      setCreateOpen(false)
-    } catch (err) {
-      setCreateError(err instanceof Error ? err.message : String(err))
-    }
-  }
 
   if (isPending) {
     return (
@@ -200,144 +61,64 @@ export function OrgTemplatesListPage({ orgName: propOrgName }: { orgName?: strin
   }
 
   return (
-    <>
-      <Card>
-        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-          <div>
-            <p className="text-sm text-muted-foreground">{orgName} / Settings / Platform Templates</p>
-            <CardTitle className="mt-1">Platform Templates</CardTitle>
-          </div>
-          {canWrite && (
-            <Button size="sm" onClick={handleOpenCreate}>Create Template</Button>
-          )}
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-sm text-muted-foreground">
-            Platform templates are automatically applied to project namespaces when projects are created.
-            Mandatory templates are marked with a lock badge.
-          </p>
-          <Separator />
-          {templates && templates.length > 0 ? (
-            <ul className="space-y-2">
-              {templates.map((tmpl) => (
-                <li key={tmpl.name}>
-                  <Link
-                    to="/orgs/$orgName/settings/org-templates/$templateName"
-                    params={{ orgName, templateName: tmpl.name }}
-                    className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium font-mono">{tmpl.name}</span>
-                        {tmpl.mandatory && (
-                          <Badge variant="secondary" className="flex items-center gap-1 text-xs">
-                            <Lock className="h-3 w-3" />
-                            Mandatory
-                          </Badge>
-                        )}
-                        {tmpl.enabled ? (
-                          <Badge variant="outline" className="text-xs text-green-500 border-green-500/30">
-                            Enabled
-                          </Badge>
-                        ) : (
-                          <Badge variant="outline" className="text-xs text-muted-foreground">
-                            Disabled
-                          </Badge>
-                        )}
-                      </div>
-                      {tmpl.description && (
-                        <p className="text-xs text-muted-foreground truncate mt-0.5">{tmpl.description}</p>
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+        <div>
+          <p className="text-sm text-muted-foreground">{orgName} / Settings / Platform Templates</p>
+          <CardTitle className="mt-1">Platform Templates</CardTitle>
+        </div>
+        {canWrite && (
+          <Link to="/orgs/$orgName/settings/org-templates/new" params={{ orgName }}>
+            <Button size="sm">Create Template</Button>
+          </Link>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Platform templates are automatically applied to project namespaces when projects are created.
+          Mandatory templates are marked with a lock badge.
+        </p>
+        <Separator />
+        {templates && templates.length > 0 ? (
+          <ul className="space-y-2">
+            {templates.map((tmpl) => (
+              <li key={tmpl.name}>
+                <Link
+                  to="/orgs/$orgName/settings/org-templates/$templateName"
+                  params={{ orgName, templateName: tmpl.name }}
+                  className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium font-mono">{tmpl.name}</span>
+                      {tmpl.mandatory && (
+                        <Badge variant="secondary" className="flex items-center gap-1 text-xs">
+                          <Lock className="h-3 w-3" />
+                          Mandatory
+                        </Badge>
+                      )}
+                      {tmpl.enabled ? (
+                        <Badge variant="outline" className="text-xs text-green-500 border-green-500/30">
+                          Enabled
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-xs text-muted-foreground">
+                          Disabled
+                        </Badge>
                       )}
                     </div>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-sm text-muted-foreground">No platform templates found.</p>
-          )}
-        </CardContent>
-      </Card>
-
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Create Platform Template</DialogTitle>
-            <DialogDescription>
-              Create a new platform template for organization &quot;{orgName}&quot;.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={handleLoadHttpbinExample}>
-                Load httpbin Example
-              </Button>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="h-4 w-4 text-muted-foreground cursor-default" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Platform templates are unified with project deployment templates at render time via CUE. This example constrains project resources to safe kinds and provides an HTTPRoute for external access.</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="create-name">Name</Label>
-              <Input
-                id="create-name"
-                aria-label="Name"
-                value={createName}
-                onChange={(e) => setCreateName(e.target.value)}
-                placeholder="my-template"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="create-display-name">Display Name</Label>
-              <Input
-                id="create-display-name"
-                aria-label="Display Name"
-                value={createDisplayName}
-                onChange={(e) => setCreateDisplayName(e.target.value)}
-                placeholder="My Template"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="create-description">Description</Label>
-              <Input
-                id="create-description"
-                aria-label="Description"
-                value={createDescription}
-                onChange={(e) => setCreateDescription(e.target.value)}
-                placeholder="What does this template produce?"
-              />
-            </div>
-            <div className="flex items-center gap-3">
-              <Switch
-                id="create-enabled"
-                aria-label="Enabled"
-                checked={createEnabled}
-                onCheckedChange={setCreateEnabled}
-              />
-              <Label htmlFor="create-enabled" className="text-sm cursor-pointer">
-                Enabled (apply to new project namespaces)
-              </Label>
-            </div>
-          </div>
-          {createError && (
-            <Alert variant="destructive">
-              <AlertDescription>{createError}</AlertDescription>
-            </Alert>
-          )}
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setCreateOpen(false)}>Cancel</Button>
-            <Button onClick={handleCreateConfirm} disabled={createMutation.isPending || !createName}>
-              {createMutation.isPending ? 'Creating...' : 'Create'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+                    {tmpl.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">{tmpl.description}</p>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">No platform templates found.</p>
+        )}
+      </CardContent>
+    </Card>
   )
 }

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/new.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/new.tsx
@@ -174,6 +174,10 @@ export function CreateOrgTemplatePage({ orgName: propOrgName }: { orgName?: stri
               {orgName}
             </Link>
             {' / '}
+            <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+              Settings
+            </Link>
+            {' / '}
             <Link
               to="/orgs/$orgName/settings/org-templates"
               params={{ orgName }}
@@ -181,7 +185,7 @@ export function CreateOrgTemplatePage({ orgName: propOrgName }: { orgName?: stri
             >
               Platform Templates
             </Link>
-            {' / New'}
+            {' / Create'}
           </p>
           <CardTitle className="mt-1">Create Platform Template</CardTitle>
         </div>

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/new.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/new.tsx
@@ -1,0 +1,294 @@
+import { useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Info } from 'lucide-react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplate, makeOrgScope } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+
+// EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE is the example org-level platform template CUE content.
+// It matches console/org_templates/example_httpbin_platform.cue.
+const EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE = `// Org-level platform template — evaluated at organization scope.
+// Any changes here affect every project in the org.
+//
+// This template does two things:
+//  1. Provides an HTTPRoute in platformResources so the gateway routes
+//     traffic to the deployment's Service.
+//  2. Closes projectResources.namespacedResources to Deployment, Service,
+//     and ServiceAccount (ADR 016 Decision 9) so project templates cannot
+//     produce any other resource kind.
+//
+// Pair with console/templates/example_httpbin.cue for the project-level template.
+
+// input and platform are available because platform templates are unified with
+// the deployment template before evaluation (ADR 016 Decision 8).
+input: #ProjectInput & {
+	port: >0 & <=65535 | *8080
+}
+platform: #PlatformInput
+
+// ── Platform resources (managed by the platform team) ───────────────────────
+
+// platformResources holds resources the platform team manages. The renderer
+// reads these only from organization/folder-level templates — project templates
+// that define platformResources are silently ignored (ADR 016 Decision 8).
+platformResources: {
+	namespacedResources: (platform.namespace): {
+		// HTTPRoute exposes the deployment's Service via the gateway.
+		// It routes all traffic from the gateway to the Service named input.name
+		// on port 80 (the Service port, which forwards to containerPort input.port).
+		HTTPRoute: (input.name): {
+			apiVersion: "gateway.networking.k8s.io/v1"
+			kind:       "HTTPRoute"
+			metadata: {
+				name:      input.name
+				namespace: platform.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+					"app.kubernetes.io/name":       input.name
+				}
+			}
+			spec: {
+				parentRefs: [{
+					group:     "gateway.networking.k8s.io"
+					kind:      "Gateway"
+					namespace: platform.gatewayNamespace
+					name:      "default"
+				}]
+				rules: [{
+					backendRefs: [{
+						name: input.name
+						port: 80
+					}]
+				}]
+			}
+		}
+	}
+	clusterResources: {}
+}
+
+// ── Project resource constraints (enforced by the platform team) ─────────────
+
+// Close projectResources.namespacedResources so that every namespace bucket
+// may only contain Deployment, Service, or ServiceAccount. Using close() with
+// optional fields is the correct CUE pattern: the close() call marks the struct
+// as closed (no additional fields allowed), and the ? marks each listed field
+// as optional (a namespace bucket need not contain all three). Any unlisted
+// Kind key — such as RoleBinding — is a CUE constraint violation at evaluation
+// time, before any Kubernetes API call (ADR 016 Decision 9).
+projectResources: namespacedResources: [_]: close({
+	Deployment?:     _
+	Service?:        _
+	ServiceAccount?: _
+})
+`
+
+export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/org-templates/new')({
+  component: CreateOrgTemplateRoute,
+})
+
+function CreateOrgTemplateRoute() {
+  const { orgName } = Route.useParams()
+  return <CreateOrgTemplatePage orgName={orgName} />
+}
+
+export function CreateOrgTemplatePage({ orgName: propOrgName }: { orgName?: string } = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const navigate = useNavigate()
+  const scope = makeOrgScope(orgName)
+  const createMutation = useCreateTemplate(scope)
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER
+
+  const [displayName, setDisplayName] = useState('')
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [cueTemplate, setCueTemplate] = useState('')
+  const [enabled, setEnabled] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const slugify = (val: string) =>
+    val.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+
+  const handleDisplayNameChange = (val: string) => {
+    setDisplayName(val)
+    setName(slugify(val))
+  }
+
+  const handleLoadHttpbinExample = () => {
+    setName('httpbin-platform')
+    setDisplayName('httpbin Platform')
+    setDescription(
+      'Provides an HTTPRoute for gateway access and constrains project templates to Deployment, Service, and ServiceAccount only.',
+    )
+    setCueTemplate(EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE)
+  }
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      setError('Template name is required')
+      return
+    }
+    setError(null)
+    try {
+      await createMutation.mutateAsync({
+        name: name.trim(),
+        displayName: displayName.trim(),
+        description: description.trim(),
+        cueTemplate,
+        mandatory: false,
+        enabled,
+      })
+      await navigate({
+        to: '/orgs/$orgName/settings/org-templates/$templateName',
+        params: { orgName, templateName: name.trim() },
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+              {orgName}
+            </Link>
+            {' / '}
+            <Link
+              to="/orgs/$orgName/settings/org-templates"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              Platform Templates
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">Create Platform Template</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="template-display-name">Display Name</Label>
+            <Input
+              id="template-display-name"
+              aria-label="Display Name"
+              autoFocus
+              value={displayName}
+              onChange={(e) => handleDisplayNameChange(e.target.value)}
+              placeholder="My Template"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <Label>Name (slug)</Label>
+            <Input
+              aria-label="Name slug"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-template"
+              disabled={!canWrite}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Auto-derived from display name. Lowercase alphanumeric and hyphens only.
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="template-description">Description</Label>
+            <Input
+              id="template-description"
+              aria-label="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this template produce?"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <Label htmlFor="template-cue-template">CUE Template</Label>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" type="button" onClick={handleLoadHttpbinExample} disabled={!canWrite}>
+                  Load httpbin Example
+                </Button>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info className="h-4 w-4 text-muted-foreground cursor-default" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>
+                        Platform templates are unified with project deployment templates at render
+                        time via CUE. This example constrains project resources to safe kinds and
+                        provides an HTTPRoute for external access.
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            </div>
+            <Textarea
+              id="template-cue-template"
+              aria-label="CUE Template"
+              value={cueTemplate}
+              onChange={(e) => setCueTemplate(e.target.value)}
+              rows={20}
+              className="font-mono text-sm field-sizing-normal max-h-[600px] overflow-y-auto"
+              disabled={!canWrite}
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="template-enabled"
+              aria-label="Enabled"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+              disabled={!canWrite}
+            />
+            <Label htmlFor="template-enabled" className="text-sm cursor-pointer">
+              Enabled (apply to new project namespaces)
+            </Label>
+          </div>
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="flex items-center gap-3 pt-2">
+            <Button onClick={handleCreate} disabled={createMutation.isPending || !canWrite}>
+              {createMutation.isPending ? 'Creating...' : 'Create'}
+            </Button>
+            <Link
+              to="/orgs/$orgName/settings/org-templates"
+              params={{ orgName }}
+            >
+              <Button variant="ghost" type="button" aria-label="Cancel">
+                Cancel
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- Added new route `/orgs/$orgName/settings/org-templates/new` with a Card layout matching the folder template new.tsx pattern
- Form fields: Display Name (auto-slugifies to Name), Name (slug), Description, CUE Template (textarea with field-sizing-normal), Enabled switch
- "Load httpbin Example" button pre-fills the EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE content
- "Create" button calls useCreateTemplate(makeOrgScope(orgName)) and navigates to the template detail page on success
- "Cancel" button links back to the org templates list
- Replaced the "Create Template" button on the index page with a Link to the new page
- Removed all modal-related code from index.tsx: Dialog imports, state, handlers, mutation, and JSX
- Updated tests: 19 new tests for the create page, rewrote index tests for Link-based button, cleaned up stale imports from -org-templates.test.tsx

Closes #834

## Test plan
- [ ] `make test` passes (54 test files, 846 tests)
- [ ] Navigating to `/orgs/$orgName/settings/org-templates/new` renders the create form
- [ ] Display Name auto-derives the slug in the Name field
- [ ] "Load httpbin Example" populates all form fields
- [ ] Creating a template navigates to the detail page
- [ ] "Cancel" returns to the templates list
- [ ] VIEWER role cannot see the Create Template link on the index page
- [ ] VIEWER role sees disabled form fields on the create page

Generated with [Claude Code](https://claude.com/claude-code)