### PR TITLE
feat(render): return resources grouped by origin in render responses

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -844,10 +844,10 @@ func (h *Handler) checkProjectAccess(ctx context.Context, claims *rpc.Claims, pr
 // validateDeploymentName checks that the name is a valid DNS label.
 // serializeUnstructured converts a slice of unstructured Kubernetes resources
 // into a multi-document YAML string (separated by "---\n") and a JSON array
-// string. Returns an empty YAML string and "[]" JSON array for an empty or nil slice.
+// string. Returns empty strings for an empty or nil slice.
 func serializeUnstructured(resources []unstructured.Unstructured) (yamlStr, jsonStr string) {
 	if len(resources) == 0 {
-		return "", "[]"
+		return "", ""
 	}
 	var buf strings.Builder
 	objects := make([]map[string]any, 0, len(resources))

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -844,10 +844,10 @@ func (h *Handler) checkProjectAccess(ctx context.Context, claims *rpc.Claims, pr
 // validateDeploymentName checks that the name is a valid DNS label.
 // serializeUnstructured converts a slice of unstructured Kubernetes resources
 // into a multi-document YAML string (separated by "---\n") and a JSON array
-// string. Returns empty strings for an empty or nil slice.
+// string. Returns an empty YAML string and "[]" JSON array for an empty or nil slice.
 func serializeUnstructured(resources []unstructured.Unstructured) (yamlStr, jsonStr string) {
 	if len(resources) == 0 {
-		return "", ""
+		return "", "[]"
 	}
 	var buf strings.Builder
 	objects := make([]map[string]any, 0, len(resources))

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -57,6 +57,12 @@ type Renderer interface {
 	// folder-level) template CUE sources with the deployment template before
 	// filling in platform and project inputs.
 	RenderWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error)
+	// RenderGrouped evaluates the CUE template and returns resources grouped by
+	// origin (platform vs project). Project-level path: platform group is empty.
+	RenderGrouped(ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error)
+	// RenderGroupedWithAncestorTemplates evaluates the deployment template unified
+	// with ancestor templates and returns resources grouped by origin.
+	RenderGroupedWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error)
 }
 
 // OrgProvider resolves the organization for a project.
@@ -183,6 +189,39 @@ func (h *Handler) renderResources(ctx context.Context, project, cueSource string
 	}
 
 	return h.renderer.RenderWithAncestorTemplates(ctx, cueSource, orgTemplateSources, platform, projectInput)
+}
+
+// renderResourcesGrouped mirrors renderResources but returns resources grouped
+// by origin (platform vs project). Used by GetDeploymentRenderPreview to populate
+// the per-collection response fields.
+func (h *Handler) renderResourcesGrouped(ctx context.Context, project, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) (*GroupedResources, error) {
+	if h.orgProvider == nil || h.orgTemplateProvider == nil {
+		return h.renderer.RenderGrouped(ctx, cueSource, platform, projectInput)
+	}
+
+	org, err := h.orgProvider.GetProjectOrg(ctx, project)
+	if err != nil {
+		slog.WarnContext(ctx, "could not resolve org for project, skipping platform template unification",
+			slog.String("project", project),
+			slog.Any("error", err),
+		)
+		return h.renderer.RenderGrouped(ctx, cueSource, platform, projectInput)
+	}
+	if org == "" {
+		return h.renderer.RenderGrouped(ctx, cueSource, platform, projectInput)
+	}
+
+	orgTemplateSources, err := h.orgTemplateProvider.ListOrgTemplateSourcesForRender(ctx, org, linkedRefs)
+	if err != nil {
+		slog.WarnContext(ctx, "could not list platform templates for render, skipping platform template unification",
+			slog.String("project", project),
+			slog.String("org", org),
+			slog.Any("error", err),
+		)
+		return h.renderer.RenderGrouped(ctx, cueSource, platform, projectInput)
+	}
+
+	return h.renderer.RenderGroupedWithAncestorTemplates(ctx, cueSource, orgTemplateSources, platform, projectInput)
 }
 
 // ListDeployments returns all deployments in a project.
@@ -734,11 +773,14 @@ func (h *Handler) GetDeploymentRenderPreview(
 	cueProjectInput := fmt.Sprintf("input: %s", string(projectJSON))
 
 	// Render the template to produce YAML and JSON output, including linked
-	// platform templates (ADR 019). Uses renderResources so the same linking
-	// logic applies at preview time as at deploy time.
+	// platform templates (ADR 019). Uses renderResourcesGrouped so the same
+	// linking logic applies at preview time as at deploy time, and the per-
+	// collection fields are populated.
 	var renderedYAML, renderedJSON string
+	var platformResourcesYAML, platformResourcesJSON string
+	var projectResourcesYAML, projectResourcesJSON string
 	if h.renderer != nil {
-		resources, renderErr := h.renderResources(ctx, project, cueTemplate, platformIn, projectIn, linkedOrgTemplatesPreview)
+		grouped, renderErr := h.renderResourcesGrouped(ctx, project, cueTemplate, platformIn, projectIn, linkedOrgTemplatesPreview)
 		if renderErr != nil {
 			slog.WarnContext(ctx, "render failed during deployment preview",
 				slog.String("project", project),
@@ -753,26 +795,13 @@ func (h *Handler) GetDeploymentRenderPreview(
 			}), nil
 		}
 
-		var buf strings.Builder
-		objects := make([]map[string]any, 0, len(resources))
-		for i, r := range resources {
-			if i > 0 {
-				buf.WriteString("---\n")
-			}
-			yamlBytes, yamlErr := yaml.Marshal(r.Object)
-			if yamlErr == nil {
-				buf.WriteString(string(yamlBytes))
-			}
-			if r.Object != nil {
-				objects = append(objects, r.Object)
-			}
-		}
-		renderedYAML = buf.String()
+		// Serialize per-collection resources.
+		platformResourcesYAML, platformResourcesJSON = serializeUnstructured(grouped.Platform)
+		projectResourcesYAML, projectResourcesJSON = serializeUnstructured(grouped.Project)
 
-		jsonBytes, jsonErr := json.MarshalIndent(objects, "", "  ")
-		if jsonErr == nil {
-			renderedJSON = string(jsonBytes)
-		}
+		// Produce the unified output (backwards compatible) by combining both collections.
+		allResources := append(grouped.Platform, grouped.Project...)
+		renderedYAML, renderedJSON = serializeUnstructured(allResources)
 	}
 
 	slog.InfoContext(ctx, "deployment render preview",
@@ -784,11 +813,15 @@ func (h *Handler) GetDeploymentRenderPreview(
 	)
 
 	return connect.NewResponse(&consolev1.GetDeploymentRenderPreviewResponse{
-		CueTemplate:      cueTemplate,
-		CuePlatformInput: cuePlatformInput,
-		CueProjectInput:  cueProjectInput,
-		RenderedYaml:     renderedYAML,
-		RenderedJson:     renderedJSON,
+		CueTemplate:           cueTemplate,
+		CuePlatformInput:      cuePlatformInput,
+		CueProjectInput:       cueProjectInput,
+		RenderedYaml:          renderedYAML,
+		RenderedJson:          renderedJSON,
+		PlatformResourcesYaml: platformResourcesYAML,
+		PlatformResourcesJson: platformResourcesJSON,
+		ProjectResourcesYaml:  projectResourcesYAML,
+		ProjectResourcesJson:  projectResourcesJSON,
 	}), nil
 }
 
@@ -809,6 +842,34 @@ func (h *Handler) checkProjectAccess(ctx context.Context, claims *rpc.Claims, pr
 }
 
 // validateDeploymentName checks that the name is a valid DNS label.
+// serializeUnstructured converts a slice of unstructured Kubernetes resources
+// into a multi-document YAML string (separated by "---\n") and a JSON array
+// string. Returns empty strings for an empty or nil slice.
+func serializeUnstructured(resources []unstructured.Unstructured) (yamlStr, jsonStr string) {
+	if len(resources) == 0 {
+		return "", ""
+	}
+	var buf strings.Builder
+	objects := make([]map[string]any, 0, len(resources))
+	for i, r := range resources {
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		yamlBytes, yamlErr := yaml.Marshal(r.Object)
+		if yamlErr == nil {
+			buf.WriteString(string(yamlBytes))
+		}
+		if r.Object != nil {
+			objects = append(objects, r.Object)
+		}
+	}
+	jsonBytes, jsonErr := json.MarshalIndent(objects, "", "  ")
+	if jsonErr == nil {
+		jsonStr = string(jsonBytes)
+	}
+	return buf.String(), jsonStr
+}
+
 func validateDeploymentName(name string) error {
 	if name == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -111,6 +111,20 @@ func (s *stubRenderer) RenderWithAncestorTemplates(_ context.Context, _ string, 
 	return s.resources, s.err
 }
 
+func (s *stubRenderer) RenderGrouped(_ context.Context, _ string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	s.called = true
+	s.lastPlatform = platform
+	s.lastProject = project
+	return &GroupedResources{Project: s.resources}, s.err
+}
+
+func (s *stubRenderer) RenderGroupedWithAncestorTemplates(_ context.Context, _ string, _ []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	s.called = true
+	s.lastPlatform = platform
+	s.lastProject = project
+	return &GroupedResources{Project: s.resources}, s.err
+}
+
 // stubApplier implements ResourceApplier for tests.
 type stubApplier struct {
 	applyCalled     bool

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -29,6 +29,14 @@ var allowedKindSet = map[string]bool{
 // renderTimeout is the maximum time allowed for CUE template evaluation.
 const renderTimeout = 5 * time.Second
 
+// GroupedResources holds Kubernetes resources partitioned by origin: resources
+// from platformResources (organization/folder-level) and resources from
+// projectResources (project-level).
+type GroupedResources struct {
+	Platform []unstructured.Unstructured
+	Project  []unstructured.Unstructured
+}
+
 // CueRenderer evaluates CUE templates with deployment parameters.
 type CueRenderer struct{}
 
@@ -55,6 +63,83 @@ func (r *CueRenderer) Render(ctx context.Context, cueSource string, platform v1a
 		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
 	case res := <-ch:
 		return res.resources, res.err
+	}
+}
+
+// RenderGrouped evaluates the CUE template with the given platform and project
+// inputs and returns resources grouped by origin (platform vs project). This is
+// the project-level path: platformResources are not read (ADR 016 Decision 8),
+// so the Platform group will always be empty.
+func (r *CueRenderer) RenderGrouped(ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
+	defer cancel()
+
+	type result struct {
+		grouped *GroupedResources
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		grouped, err := evaluateGrouped(cueSource, platform, project)
+		ch <- result{grouped, err}
+	}()
+
+	select {
+	case <-evalCtx.Done():
+		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
+	case res := <-ch:
+		return res.grouped, res.err
+	}
+}
+
+// RenderGroupedWithAncestorTemplates evaluates the deployment template unified
+// with zero or more ancestor template CUE sources and returns resources grouped
+// by origin (platform vs project). This is the org/folder-level path that reads
+// both platformResources and projectResources.
+func (r *CueRenderer) RenderGroupedWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
+	defer cancel()
+
+	type result struct {
+		grouped *GroupedResources
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		grouped, err := evaluateWithOrgTemplatesGrouped(deploymentCUE, ancestorTemplateCUESources, platform, project)
+		ch <- result{grouped, err}
+	}()
+
+	select {
+	case <-evalCtx.Done():
+		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
+	case res := <-ch:
+		return res.grouped, res.err
+	}
+}
+
+// RenderGroupedWithCueInput evaluates the CUE template unified with a raw CUE
+// input string and returns resources grouped by origin (platform vs project).
+// This is the preview path that reads both collections (ADR 016 Decision 8).
+func (r *CueRenderer) RenderGroupedWithCueInput(ctx context.Context, cueSource, cueInput string) (*GroupedResources, error) {
+	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
+	defer cancel()
+
+	type result struct {
+		grouped *GroupedResources
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		grouped, err := evaluateWithCueInputGrouped(cueSource, cueInput)
+		ch <- result{grouped, err}
+	}()
+
+	select {
+	case <-evalCtx.Done():
+		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
+	case res := <-ch:
+		return res.grouped, res.err
 	}
 }
 
@@ -279,6 +364,197 @@ func evaluateWithCueInput(cueSource, cueInput string) ([]unstructured.Unstructur
 
 	// Preview mode reads both collections (ADR 016 Decision 8).
 	return evaluateStructured(unified, expectedNamespace, true)
+}
+
+// evaluateGrouped performs synchronous CUE template evaluation and returns
+// resources grouped by origin. This is the project-level path: platformResources
+// are not read (ADR 016 Decision 8), so Platform will always be empty.
+func evaluateGrouped(cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	cueCtx := cuecontext.New()
+
+	fullSource := v1alpha2.GeneratedSchema + "\n" + cueSource
+
+	tmpl := cueCtx.CompileString(fullSource)
+	if err := tmpl.Err(); err != nil {
+		return nil, fmt.Errorf("invalid CUE template: %w", err)
+	}
+
+	inputJSON, err := json.Marshal(project)
+	if err != nil {
+		return nil, fmt.Errorf("encoding project input: %w", err)
+	}
+	inputValue := cueCtx.CompileBytes(inputJSON)
+	if err := inputValue.Err(); err != nil {
+		return nil, fmt.Errorf("compiling project input: %w", err)
+	}
+
+	platformJSON, err := json.Marshal(platform)
+	if err != nil {
+		return nil, fmt.Errorf("encoding platform input: %w", err)
+	}
+	platformValue := cueCtx.CompileBytes(platformJSON)
+	if err := platformValue.Err(); err != nil {
+		return nil, fmt.Errorf("compiling platform input: %w", err)
+	}
+
+	unified := tmpl.FillPath(cue.ParsePath("input"), inputValue)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("unifying template with project input: %w", err)
+	}
+	unified = unified.FillPath(cue.ParsePath("platform"), platformValue)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("unifying template with platform input: %w", err)
+	}
+
+	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
+	if namespacedValue.Err() != nil || !namespacedValue.Exists() {
+		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' (structured output format required)")
+	}
+
+	// Project-level render: do not read platformResources (ADR 016 Decision 8).
+	return evaluateStructuredGrouped(unified, platform.Namespace, false)
+}
+
+// evaluateWithOrgTemplatesGrouped performs synchronous CUE template evaluation
+// with org/folder templates and returns resources grouped by origin.
+func evaluateWithOrgTemplatesGrouped(deploymentCUE string, orgTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	cueCtx := cuecontext.New()
+
+	combined := v1alpha2.GeneratedSchema + "\n" + deploymentCUE
+	for _, orgTemplateSrc := range orgTemplateCUESources {
+		combined = combined + "\n" + orgTemplateSrc
+	}
+
+	unified := cueCtx.CompileString(combined)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("invalid CUE template (deployment + platform templates): %w", err)
+	}
+
+	inputJSON, err := json.Marshal(project)
+	if err != nil {
+		return nil, fmt.Errorf("encoding project input: %w", err)
+	}
+	inputValue := cueCtx.CompileBytes(inputJSON)
+	if err := inputValue.Err(); err != nil {
+		return nil, fmt.Errorf("compiling project input: %w", err)
+	}
+
+	platformJSON, err := json.Marshal(platform)
+	if err != nil {
+		return nil, fmt.Errorf("encoding platform input: %w", err)
+	}
+	platformValue := cueCtx.CompileBytes(platformJSON)
+	if err := platformValue.Err(); err != nil {
+		return nil, fmt.Errorf("compiling platform input: %w", err)
+	}
+
+	unified = unified.FillPath(cue.ParsePath("input"), inputValue)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("unifying template with project input: %w", err)
+	}
+	unified = unified.FillPath(cue.ParsePath("platform"), platformValue)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("unifying template with platform input: %w", err)
+	}
+
+	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
+	if namespacedValue.Err() != nil || !namespacedValue.Exists() {
+		return nil, fmt.Errorf("deployment template must define 'projectResources.namespacedResources' (structured output format required)")
+	}
+
+	return evaluateStructuredGrouped(unified, platform.Namespace, true)
+}
+
+// evaluateWithCueInputGrouped performs synchronous CUE template evaluation using
+// a raw CUE string as input and returns resources grouped by origin.
+func evaluateWithCueInputGrouped(cueSource, cueInput string) (*GroupedResources, error) {
+	cueCtx := cuecontext.New()
+
+	combined := v1alpha2.GeneratedSchema + "\n" + cueSource + "\n" + cueInput
+	unified := cueCtx.CompileString(combined)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("invalid CUE template: %w", err)
+	}
+
+	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
+	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
+	if (namespacedValue.Err() != nil || !namespacedValue.Exists()) &&
+		(platformNamespacedValue.Err() != nil || !platformNamespacedValue.Exists()) {
+		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
+	}
+
+	nsValue := unified.LookupPath(cue.ParsePath("platform.namespace"))
+	if nsValue.Err() != nil || !nsValue.Exists() {
+		return nil, fmt.Errorf("cue_input must provide a 'platform.namespace' field")
+	}
+	expectedNamespace, err := nsValue.String()
+	if err != nil {
+		return nil, fmt.Errorf("platform.namespace must be a concrete string: %w", err)
+	}
+
+	// Preview mode reads both collections (ADR 016 Decision 8).
+	return evaluateStructuredGrouped(unified, expectedNamespace, true)
+}
+
+// evaluateStructuredGrouped walks the structured output fields of a unified CUE
+// value and returns validated Kubernetes resources partitioned into Platform and
+// Project groups. The logic mirrors evaluateStructured but collects resources
+// into separate slices instead of a single flat list.
+func evaluateStructuredGrouped(unified cue.Value, expectedNamespace string, readPlatformResources bool) (*GroupedResources, error) {
+	var projectResources []unstructured.Unstructured
+	var platformResources []unstructured.Unstructured
+
+	// Walk projectResources.namespacedResources: <namespace>.<Kind>.<name>
+	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
+	if namespacedValue.Err() == nil && namespacedValue.Exists() {
+		resources, err := walkNamespacedResources(namespacedValue, expectedNamespace, "projectResources.namespacedResources")
+		if err != nil {
+			return nil, err
+		}
+		projectResources = append(projectResources, resources...)
+	}
+
+	// Walk projectResources.clusterResources: <Kind>.<name>
+	clusterValue := unified.LookupPath(cue.ParsePath("projectResources.clusterResources"))
+	if clusterValue.Err() == nil && clusterValue.Exists() {
+		resources, err := walkClusterResources(clusterValue, "projectResources.clusterResources")
+		if err != nil {
+			return nil, err
+		}
+		projectResources = append(projectResources, resources...)
+	}
+
+	if !readPlatformResources {
+		return &GroupedResources{
+			Platform: nil,
+			Project:  projectResources,
+		}, nil
+	}
+
+	// Walk platformResources.namespacedResources
+	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
+	if platformNamespacedValue.Err() == nil && platformNamespacedValue.Exists() {
+		resources, err := walkNamespacedResources(platformNamespacedValue, expectedNamespace, "platformResources.namespacedResources")
+		if err != nil {
+			return nil, err
+		}
+		platformResources = append(platformResources, resources...)
+	}
+
+	// Walk platformResources.clusterResources
+	platformClusterValue := unified.LookupPath(cue.ParsePath("platformResources.clusterResources"))
+	if platformClusterValue.Err() == nil && platformClusterValue.Exists() {
+		resources, err := walkClusterResources(platformClusterValue, "platformResources.clusterResources")
+		if err != nil {
+			return nil, err
+		}
+		platformResources = append(platformResources, resources...)
+	}
+
+	return &GroupedResources{
+		Platform: platformResources,
+		Project:  projectResources,
+	}, nil
 }
 
 // evaluateStructured walks the structured output fields of a unified CUE value

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -2235,3 +2235,138 @@ func TestCueRenderer_AncestorTemplateWalk(t *testing.T) {
 		}
 	})
 }
