### PR TITLE
chore: cleanup dead code after modal-to-page template migration

### DIFF
--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
@@ -28,8 +28,6 @@ vi.mock('@/queries/folders', () => ({
   useGetFolder: vi.fn(),
 }))
 
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-
 import { useCreateTemplate } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-new.test.tsx
@@ -28,8 +28,6 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-
 import { useCreateTemplate } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'


### PR DESCRIPTION
## Summary

- Removed stale `vi.mock('sonner')` calls from both folder and org template `new.test.tsx` files. The `CreateFolderTemplatePage` and `CreateOrgTemplatePage` components never import or use sonner/toast, so these mocks were dead code left by the modal-to-page migration (PRs #849 and #859).
- Verified all acceptance criteria from the issue:
  - No unused imports in modified files (ESLint passes clean)
  - No stale comments referencing the old modal-based creation flow
  - No orphaned example template constants -- each exists in exactly one file
  - `EXAMPLE_FOLDER_PLATFORM_TEMPLATE` exists only in `folders/$folderName/templates/new.tsx`
  - `EXAMPLE_HTTPBIN_PLATFORM_TEMPLATE` exists only in `orgs/$orgName/settings/org-templates/new.tsx`
  - No Dialog, modal state, or create handler remnants in either index page

Closes #835

## Test plan

- [x] `make test-ui` passes (846/846 tests)
- [x] ESLint reports no errors on modified files
- [x] Grep confirms no Dialog/modal references in template index pages
- [x] Grep confirms each example constant exists in exactly one file

Generated with [Claude Code](https://claude.com/claude-code)