### PR TITLE
chore(preview): clean up dead code and stale docs after resource grouping

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -799,7 +799,7 @@ func (h *Handler) GetDeploymentRenderPreview(
 		platformResourcesYAML, platformResourcesJSON = serializeUnstructured(grouped.Platform)
 		projectResourcesYAML, projectResourcesJSON = serializeUnstructured(grouped.Project)
 
-		// Produce the unified output (backwards compatible) by combining both collections.
+		// Produce the unified rendered output by combining both collections.
 		allResources := append(grouped.Platform, grouped.Project...)
 		renderedYAML, renderedJSON = serializeUnstructured(allResources)
 	}
@@ -841,7 +841,6 @@ func (h *Handler) checkProjectAccess(ctx context.Context, claims *rpc.Claims, pr
 	return rbac.CheckCascadeAccess(claims.Email, claims.Roles, users, roles, permission, rbac.ProjectCascadeDeploymentPerms)
 }
 
-// validateDeploymentName checks that the name is a valid DNS label.
 // serializeUnstructured converts a slice of unstructured Kubernetes resources
 // into a multi-document YAML string (separated by "---\n") and a JSON array
 // string. Returns empty strings for an empty or nil slice.
@@ -870,6 +869,7 @@ func serializeUnstructured(resources []unstructured.Unstructured) (yamlStr, json
 	return buf.String(), jsonStr
 }
 
