### PR TITLE
chore: cleanup stale comments and docs after render preview improvements

### DIFF
--- a/console/templates/apply.go
+++ b/console/templates/apply.go
@@ -75,7 +75,7 @@ func (a *MandatoryTemplateApplier) ApplyMandatoryOrgTemplates(ctx context.Contex
 			return nil
 		}
 	} else {
-		// No walker: apply org-level only (backward compatible behavior).
+		// No walker configured: apply org-level templates only.
 		orgNs := a.k8s.Resolver.OrgNamespace(org)
 		orgNsObj := &corev1.Namespace{}
 		orgNsObj.Name = orgNs

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -348,8 +348,8 @@ func (k *K8sClient) ListTemplateSourcesForRender(ctx context.Context, ns string,
 }
 
 // ListOrgTemplateSourcesForRender satisfies the deployments.OrgTemplateProvider
-// interface. It returns CUE sources for the effective set of org-level templates
-// using the render set formula:
+// interface. It returns CUE sources for the effective set of organization-scope
+// templates using the render set formula:
 //
 //	(mandatory AND enabled) UNION (enabled AND ref.Name IN linkedRefs)
 //

--- a/docs/agents/deployment-service.md
+++ b/docs/agents/deployment-service.md
@@ -6,7 +6,7 @@
 
 CUE render uses split `PlatformInput` (project, namespace, gatewayNamespace, claims) and `ProjectInput` (name, image, tag, etc.) — see `docs/cue-template-guide.md`.
 
-At render time, `OrgTemplateProvider.ListOrgTemplateSourcesForRender(ctx, org, linkedNames)` is called with the linked names resolved from the deployment template's `console.holos.run/linked-templates` annotation; platform templates may define resources under `platformResources` and/or `projectResources` — the renderer reads both collections when processing platform templates (ADR 016 Decision 8).
+At render time, the handler builds a `PlatformInput` that includes `Folders` (resolved via `AncestorWalker`) and calls `OrgTemplateProvider.ListOrgTemplateSourcesForRender(ctx, org, linkedRefs)` with the linked refs resolved from the deployment template's `console.holos.run/linked-templates` annotation. The provider currently resolves organization-scope templates only; folder-scope templates are not yet included in the render set. Platform templates may define resources under `platformResources` and/or `projectResources` -- the renderer reads both collections when processing platform templates (ADR 016 Decision 8). `GetDeploymentRenderPreview` returns per-collection fields (`platform_resources_yaml`, `platform_resources_json`, `project_resources_yaml`, `project_resources_json`) that partition resources by origin.
 
 ## Lifecycle Semantics
 

--- a/docs/agents/guardrail-template-linking.md
+++ b/docs/agents/guardrail-template-linking.md
@@ -3,7 +3,7 @@
 **When adding new fields that affect which platform templates are included in a render**, ensure:
 
 1. The linking list is read from the `console.holos.run/linked-templates` annotation on the deployment template ConfigMap (JSON array of `{scope, scope_name, name, version_constraint}` objects -- v1alpha2 format). The `version_constraint` field is optional.
-2. `OrgTemplateProvider.ListOrgTemplateSourcesForRender(ctx, org, linkedNames)` is called with the resolved linked names (not `ListEnabledOrgTemplateSources` — that method no longer exists).
+2. `OrgTemplateProvider.ListOrgTemplateSourcesForRender(ctx, org, linkedRefs)` is called with the resolved linked refs (not `ListEnabledOrgTemplateSources` -- that method no longer exists). This currently resolves organization-scope templates only.
 3. `docs/cue-template-guide.md` "Linking Platform Templates" section and the render set formula remain accurate.
 
 When adding new fields that affect template linking, update `docs/cue-template-guide.md` and the AGENTS.md context map.

--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -37,7 +37,7 @@ Platform templates (org-scoped or folder-scoped) can be marked `mandatory` (appl
 
 ## Explicit Linking Model
 
-ADR 019, extended to cross-level refs: each deployment template ConfigMap may carry the annotation `console.holos.run/linked-templates` (JSON array of `{scope, scope_name, name, version_constraint}` objects); at render time these refs are resolved and passed to `ListOrgTemplateSourcesForRender`. The `version_constraint` field is optional; when present it selects the latest Release satisfying the semver range instead of the mutable working copy.
+ADR 019, extended to cross-level refs: each deployment template ConfigMap may carry the annotation `console.holos.run/linked-templates` (JSON array of `{scope, scope_name, name, version_constraint}` objects); at render time these refs are resolved and passed to `ListOrgTemplateSourcesForRender` (currently resolves organization-scope templates only). The `version_constraint` field is optional; when present it selects the latest Release satisfying the semver range instead of the mutable working copy.
 
 The render set formula is: `(mandatory AND enabled) UNION (enabled AND ref IN linked_list)`.
 

--- a/docs/cue-template-guide.md
+++ b/docs/cue-template-guide.md
@@ -1236,7 +1236,7 @@ Two render paths exist — one for the deployment service and one for the templa
 | File | Purpose |
 |------|---------|
 | `console/templates/handler.go` | Unified `TemplateService` handler — scope-aware CRUD for templates at organization, folder, and project levels. Dispatches access checks to `OrgGrantResolver`, `FolderGrantResolver`, or `ProjectGrantResolver` depending on scope. `collectAncestorTemplates()` walks the hierarchy (org → folders → project) to build the render set. |
-| `console/templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `console.holos.run/template-scope` label (`organization|folder|project`), `mandatory` and `enabled` annotations. `ListOrgTemplateSourcesForRender(ctx, org, linkedNames)` implements the explicit linking formula `(mandatory AND enabled) UNION (enabled AND name IN linkedNames)` (satisfies `deployments.OrgTemplateProvider`). |
+| `console/templates/k8s.go` | ConfigMap storage: templates stored with `template.cue` data key, `console.holos.run/template-scope` label (`organization|folder|project`), `mandatory` and `enabled` annotations. `ListOrgTemplateSourcesForRender(ctx, org, linkedRefs)` implements the explicit linking formula `(mandatory AND enabled) UNION (enabled AND ref.Name IN linkedRefs)` for organization-scope templates (satisfies `deployments.OrgTemplateProvider`). |
 | `console/templates/apply.go` | `MandatoryTemplateApplier.ApplyMandatoryOrgTemplates()` — walks the full ancestor chain and applies all mandatory+enabled templates at project creation time. |
 | `console/templates/render_adapter.go` | `CueRendererAdapter` — wraps `deployments.CueRenderer` to produce YAML and structured object data for the template preview RPC. |
 


### PR DESCRIPTION
## Summary
- Remove "backward compatible" comment in `apply.go` since the code is unreleased
- Clarify that `ListOrgTemplateSourcesForRender` resolves organization-scope templates only in doc comments and agent docs
- Update `deployment-service.md` to describe ancestor-aware `PlatformInput` (Folders via `AncestorWalker`) and per-collection render preview fields
- Align parameter names in `guardrail-template-linking.md` with current code (`linkedRefs` not `linkedNames`)
- Note organization-scope limitation in `template-service.md` and `cue-template-guide.md`

This is the follow-up to PR #879, which addressed the first round of cleanup from #848. The remaining items tracked in #876 are addressed here.

Closes #876

## Test plan
- [x] `make test-go` -- all packages pass
- [x] `make test-ui` -- 876 tests passed across 55 test files
- [x] `make generate` -- produces no diff
- [x] `go vet ./console/...` -- clean, no unused imports

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)