### PR TITLE
Require critical and important review findings to be addressed before merge

### DIFF
--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -6,7 +6,7 @@ version: 3.0.0
 
 # Implement Plan
 
-Automated implementation cycle for a parent GitHub issue containing sub-issues. Each sub-issue is implemented by an Opus sub-agent, reviewed by the `/review-pr` skill (Codex backend) in a sub-agent, fixed in-PR if findings exist, and merged or escalated -- all without human intervention unless critical findings persist. After all sub-issues are processed, the plan re-reads the parent issue for follow-up issues created during review and implements those too. Wall clock timing is tracked per sub-issue and overall.
+Automated implementation cycle for a parent GitHub issue containing sub-issues. Each sub-issue is implemented by an Opus sub-agent, reviewed by the `/review-pr` skill (Codex backend) in a sub-agent, fixed in-PR if findings exist, and merged or escalated -- all without human intervention unless critical or important findings persist. After all sub-issues are processed, the plan re-reads the parent issue for follow-up issues created during review and implements those too. Wall clock timing is tracked per sub-issue and overall.
 
 ## Arguments
 
@@ -342,7 +342,7 @@ gh pr edit $PR_NUMBER --add-label "needs-human-review"
 
 ### 9. Merge the PR
 
-Before merging, handle any remaining non-critical findings from round 2:
+Before merging, handle any remaining style-only findings from round 2:
 
 **If style-only findings remain after round 2** (no CRITICAL or IMPORTANT), create a follow-up issue **attached to the parent issue**:
 
@@ -471,7 +471,7 @@ No follow-up issues were created during review.
 </if>
 
 <if any escalated>
-**Action required**: Some PRs have the \`needs-human-review\` label and were not merged. Please review the critical findings and merge manually.
+**Action required**: Some PRs have the \`needs-human-review\` label and were not merged. Please review the critical/important findings and merge manually.
 </if>
 EOF
 )"
@@ -495,7 +495,7 @@ Each sub-agent runs in the same working directory but is isolated by purpose:
 |-----------|-------|---------|-------|--------|
 | Implement | Opus | Code the sub-issue | Issue body, codebase | Branch, commits, PR |
 | Review | Default | Run `/review-pr` (Codex) | PR diff, conventions | Review file, GitHub review |
-| Fix | Opus | Fix critical findings | Review file, codebase | Commits, push |
+| Fix | Opus | Fix review findings | Review file, codebase | Commits, push |
 | CI Fix | Opus | Fix CI failures | CI output, codebase | Commits, push |
 
 Using sub-agents preserves the orchestrator's context window. The orchestrator only tracks issue state, PR numbers, and verdicts -- not the full implementation or review details.
@@ -551,6 +551,6 @@ The skill will:
 1. Fetch issue #42, find sub-issues #43, #44, #45
 2. Implement #43 -> PR #50 -> review (findings) -> fix all in-PR -> re-review (clean) -> merge
 3. Implement #44 -> PR #51 -> review -> approve -> merge
-4. Implement #45 -> PR #52 -> review (findings) -> fix in-PR -> re-review (non-critical remain) -> merge + follow-up #60
+4. Implement #45 -> PR #52 -> review (findings) -> fix in-PR -> re-review (style-only remain) -> merge + follow-up #60
 5. Re-read #42, find follow-up #60 -> implement #60 -> PR #53 -> review -> merge
 6. Post summary with wall clock timing on #42

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -254,7 +254,7 @@ Agent(
 
 **If APPROVE (no findings):** Skip to step 9 (merge).
 
-**If any findings exist (any severity):** Proceed to step 8 (fix all findings in-PR).
+**If any findings exist (any severity):** Proceed to step 8 (fix all findings in-PR). Both `[CRITICAL]` and `[IMPORTANT]` findings are merge-blocking; only `[STYLE]` findings are fix-forward.
 
 ### 8. Fix-First Review Loop
 
@@ -309,22 +309,22 @@ Agent(
 Parse the result:
 
 - **If APPROVE (no findings):** Proceed to step 9 (merge).
-- **If non-critical findings only (no CRITICAL):** Proceed to step 9 (merge with follow-up issue).
-- **If critical findings remain:** Proceed to step 8c (escalation).
+- **If style-only findings remain (no CRITICAL or IMPORTANT):** Proceed to step 9 (merge with follow-up issue).
+- **If critical or important findings remain:** Proceed to step 8c (escalation).
 
 #### 8c. Escalation After Round 2
 
-If critical findings remain after round 2:
+If critical or important findings remain after round 2:
 
-1. Post a summary comment on the PR listing the unresolved critical findings:
+1. Post a summary comment on the PR listing the unresolved findings:
 
 ```bash
 gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
