### PR TITLE
chore(templates): cleanup stale defaults extraction references

### DIFF
--- a/console/templates/default_template.cue
+++ b/console/templates/default_template.cue
@@ -3,7 +3,7 @@
 
 // defaults declares the template's default values as concrete CUE data.
 // The backend reads this block to pre-fill the Create Deployment form.
-// See ADR 018 for the design rationale.
+// See ADR 018 for the design rationale and ADR 025 for per-field extraction.
 defaults: #ProjectInput & {
 	name:        "httpbin"
 	image:       "ghcr.io/mccutchen/go-httpbin"

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -734,7 +734,7 @@ func configMapToTemplate(cm *corev1.ConfigMap, scope consolev1.TemplateScope, sc
 		}
 	}
 
-	// Priority 1: CUE extraction from the template source (ADR 018 pattern).
+	// Priority 1: CUE extraction from the template source (ADR 018 design, ADR 025 per-field extraction).
 	// Only project-scope templates carry deployment defaults.
 	if scope == consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT && cueSource != "" {
 		extracted, err := ExtractDefaults(cueSource)

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
@@ -59,7 +59,7 @@ export function CreateDeploymentPage({ projectName: propProjectName }: { project
     setTemplate(templateName)
     const selected = templates.find((t) => t.name === templateName)
     const defaults = selected?.defaults
-    // Pre-fill name and description from CUE-extracted defaults (ADR 018).
+    // Pre-fill form fields from CUE-extracted defaults (ADR 018 design, ADR 025 per-field extraction).
     if (defaults?.name) {
       setDisplayName(defaults.name)
       setName(slugify(defaults.name))


### PR DESCRIPTION
## Summary
- Updated three stale ADR 018-only references in code comments to cite both ADR 018 (design) and ADR 025 (per-field extraction mechanism)
- Fixed `configMapToTemplate` comment in `k8s.go`, `defaults` block comment in `default_template.cue`, and `handleTemplateChange` comment in the Create Deployment frontend
- Corrected frontend comment from "Pre-fill name and description" to "Pre-fill form fields" since all fields are pre-filled
- Verified ADR 018 Decision 4 already has the note pointing to ADR 025
- Confirmed no dead code paths from the old whole-block extraction remain in `defaults.go`
- No unused imports in any modified files

Closes #855

## Test plan
- [x] `make test` passes (all Go tests + 867 UI tests)
- [x] `make vet` clean
- [x] Grep for stale "whole-block" and ADR 018-only references in code files returns no results

Generated with [Claude Code](https://claude.com/claude-code)