+// validateDeploymentName checks that the name is a valid DNS label.
 func validateDeploymentName(name string) error {
 	if name == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -479,7 +479,7 @@ func (h *Handler) RenderTemplate(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to serialize project resources: %w", err))
 	}
 
-	// Produce the unified output (backwards compatible) by combining both collections.
+	// Produce the unified rendered output by combining both collections.
 	allResources := append(grouped.Platform, grouped.Project...)
 	unifiedYAML, unifiedJSON, err := serializeResources(allResources)
 	if err != nil {

--- a/docs/advanced-user-guide.md
+++ b/docs/advanced-user-guide.md
@@ -93,7 +93,7 @@ project namespace.
 | `CreateTemplate` | `PERMISSION_TEMPLATES_WRITE` | Creates a new template in the scope. |
 | `UpdateTemplate` | `PERMISSION_TEMPLATES_WRITE` | Updates the CUE source, display name, description, or default values of an existing template. |
 | `DeleteTemplate` | `PERMISSION_TEMPLATES_DELETE` | Deletes a template. |
-| `RenderDeploymentTemplate` | `PERMISSION_TEMPLATES_READ` | Renders a CUE template against supplied inputs and returns the resulting Kubernetes manifests as YAML and JSON. Does not create or modify any deployment — useful for previewing during authoring. |
+| `RenderTemplate` | `PERMISSION_TEMPLATES_READ` | Renders a CUE template against supplied inputs and returns the resulting Kubernetes manifests as YAML and JSON. Does not create or modify any deployment — useful for previewing during authoring. |
 
 ### TemplateService (platform templates — org and folder scope)
 
@@ -114,7 +114,7 @@ deployment template at deploy time). New templates start disabled.
 | `CreateTemplate` | `PERMISSION_TEMPLATES_WRITE` | Creates a new platform template. Starts disabled and non-mandatory by default. |
 | `UpdateTemplate` | `PERMISSION_TEMPLATES_WRITE` | Updates the CUE source, display name, description, or the mandatory/enabled flags. |
 | `DeleteTemplate` | `PERMISSION_TEMPLATES_DELETE` | Deletes a platform template. |
-| `RenderDeploymentTemplate` | `PERMISSION_TEMPLATES_READ` | Renders the platform template CUE against supplied inputs and returns manifests as YAML and JSON. Does not create any deployment. |
+| `RenderTemplate` | `PERMISSION_TEMPLATES_READ` | Renders the platform template CUE against supplied inputs and returns manifests as YAML and JSON. Does not create any deployment. |
 
 > All `TemplateService` write operations require `PERMISSION_TEMPLATES_WRITE`.
 > The unified `TemplateCascadePerms` table applies the same role→permission mapping
@@ -640,9 +640,9 @@ contacted.
 |-----|------|-----|
 | Platform engineer | Enable deployments on the project | `ProjectSettingsService.UpdateProjectSettings` |
 | Platform engineer | Author and enable the org-level template | `TemplateService.CreateTemplate` + `UpdateTemplate` |
-| Platform engineer | Preview the org-level template | `TemplateService.RenderDeploymentTemplate` |
+| Platform engineer | Preview the org-level template | `TemplateService.RenderTemplate` |
 | Project engineer | Create the deployment template | `TemplateService.CreateTemplate` |
-| Project engineer | Preview the deployment template | `TemplateService.RenderDeploymentTemplate` |
+| Project engineer | Preview the deployment template | `TemplateService.RenderTemplate` |
 | Project owner | Deploy an instance | `DeploymentService.CreateDeployment` |
 | Project owner | Check deployment health | `DeploymentService.GetDeploymentStatus` |
 | Project owner | Tail logs | `DeploymentService.GetDeploymentLogs` |

--- a/docs/agents/deployment-service.md
+++ b/docs/agents/deployment-service.md
@@ -1,6 +1,6 @@
 # Deployment Service
 
-`DeploymentService` in `console/deployments/` manages Kubernetes Deployments: CRUD, status polling, log streaming, CUE render and apply (structured `projectResources`/`platformResources` output), container command/args override, container env vars (literal values, SecretKeyRef, ConfigMapKeyRef), container port configuration, listing project-namespace Secrets/ConfigMaps for env var references, and `GetDeploymentRenderPreview` (returns the CUE template, platform input, project input, rendered YAML, and rendered JSON for a live deployment).
+`DeploymentService` in `console/deployments/` manages Kubernetes Deployments: CRUD, status polling, log streaming, CUE render and apply (structured `projectResources`/`platformResources` output), container command/args override, container env vars (literal values, SecretKeyRef, ConfigMapKeyRef), container port configuration, listing project-namespace Secrets/ConfigMaps for env var references, and `GetDeploymentRenderPreview` (returns the CUE template, platform input, project input, rendered YAML/JSON, and per-collection platform/project resources YAML/JSON for a live deployment).
 
 ## CUE Rendering
 

--- a/docs/agents/guardrail-linking-ui.md
+++ b/docs/agents/guardrail-linking-ui.md
@@ -7,7 +7,7 @@ create and edit pages, regardless of whether linkable ancestor templates exist.
 
 1. Never conditionally hide the section based on `linkableTemplates.length`.
 2. When no linkable templates exist, show an empty state message.
-3. The preview pane must pass linked templates to `useRenderTemplate` for unified output.
+3. The preview pane must pass linked templates to `useRenderTemplate` for grouped output (platform and project resources displayed separately).
 4. Regression tests in `-linking-regression.test.tsx` must pass.
 5. When a linkable template has releases, the linking dialog must show a version selector dropdown next to the checkbox allowing the user to pin to a specific version or select "Latest (auto-update)".
 6. On the detail page, linked template pill badges must show a version status indicator: a green check when up to date, an amber arrow when an update is available, or "unversioned" when the template has no releases.

--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -17,7 +17,7 @@ Scope is encoded in the `console.holos.run/template-scope` label (`organization|
 
 Templates can carry `TemplateDefaults` (name, description, image, tag, command, args, port) extracted from the `defaults` block in the CUE source (ADR 018). The backend uses per-field extraction (ADR 025) to read each field independently, so a non-concrete field does not prevent extraction of concrete siblings. The extracted defaults pre-fill the Create Deployment form.
 
-The `RenderDeploymentTemplate` RPC returns rendered resources as both YAML (`rendered_yaml`) and JSON (`rendered_json`).
+The `RenderTemplate` RPC returns rendered resources as both YAML (`rendered_yaml`) and JSON (`rendered_json`), plus per-collection fields (`platform_resources_yaml`, `platform_resources_json`, `project_resources_yaml`, `project_resources_json`) that partition resources by origin (platform templates vs project templates).
 
 The default template adds a `console.holos.run/deployer-email` annotation to all resources from `platform.claims.email`. The default template includes a `ReferenceGrant` (using `platform.gatewayNamespace`, default "istio-ingress") that allows HTTPRoute resources from the gateway namespace to reference Services in the project namespace.
 

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -549,7 +549,7 @@ projectResources.namespacedResources.<ns>.RoleBinding: field not allowed
 ```
 
 The error names the exact field path. Because it is a CUE evaluation error, it
-is reported by the `RenderDeploymentTemplate` preview RPC and by the deployment
+is reported by the `RenderTemplate` preview RPC and by the deployment
 create/update RPC before any Kubernetes call is attempted.
 
 #### Enforcement Layers
@@ -675,7 +675,7 @@ descriptive error.
 
 ### Previewing Your Template
 
-Use the `RenderDeploymentTemplate` RPC to preview a template without creating a
+Use the `RenderTemplate` RPC to preview a template without creating a
 deployment. This accepts a `cue_template` (raw CUE source) and a `cue_input`
 (valid CUE source that supplies concrete values for template parameters),
 returning the rendered resources as multi-document YAML (`rendered_yaml`) and as

--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -83,7 +83,7 @@ export interface CueTemplateEditorProps {
   defaultProjectInput?: string
   /** Scope used to resolve ancestor platform templates when rendering the preview */
   scope: TemplateScopeRef
-  /** Linked template refs to include in the render preview for unified output */
+  /** Linked template refs to include in the render preview for grouped output */
   linkedTemplates?: LinkedTemplateRef[]
 }
 
@@ -126,8 +126,8 @@ export function CueTemplateEditor({
   )
 
   // Per-collection fields take precedence over the unified renderedYaml
-  // when populated by the backend. Fall back to unified view for backwards
-  // compatibility with older backends that only return renderedYaml.
+  // when populated by the backend. Fall back to unified view when the
+  // per-collection fields are empty (e.g. project-only templates).
   const platformResourcesYaml = renderData?.platformResourcesYaml ?? ''
   const projectResourcesYaml = renderData?.projectResourcesYaml ?? ''
   const hasPerCollectionFields = !!(platformResourcesYaml || projectResourcesYaml)

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -283,7 +283,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
 }`
 
   // Build LinkedTemplateRef objects from the currently selected keys for the
-  // preview render so the preview pane shows unified output.
+  // preview render so the preview pane shows grouped output (platform + project).
   const previewLinkedTemplates: LinkedTemplateRef[] = selectedLinkedKeys.map((key) => {
     const parsed = parseLinkableKey(key)
     const vc = selectedVersionConstraints.get(key) ?? ''


### PR DESCRIPTION
## Summary
- Fix misplaced doc comment for `serializeUnstructured` that was concatenated with `validateDeploymentName`'s doc comment
- Replace stale "backwards compatible" comments with accurate descriptions (code is unreleased)
- Update "unified output" references in frontend comments and guardrail docs to reflect grouped output
- Rename stale `RenderDeploymentTemplate` RPC references to `RenderTemplate` in docs
- Update deployment-service.md and template-service.md to describe per-collection render preview fields

Closes #848

## Test plan
- [x] `make test-go` -- all packages pass
- [x] `make test-ui` -- 876 tests passed across 55 test files
- [x] `go vet ./console/...` -- clean, no unused imports

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)