-## Unresolved Critical Findings
+## Unresolved Critical/Important Findings
 
-After 2 review rounds, the following critical findings remain unresolved:
+After 2 review rounds, the following critical or important findings remain unresolved:
 
-<list each unresolved critical finding with file, line, and description>
+<list each unresolved critical/important finding with file, line, and description>
 
 This PR requires human review before merge.
 EOF
@@ -344,7 +344,7 @@ gh pr edit $PR_NUMBER --add-label "needs-human-review"
 
 Before merging, handle any remaining non-critical findings from round 2:
 
-**If non-critical findings remain after round 2**, create a follow-up issue **attached to the parent issue**:
+**If style-only findings remain after round 2** (no CRITICAL or IMPORTANT), create a follow-up issue **attached to the parent issue**:
 
 ```bash
 FOLLOW_UP=$(gh issue create \
@@ -352,11 +352,11 @@ FOLLOW_UP=$(gh issue create \
   --body "$(cat <<EOF
 ## Context
 
-PR #${PR_NUMBER} was merged with non-critical review findings that remain after round 2 fixes. These should be addressed in a follow-up.
+PR #${PR_NUMBER} was merged with style-only review findings that remain after round 2 fixes. These should be addressed in a follow-up.
 
 ## Findings
 
-<paste remaining non-critical findings from round 2 review output>
+<paste remaining style findings from round 2 review output>
 
 ## Source
 
@@ -508,8 +508,8 @@ Using sub-agents preserves the orchestrator's context window. The orchestrator o
 |-----------|--------|
 | Clean review (APPROVE, no findings) | Merge immediately |
 | All findings fixed in round 1, clean re-review | Merge after clean re-review |
-| Non-critical findings remain after round 2 | Merge, create follow-up issue attached to parent |
-| Critical findings unresolved after round 2 | Do NOT merge, add `needs-human-review` label |
+| Style-only findings remain after round 2 | Merge, create follow-up issue attached to parent |
+| Critical or important findings unresolved after round 2 | Do NOT merge, add `needs-human-review` label |
 | CI failures unresolved after 1 fix attempt | Add `needs-human-review` label, continue to review |
 
 ### Safety
@@ -517,7 +517,7 @@ Using sub-agents preserves the orchestrator's context window. The orchestrator o
 - **One sub-issue at a time**: Sub-issues are processed sequentially. No parallel PRs.
 - **No force merges**: If a merge fails due to conflicts, rebase and retry once. If it fails again, escalate.
 - **Review isolation**: The Codex review runs in a separate sub-agent process with no influence from the implementing agent. This ensures independent cross-model review.
-- **Fix-first model**: Round 1 fix sub-agents address ALL findings (critical, important, and style) in the PR directly. Follow-up issues are only created for findings that remain after round 2.
+- **Fix-first model**: Round 1 fix sub-agents address ALL findings (critical, important, and style) in the PR directly. Follow-up issues are only created for style-only findings that remain after round 2. Critical and important findings that persist after round 2 trigger escalation.
 - **Follow-up attachment**: Follow-up issues are added to the parent issue's task list so the plan can discover and implement them.
 - **Follow-up sweep**: After all original sub-issues are processed, the plan re-reads the parent issue and implements any follow-up issues that were added during review.
 - **Escalation is permanent**: Once a PR gets `needs-human-review`, the agent does not re-attempt it. A human must intervene.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -223,10 +223,10 @@ Classify each finding for the fix-forward decision:
 
 | Classification | Criteria | Action |
 |----------------|----------|--------|
-| **Critical (blocks merge)** | Security vulnerabilities, reliability issues (data loss, cascading failures, resource leaks), TLS guardrail violations | Must fix before merge |
-| **Non-critical (fix-forward)** | Test coverage gaps, terminology, code generation consistency, error handling improvements, style issues | Merge now, track in follow-up issue |
+| **Merge-blocking** | Security vulnerabilities, reliability issues, TLS guardrail violations, generated code editing, template field propagation, acceptance criteria gaps, test coverage gaps, RED-GREEN violations, terminology violations, codegen consistency issues, error handling issues | Must fix before merge |
+| **Non-critical (fix-forward)** | UI convention issues, dead code | Merge now, track in follow-up issue |
 
-Findings tagged `[CRITICAL]` by Codex are critical. Findings tagged `[IMPORTANT]` or `[STYLE]` are non-critical.
+Findings tagged `[CRITICAL]` or `[IMPORTANT]` by Codex are merge-blocking. Only findings tagged `[STYLE]` are non-critical.
 
 ### 9. Post GitHub Review
 
@@ -244,7 +244,7 @@ gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
 
 **If findings exist**, build an inline comments array and post a review:
 
-For each finding with a file and line number, create an inline comment. Post as `REQUEST_CHANGES` if any `[CRITICAL]` findings exist, otherwise as `COMMENT`.
+For each finding with a file and line number, create an inline comment. Post as `REQUEST_CHANGES` if any `[CRITICAL]` or `[IMPORTANT]` findings exist, otherwise as `COMMENT`.
 
 ```bash
 # Example: posting a review with inline comments
