### PR TITLE
feat(ui): version status indicator on template detail page

### DIFF
--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -277,15 +277,18 @@ function checkUpdatesKey(scope: TemplateScopeRef, templateName: string) {
 // When templateName is provided, only that template's links are checked.
 // When empty, all templates in the scope are checked.
 // Pass options.enabled to control when the query fires (defaults to true).
-export function useCheckUpdates(scope: TemplateScopeRef, templateName = '', options?: { enabled?: boolean }) {
+// Pass options.includeCurrent to include entries for templates already at their
+// latest version (useful for the version status indicator).
+export function useCheckUpdates(scope: TemplateScopeRef, templateName = '', options?: { enabled?: boolean; includeCurrent?: boolean }) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   const callerEnabled = options?.enabled ?? true
+  const includeCurrent = options?.includeCurrent ?? false
   return useQuery({
-    queryKey: checkUpdatesKey(scope, templateName),
+    queryKey: [...checkUpdatesKey(scope, templateName), includeCurrent] as const,
     queryFn: async () => {
-      const response = await client.checkUpdates({ scope, templateName })
+      const response = await client.checkUpdates({ scope, templateName, includeCurrent })
       return response.updates
     },
     enabled: isAuthenticated && !!scope.scopeName && callerEnabled,

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -280,11 +280,6 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                         <div className="flex flex-wrap gap-1">
                           {dedupedLinked.map((t) => {
                             const scopeLbl = t.scopeRef?.scope === TemplateScope.ORGANIZATION ? 'Org' : t.scopeRef?.scope === TemplateScope.FOLDER ? 'Folder' : undefined
-                            // Look up the version constraint from the template's linkedTemplates.
-                            const linkedRef = (template?.linkedTemplates ?? []).find(
-                              (lt) => lt.scope === t.scopeRef?.scope && lt.scopeName === t.scopeRef?.scopeName && lt.name === t.name
-                            )
-                            const constraint = linkedRef?.versionConstraint
                             // Look up version status from the check-updates response.
                             const updateEntry = templateUpdates.find(
                               (u) => u.ref?.scope === t.scopeRef?.scope && u.ref?.scopeName === t.scopeRef?.scopeName && u.ref?.name === t.name

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import { Pencil, Copy, Lock, ArrowUpCircle } from 'lucide-react'
+import { Pencil, Copy, Lock, ArrowUpCircle, CheckCircle2 } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -74,7 +74,10 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const [upgradeOpen, setUpgradeOpen] = useState(false)
 
   // Check for available updates on this template's linked templates.
-  const { data: templateUpdates = [] } = useCheckUpdates(scope, templateName)
+  // Pass includeCurrent so the response includes version info for all linked
+  // templates (not just those with pending updates), enabling the version
+  // status indicator on each pill badge.
+  const { data: templateUpdates = [] } = useCheckUpdates(scope, templateName, { includeCurrent: true })
 
   useEffect(() => {
     if (template?.cueTemplate !== undefined) {
@@ -282,25 +285,65 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
                               (lt) => lt.scope === t.scopeRef?.scope && lt.scopeName === t.scopeRef?.scopeName && lt.name === t.name
                             )
                             const constraint = linkedRef?.versionConstraint
+                            // Look up version status from the check-updates response.
+                            const updateEntry = templateUpdates.find(
+                              (u) => u.ref?.scope === t.scopeRef?.scope && u.ref?.scopeName === t.scopeRef?.scopeName && u.ref?.name === t.name
+                            )
+                            const currentVersion = updateEntry?.currentVersion
+                            const latestVersion = updateEntry?.latestVersion
+                            const isUpToDate = !!currentVersion && currentVersion === latestVersion
+                            const hasUpdate = !!currentVersion && !!latestVersion && currentVersion !== latestVersion
+                            const isUnversioned = updateEntry && !currentVersion && !latestVersion
                             return (
                               <span key={keyOf(t)} className="inline-flex items-center gap-1 text-xs bg-muted px-2 py-0.5 rounded-full">
                                 {t.displayName || t.name}
                                 {scopeLbl && <span className="text-xs text-muted-foreground">{scopeLbl}</span>}
-                                {constraint && <span className="text-xs font-mono text-muted-foreground">{constraint}</span>}
+                                {currentVersion && <span className="text-xs font-mono text-muted-foreground">v{currentVersion}</span>}
+                                {isUpToDate && (
+                                  <TooltipProvider>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <CheckCircle2 className="h-3 w-3 text-green-500" aria-label="Up to date" />
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        <p>Up to date &mdash; v{currentVersion}</p>
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </TooltipProvider>
+                                )}
+                                {hasUpdate && (
+                                  <TooltipProvider>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <ArrowUpCircle className="h-3 w-3 text-amber-500" aria-label="Update available" />
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        <p>Update available: v{currentVersion} &rarr; v{latestVersion}</p>
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </TooltipProvider>
+                                )}
+                                {isUnversioned && <span className="text-xs text-muted-foreground italic">unversioned</span>}
                                 {t.mandatory && <Lock className="h-3 w-3 text-muted-foreground" aria-label="mandatory" />}
                               </span>
                             )
                           })}
                         </div>
-                        {templateUpdates.length > 0 && (
-                          <button
-                            onClick={() => setUpgradeOpen(true)}
-                            className="inline-flex items-center gap-1 text-xs text-primary hover:underline cursor-pointer w-fit"
-                          >
-                            <ArrowUpCircle className="h-3 w-3" />
-                            {templateUpdates.length === 1 ? '1 update available' : `${templateUpdates.length} updates available`}
-                          </button>
-                        )}
+                        {(() => {
+                          const pendingUpdates = templateUpdates.filter(
+                            (u) => !!u.currentVersion && !!u.latestVersion && u.currentVersion !== u.latestVersion
+                          )
+                          if (pendingUpdates.length === 0) return null
+                          return (
+                            <button
+                              onClick={() => setUpgradeOpen(true)}
+                              className="inline-flex items-center gap-1 text-xs text-primary hover:underline cursor-pointer w-fit"
+                            >
+                              <ArrowUpCircle className="h-3 w-3" />
+                              {pendingUpdates.length === 1 ? '1 update available' : `${pendingUpdates.length} updates available`}
+                            </button>
+                          )
+                        })()}
                       </div>
                     )
                   })()}
@@ -571,7 +614,9 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
       <UpgradeDialog
         open={upgradeOpen}
         onOpenChange={setUpgradeOpen}
-        updates={templateUpdates}
+        updates={templateUpdates.filter(
+          (u) => !!u.currentVersion && !!u.latestVersion && u.currentVersion !== u.latestVersion
+        )}
         scope={scope}
         templateName={templateName}
         linkedTemplates={template?.linkedTemplates ?? []}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -49,7 +49,7 @@ vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: vi.fn((value: unknown) => value),
 }))
 
