### PR TITLE
docs(templates): add guardrail for template defaults pre-fill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Before making changes, review `CONTRIBUTING.md` for commit message requirements.
 - [Linking UI](docs/agents/guardrail-linking-ui.md) — Linked templates section must always render on create and edit pages.
 - [CI Check Names](docs/agents/guardrail-ci-check-names.md) — Use actual GitHub Actions names: "Unit Tests", "Lint", "E2E Tests" — not lowercase shorthand.
 - [Pages Over Modals](docs/agents/guardrail-pages-over-modals.md) — Create and update UIs use dedicated route pages, not modals; modals only for brief confirmations and lightweight actions.
+- [Template Defaults Pre-Fill](docs/agents/guardrail-template-defaults.md) — Per-field CUE defaults extraction and frontend pre-fill; non-concrete fields must not drop concrete siblings.
 
 ## Planning & Execution
 

--- a/docs/adrs/018-cue-template-default-values.md
+++ b/docs/adrs/018-cue-template-default-values.md
@@ -115,6 +115,11 @@ It then marshals `defaultsVal` into a `ProjectInput` struct and maps the fields 
 `ListDeploymentTemplates` responses so the frontend can pre-fill the Create Deployment form
 without making a second render round-trip.
 
+> **Note:** The whole-block marshaling mechanism described here has been superseded by
+> per-field extraction in [ADR 025](025-per-field-defaults-extraction.md). Each field is now
+> marshaled independently so that a non-concrete field does not prevent extraction of concrete
+> siblings. The overall flow (compile CUE, look up `defaults`, map to proto) remains the same.
+
 If the template has no `defaults` block (e.g., legacy templates), the extraction returns
 empty and the frontend falls back to its current zero-value defaults. This preserves
 backwards compatibility.