@@ -255,8 +255,8 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 COMMENTS='[{"path":"console/rpc/auth.go","line":42,"body":"[CRITICAL] ..."}]'
 
 # Determine event type
-EVENT="COMMENT"  # default for non-critical only
-# If any [CRITICAL] findings exist: EVENT="REQUEST_CHANGES"
+EVENT="COMMENT"  # default for style-only findings
+# If any [CRITICAL] or [IMPORTANT] findings exist: EVENT="REQUEST_CHANGES"
 
 gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
   --method POST \
@@ -286,8 +286,8 @@ Then provide guidance based on the classification:
 | Situation | Guidance |
 |-----------|----------|
 | APPROVE (no findings) | "Review is clean. Ready to merge." |
-| Non-critical findings only | "Non-critical findings only. Safe to merge and create a follow-up issue for the findings." |
-| Critical findings exist | "Critical findings must be addressed. Fix and re-run `/review-pr <PR_NUMBER>` (round <N+1>)." |
+| Style findings only (no CRITICAL or IMPORTANT) | "Style findings only. Safe to merge and create a follow-up issue for the findings." |
+| Critical or important findings exist | "Critical/important findings must be addressed. Fix and re-run `/review-pr <PR_NUMBER>` (round <N+1>)." |
 
 ## Fix-Review Loop
 
@@ -305,8 +305,8 @@ When used during implementation (integrated into the implement-plan workflow), t
    e. Re-run /review-pr <PR_NUMBER> (round 2)
 5. After round 2:
    a. If APPROVE -> merge
