### PR TITLE
feat(ui): version-aware linking dialog with release selection

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   Dialog,
@@ -68,6 +69,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const [cloneError, setCloneError] = useState<string | null>(null)
   const [linkedEditOpen, setLinkedEditOpen] = useState(false)
   const [draftLinkedTemplateKeys, setDraftLinkedTemplateKeys] = useState<string[]>([])
+  const [draftVersionConstraints, setDraftVersionConstraints] = useState<Map<string, string>>(new Map())
   const [linkedEditError, setLinkedEditError] = useState<string | null>(null)
   const [upgradeOpen, setUpgradeOpen] = useState(false)
 
@@ -127,17 +129,23 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
 
   const handleOpenLinkedEdit = () => {
     setDraftLinkedTemplateKeys((template?.linkedTemplates ?? []).map(t => linkableKey(t.scope, t.scopeName, t.name)))
+    const vcMap = new Map<string, string>()
+    for (const lt of template?.linkedTemplates ?? []) {
+      vcMap.set(linkableKey(lt.scope, lt.scopeName, lt.name), lt.versionConstraint ?? '')
+    }
+    setDraftVersionConstraints(vcMap)
     setLinkedEditError(null)
     setLinkedEditOpen(true)
   }
 
   const handleSaveLinkedTemplates = async () => {
     try {
-      // Parse composite keys back into LinkedTemplateRef objects.
+      // Parse composite keys back into LinkedTemplateRef objects with version constraints.
       const linkedTemplates: LinkedTemplateRef[] = draftLinkedTemplateKeys
         .map((key) => {
           const parsed = parseLinkableKey(key)
-          return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name } as LinkedTemplateRef
+          const vc = draftVersionConstraints.get(key) ?? ''
+          return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name, versionConstraint: vc } as LinkedTemplateRef
         })
       await updateMutation.mutateAsync({ linkedTemplates, updateLinkedTemplates: true })
       toast.success('Saved')
@@ -422,6 +430,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
               const renderGroup = (templates: typeof linkableTemplates) =>
                 templates.map((t) => {
                   const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                  const hasReleases = t.releases && t.releases.length > 0
                   return (
                   <div key={key} className="flex items-start gap-2">
                     <Checkbox
@@ -435,7 +444,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                         )
                       }}
                     />