+
+// TestEvaluateStructuredGrouped verifies that evaluateStructuredGrouped
+// partitions resources into Platform and Project groups correctly.
+func TestEvaluateStructuredGrouped(t *testing.T) {
+	renderer := &CueRenderer{}
+	namespace := "prj-my-project"
+
+	t.Run("project-only template produces empty platform group", func(t *testing.T) {
+		grouped, err := renderer.RenderGrouped(context.Background(),
+			validTemplate,
+			defaultPlatform(namespace),
+			defaultProject(),
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(grouped.Platform) != 0 {
+			t.Errorf("expected 0 platform resources, got %d: %v",
+				len(grouped.Platform), resourceKinds(grouped.Platform))
+		}
+		if len(grouped.Project) != 1 {
+			t.Fatalf("expected 1 project resource, got %d: %v",
+				len(grouped.Project), resourceKinds(grouped.Project))
+		}
+		if grouped.Project[0].GetKind() != "Deployment" {
+			t.Errorf("expected Deployment, got %q", grouped.Project[0].GetKind())
+		}
+	})
+
+	t.Run("template with both collections produces populated platform and project groups", func(t *testing.T) {
+		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+			systemOutputTemplate,
+			nil, // deployment template itself defines platformResources
+			defaultPlatform(namespace),
+			defaultProject(),
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(grouped.Platform) != 1 {
+			t.Fatalf("expected 1 platform resource, got %d: %v",
+				len(grouped.Platform), resourceKinds(grouped.Platform))
+		}
+		if grouped.Platform[0].GetKind() != "ServiceAccount" {
+			t.Errorf("expected platform ServiceAccount, got %q", grouped.Platform[0].GetKind())
+		}
+		if len(grouped.Project) != 1 {
+			t.Fatalf("expected 1 project resource, got %d: %v",
+				len(grouped.Project), resourceKinds(grouped.Project))
+		}
+		if grouped.Project[0].GetKind() != "Deployment" {
+			t.Errorf("expected project Deployment, got %q", grouped.Project[0].GetKind())
+		}
+	})
+
+	t.Run("unified fields equal union of both groups", func(t *testing.T) {
+		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+			systemOutputTemplate,
+			nil,
+			defaultPlatform(namespace),
+			defaultProject(),
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// The flat render should return the same total count as Platform + Project.
+		flat, err := renderer.RenderWithAncestorTemplates(context.Background(),
+			systemOutputTemplate,
+			nil,
+			defaultPlatform(namespace),
+			defaultProject(),
+		)
+		if err != nil {
+			t.Fatalf("expected no error from flat render, got %v", err)
+		}
+
+		totalGrouped := len(grouped.Platform) + len(grouped.Project)
+		if totalGrouped != len(flat) {
+			t.Errorf("grouped total (%d) != flat total (%d)", totalGrouped, len(flat))
+		}
+
+		// Build a set of kind/name pairs from the grouped result and verify
+		// they match the flat result exactly.
+		groupedSet := make(map[string]bool)
+		for _, r := range grouped.Platform {
+			groupedSet[r.GetKind()+"/"+r.GetName()] = true
+		}
+		for _, r := range grouped.Project {
+			groupedSet[r.GetKind()+"/"+r.GetName()] = true
+		}
+		for _, r := range flat {
+			key := r.GetKind() + "/" + r.GetName()
+			if !groupedSet[key] {
+				t.Errorf("flat resource %s not found in grouped result", key)
+			}
+		}
+	})
+
+	t.Run("org template with closed struct produces grouped results", func(t *testing.T) {
+		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+			closedStructProjectTemplate,
+			[]string{closedStructOrgTemplate},
+			v1alpha2.PlatformInput{
+				Project:          "my-project",
+				Namespace:        namespace,
+				GatewayNamespace: DefaultGatewayNamespace,
+			},
+			v1alpha2.ProjectInput{Name: "web-app", Image: "nginx", Tag: "1.25", Port: 8080},
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		// Platform group should have HTTPRoute from the org template.
+		if len(grouped.Platform) != 1 {
+			t.Fatalf("expected 1 platform resource, got %d: %v",
+				len(grouped.Platform), resourceKinds(grouped.Platform))
+		}
+		if grouped.Platform[0].GetKind() != "HTTPRoute" {
+			t.Errorf("expected platform HTTPRoute, got %q", grouped.Platform[0].GetKind())
+		}
+		// Project group should have Deployment, Service, ServiceAccount.
+		if len(grouped.Project) != 3 {
+			t.Fatalf("expected 3 project resources, got %d: %v",
+				len(grouped.Project), resourceKinds(grouped.Project))
+		}
+		kindSet := make(map[string]bool)
+		for _, r := range grouped.Project {
+			kindSet[r.GetKind()] = true
+		}
+		if !kindSet["Deployment"] || !kindSet["Service"] || !kindSet["ServiceAccount"] {
+			t.Errorf("expected Deployment, Service, ServiceAccount in project group, got %v", kindSet)
+		}
+	})
+}

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -1123,11 +1123,11 @@ func validateCueSyntax(source string) error {
 }
 
 // serializeResources converts a slice of RenderResource into a multi-document
-// YAML string (separated by "---\n") and a JSON array string. Returns empty
-// strings for an empty slice.
+// YAML string (separated by "---\n") and a JSON array string. Returns an empty
+// YAML string and "[]" JSON array for an empty slice.
 func serializeResources(resources []RenderResource) (yamlStr, jsonStr string, err error) {
 	if len(resources) == 0 {
-		return "", "", nil
+		return "", "[]", nil
 	}
 
 	var buf strings.Builder

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -58,6 +58,13 @@ type RenderResource struct {
 	Object map[string]any
 }
 
+// GroupedRenderResources holds rendered resources partitioned by origin: platform
+// (organization/folder-level templates) and project (project-level templates).
+type GroupedRenderResources struct {
+	Platform []RenderResource
+	Project  []RenderResource
+}
+
 // Renderer evaluates a CUE template unified with platform and user CUE input
 // strings and returns a list of rendered Kubernetes manifests.
 type Renderer interface {
@@ -65,6 +72,11 @@ type Renderer interface {
 	// RenderWithTemplateSources evaluates the template unified with zero or more
 	// ancestor template CUE sources, then with the CUE input.
 	RenderWithTemplateSources(ctx context.Context, cueTemplate string, templateSources []string, cuePlatformInput string, cueInput string) ([]RenderResource, error)
+	// RenderGrouped evaluates the template and returns resources grouped by origin.
+	RenderGrouped(ctx context.Context, cueTemplate string, cuePlatformInput string, cueInput string) (*GroupedRenderResources, error)
+	// RenderGroupedWithTemplateSources evaluates the template unified with ancestor
+	// sources and returns resources grouped by origin.
+	RenderGroupedWithTemplateSources(ctx context.Context, cueTemplate string, templateSources []string, cuePlatformInput string, cueInput string) (*GroupedRenderResources, error)
 }
 
 // Handler implements the unified TemplateService (ADR 021).
@@ -452,31 +464,35 @@ func (h *Handler) RenderTemplate(
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("renderer not configured"))
 	}
 
-	resources, err := h.renderer.Render(ctx, req.Msg.CueTemplate, req.Msg.CuePlatformInput, req.Msg.CueProjectInput)
+	grouped, err := h.renderer.RenderGrouped(ctx, req.Msg.CueTemplate, req.Msg.CuePlatformInput, req.Msg.CueProjectInput)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
 	}
 
-	var buf strings.Builder
-	objects := make([]map[string]any, 0, len(resources))
-	for i, r := range resources {
-		if i > 0 {
-			buf.WriteString("---\n")
-		}
-		buf.WriteString(r.YAML)
-		if r.Object != nil {
-			objects = append(objects, r.Object)
-		}
+	// Serialize per-collection resources.
+	platformYAML, platformJSON, err := serializeResources(grouped.Platform)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to serialize platform resources: %w", err))
+	}
+	projectYAML, projectJSON, err := serializeResources(grouped.Project)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to serialize project resources: %w", err))
 	}
 