-   b. If non-critical findings only -> merge, create follow-up issue attached to parent
-   c. If critical findings remain -> escalate (needs-human-review), do NOT merge
+   b. If style-only findings remain (no CRITICAL or IMPORTANT) -> merge, create follow-up issue attached to parent
+   c. If critical or important findings remain -> escalate (needs-human-review), do NOT merge
 6. Follow-up issues created in step 5b are attached to the parent issue
    so implement-plan can pick them up at the end.
 ```
@@ -319,17 +319,17 @@ When used during implementation (integrated into the implement-plan workflow), t
 |-----------|--------|
 | Clean review (no findings) | Merge immediately |
 | All findings fixed in round 1, clean re-review | Merge after clean re-review |
-| Non-critical findings remain after round 2 | Merge, create follow-up issue attached to parent |
-| Critical findings unresolved after round 2 | Do NOT merge. Add `needs-human-review` label |
+| Style-only findings remain after round 2 | Merge, create follow-up issue attached to parent |
+| Critical or important findings unresolved after round 2 | Do NOT merge. Add `needs-human-review` label |
 
 ### Handling Disagreements
 
-When Claude disagrees with a critical Codex finding:
+When Claude disagrees with a critical or important Codex finding:
 1. Reply to the specific review comment on GitHub with a rationale
 2. If the same finding persists after re-review, it counts toward the cycle limit
 3. After 2 rounds, disagreement escalates to human review
 
-For non-critical disagreements after round 2, merge and create the follow-up issue attached to the parent. The human decides at their own pace.
+For style-only disagreements after round 2, merge and create the follow-up issue attached to the parent. The human decides at their own pace.
 
 ### Resetting Review Rounds
 

--- a/docs/plan-implement-review.md
+++ b/docs/plan-implement-review.md
@@ -202,8 +202,8 @@ claude "/implement-issue <master-issue-number>"
 - Master issue closed with all sub-issues checked off
 - One merged PR per sub-issue
 - Review comments on each PR (from Codex)
-- Follow-up issues for any non-critical review findings
-- Any PRs labeled `needs-human-review` if critical findings were unresolved
+- Follow-up issues for any remaining style findings
+- Any PRs labeled `needs-human-review` if critical or important findings were unresolved
 
 ### Dispatch via tmux
 

--- a/docs/plan-implement-review.md
+++ b/docs/plan-implement-review.md
@@ -15,9 +15,9 @@ The development cycle has three phases:
 /plan-issue  →  /implement-issue  →  Codex review (local)
                                           │
                                           ├── clean → merge
-                                          ├── non-critical findings → merge + follow-up issue
-                                          └── critical findings → fix loop (max 2 cycles)
-                                                                    └── escalate if unresolved
+                                          ├── style-only findings → merge + follow-up issue
+                                          └── critical/important findings → fix loop (max 2 cycles)
+                                                                             └── escalate if unresolved
 ```
 
 Each phase is backed by a Claude Code skill. The plan-issue and implement-issue skills already exist. The review step is integrated into implement-issue via a local Codex CLI invocation.
@@ -30,12 +30,12 @@ These constraints shape every design decision in the cycle.
 
 **2. Artifacts on GitHub.** While execution is local, all outputs (issues, PRs, review comments) are posted to GitHub. GitHub is the record of work, not the orchestrator of it. This means anyone on the team can audit what happened after the fact by reading the issue, PR, and review threads.
 
-**3. Good enough, fully automated, fix-forward.** The cycle optimizes for throughput over perfection. As long as there are no critical security vulnerabilities or structural design errors, it is acceptable to merge the PR and fix-forward. Only two categories block progress during review:
+**3. Good enough, fully automated, fix-forward.** The cycle optimizes for throughput over perfection, but requires all critical and important findings to be addressed before merge. Two severity tiers block progress during review:
 
-- **Security** — vulnerabilities that could be exploited (injection, auth bypass, credential exposure)
-- **Reliability** — structural errors that would cause data loss, outages, or cascading failures
+- **Critical** — Security vulnerabilities (injection, auth bypass, credential exposure), reliability issues (data loss, outages, cascading failures), TLS guardrail violations, generated code editing, template field propagation violations
+- **Important** — Acceptance criteria gaps, test coverage gaps, RED-GREEN violations, terminology violations, codegen consistency issues, error handling issues
 
-Everything else — style, naming, minor refactoring opportunities, non-critical edge cases — merges now with a follow-up issue. The goal is an unattended cycle that completes without human intervention. Blocking on cosmetic findings defeats the purpose.
+Only **style** findings (UI conventions, dead code) merge now with a follow-up issue. The goal is an unattended cycle that completes without human intervention unless critical or important findings persist. Blocking on cosmetic style findings defeats the purpose, but substantive quality issues (important findings) must be resolved in-PR.
 
 ## Prerequisites
 
