### PR TITLE
feat(ui): display platform and project resources separately in previews

### DIFF
--- a/frontend/src/components/cue-template-editor.test.tsx
+++ b/frontend/src/components/cue-template-editor.test.tsx
@@ -188,4 +188,96 @@ describe('CueTemplateEditor', () => {
     await user.click(screen.getByRole('tab', { name: /preview/i }))
     expect(screen.getByLabelText('Render status: fresh')).toBeInTheDocument()
   })
+
+  describe('per-collection resource display', () => {
+    it('renders both platform and project sections when both are present', async () => {
+      const user = userEvent.setup()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: {
+          renderedYaml: 'all-resources',
+          renderedJson: '',
+          platformResourcesYaml: 'apiVersion: v1\nkind: ReferenceGrant',
+          platformResourcesJson: '',
+          projectResourcesYaml: 'apiVersion: apps/v1\nkind: Deployment',
+          projectResourcesJson: '',
+        },
+        error: null,
+        isFetching: false,
+      })
+      render(
+        <CueTemplateEditor
+          cueTemplate="content"
+          onChange={vi.fn()}
+          scope={testScope}
+        />
+      )
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      // Both labeled sections should be present
+      expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+      expect(screen.getByText('Project Resources')).toBeInTheDocument()
+      expect(screen.getByLabelText('Platform Resources YAML')).toHaveTextContent('ReferenceGrant')
+      expect(screen.getByLabelText('Project Resources YAML')).toHaveTextContent('Deployment')
+      // Unified renderedYaml should NOT be shown
+      expect(screen.queryByText('all-resources')).not.toBeInTheDocument()
+    })
+
+    it('renders only project section when platform resources are empty', async () => {
+      const user = userEvent.setup()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: {
+          renderedYaml: 'unified-yaml',
+          renderedJson: '',
+          platformResourcesYaml: '',
+          platformResourcesJson: '',
+          projectResourcesYaml: 'apiVersion: apps/v1\nkind: Deployment',
+          projectResourcesJson: '',
+        },
+        error: null,
+        isFetching: false,
+      })
+      render(
+        <CueTemplateEditor
+          cueTemplate="content"
+          onChange={vi.fn()}
+          scope={testScope}
+        />
+      )
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      // Should not show "Platform Resources" heading
+      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
+      // Should not show "Project Resources" heading (just shows "Rendered YAML")
+      expect(screen.queryByText('Project Resources')).not.toBeInTheDocument()
+      // Should show the label as "Rendered YAML"
+      expect(screen.getByText('Rendered YAML')).toBeInTheDocument()
+      // The content should be from projectResourcesYaml
+      expect(screen.getByLabelText('Rendered YAML')).toHaveTextContent('Deployment')
+    })
+
+    it('falls back to unified renderedYaml when no per-collection fields are present', async () => {
+      const user = userEvent.setup()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: {
+          renderedYaml: 'apiVersion: v1\nkind: Service',
+          renderedJson: '',
+        },
+        error: null,
+        isFetching: false,
+      })
+      render(
+        <CueTemplateEditor
+          cueTemplate="content"
+          onChange={vi.fn()}
+          scope={testScope}
+        />
+      )
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      expect(screen.getByText('Rendered YAML')).toBeInTheDocument()
+      expect(screen.getByLabelText('Rendered YAML')).toHaveTextContent('Service')
+      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
+      expect(screen.queryByText('Project Resources')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -205,7 +205,7 @@ export function CueTemplateEditor({
                   {platformResourcesYaml}
                 </pre>
               )}
-              {platformResourcesYaml && projectResourcesYaml && (
+              {platformResourcesYaml && (
                 <div className="flex items-center gap-2 pt-2">
                   <Label>Project Resources</Label>
                 </div>

--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -125,6 +125,12 @@ export function CueTemplateEditor({
     linkedTemplates,
   )
 
+  // Per-collection fields take precedence over the unified renderedYaml
+  // when populated by the backend. Fall back to unified view for backwards
+  // compatibility with older backends that only return renderedYaml.
+  const platformResourcesYaml = renderData?.platformResourcesYaml ?? ''
+  const projectResourcesYaml = renderData?.projectResourcesYaml ?? ''
+  const hasPerCollectionFields = !!(platformResourcesYaml || projectResourcesYaml)
   const renderedYaml = renderData?.renderedYaml
 
   return (
@@ -182,13 +188,35 @@ export function CueTemplateEditor({
         </div>
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Label>Rendered YAML</Label>
+            <Label>{hasPerCollectionFields && platformResourcesYaml ? 'Platform Resources' : 'Rendered YAML'}</Label>
             <RenderStatusIndicator isStale={isStale} isRendering={isRendering} hasError={!!renderError} />
           </div>
           {renderError ? (
             <Alert variant="destructive">
               <AlertDescription aria-label="Preview error">{renderError.message}</AlertDescription>
             </Alert>
+          ) : hasPerCollectionFields ? (
+            <>
+              {platformResourcesYaml && (
+                <pre
+                  aria-label="Platform Resources YAML"
+                  className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre"
+                >
+                  {platformResourcesYaml}
+                </pre>
+              )}
+              {platformResourcesYaml && projectResourcesYaml && (
+                <div className="flex items-center gap-2 pt-2">
+                  <Label>Project Resources</Label>
+                </div>
+              )}
+              <pre
+                aria-label={platformResourcesYaml ? 'Project Resources YAML' : 'Rendered YAML'}
+                className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre"
+              >
+                {projectResourcesYaml}
+              </pre>
+            </>
           ) : (
             <pre
               aria-label="Rendered YAML"

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -323,7 +323,14 @@ export function useRenderTemplate(
         cuePlatformInput,
         linkedTemplates,
       })
-      return { renderedYaml: response.renderedYaml, renderedJson: response.renderedJson }
+      return {
+        renderedYaml: response.renderedYaml,
+        renderedJson: response.renderedJson,
+        platformResourcesYaml: response.platformResourcesYaml,
+        platformResourcesJson: response.platformResourcesJson,
+        projectResourcesYaml: response.projectResourcesYaml,
+        projectResourcesJson: response.projectResourcesJson,
+      }
     },
     enabled: isAuthenticated && !!cueTemplate && enabled,
     retry: false,

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -618,6 +618,74 @@ describe('DeploymentDetailPage', () => {
     })
   })
 
+  describe('Template tab per-collection resource display', () => {
+    it('shows both platform and project resource sections when per-collection fields are present', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: {
+          renderedYaml: 'unified-yaml',
+          renderedJson: '',
+          platformResourcesYaml: 'apiVersion: v1\nkind: ReferenceGrant',
+          platformResourcesJson: '',
+          projectResourcesYaml: 'apiVersion: apps/v1\nkind: Deployment',
+          projectResourcesJson: '',
+        },
+        error: null,
+        isFetching: false,
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /template/i }))
+      // Switch to preview sub-tab inside CueTemplateEditor
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+      expect(screen.getByText('Project Resources')).toBeInTheDocument()
+      expect(screen.getByLabelText('Platform Resources YAML')).toHaveTextContent('ReferenceGrant')
+      expect(screen.getByLabelText('Project Resources YAML')).toHaveTextContent('Deployment')
+    })
+
+    it('shows only project section when platform resources are empty', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: {
+          renderedYaml: 'unified-yaml',
+          renderedJson: '',
+          platformResourcesYaml: '',
+          platformResourcesJson: '',
+          projectResourcesYaml: 'apiVersion: apps/v1\nkind: Service',
+          projectResourcesJson: '',
+        },
+        error: null,
+        isFetching: false,
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /template/i }))
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
+      expect(screen.getByText('Rendered YAML')).toBeInTheDocument()
+    })
+
+    it('falls back to unified renderedYaml when no per-collection fields present', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: { renderedYaml: 'apiVersion: v1\nkind: ConfigMap', renderedJson: '' },
+        error: null,
+        isFetching: false,
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /template/i }))
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      expect(screen.getByText('Rendered YAML')).toBeInTheDocument()
+      expect(screen.getByLabelText('Rendered YAML')).toHaveTextContent('ConfigMap')
+      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
+    })
+  })
+
   describe('Logs tab section', () => {
     it('renders log content after clicking Logs tab', async () => {
       const user = userEvent.setup()

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -455,4 +455,54 @@ describe('CreateTemplatePage', () => {
       expect(screen.getByText(/no platform templates available to link/i)).toBeInTheDocument()
     })
   })
+
+  describe('per-collection preview sections', () => {
+    it('shows both platform and project JSON sections when both are present', () => {
+      setupMocks(
+        vi.fn().mockResolvedValue({}),
+        {
+          renderedJson: '{"unified":"data"}',
+          platformResourcesJson: '{"kind":"ReferenceGrant"}',
+          projectResourcesJson: '{"kind":"Deployment"}',
+        },
+      )
+      render(<CreateTemplatePage />)
+      fireEvent.click(screen.getByRole('button', { name: /preview/i }))
+
+      expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+      expect(screen.getByText('Project Resources')).toBeInTheDocument()
+      expect(screen.getByLabelText('Platform Resources JSON')).toHaveTextContent('ReferenceGrant')
+      expect(screen.getByLabelText('Project Resources JSON')).toHaveTextContent('Deployment')
+    })
+
+    it('shows only project section when platform resources JSON is empty', () => {
+      setupMocks(
+        vi.fn().mockResolvedValue({}),
+        {
+          renderedJson: '{"unified":"data"}',
+          platformResourcesJson: '',
+          projectResourcesJson: '{"kind":"Deployment"}',
+        },
+      )
+      render(<CreateTemplatePage />)
+      fireEvent.click(screen.getByRole('button', { name: /preview/i }))
+
+      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
+      expect(screen.getByText('Rendered JSON')).toBeInTheDocument()
+      expect(screen.getByLabelText('Rendered JSON')).toHaveTextContent('Deployment')
+    })
+
+    it('falls back to unified renderedJson when no per-collection fields', () => {
+      setupMocks(
+        vi.fn().mockResolvedValue({}),
+        { renderedJson: '{"apiVersion":"apps/v1"}' },
+      )
+      render(<CreateTemplatePage />)
+      fireEvent.click(screen.getByRole('button', { name: /preview/i }))
+
+      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
+      expect(screen.queryByText('Project Resources')).not.toBeInTheDocument()
+      expect(screen.getByText(/"apiVersion":"apps\/v1"/)).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -583,11 +583,43 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                     </AlertDescription>
                   </Alert>
                 )}
-                {renderQuery.data?.renderedJson && (
-                  <pre className="font-mono text-sm bg-muted p-3 rounded-md max-h-96 overflow-y-auto whitespace-pre-wrap break-all">
-                    {renderQuery.data.renderedJson}
-                  </pre>
-                )}
+                {renderQuery.data && (() => {
+                  const platformJson = renderQuery.data.platformResourcesJson ?? ''
+                  const projectJson = renderQuery.data.projectResourcesJson ?? ''
+                  const hasPerCollection = !!(platformJson || projectJson)
+                  if (hasPerCollection) {
+                    return (
+                      <div className="space-y-3">
+                        {platformJson && (
+                          <>
+                            <Label>Platform Resources</Label>
+                            <pre
+                              aria-label="Platform Resources JSON"
+                              className="font-mono text-sm bg-muted p-3 rounded-md max-h-96 overflow-y-auto whitespace-pre-wrap break-all"
+                            >
+                              {platformJson}
+                            </pre>
+                          </>
+                        )}
+                        <Label>{platformJson ? 'Project Resources' : 'Rendered JSON'}</Label>
+                        <pre
+                          aria-label={platformJson ? 'Project Resources JSON' : 'Rendered JSON'}
+                          className="font-mono text-sm bg-muted p-3 rounded-md max-h-96 overflow-y-auto whitespace-pre-wrap break-all"
+                        >
+                          {projectJson}
+                        </pre>
+                      </div>
+                    )
+                  }
+                  if (renderQuery.data.renderedJson) {
+                    return (
+                      <pre className="font-mono text-sm bg-muted p-3 rounded-md max-h-96 overflow-y-auto whitespace-pre-wrap break-all">
+                        {renderQuery.data.renderedJson}
+                      </pre>
+                    )
+                  }
+                  return null
+                })()}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Update `useRenderTemplate` hook to return the four new per-collection fields (`platformResourcesYaml`, `platformResourcesJson`, `projectResourcesYaml`, `projectResourcesJson`)
- Split the `CueTemplateEditor` preview tab into two labeled sections ("Platform Resources" and "Project Resources") when platform resources are present
- Update the create template page preview to show split JSON sections with the same pattern
- Deployment detail Template tab gets split display automatically via `CueTemplateEditor`
- Fall back to unified `renderedYaml`/`renderedJson` when per-collection fields are absent (backwards compat)
- When `platformResourcesYaml` is empty, show only "Rendered YAML" (no empty platform section)

Closes #847

## Test plan
- [x] All 876 existing tests pass (`make test`)
- [x] CueTemplateEditor tests: both sections rendered when platform resources present, only project when empty, fallback to unified view
- [x] Create template page tests: both JSON sections rendered when present, only project when empty, fallback
- [x] Deployment detail page tests: same three scenarios via CueTemplateEditor

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)