-import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useRenderTemplate, useListLinkableTemplates } from '@/queries/templates'
+import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useRenderTemplate, useListLinkableTemplates, useCheckUpdates } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -767,6 +767,70 @@ describe('DeploymentTemplateDetailPage', () => {
       render(<DeploymentTemplateDetailPage />)
       expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
       expect(screen.getByText(/none linked/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('version status indicator', () => {
+    const mockLinkable = [
+      { name: 'reference-grant', displayName: 'Reference Grant', description: 'Adds a ReferenceGrant', mandatory: true, scopeRef: { scope: 1, scopeName: 'acme' }, releases: [{ version: '1.0.0' }, { version: '1.1.0' }] },
+      { name: 'httproute', displayName: 'HTTPRoute Gateway', description: 'Adds an HTTPRoute', mandatory: false, scopeRef: { scope: 1, scopeName: 'acme' }, releases: [{ version: '2.0.0' }, { version: '2.1.0' }] },
+      { name: 'no-releases', displayName: 'No Releases Template', description: 'No releases', mandatory: false, scopeRef: { scope: 2, scopeName: 'platform' }, releases: [] },
+    ]
+
+    it('shows green check icon when current version equals latest version', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
+      ;(useCheckUpdates as Mock).mockReturnValue({
+        data: [
+          { ref: { scope: 1, scopeName: 'acme', name: 'httproute' }, currentVersion: '2.1.0', latestVersion: '2.1.0', latestCompatibleVersion: '2.1.0', breakingUpdateAvailable: false },
+        ],
+        isPending: false,
+        error: null,
+      })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme', versionConstraint: '^2.0.0' }] })
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByLabelText('Up to date')).toBeInTheDocument()
+      expect(screen.getByText('v2.1.0')).toBeInTheDocument()
+    })
+
+    it('shows amber update icon when current version is behind latest', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
+      ;(useCheckUpdates as Mock).mockReturnValue({
+        data: [
+          { ref: { scope: 1, scopeName: 'acme', name: 'httproute' }, currentVersion: '2.0.0', latestVersion: '2.1.0', latestCompatibleVersion: '2.1.0', breakingUpdateAvailable: false },
+        ],
+        isPending: false,
+        error: null,
+      })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme', versionConstraint: '^2.0.0' }] })
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByLabelText('Update available')).toBeInTheDocument()
+      expect(screen.getByText('v2.0.0')).toBeInTheDocument()
+    })
+
+    it('shows unversioned indicator for templates with no releases', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
+      ;(useCheckUpdates as Mock).mockReturnValue({
+        data: [
+          { ref: { scope: 2, scopeName: 'platform', name: 'no-releases' }, currentVersion: '', latestVersion: '', latestCompatibleVersion: '', breakingUpdateAvailable: false },
+        ],
+        isPending: false,
+        error: null,
+      })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'no-releases', scope: 2, scopeName: 'platform' }] })
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByText('unversioned')).toBeInTheDocument()
+    })
+
+    it('passes includeCurrent: true to useCheckUpdates', () => {
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: mockLinkable, isPending: false })
+      setupMocks(Role.OWNER, { ...mockTemplate, linkedTemplates: [{ name: 'httproute', scope: 1, scopeName: 'acme' }] })
+      render(<DeploymentTemplateDetailPage />)
+      // useCheckUpdates should be called with scope, templateName, and options including includeCurrent
+      expect(useCheckUpdates as Mock).toHaveBeenCalledWith(
+        expect.anything(), // scope
+        expect.any(String), // templateName
+        expect.objectContaining({ includeCurrent: true }),
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary
- Updated `useCheckUpdates` hook to accept and forward `includeCurrent` option, which causes the backend to return version info for ALL linked templates (not just those with pending updates)
- Each linked platform template pill on the template detail page now shows the resolved current version (e.g., `v1.2.0`) in monospace
- Green CheckCircle2 icon with tooltip when current version matches latest version (up to date)
- Amber ArrowUpCircle icon with tooltip when current version is behind latest (update available)
- Italic "unversioned" label for templates with no releases
- The "N updates available" button and UpgradeDialog now filter to only count entries with actual pending updates (since `includeCurrent` returns all entries)
- Removed dead code: unused `constraint` variable left from the refactor
- Added 4 new UI unit tests for version status indicator states (up-to-date, outdated, unversioned, includeCurrent param)

Closes #841

## Test plan
- [x] `make test` — 55 test files, 864 tests passed
- [ ] Green check icon renders when current version equals latest version
- [ ] Amber update icon renders when current version is behind latest
- [ ] "unversioned" label renders for templates with no releases
- [ ] `useCheckUpdates` is called with `includeCurrent: true`
- [ ] "N updates available" button only counts entries with actual pending updates
- [ ] UpgradeDialog only receives entries with actual pending updates

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)