@@ -142,7 +142,7 @@ After CI passes and before merge, the implement-issue skill invokes Codex CLI lo
 1. **Fetch the diff** — `gh pr diff <N>`
 2. **Fetch linked issue** — parse `Closes #M` from PR body, fetch acceptance criteria
 3. **Invoke Codex locally** — run `codex --quiet` with the diff, acceptance criteria, and review instructions
-4. **Classify findings** — each finding is either critical (security/reliability) or non-critical (everything else)
+4. **Classify findings** — each finding is merge-blocking (critical or important) or non-critical (style only)
 5. **Post review** — post findings as a GitHub review via `gh api`
 
 ### Review criteria
@@ -164,20 +164,20 @@ The reviewer does **not** comment on: style preferences, comment formatting, nam
 
 **No findings** — post APPROVE, merge immediately. This is the common case.
 
-**Non-critical findings only** — post a COMMENT review (not REQUEST_CHANGES), merge the PR, and create a follow-up issue linking the review comments. Non-critical findings are not worth blocking the automated cycle.
+**Style-only findings** — post a COMMENT review (not REQUEST_CHANGES), merge the PR, and create a follow-up issue linking the review comments. Style findings are not worth blocking the automated cycle.
 
-**Critical findings (security or reliability)** — enter the fix loop:
+**Critical or important findings** — enter the fix loop:
 
 1. Claude reads the findings, fixes each issue, commits with `fix: address review finding — <summary>`
 2. Push fixes, re-invoke Codex
 3. If clean after re-review, merge
-4. Maximum 2 cycles — after that, unresolved critical findings escalate
+4. Maximum 2 cycles — after that, unresolved critical or important findings escalate
 
-**Escalation** — if critical findings remain after 2 fix cycles, the PR gets a `needs-human-review` label and is not merged. The agent moves to the next sub-issue. This keeps the pipeline moving — one stuck PR doesn't block the entire plan.
+**Escalation** — if critical or important findings remain after 2 fix cycles, the PR gets a `needs-human-review` label and is not merged. The agent moves to the next sub-issue. This keeps the pipeline moving — one stuck PR doesn't block the entire plan.
 
 ### Why 2 cycles
 
-After 2 rounds, if Claude and Codex still disagree on a critical finding, it's almost certainly a judgment call that requires human context — not a clear-cut bug. Continuing to cycle wastes compute without converging.
+After 2 rounds, if Claude and Codex still disagree on a critical or important finding, it's almost certainly a judgment call that requires human context — not a clear-cut bug. Continuing to cycle wastes compute without converging.
 
 ### Why local is better
 
@@ -220,7 +220,7 @@ This creates a worktree, opens a tmux window, and runs Claude with the implement
 ### Tuning review behavior
 
 The review prompt lives in `.claude/skills/review-pr.md`. Edit it to:
-- Adjust what counts as critical vs. non-critical
+- Adjust what counts as merge-blocking vs. fix-forward
 - Add repo-specific review criteria (e.g., proto backwards compatibility rules)
 - Change the Codex model (`codex-mini` for speed, larger models for depth)
 - Modify the review output format
@@ -242,7 +242,7 @@ Self-review (Claude reviewing its own PRs) produces reviews that confirm the imp
 
 ### Why fix-forward
 
-Blocking the automated cycle on non-critical findings (style, naming, minor edge cases) defeats the purpose of unattended execution. The cost of shipping a naming inconsistency is low; the cost of human-gating every PR is high (breaks the automated cycle, requires synchronous attention). Critical security and reliability issues are the exception because the cost of shipping those bugs is genuinely high.
+Blocking the automated cycle on style findings (UI conventions, dead code) defeats the purpose of unattended execution. The cost of shipping a minor style inconsistency is low; the cost of human-gating every PR is high (breaks the automated cycle, requires synchronous attention). Critical and important findings — security, reliability, acceptance criteria, test coverage, error handling — are the exception because the cost of shipping those issues is genuinely high.
 
 ### Why local execution
 


### PR DESCRIPTION
## Summary

Update code-review skill and guardrails so that both critical and important findings from Codex review must be addressed in the PR before merge. Previously only critical findings blocked merge. Now only style findings are fix-forward (merge + follow-up issue).

Automated by agent-3 (worktree slot agent-3).