-	jsonBytes, err := json.MarshalIndent(objects, "", "  ")
+	// Produce the unified output (backwards compatible) by combining both collections.
+	allResources := append(grouped.Platform, grouped.Project...)
+	unifiedYAML, unifiedJSON, err := serializeResources(allResources)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to marshal rendered resources to JSON: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to serialize unified resources: %w", err))
 	}
 
 	return connect.NewResponse(&consolev1.RenderTemplateResponse{
-		RenderedYaml: buf.String(),
-		RenderedJson: string(jsonBytes),
+		RenderedYaml:          unifiedYAML,
+		RenderedJson:          unifiedJSON,
+		PlatformResourcesYaml: platformYAML,
+		PlatformResourcesJson: platformJSON,
+		ProjectResourcesYaml:  projectYAML,
+		ProjectResourcesJson:  projectJSON,
 	}), nil
 }
 
@@ -1104,6 +1120,33 @@ func validateCueSyntax(source string) error {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid CUE syntax: %w", err))
 	}
 	return nil
+}
+
+// serializeResources converts a slice of RenderResource into a multi-document
+// YAML string (separated by "---\n") and a JSON array string. Returns empty
+// strings for an empty slice.
+func serializeResources(resources []RenderResource) (yamlStr, jsonStr string, err error) {
+	if len(resources) == 0 {
+		return "", "", nil
+	}
+
+	var buf strings.Builder
+	objects := make([]map[string]any, 0, len(resources))
+	for i, r := range resources {
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		buf.WriteString(r.YAML)
+		if r.Object != nil {
+			objects = append(objects, r.Object)
+		}
+	}
+
+	jsonBytes, err := json.MarshalIndent(objects, "", "  ")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal rendered resources to JSON: %w", err)
+	}
+	return buf.String(), string(jsonBytes), nil
 }
 
 // mapK8sError converts Kubernetes API errors to ConnectRPC errors.

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -464,9 +464,9 @@ func (h *Handler) RenderTemplate(
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("renderer not configured"))
 	}
 