--- a/docs/agents/guardrail-template-defaults.md
+++ b/docs/agents/guardrail-template-defaults.md
@@ -1,0 +1,73 @@
+# Guardrail: Template Defaults Pre-Fill
+
+**The backend must extract each `ProjectInput` field independently from the CUE `defaults` block (per-field extraction). The frontend must pre-fill all Create Deployment form fields from the extracted `TemplateDefaults` when a template is selected.** A non-concrete field must not prevent extraction of concrete siblings. All pre-filled fields must update when the user switches templates.
+
+## Rationale
+
+This feature has regressed multiple times. The original implementation (ADR 018) used whole-block `MarshalJSON()` on the entire `defaults` CUE value. If any single field was non-concrete (e.g., `env: _`), the marshal call failed for the entire value and silently dropped all defaults -- even fields like `name`, `image`, and `tag` that were perfectly concrete. ADR 025 replaced this with per-field extraction to eliminate the silent data loss.
+
+On the frontend side, `handleTemplateChange` in the Create Deployment form must map every `TemplateDefaults` field to its corresponding form field. Missing a field means the form shows stale values from a previously selected template or empty values when the template intended to provide defaults.
+
+## Enforcement
+
+### Backend
+
+`console/templates/defaults_test.go` includes a "mixed concrete and non-concrete fields" test case that verifies concrete fields are extracted while non-concrete fields are silently omitted:
+
+```go
+t.Run("mixed concrete and non-concrete fields returns partial defaults", func(t *testing.T) {
+    cueSource := `
+defaults: #ProjectInput & {
+    name:  "httpbin"
+    image: string  // non-concrete — constrained but no value
+    tag:   "2.21.0"
+    port:  8080
+}
+`
+    d, err := ExtractDefaults(cueSource)
+    // ... asserts name="httpbin", image="", tag="2.21.0", port=8080
+})
+```
+
+### Frontend
+
+`frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx` includes comprehensive defaults pre-fill regression tests (added in issue #853):
+
+- `selecting a template with full defaults pre-fills all form fields` -- verifies every field is populated
+- `selecting a different template updates all fields to new defaults` -- verifies switching templates replaces all values
+- `selecting a template with partial defaults leaves other fields at default values` -- verifies missing defaults do not corrupt other fields
+
+CI fails if either the backend extraction or the frontend pre-fill regresses.
+
+## Common Failure Mode
+
+Reverting `ExtractDefaults()` in `console/templates/defaults.go` to whole-block `MarshalJSON()` on the entire `defaults` value instead of per-field extraction. This causes all defaults to silently disappear when any single field is non-concrete.
+
+On the frontend, omitting a field from the `handleTemplateChange` callback means that field retains its value from a previously selected template instead of updating to the new template's default.
+
+## Triggers
+
+Apply this rule when:
+
+- Editing `console/templates/defaults.go` (backend extraction logic)
+- Editing `frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx` (the `handleTemplateChange` callback)
+- Adding new fields to the `TemplateDefaults` proto message in `proto/holos/console/v1/templates.proto`
+- Adding new fields to `ProjectInput` in `api/v1alpha2/types.go` that should have default values
+- Resolving merge conflicts in any of the above files
+
+## Incorrect Patterns
+
+| Pattern | Why it is wrong |
+|---------|-----------------|
+| `defaultsVal.MarshalJSON()` on the whole `defaults` value | One non-concrete field drops all defaults silently |
+| `handleTemplateChange` that does not set every `TemplateDefaults` field | Stale values persist from previously selected template |
+| Removing the "mixed concrete and non-concrete" backend test | The per-field extraction regression guard must stay |
+| Removing the frontend defaults pre-fill regression tests | The form pre-fill regression guard must stay |
+| Using `json.Unmarshal` on the entire defaults block into `ProjectInput` | Same whole-block failure mode as `MarshalJSON()` |
+
+## Related
+
+- [Template Service](template-service.md) -- Deployment Defaults section describes the extraction mechanism
+- [Guardrail: Template Fields](guardrail-template-fields.md) -- New proto fields must propagate through defaults extraction
+- [ADR 018: CUE Template Default Values](../adrs/018-cue-template-default-values.md) -- Original design for the `defaults` block
+- [ADR 025: Per-Field CUE Defaults Extraction](../adrs/025-per-field-defaults-extraction.md) -- Per-field extraction design replacing whole-block marshaling

--- a/docs/agents/guardrail-template-fields.md
+++ b/docs/agents/guardrail-template-fields.md
@@ -1,6 +1,6 @@
 # Guardrail: Template Fields
 
-**When adding new fields to `CreateDeploymentRequest`, `DeploymentDefaults`, or related template proto messages**, the field must also be:
+**When adding new fields to `CreateDeploymentRequest`, `TemplateDefaults`, or related template proto messages**, the field must also be:
 
 1. Added to the `ProjectInput` (user-provided fields) or `PlatformInput` (platform fields) Go struct in `api/v1alpha2/types.go` — CUE schema is generated from these types via `cue get go`
 2. Included in the rendering pipeline in `console/deployments/render.go`
@@ -15,5 +15,6 @@ This ensures template authors always see new fields in the preview, that the CUE
 
 - [Template Service](template-service.md) — The service these fields belong to
 - [Deployment Service](deployment-service.md) — The rendering pipeline that consumes these fields
+- [Guardrail: Template Defaults Pre-Fill](guardrail-template-defaults.md) — Per-field defaults extraction must cover all form fields
 - [Guardrail: Template Linking](guardrail-template-linking.md) — Another template guardrail
 - [Guardrail: Template Docs](guardrail-template-docs.md) — Keep docs in sync with template changes

--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -15,7 +15,7 @@ Scope is encoded in the `console.holos.run/template-scope` label (`organization|
 
 ## Deployment Defaults
 
-Templates can carry `DeploymentDefaults` (name, description, image, tag, command, args, env, port) extracted from the `defaults` block in the CUE source (ADR 018) that pre-fill the Create Deployment form.
+Templates can carry `TemplateDefaults` (name, description, image, tag, command, args, port) extracted from the `defaults` block in the CUE source (ADR 018). The backend uses per-field extraction (ADR 025) to read each field independently, so a non-concrete field does not prevent extraction of concrete siblings. The extracted defaults pre-fill the Create Deployment form.
 
 The `RenderDeploymentTemplate` RPC returns rendered resources as both YAML (`rendered_yaml`) and JSON (`rendered_json`).
 
@@ -68,6 +68,7 @@ Edit access requires `PERMISSION_TEMPLATES_WRITE`, enforced via the unified `Tem
 - [Guardrail: Template Fields](guardrail-template-fields.md) — New fields must be added across the full pipeline
 - [Guardrail: Template Linking](guardrail-template-linking.md) — Linked templates annotation handling
 - [Guardrail: Template Docs](guardrail-template-docs.md) — Keep cue-template-guide.md current
+- [Guardrail: Template Defaults Pre-Fill](guardrail-template-defaults.md) — Per-field defaults extraction and frontend pre-fill
 - [Guardrail: Terminology](guardrail-terminology.md) — Use "platform template" not "system template"
 - [Tool Dependencies](tool-dependencies.md) — CUE runtime dependency
 - [ADR 024](../adrs/024-template-versioning.md) — Versioning, releases, and version constraints design

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -756,15 +756,19 @@ fills in a value, that concrete value wins.
 ### How defaults are extracted
 
 When the backend loads a template (in `GetDeploymentTemplate` or `ListDeploymentTemplates`),
-it evaluates the CUE source and reads the `defaults` path. It maps the concrete field values
-to `DeploymentDefaults` in the proto response:
+it evaluates the CUE source and reads the `defaults` path. Each field is extracted
+independently (per-field extraction, [ADR 025](adrs/025-per-field-defaults-extraction.md))
+so that a non-concrete field does not prevent extraction of concrete siblings. The concrete
+field values are mapped to `TemplateDefaults` in the proto response:
 
 ```
-defaults.name        → DeploymentDefaults.name
-defaults.image       → DeploymentDefaults.image
-defaults.tag         → DeploymentDefaults.tag
-defaults.description → DeploymentDefaults.description
-defaults.port        → DeploymentDefaults.port
+defaults.name        → TemplateDefaults.name
+defaults.image       → TemplateDefaults.image
+defaults.tag         → TemplateDefaults.tag
+defaults.description → TemplateDefaults.description
+defaults.port        → TemplateDefaults.port
+defaults.command     → TemplateDefaults.command
+defaults.args        → TemplateDefaults.args
 ```
 
 The frontend receives these fields and uses them to pre-fill the Create Deployment form.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -44,7 +44,7 @@ A project-level CUE template that defines the application resources for a
 deployment. Deployment templates are stored as Kubernetes ConfigMaps in the
 project namespace and written by product engineers. They produce resources in
 `projectResources` (Deployments, Services, ServiceAccounts) and may carry
-`DeploymentDefaults` (image, tag, port, etc.) that pre-fill the Create
+`TemplateDefaults` (image, tag, port, etc.) that pre-fill the Create
 Deployment form. At render time, the deployment template is unified with the
 applicable platform templates — always including mandatory platform templates,
 plus any enabled platform templates explicitly linked via the


### PR DESCRIPTION
## Summary
- Add `docs/agents/guardrail-template-defaults.md` codifying the per-field defaults extraction invariant and frontend pre-fill behavior
- Update `AGENTS.md` to list the new guardrail in the Guardrails section
- Update `docs/agents/template-service.md` Deployment Defaults paragraph to reference per-field extraction (ADR 025) and rename DeploymentDefaults to TemplateDefaults
- Update `docs/agents/guardrail-template-fields.md` to rename DeploymentDefaults to TemplateDefaults and cross-link the new guardrail
- Add supersession note to ADR 018 Decision 4 pointing to ADR 025
- Update `docs/cue-template-guide.md` "How defaults are extracted" section to mention per-field extraction, use TemplateDefaults name, and add command/args to field mapping
- Update `docs/glossary.md` to use current TemplateDefaults proto name

Closes #854

## Test plan
- [x] `make test` passes (55 test files, 863 tests, all green)
- [ ] Verify all documentation cross-links resolve correctly
- [ ] Verify no conflicting references to DeploymentDefaults remain in `docs/agents/`

Generated with [Claude Code](https://claude.com/claude-code)