### PR TITLE
test(templates): frontend regression tests for template defaults pre-fill

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx
@@ -557,8 +557,13 @@ describe('CreateDeploymentPage', () => {
     expect(screen.getByLabelText(/name slug/i)).toHaveValue('')
     expect(screen.getByLabelText(/^description$/i)).toHaveValue('')
     expect(screen.getByLabelText(/^port$/i)).toHaveValue(8080)
-    // No command or args items should be rendered (only the entry inputs)
-    expect(screen.queryByText('/bin/httpbin')).not.toBeInTheDocument()
+    // Command and args lists should be empty (no list items rendered).
+    // StringListInput renders a "remove item N" button for each entry, so
+    // zero such buttons positively confirms both lists are empty.
+    expect(screen.queryAllByRole('button', { name: /remove item/i })).toHaveLength(0)
+    // Entry inputs should also be empty (no pending text)
+    expect(screen.getByLabelText(/command entry/i)).toHaveValue('')
+    expect(screen.getByLabelText(/args entry/i)).toHaveValue('')
   })
 
   // --- End template defaults pre-fill regression tests ---

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx
@@ -456,6 +456,113 @@ describe('CreateDeploymentPage', () => {
 
   // --- End field-ordering regression tests ---
 
+  // --- Template defaults pre-fill regression tests (issue #853) ---
+
+  it('selecting a template with full defaults pre-fills all form fields', async () => {
+    const templates = [makeTemplate('full-defaults', {
+      name: 'httpbin',
+      description: 'A simple HTTP service',
+      image: 'ghcr.io/mccutchen/go-httpbin',
+      tag: '2.21.0',
+      port: 9090,
+      command: ['/bin/httpbin'],
+      args: ['--port', '9090'],
+    })]
+    setupMocks(vi.fn(), templates)
+    render(<CreateDeploymentPage />)
+
+    fireEvent.change(screen.getByTestId('template-select'), { target: { value: 'full-defaults' } })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/display name/i)).toHaveValue('httpbin')
+      expect(screen.getByLabelText(/name slug/i)).toHaveValue('httpbin')
+      expect(screen.getByLabelText(/^description$/i)).toHaveValue('A simple HTTP service')
+      expect(screen.getByLabelText(/^image$/i)).toHaveValue('ghcr.io/mccutchen/go-httpbin')
+      expect(screen.getByLabelText(/^tag$/i)).toHaveValue('2.21.0')
+      expect(screen.getByLabelText(/^port$/i)).toHaveValue(9090)
+    })
+    // Command and args are rendered by StringListInput as spans
+    expect(screen.getByText('/bin/httpbin')).toBeInTheDocument()
+    expect(screen.getByText('--port')).toBeInTheDocument()
+    expect(screen.getByText('9090')).toBeInTheDocument()
+  })
+
+  it('selecting a different template updates all fields to new defaults', async () => {
+    const templates = [
+      makeTemplate('template-a', {
+        name: 'alpha-svc',
+        description: 'Alpha service',
+        image: 'ghcr.io/org/alpha',
+        tag: '1.0.0',
+        port: 3000,
+        command: ['/alpha'],
+        args: ['--verbose'],
+      }),
+      makeTemplate('template-b', {
+        name: 'beta-svc',
+        description: 'Beta service',
+        image: 'ghcr.io/org/beta',
+        tag: '2.0.0',
+        port: 4000,
+        command: ['/beta'],
+        args: ['--quiet'],
+      }),
+    ]
+    setupMocks(vi.fn(), templates)
+    render(<CreateDeploymentPage />)
+
+    // Select first template
+    fireEvent.change(screen.getByTestId('template-select'), { target: { value: 'template-a' } })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/display name/i)).toHaveValue('alpha-svc')
+      expect(screen.getByLabelText(/^image$/i)).toHaveValue('ghcr.io/org/alpha')
+    })
+    expect(screen.getByText('/alpha')).toBeInTheDocument()
+
+    // Switch to second template
+    fireEvent.change(screen.getByTestId('template-select'), { target: { value: 'template-b' } })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/display name/i)).toHaveValue('beta-svc')
+      expect(screen.getByLabelText(/name slug/i)).toHaveValue('beta-svc')
+      expect(screen.getByLabelText(/^description$/i)).toHaveValue('Beta service')
+      expect(screen.getByLabelText(/^image$/i)).toHaveValue('ghcr.io/org/beta')
+      expect(screen.getByLabelText(/^tag$/i)).toHaveValue('2.0.0')
+      expect(screen.getByLabelText(/^port$/i)).toHaveValue(4000)
+    })
+    // Old command/args should be gone, new ones present
+    expect(screen.queryByText('/alpha')).not.toBeInTheDocument()
+    expect(screen.queryByText('--verbose')).not.toBeInTheDocument()
+    expect(screen.getByText('/beta')).toBeInTheDocument()
+    expect(screen.getByText('--quiet')).toBeInTheDocument()
+  })
+
+  it('selecting a template with partial defaults leaves other fields at default values', async () => {
+    const templates = [makeTemplate('partial-tmpl', {
+      image: 'ghcr.io/org/partial',
+      tag: 'latest',
+    })]
+    setupMocks(vi.fn(), templates)
+    render(<CreateDeploymentPage />)
+
+    fireEvent.change(screen.getByTestId('template-select'), { target: { value: 'partial-tmpl' } })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^image$/i)).toHaveValue('ghcr.io/org/partial')
+      expect(screen.getByLabelText(/^tag$/i)).toHaveValue('latest')
+    })
+    // Fields without defaults should be at their default/empty values
+    expect(screen.getByLabelText(/display name/i)).toHaveValue('')
+    expect(screen.getByLabelText(/name slug/i)).toHaveValue('')
+    expect(screen.getByLabelText(/^description$/i)).toHaveValue('')
+    expect(screen.getByLabelText(/^port$/i)).toHaveValue(8080)
+    // No command or args items should be rendered (only the entry inputs)
+    expect(screen.queryByText('/bin/httpbin')).not.toBeInTheDocument()
+  })
+
+  // --- End template defaults pre-fill regression tests ---
+
   it('passes command and args to mutateAsync', async () => {
     const mutateAsync = vi.fn().mockResolvedValue({ name: 'my-api' })
     setupMocks(mutateAsync)


### PR DESCRIPTION
## Summary
- Add comprehensive regression test that verifies ALL form fields (name, description, image, tag, port, command, args) are pre-filled simultaneously when selecting a template with full defaults
- Add template-switching test that selects template A then switches to template B, asserting all fields update to B's defaults and A's command/args are removed
- Add partial-defaults test that verifies only image and tag are populated when the template lacks other defaults, with remaining fields at empty/default values

Closes #853

## Test plan
- [x] `make test-ui` passes -- 849 tests across 54 files, 40 tests in `-new.test.tsx` (up from 37)
- [ ] CI Unit Tests pass
- [ ] Existing template defaults tests continue to pass (verified locally)

> Local E2E was not run (test-only change to frontend unit tests). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)