-	grouped, err := h.renderer.RenderGrouped(ctx, req.Msg.CueTemplate, req.Msg.CuePlatformInput, req.Msg.CueProjectInput)
+	grouped, err := h.renderTemplateGrouped(ctx, req.Msg)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
+		return nil, err
 	}
 
 	// Serialize per-collection resources.
@@ -494,6 +494,57 @@ func (h *Handler) RenderTemplate(
 		ProjectResourcesYaml:  projectYAML,
 		ProjectResourcesJson:  projectJSON,
 	}), nil
+}
+
+// renderTemplateGrouped resolves linked template sources (if any) and delegates
+// to the appropriate renderer method. When linked_templates are provided in the
+// request, org-level template CUE sources are resolved and unified with the main
+// template so that platform resources appear in the grouped output.
+func (h *Handler) renderTemplateGrouped(ctx context.Context, msg *consolev1.RenderTemplateRequest) (*GroupedRenderResources, error) {
+	if len(msg.LinkedTemplates) == 0 || h.k8s == nil {
+		grouped, err := h.renderer.RenderGrouped(ctx, msg.CueTemplate, msg.CuePlatformInput, msg.CueProjectInput)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
+		}
+		return grouped, nil
+	}
+
+	// Derive the org name from the linked template refs. Linked templates are
+	// org-level, so we use the scope_name from the first org-scoped ref.
+	var org string
+	for _, ref := range msg.LinkedTemplates {
+		if ref.GetScope() == consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION && ref.GetScopeName() != "" {
+			org = ref.GetScopeName()
+			break
+		}
+	}
+	if org == "" {
+		// No org-scoped linked templates; render without ancestor unification.
+		grouped, err := h.renderer.RenderGrouped(ctx, msg.CueTemplate, msg.CuePlatformInput, msg.CueProjectInput)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
+		}
+		return grouped, nil
+	}
+
+	templateSources, err := h.k8s.ListOrgTemplateSourcesForRender(ctx, org, msg.LinkedTemplates)
+	if err != nil {
+		slog.WarnContext(ctx, "could not list platform templates for render, skipping platform template unification",
+			slog.String("org", org),
+			slog.Any("error", err),
+		)
+		grouped, err := h.renderer.RenderGrouped(ctx, msg.CueTemplate, msg.CuePlatformInput, msg.CueProjectInput)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
+		}
+		return grouped, nil
+	}
+
+	grouped, err := h.renderer.RenderGroupedWithTemplateSources(ctx, msg.CueTemplate, templateSources, msg.CuePlatformInput, msg.CueProjectInput)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
+	}
+	return grouped, nil
 }
 
 // ListLinkableTemplates returns all enabled templates in ancestor scopes that
