### PR TITLE
fix(templates): per-field defaults extraction in ExtractDefaults

### DIFF
--- a/console/templates/defaults.go
+++ b/console/templates/defaults.go
@@ -72,12 +72,16 @@ func ExtractDefaults(cueSource string) (*consolev1.TemplateDefaults, error) {
 	}
 
 	// Integer field: port.
-	if v := defaultsVal.LookupPath(cue.ParsePath("port")); v.Exists() && v.IsConcrete() {
-		if b, err := v.MarshalJSON(); err == nil {
-			var n int32
-			if err := json.Unmarshal(b, &n); err == nil {
-				d.Port = n
-			}
+	if v := defaultsVal.LookupPath(cue.ParsePath("port")); !v.Exists() || !v.IsConcrete() {
+		slog.Debug("defaults field not concrete, skipping", "field", "port")
+	} else if b, err := v.MarshalJSON(); err != nil {
+		slog.Debug("defaults field marshal failed, skipping", "field", "port", "error", err)
+	} else {
+		var n int32
+		if err := json.Unmarshal(b, &n); err != nil {
+			slog.Debug("defaults field unmarshal failed, skipping", "field", "port", "error", err)
+		} else {
+			d.Port = n
 		}
 	}
 
@@ -91,14 +95,20 @@ func ExtractDefaults(cueSource string) (*consolev1.TemplateDefaults, error) {
 	} {
 		v := defaultsVal.LookupPath(cue.ParsePath(f.path))
 		if !v.Exists() || !v.IsConcrete() {
+			slog.Debug("defaults field not concrete, skipping", "field", f.path)
 			continue
 		}
 		b, err := v.MarshalJSON()
 		if err != nil {
+			slog.Debug("defaults field marshal failed, skipping", "field", f.path, "error", err)
 			continue
 		}
 		var ss []string
-		if err := json.Unmarshal(b, &ss); err == nil && len(ss) > 0 {
+		if err := json.Unmarshal(b, &ss); err != nil {
+			slog.Debug("defaults field unmarshal failed, skipping", "field", f.path, "error", err)
+			continue
+		}
+		if len(ss) > 0 {
 			*f.dest = ss
 		}
 	}

--- a/console/templates/defaults.go
+++ b/console/templates/defaults.go
@@ -39,39 +39,72 @@ func ExtractDefaults(cueSource string) (*consolev1.TemplateDefaults, error) {
 		return nil, fmt.Errorf("evaluating defaults field: %w", err)
 	}
 
-	// Marshal the CUE defaults value to JSON, then unmarshal into a ProjectInput
-	// struct. This gives us typed access to the defaults fields.
-	b, err := defaultsVal.MarshalJSON()
-	if err != nil {
-		// Defaults are not fully concrete — skip rather than error.
-		slog.Debug("defaults field not concrete, skipping extraction", "error", err)
-		return nil, nil
+	// Extract each field independently so that a non-concrete field does not
+	// prevent extraction of concrete siblings. See ADR 025 for rationale.
+	d := &consolev1.TemplateDefaults{}
+
+	// String fields: name, image, tag, description.
+	for _, f := range []struct {
+		path string
+		dest *string
+	}{
+		{"name", &d.Name},
+		{"image", &d.Image},
+		{"tag", &d.Tag},
+		{"description", &d.Description},
+	} {
+		v := defaultsVal.LookupPath(cue.ParsePath(f.path))
+		if !v.Exists() || !v.IsConcrete() {
+			slog.Debug("defaults field not concrete, skipping", "field", f.path)
+			continue
+		}
+		b, err := v.MarshalJSON()
+		if err != nil {
+			slog.Debug("defaults field marshal failed, skipping", "field", f.path, "error", err)
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			slog.Debug("defaults field unmarshal failed, skipping", "field", f.path, "error", err)
+			continue
+		}
+		*f.dest = s
 	}
 
-	var pi v1alpha2.ProjectInput
-	if err := json.Unmarshal(b, &pi); err != nil {
-		return nil, fmt.Errorf("unmarshalling defaults into ProjectInput: %w", err)
+	// Integer field: port.
+	if v := defaultsVal.LookupPath(cue.ParsePath("port")); v.Exists() && v.IsConcrete() {
+		if b, err := v.MarshalJSON(); err == nil {
+			var n int32
+			if err := json.Unmarshal(b, &n); err == nil {
+				d.Port = n
+			}
+		}
 	}
 
-	d := &consolev1.TemplateDefaults{
-		Name:        pi.Name,
-		Image:       pi.Image,
-		Tag:         pi.Tag,
-		Description: pi.Description,
-		Port:        int32(pi.Port),
+	// String slice fields: command, args.
+	for _, f := range []struct {
+		path string
+		dest *[]string
+	}{
+		{"command", &d.Command},
+		{"args", &d.Args},
+	} {
+		v := defaultsVal.LookupPath(cue.ParsePath(f.path))
+		if !v.Exists() || !v.IsConcrete() {
+			continue
+		}
+		b, err := v.MarshalJSON()
+		if err != nil {
+			continue
+		}
+		var ss []string
+		if err := json.Unmarshal(b, &ss); err == nil && len(ss) > 0 {
+			*f.dest = ss
+		}
 	}
-
-	// Map optional fields.
-	if len(pi.Command) > 0 {
-		d.Command = pi.Command
-	}
-	if len(pi.Args) > 0 {
-		d.Args = pi.Args
-	}
-	// Env is not typically set in defaults; skip for now.
 
 	// Return nil if all fields are zero — means no meaningful defaults.
-	if d.Name == "" && d.Image == "" && d.Tag == "" && d.Description == "" && d.Port == 0 {
+	if d.Name == "" && d.Image == "" && d.Tag == "" && d.Description == "" && d.Port == 0 && len(d.Command) == 0 && len(d.Args) == 0 {
 		return nil, nil
 	}
 

--- a/console/templates/defaults_test.go
+++ b/console/templates/defaults_test.go
@@ -150,4 +150,94 @@ defaults: #ProjectInput & {
 			t.Errorf("expected port 9090, got %d", d.Port)
 		}
 	})
+
+	t.Run("mixed concrete and non-concrete fields returns partial defaults", func(t *testing.T) {
+		// When some fields are concrete and others are non-concrete (e.g. bare
+		// string type), only the concrete fields should be extracted. The
+		// non-concrete fields should be silently omitted.
+		cueSource := `
+defaults: #ProjectInput & {
+    name:  "httpbin"
+    image: string  // non-concrete — constrained but no value
+    tag:   "2.21.0"
+    port:  8080
+}
+`
+		d, err := ExtractDefaults(cueSource)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if d == nil {
+			t.Fatal("expected non-nil DeploymentDefaults for mixed concrete/non-concrete")
+		}
+		if d.Name != "httpbin" {
+			t.Errorf("expected name 'httpbin', got %q", d.Name)
+		}
+		if d.Image != "" {
+			t.Errorf("expected empty image (non-concrete), got %q", d.Image)
+		}
+		if d.Tag != "2.21.0" {
+			t.Errorf("expected tag '2.21.0', got %q", d.Tag)
+		}
+		if d.Port != 8080 {
+			t.Errorf("expected port 8080, got %d", d.Port)
+		}
+	})
+
+	t.Run("all non-concrete fields returns nil", func(t *testing.T) {
+		// When every field in the defaults block is non-concrete (bare type
+		// constraints with no values), ExtractDefaults should return nil because
+		// there are no meaningful defaults to pre-fill.
+		cueSource := `
+defaults: {
+    name:  string
+    image: string
+    tag:   string
+    port:  int
+}
+`
+		d, err := ExtractDefaults(cueSource)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if d != nil {
+			t.Errorf("expected nil for all non-concrete defaults, got %+v", d)
+		}
+	})
+
+	t.Run("typed defaults with one non-concrete field extracts concrete fields", func(t *testing.T) {
+		// A template using #ProjectInput & { ... } with one non-concrete field
+		// should still extract all the concrete fields.
+		cueSource := `
+defaults: #ProjectInput & {
+    name:        "my-service"
+    image:       "registry.example.com/my-service"
+    tag:         string  // non-concrete — user must provide
+    description: "My production service"
+    port:        3000
+}
+`
+		d, err := ExtractDefaults(cueSource)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if d == nil {
+			t.Fatal("expected non-nil DeploymentDefaults")
+		}
+		if d.Name != "my-service" {
+			t.Errorf("expected name 'my-service', got %q", d.Name)
+		}
+		if d.Image != "registry.example.com/my-service" {
+			t.Errorf("expected image 'registry.example.com/my-service', got %q", d.Image)
+		}
+		if d.Tag != "" {
+			t.Errorf("expected empty tag (non-concrete), got %q", d.Tag)
+		}
+		if d.Description != "My production service" {
+			t.Errorf("expected description 'My production service', got %q", d.Description)
+		}
+		if d.Port != 3000 {
+			t.Errorf("expected port 3000, got %d", d.Port)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Rewrites `ExtractDefaults()` in `console/templates/defaults.go` to extract each CUE `defaults` field independently using `LookupPath` + `IsConcrete` + `MarshalJSON` per field
- Non-concrete fields are silently omitted (debug log); concrete fields in the same `defaults` block are preserved
- Adds 3 new test cases: mixed concrete/non-concrete fields, all non-concrete fields, and typed `#ProjectInput &` with one non-concrete field
- All 9 existing and new `ExtractDefaults` tests pass; full `make test` passes (Go + UI)

Closes #852

## Test plan

- [x] `make test` passes (Go + UI: 829 tests)
- [x] New test: CUE template with mixed concrete and non-concrete fields returns partial `TemplateDefaults` with only the concrete fields populated
- [x] New test: CUE template where all `defaults` fields are non-concrete returns `nil`
- [x] New test: CUE template with `#ProjectInput &` typed defaults and one non-concrete field still extracts the concrete fields
- [x] Existing `default_template.cue` extraction test continues to pass
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
Agent slot: agent-4