-                    <div className="flex flex-col">
+                    <div className="flex flex-col gap-1 flex-1">
                       <label htmlFor={`linked-edit-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
                         {t.displayName || t.name}
                         {t.mandatory && (
@@ -452,19 +461,31 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                         )}
                       </label>
                       {t.description && (
-                        <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                        <p className="text-xs text-muted-foreground">{t.description}</p>
                       )}
-                      {(() => {
-                        const linkedRef = (template?.linkedTemplates ?? []).find(
-                          (lt) => lt.scope === t.scopeRef?.scope && lt.scopeName === t.scopeRef?.scopeName && lt.name === t.name
-                        )
-                        if (!linkedRef?.versionConstraint) return null
-                        return (
-                          <span className="text-xs font-mono text-muted-foreground mt-0.5">
-                            Version: {linkedRef.versionConstraint}
-                          </span>
-                        )
-                      })()}
+                      {hasReleases && (
+                        <Select
+                          value={draftVersionConstraints.get(key) ?? ''}
+                          onValueChange={(val) => {
+                            setDraftVersionConstraints((prev) => {
+                              const next = new Map(prev)
+                              next.set(key, val === '__latest__' ? '' : val)
+                              return next
+                            })
+                          }}
+                          disabled={t.mandatory || !canEditLinks}
+                        >
+                          <SelectTrigger size="sm" className="w-40 text-xs">
+                            <SelectValue placeholder="Latest (auto-update)" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="__latest__">Latest (auto-update)</SelectItem>
+                            {t.releases.map((r) => (
+                              <SelectItem key={r.version} value={r.version}>{r.version}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
                     </div>
                   </div>
                   )

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-version-selector.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-version-selector.test.tsx
@@ -1,0 +1,459 @@
+/**
+ * Tests for the version-aware linking dialog (issue #840).
+ *
+ * Validates that the linking UI shows version selectors for linkable templates
+ * that have releases, and correctly sends version_constraint values when saving.
+ */
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project', templateName: 'web-app' }),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({ children, className, to, params }: { children: React.ReactNode; className?: string; to?: string; params?: Record<string, string> }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>{children}</a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templates', () => ({
+  useCreateTemplate: vi.fn(),
+  useGetTemplate: vi.fn(),
+  useUpdateTemplate: vi.fn(),
+  useDeleteTemplate: vi.fn(),
+  useCloneTemplate: vi.fn(),
+  useRenderTemplate: vi.fn(),
+  useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
+  useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
+  TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
+  linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
+    `${scope ?? 0}/${scopeName ?? ''}/${name}`,
+  parseLinkableKey: (key: string) => {
+    const parts = key.split('/')
+    return { scope: Number(parts[0]), scopeName: parts[1] ?? '', name: parts.slice(2).join('/') }
+  },
+}))
+
+vi.mock('@/components/template-updates', () => ({
+  UpgradeDialog: () => null,
+}))
+
+// Mock the Select component to use native HTML elements for testability in jsdom.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ value, onValueChange, disabled, children }: { value?: string; onValueChange?: (v: string) => void; disabled?: boolean; children: React.ReactNode }) => (
+    <select
+      data-testid="version-select"
+      value={value ?? ''}
+      disabled={disabled}
+      onChange={(e) => onValueChange?.(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useGetProject: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-debounced-value', () => ({
+  useDebouncedValue: vi.fn((value: unknown) => value),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import {
+  useCreateTemplate,
+  useGetTemplate,
+  useUpdateTemplate,
+  useDeleteTemplate,
+  useCloneTemplate,
+  useRenderTemplate,
+  useListLinkableTemplates,
+} from '@/queries/templates'
+import { useGetProject } from '@/queries/projects'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateTemplatePage } from './new'
+import { DeploymentTemplateDetailPage } from './$templateName'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const releasesForHttpbin = [
+  { version: '2.0.0', changelog: 'Breaking change', templateName: 'httpbin-platform' },
+  { version: '1.1.0', changelog: 'Minor improvement', templateName: 'httpbin-platform' },
+  { version: '1.0.0', changelog: 'Initial release', templateName: 'httpbin-platform' },
+]
+
+const linkableWithReleases = [
+  {
+    name: 'reference-grant',
+    displayName: 'Reference Grant',
+    description: 'Default ReferenceGrant',
+    mandatory: true,
+    scopeRef: { scope: 1, scopeName: 'default' },
+    releases: [
+      { version: '1.0.0', changelog: 'Initial', templateName: 'reference-grant' },
+    ],
+  },
+  {
+    name: 'httpbin-platform',
+    displayName: 'HTTPbin Platform',
+    description: 'Platform HTTPRoute for go-httpbin',
+    mandatory: false,
+    scopeRef: { scope: 1, scopeName: 'default' },
+    releases: releasesForHttpbin,
+  },
+  {
+    name: 'team-network-policy',
+    displayName: 'Team Network Policy',
+    description: 'Standard NetworkPolicy',
+    mandatory: false,
+    scopeRef: { scope: 2, scopeName: 'team-a' },
+    releases: [], // No releases
+  },
+]
+
+const mockTemplate = {
+  name: 'web-app',
+  project: 'test-project',
+  displayName: 'Web App',
+  description: 'Standard web application',
+  cueTemplate: '// cue template content',
+  linkedTemplates: [] as Array<{ name: string; scope: number; scopeName: string; versionConstraint?: string }>,
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+function setupCreateMocks(userRole = Role.OWNER) {
+  ;(useCreateTemplate as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+    reset: vi.fn(),
+  })
+  ;(useRenderTemplate as Mock).mockReturnValue({
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isError: false,
+  })
+  ;(useGetProject as Mock).mockReturnValue({
+    data: { name: 'test-project', userRole },
+    isLoading: false,
+  })
+}
+
+function setupDetailMocks(userRole = Role.OWNER, templateOverrides?: Partial<typeof mockTemplate>) {
+  const template = { ...mockTemplate, ...templateOverrides }
+  ;(useGetTemplate as Mock).mockReturnValue({ data: template, isPending: false, error: null })
+  ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
+  ;(useDeleteTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+  ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'new-template' }), isPending: false })
+  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole }, isLoading: false })
+  ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+}
+
+// ---------------------------------------------------------------------------
+// Create page version selector tests
+// ---------------------------------------------------------------------------
+
+describe('Version selector — CreateTemplatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useListLinkableTemplates as Mock).mockReturnValue({ data: linkableWithReleases, isPending: false })
+    setupCreateMocks(Role.OWNER)
+  })
+
+  it('renders version selectors for templates with releases', () => {
+    render(<CreateTemplatePage />)
+    // reference-grant (mandatory, has releases) + httpbin-platform (has releases) = 2
+    const selects = screen.getAllByTestId('version-select')
+    expect(selects.length).toBe(2)
+  })
+
+  it('does not render version selector for templates without releases', () => {
+    render(<CreateTemplatePage />)
+    // team-network-policy has no releases, so no select for it.
+    expect(screen.getByText('Team Network Policy')).toBeInTheDocument()
+    // Only 2 selects total (for templates with releases)
+    const selects = screen.getAllByTestId('version-select')
+    expect(selects.length).toBe(2)
+  })
+
+  it('defaults version selector to "Latest (auto-update)"', () => {
+    render(<CreateTemplatePage />)
+    const selects = screen.getAllByTestId('version-select') as HTMLSelectElement[]
+    // When value is empty string, native <select> falls back to first option (__latest__).
+    // Both "" and "__latest__" represent "Latest (auto-update)" — this is correct.
+    selects.forEach((select) => {
+      expect(select.value === '' || select.value === '__latest__').toBe(true)
+    })
+  })
+
+  it('sends empty version_constraint when "Latest (auto-update)" is selected', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    ;(useCreateTemplate as Mock).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+      reset: vi.fn(),
+    })
+    const user = userEvent.setup()
+    render(<CreateTemplatePage />)
+
+    // Fill required fields
+    const displayNameInput = screen.getByLabelText(/display name/i)
+    await user.type(displayNameInput, 'My Template')
+
+    // Check httpbin-platform (non-mandatory, has releases)
+    await user.click(screen.getByRole('checkbox', { name: /httpbin platform/i }))
+
+    // Leave version as default (Latest)
+    await user.click(screen.getByRole('button', { name: /create template/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          linkedTemplates: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'httpbin-platform',
+              versionConstraint: '',
+            }),
+          ]),
+        }),
+      )
+    })
+  })
+
+  it('sends exact version when a specific version is selected', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    ;(useCreateTemplate as Mock).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+      reset: vi.fn(),
+    })
+    const user = userEvent.setup()
+    render(<CreateTemplatePage />)
+
+    // Fill required fields
+    const displayNameInput = screen.getByLabelText(/display name/i)
+    await user.type(displayNameInput, 'My Template')
+
+    // Check httpbin-platform
+    await user.click(screen.getByRole('checkbox', { name: /httpbin platform/i }))
+
+    // Select version 1.1.0 using native select change
+    const selects = screen.getAllByTestId('version-select') as HTMLSelectElement[]
+    // The second select is for httpbin-platform (first is for mandatory reference-grant)
+    fireEvent.change(selects[1], { target: { value: '1.1.0' } })
+
+    await user.click(screen.getByRole('button', { name: /create template/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          linkedTemplates: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'httpbin-platform',
+              versionConstraint: '1.1.0',
+            }),
+          ]),
+        }),
+      )
+    })
+  })
+
+  it('mandatory template version selector is disabled', () => {
+    render(<CreateTemplatePage />)
+    const selects = screen.getAllByTestId('version-select') as HTMLSelectElement[]
+    // The first select is for mandatory reference-grant and should be disabled
+    expect(selects[0]).toBeDisabled()
+    // The second (httpbin-platform) should not be disabled
+    expect(selects[1]).not.toBeDisabled()
+  })
+
+  it('version options include all releases in descending order plus Latest', () => {
+    render(<CreateTemplatePage />)
+    const selects = screen.getAllByTestId('version-select') as HTMLSelectElement[]
+    // httpbin-platform select (second) should have: __latest__, 2.0.0, 1.1.0, 1.0.0
+    const options = Array.from(selects[1].querySelectorAll('option'))
+    expect(options.map((o) => o.value)).toEqual(['__latest__', '2.0.0', '1.1.0', '1.0.0'])
+    expect(options[0].textContent).toBe('Latest (auto-update)')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Detail/edit page version selector tests
+// ---------------------------------------------------------------------------
+
+describe('Version selector — DeploymentTemplateDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useListLinkableTemplates as Mock).mockReturnValue({ data: linkableWithReleases, isPending: false })
+  })
+
+  it('renders version selectors in the linked templates edit dialog', async () => {
+    setupDetailMocks(Role.OWNER)
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage />)
+
+    await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+    const dialog = screen.getByRole('dialog')
+    // Should have selects for templates with releases
+    const selects = within(dialog).getAllByTestId('version-select')
+    expect(selects.length).toBe(2) // reference-grant + httpbin-platform
+  })
+
+  it('does not render version selector for templates without releases in edit dialog', async () => {
+    setupDetailMocks(Role.OWNER)
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage />)
+
+    await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+    const dialog = screen.getByRole('dialog')
+    // team-network-policy has no releases => no select
+    const selects = within(dialog).getAllByTestId('version-select')
+    expect(selects.length).toBe(2)
+  })
+
+  it('pre-populates version selector with existing version constraint when opening edit dialog', async () => {
+    setupDetailMocks(Role.OWNER, {
+      linkedTemplates: [
+        { name: 'httpbin-platform', scope: 1, scopeName: 'default', versionConstraint: '1.1.0' },
+      ],
+    })
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage />)
+
+    await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+    const dialog = screen.getByRole('dialog')
+    const selects = within(dialog).getAllByTestId('version-select') as HTMLSelectElement[]
+    // httpbin-platform select (second) should show 1.1.0
+    expect(selects[1].value).toBe('1.1.0')
+  })
+
+  it('saves version_constraint when a specific version is selected', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupDetailMocks(Role.OWNER, {
+      linkedTemplates: [
+        { name: 'httpbin-platform', scope: 1, scopeName: 'default', versionConstraint: '' },
+      ],
+    })
+    // Re-set the update mock after setupDetailMocks
+    ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync, isPending: false })
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage />)
+
+    await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+    const dialog = screen.getByRole('dialog')
+
+    // Select version 2.0.0 for httpbin-platform
+    const selects = within(dialog).getAllByTestId('version-select') as HTMLSelectElement[]
+    fireEvent.change(selects[1], { target: { value: '2.0.0' } })
+
+    // Save
+    await user.click(within(dialog).getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          linkedTemplates: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'httpbin-platform',
+              versionConstraint: '2.0.0',
+            }),
+          ]),
+          updateLinkedTemplates: true,
+        }),
+      )
+    })
+  })
+
+  it('defaults to Latest for newly checked templates', async () => {
+    setupDetailMocks(Role.OWNER)
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage />)
+
+    await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+    const dialog = screen.getByRole('dialog')
+
+    // Check httpbin-platform
+    await user.click(within(dialog).getByRole('checkbox', { name: /httpbin platform/i }))
+
+    // The version selector should default to Latest (auto-update).
+    // With the native select mock, "" maps to __latest__ (first option).
+    const selects = within(dialog).getAllByTestId('version-select') as HTMLSelectElement[]
+    expect(selects[1].value === '' || selects[1].value === '__latest__').toBe(true)
+  })
+
+  it('mandatory template version selector is disabled in edit dialog', async () => {
+    setupDetailMocks(Role.OWNER)
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage />)
+
+    await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+    const dialog = screen.getByRole('dialog')
+    const selects = within(dialog).getAllByTestId('version-select') as HTMLSelectElement[]
+    // First select is for mandatory reference-grant
+    expect(selects[0]).toBeDisabled()
+  })
+
+  it('switching from a pinned version to Latest sends empty version_constraint', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupDetailMocks(Role.OWNER, {
+      linkedTemplates: [
+        { name: 'httpbin-platform', scope: 1, scopeName: 'default', versionConstraint: '1.1.0' },
+      ],
+    })
+    ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync, isPending: false })
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage />)
+
+    await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+    const dialog = screen.getByRole('dialog')
+
+    // Change from 1.1.0 back to Latest
+    const selects = within(dialog).getAllByTestId('version-select') as HTMLSelectElement[]
+    fireEvent.change(selects[1], { target: { value: '__latest__' } })
+
+    // Save
+    await user.click(within(dialog).getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          linkedTemplates: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'httpbin-platform',
+              versionConstraint: '',
+            }),
+          ]),
+          updateLinkedTemplates: true,
+        }),
+      )
+    })
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Info, Lock } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -250,6 +251,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const [error, setError] = useState<string | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
   const [selectedLinkedKeys, setSelectedLinkedKeys] = useState<string[]>([])
+  const [selectedVersionConstraints, setSelectedVersionConstraints] = useState<Map<string, string>>(new Map())
 
   // Group linkable templates by scope for display.
   const orgTemplates = linkableTemplates.filter(
@@ -284,7 +286,8 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   // preview render so the preview pane shows unified output.
   const previewLinkedTemplates: LinkedTemplateRef[] = selectedLinkedKeys.map((key) => {
     const parsed = parseLinkableKey(key)
-    return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name } as LinkedTemplateRef
+    const vc = selectedVersionConstraints.get(key) ?? ''
+    return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name, versionConstraint: vc } as LinkedTemplateRef
   })
 
   const debouncedCueTemplate = useDebouncedValue(cueTemplate, 500)
@@ -316,11 +319,12 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
     }
     setError(null)
     try {
-      // Build LinkedTemplateRef objects from scope-qualified keys.
+      // Build LinkedTemplateRef objects from scope-qualified keys with version constraints.
       const linkedTemplates: LinkedTemplateRef[] = selectedLinkedKeys
         .map((key) => {
           const parsed = parseLinkableKey(key)
-          return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name } as LinkedTemplateRef
+          const vc = selectedVersionConstraints.get(key) ?? ''
+          return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name, versionConstraint: vc } as LinkedTemplateRef
         })
 
       await createMutation.mutateAsync({
@@ -420,6 +424,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                     <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Organization Templates</p>
                     {orgTemplates.map((t) => {
                       const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                      const hasReleases = t.releases && t.releases.length > 0
                       return (
                       <div key={key} className="flex items-start gap-2">
                         <Checkbox
@@ -433,7 +438,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                             )
                           }}
                         />
-                        <div className="flex flex-col">
+                        <div className="flex flex-col gap-1">
                           <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
                             {t.displayName || t.name}
                             {t.mandatory && (
@@ -450,7 +455,30 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                             )}
                           </label>
                           {t.description && (
-                            <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                            <p className="text-xs text-muted-foreground">{t.description}</p>
+                          )}
+                          {hasReleases && (
+                            <Select
+                              value={selectedVersionConstraints.get(key) ?? ''}
+                              onValueChange={(val) => {
+                                setSelectedVersionConstraints((prev) => {
+                                  const next = new Map(prev)
+                                  next.set(key, val === '__latest__' ? '' : val)
+                                  return next
+                                })
+                              }}
+                              disabled={t.mandatory}
+                            >
+                              <SelectTrigger size="sm" className="w-40 text-xs">
+                                <SelectValue placeholder="Latest (auto-update)" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="__latest__">Latest (auto-update)</SelectItem>
+                                {t.releases.map((r) => (
+                                  <SelectItem key={r.version} value={r.version}>{r.version}</SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
                           )}
                         </div>
                       </div>
@@ -463,6 +491,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                     <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Folder Templates</p>
                     {folderTemplates.map((t) => {
                       const key = linkableKey(t.scopeRef?.scope, t.scopeRef?.scopeName, t.name)
+                      const hasReleases = t.releases && t.releases.length > 0
                       return (
                       <div key={key} className="flex items-start gap-2">
                         <Checkbox
@@ -476,7 +505,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                             )
                           }}
                         />
-                        <div className="flex flex-col">
+                        <div className="flex flex-col gap-1">
                           <label htmlFor={`linked-create-${key}`} className="text-sm font-medium leading-none cursor-pointer flex items-center gap-1">
                             {t.displayName || t.name}
                             {t.mandatory && (
@@ -493,7 +522,30 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                             )}
                           </label>
                           {t.description && (
-                            <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                            <p className="text-xs text-muted-foreground">{t.description}</p>
+                          )}
+                          {hasReleases && (
+                            <Select
+                              value={selectedVersionConstraints.get(key) ?? ''}
+                              onValueChange={(val) => {
+                                setSelectedVersionConstraints((prev) => {
+                                  const next = new Map(prev)
+                                  next.set(key, val === '__latest__' ? '' : val)
+                                  return next
+                                })
+                              }}
+                              disabled={t.mandatory}
+                            >
+                              <SelectTrigger size="sm" className="w-40 text-xs">
+                                <SelectValue placeholder="Latest (auto-update)" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="__latest__">Latest (auto-update)</SelectItem>
+                                {t.releases.map((r) => (
+                                  <SelectItem key={r.version} value={r.version}>{r.version}</SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
                           )}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary

- Adds a version Select dropdown next to each linkable platform template that has published releases in both the create and edit template linking dialogs
- "Latest (auto-update)" option maps to empty `version_constraint` (preserving current behavior); specific versions set the exact semver string
- Mandatory templates show a disabled version selector; templates without releases show no selector
- Edit dialog pre-populates the version selector from existing `versionConstraint` on linked templates
- Both `handleSaveLinkedTemplates` (edit) and `handleCreate` (create) include `versionConstraint` in `LinkedTemplateRef` objects sent to the backend
- 14 new Vitest + RTL tests covering rendering, selection, save round-trips, and disabled state

Closes #840

## Test plan

- [x] `make test` -- all 843 tests pass (54 files), including 14 new version selector tests
- [ ] Manual verification: create page shows version dropdown for templates with releases
- [ ] Manual verification: edit dialog pre-populates existing version constraints
- [ ] Manual verification: saving with a specific version sends correct `version_constraint`

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
<sub>Agent: `agent-1`</sub>