@@ -1123,11 +1174,11 @@ func validateCueSyntax(source string) error {
 }
 
 // serializeResources converts a slice of RenderResource into a multi-document
-// YAML string (separated by "---\n") and a JSON array string. Returns an empty
-// YAML string and "[]" JSON array for an empty slice.
+// YAML string (separated by "---\n") and a JSON array string. Returns empty
+// strings for an empty or nil slice.
 func serializeResources(resources []RenderResource) (yamlStr, jsonStr string, err error) {
 	if len(resources) == 0 {
-		return "", "[]", nil
+		return "", "", nil
 	}
 
 	var buf strings.Builder

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -42,6 +42,14 @@ func (r *stubRenderer) RenderWithTemplateSources(_ context.Context, _ string, _ 
 	return r.resources, r.err
 }
 
+func (r *stubRenderer) RenderGrouped(_ context.Context, _ string, _ string, _ string) (*GroupedRenderResources, error) {
+	return &GroupedRenderResources{Project: r.resources}, r.err
+}
+
+func (r *stubRenderer) RenderGroupedWithTemplateSources(_ context.Context, _ string, _ []string, _ string, _ string) (*GroupedRenderResources, error) {
+	return &GroupedRenderResources{Project: r.resources}, r.err
+}
+
 func authedCtx(email string, roles []string) context.Context {
 	return rpc.ContextWithClaims(context.Background(), &rpc.Claims{
 		Sub:   "user-123",

--- a/console/templates/render_adapter.go
+++ b/console/templates/render_adapter.go
@@ -57,6 +57,61 @@ func (a *CueRendererAdapter) RenderWithTemplateSources(ctx context.Context, cueT
 	return unstructuredToRenderResources(resources)
 }
 
+// RenderGrouped evaluates cueTemplate unified with cuePlatformInput and cueInput
+// and returns resources grouped by origin (platform vs project).
+func (a *CueRendererAdapter) RenderGrouped(ctx context.Context, cueTemplate string, cuePlatformInput string, cueInput string) (*GroupedRenderResources, error) {
+	combined := cuePlatformInput
+	if combined != "" && cueInput != "" {
+		combined = combined + "\n" + cueInput
+	} else if cueInput != "" {
+		combined = cueInput
+	}
+	grouped, err := a.inner.RenderGroupedWithCueInput(ctx, cueTemplate, combined)
+	if err != nil {
+		return nil, err
+	}
+	return groupedUnstructuredToRenderResources(grouped)
+}
+
+// RenderGroupedWithTemplateSources evaluates the template unified with ancestor
+// template CUE sources and returns resources grouped by origin.
+func (a *CueRendererAdapter) RenderGroupedWithTemplateSources(ctx context.Context, cueTemplate string, templateSources []string, cuePlatformInput string, cueInput string) (*GroupedRenderResources, error) {
+	combinedInput := cuePlatformInput
+	if combinedInput != "" && cueInput != "" {
+		combinedInput = combinedInput + "\n" + cueInput
+	} else if cueInput != "" {
+		combinedInput = cueInput
+	}
+	combinedTemplate := cueTemplate
+	for _, src := range templateSources {
+		if src != "" {
+			combinedTemplate = combinedTemplate + "\n" + src
+		}
+	}
+	grouped, err := a.inner.RenderGroupedWithCueInput(ctx, combinedTemplate, combinedInput)
+	if err != nil {
+		return nil, err
+	}
+	return groupedUnstructuredToRenderResources(grouped)
+}
+
+// groupedUnstructuredToRenderResources converts GroupedResources from the
+// deployments package to GroupedRenderResources in the templates package.
+func groupedUnstructuredToRenderResources(grouped *deployments.GroupedResources) (*GroupedRenderResources, error) {
+	platform, err := unstructuredToRenderResources(grouped.Platform)
+	if err != nil {
+		return nil, err
+	}
+	project, err := unstructuredToRenderResources(grouped.Project)
+	if err != nil {
+		return nil, err
+	}
+	return &GroupedRenderResources{
+		Platform: platform,
+		Project:  project,
+	}, nil
+}
+
 // unstructuredToRenderResources converts unstructured K8s objects to RenderResource slice.
 func unstructuredToRenderResources(resources []unstructured.Unstructured) ([]RenderResource, error) {
 	out := make([]RenderResource, 0, len(resources))


### PR DESCRIPTION
## Summary
- Add `GroupedResources` type in `console/deployments/render.go` to partition rendered K8s resources into Platform (org/folder-level) and Project (project-level) collections
- Add `evaluateStructuredGrouped` and grouped variants of `evaluate`, `evaluateWithOrgTemplates`, and `evaluateWithCueInput` that return `*GroupedResources` instead of flat `[]unstructured.Unstructured`
- Add `RenderGrouped`, `RenderGroupedWithAncestorTemplates`, and `RenderGroupedWithCueInput` methods on `CueRenderer`
- Extend `Renderer` interfaces in both `console/templates` and `console/deployments` packages with grouped render methods
- Add `GroupedRenderResources` type and grouped render methods (`RenderGrouped`, `RenderGroupedWithTemplateSources`) to `CueRendererAdapter`
- Update `RenderTemplate` RPC handler to populate `platform_resources_yaml`, `platform_resources_json`, `project_resources_yaml`, `project_resources_json` fields alongside the existing unified `rendered_yaml`/`rendered_json` for backwards compatibility
- Update `GetDeploymentRenderPreview` RPC handler with `renderResourcesGrouped` method to populate the same four new fields
- Add `serializeResources` (templates) and `serializeUnstructured` (deployments) helpers for YAML/JSON serialization
- Add table-driven tests verifying: project-only templates produce empty platform fields, templates with both collections produce populated fields, the union equals the flat render, and org templates with closed structs produce correct grouping

Closes #846

## Test plan
- [x] `make test` passes (all Go and UI tests)
- [x] Project-only templates produce empty platform fields and populated project fields
- [x] Templates with both `projectResources` and `platformResources` produce populated platform and project fields
- [x] Unified `rendered_yaml`/`rendered_json` contain the union of both collections
- [x] Org templates with closed struct constraints produce correctly grouped results
- [x] Existing flat render methods remain unchanged (backwards compatible)

Generated with [Claude Code](https://claude.com/claude-code)