### PR TITLE
chore(templates): cleanup stale docs after version-aware linking

### DIFF
--- a/docs/agents/guardrail-linking-ui.md
+++ b/docs/agents/guardrail-linking-ui.md
@@ -9,6 +9,8 @@ create and edit pages, regardless of whether linkable ancestor templates exist.
 2. When no linkable templates exist, show an empty state message.
 3. The preview pane must pass linked templates to `useRenderTemplate` for unified output.
 4. Regression tests in `-linking-regression.test.tsx` must pass.
+5. When a linkable template has releases, the linking dialog must show a version selector dropdown next to the checkbox allowing the user to pin to a specific version or select "Latest (auto-update)".
+6. On the detail page, linked template pill badges must show a version status indicator: a green check when up to date, an amber arrow when an update is available, or "unversioned" when the template has no releases.
 
 ## Why
 
@@ -18,5 +20,6 @@ tests and this document prevent that regression.
 
 ## Related
 
-- [Guardrail: Template Linking](guardrail-template-linking.md) -- Backend linking model
-- [Template Service](template-service.md) -- Render set formula
+- [Guardrail: Template Linking](guardrail-template-linking.md) -- Backend linking model and version constraints
+- [Template Service](template-service.md) -- Render set formula and versioning
+- [ADR 024](../adrs/024-template-versioning.md) -- Versioning, releases, and version constraints design

--- a/docs/agents/guardrail-template-linking.md
+++ b/docs/agents/guardrail-template-linking.md
@@ -2,7 +2,7 @@
 
 **When adding new fields that affect which platform templates are included in a render**, ensure:
 
-1. The linking list is read from the `console.holos.run/linked-templates` annotation on the deployment template ConfigMap (JSON array of `{scope, scope_name, name}` objects — v1alpha2 format).
+1. The linking list is read from the `console.holos.run/linked-templates` annotation on the deployment template ConfigMap (JSON array of `{scope, scope_name, name, version_constraint}` objects -- v1alpha2 format). The `version_constraint` field is optional.
 2. `OrgTemplateProvider.ListOrgTemplateSourcesForRender(ctx, org, linkedNames)` is called with the resolved linked names (not `ListEnabledOrgTemplateSources` — that method no longer exists).
 3. `docs/cue-template-guide.md` "Linking Platform Templates" section and the render set formula remain accurate.
 

--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -37,7 +37,7 @@ Platform templates (org-scoped or folder-scoped) can be marked `mandatory` (appl
 
 ## Explicit Linking Model
 
-ADR 019, extended to cross-level refs: each deployment template ConfigMap may carry the annotation `console.holos.run/linked-templates` (JSON array of `{scope, scope_name, name}` objects); at render time these refs are resolved and passed to `ListOrgTemplateSourcesForRender`.
+ADR 019, extended to cross-level refs: each deployment template ConfigMap may carry the annotation `console.holos.run/linked-templates` (JSON array of `{scope, scope_name, name, version_constraint}` objects); at render time these refs are resolved and passed to `ListOrgTemplateSourcesForRender`. The `version_constraint` field is optional; when present it selects the latest Release satisfying the semver range instead of the mutable working copy.
 
 The render set formula is: `(mandatory AND enabled) UNION (enabled AND ref IN linked_list)`.
 

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -590,9 +590,12 @@ multiple non-overlapping archetypes to coexist in the same organization.
 When creating or editing a deployment template, the form shows a
 "Linked Platform Templates" section listing all enabled ancestor platform
 templates (organization and folder scopes), grouped by scope. Each non-mandatory
-template has a checkbox — check it to include that template in every render of
+template has a checkbox -- check it to include that template in every render of
 this deployment template. Mandatory templates appear pre-checked with a lock
-icon; they are always included and cannot be deselected.
+icon; they are always included and cannot be deselected. When a platform template
+has published releases, a version selector dropdown appears next to the checkbox
+allowing the user to pin to a specific version or select "Latest (auto-update)"
+which tracks the newest release automatically.
 
 **Render set formula**
 
@@ -604,8 +607,10 @@ render_set = (mandatory AND enabled) UNION (enabled AND name IN linked_list)
 
 The `linked_list` is derived from the `console.holos.run/linked-templates`
 annotation on the deployment template ConfigMap (v1alpha2 format: JSON array of
-`{scope, scope_name, name}` objects). Disabled templates are never
-included, even if they appear in the linked list.
+`{scope, scope_name, name, version_constraint}` objects). The
+`version_constraint` field is optional; when present it pins the linked template
+to a semver range (see [Versioning and Releases](#versioning-and-releases)).
+Disabled templates are never included, even if they appear in the linked list.
 
 **Authoring implications**
 


### PR DESCRIPTION
## Summary
- Updated `docs/agents/template-service.md` to include `version_constraint` in the linked-templates annotation format description
- Updated `docs/agents/guardrail-template-linking.md` to include `version_constraint` in the annotation format description
- Updated `docs/agents/guardrail-linking-ui.md` to add rules for version selector dropdown and version status indicator; added ADR 024 cross-reference
- Updated `docs/cue-template-guide.md` to include `version_constraint` in the annotation format and describe the version selector in the linking editor section
- Reviewed all implementation files (`$templateName.tsx`, `new.tsx`, `queries/templates.ts`, `handler.go`) for dead code, unused imports, stale TODOs, and debug logging -- found none

Closes #842

## Test plan
- [x] `make test` passes (all Go tests, 867 UI tests)
- [x] No dead code or unused imports found in implementation files
- [x] Documentation accurately reflects version-aware linking behavior
- [x] `docs/agents/cue-template-guide.md` reviewed for accuracy (guardrail requirement)

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)