### PR TITLE
fix(render): return empty JSON arrays instead of empty strings

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -843,10 +843,11 @@ func (h *Handler) checkProjectAccess(ctx context.Context, claims *rpc.Claims, pr
 
 // serializeUnstructured converts a slice of unstructured Kubernetes resources
 // into a multi-document YAML string (separated by "---\n") and a JSON array
-// string. Returns empty strings for an empty or nil slice.
+// string. Returns an empty YAML string and "[]" for an empty or nil slice so
+// that JSON fields are always valid parseable JSON arrays.
 func serializeUnstructured(resources []unstructured.Unstructured) (yamlStr, jsonStr string) {
 	if len(resources) == 0 {
-		return "", ""
+		return "", "[]"
 	}
 	var buf strings.Builder
 	objects := make([]map[string]any, 0, len(resources))

--- a/console/deployments/serialize_test.go
+++ b/console/deployments/serialize_test.go
@@ -1,0 +1,80 @@
+package deployments
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSerializeUnstructured_Empty(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []unstructured.Unstructured
+		wantYAML  string
+		wantJSON  string
+		wantValid bool // JSON output must be valid JSON
+	}{
+		{
+			name:      "nil input returns empty JSON array",
+			input:     nil,
+			wantYAML:  "",
+			wantJSON:  "[]",
+			wantValid: true,
+		},
+		{
+			name:      "empty slice returns empty JSON array",
+			input:     []unstructured.Unstructured{},
+			wantYAML:  "",
+			wantJSON:  "[]",
+			wantValid: true,
+		},
+		{
+			name: "single resource",
+			input: []unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata":   map[string]any{"name": "test"},
+					},
+				},
+			},
+			wantValid: true,
+		},
+		{
+			name: "multiple resources",
+			input: []unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata":   map[string]any{"name": "cm1"},
+					},
+				},
+				{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]any{"name": "sec1"},
+					},
+				},
+			},
+			wantValid: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlStr, jsonStr := serializeUnstructured(tt.input)
+			if tt.wantYAML != "" && yamlStr != tt.wantYAML {
+				t.Errorf("serializeUnstructured() yamlStr = %q, want %q", yamlStr, tt.wantYAML)
+			}
+			if tt.wantJSON != "" && jsonStr != tt.wantJSON {
+				t.Errorf("serializeUnstructured() jsonStr = %q, want %q", jsonStr, tt.wantJSON)
+			}
+			if tt.wantValid && !json.Valid([]byte(jsonStr)) {
+				t.Errorf("serializeUnstructured() jsonStr = %q is not valid JSON", jsonStr)
+			}
+		})
+	}
+}

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -1174,11 +1174,12 @@ func validateCueSyntax(source string) error {
 }
 
 // serializeResources converts a slice of RenderResource into a multi-document
-// YAML string (separated by "---\n") and a JSON array string. Returns empty
-// strings for an empty or nil slice.
+// YAML string (separated by "---\n") and a JSON array string. Returns an empty
+// YAML string and "[]" for an empty or nil slice so that JSON fields are always
+// valid parseable JSON arrays.
 func serializeResources(resources []RenderResource) (yamlStr, jsonStr string, err error) {
 	if len(resources) == 0 {
-		return "", "", nil
+		return "", "[]", nil
 	}
 
 	var buf strings.Builder

--- a/console/templates/serialize_test.go
+++ b/console/templates/serialize_test.go
@@ -1,0 +1,75 @@
+package templates
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSerializeResources_Empty(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []RenderResource
+		wantYAML  string
+		wantJSON  string
+		wantErr   bool
+		wantValid bool // JSON output must be valid JSON
+	}{
+		{
+			name:      "nil input returns empty JSON array",
+			input:     nil,
+			wantYAML:  "",
+			wantJSON:  "[]",
+			wantValid: true,
+		},
+		{
+			name:      "empty slice returns empty JSON array",
+			input:     []RenderResource{},
+			wantYAML:  "",
+			wantJSON:  "[]",
+			wantValid: true,
+		},
+		{
+			name: "single resource",
+			input: []RenderResource{
+				{
+					YAML:   "apiVersion: v1\nkind: ConfigMap\n",
+					Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap"},
+				},
+			},
+			wantYAML:  "apiVersion: v1\nkind: ConfigMap\n",
+			wantValid: true,
+		},
+		{
+			name: "multiple resources",
+			input: []RenderResource{
+				{
+					YAML:   "apiVersion: v1\nkind: ConfigMap\n",
+					Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap"},
+				},
+				{
+					YAML:   "apiVersion: v1\nkind: Secret\n",
+					Object: map[string]any{"apiVersion": "v1", "kind": "Secret"},
+				},
+			},
+			wantYAML:  "apiVersion: v1\nkind: ConfigMap\n---\napiVersion: v1\nkind: Secret\n",
+			wantValid: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlStr, jsonStr, err := serializeResources(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("serializeResources() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantYAML != "" && yamlStr != tt.wantYAML {
+				t.Errorf("serializeResources() yamlStr = %q, want %q", yamlStr, tt.wantYAML)
+			}
+			if tt.wantJSON != "" && jsonStr != tt.wantJSON {
+				t.Errorf("serializeResources() jsonStr = %q, want %q", jsonStr, tt.wantJSON)
+			}
+			if tt.wantValid && !json.Valid([]byte(jsonStr)) {
+				t.Errorf("serializeResources() jsonStr = %q is not valid JSON", jsonStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `serializeResources` (templates handler) to return `"[]"` instead of `""` when the resource slice is nil or empty
- Fix `serializeUnstructured` (deployments handler) to return `"[]"` instead of `""` when the resource slice is nil or empty
- Add table-driven unit tests covering nil, empty, single, and multiple resource inputs for both functions with `json.Valid()` assertions

Closes #873

## Test plan
- [x] `TestSerializeResources_Empty` passes all four sub-cases (nil, empty, single, multiple)
- [x] `TestSerializeUnstructured_Empty` passes all four sub-cases (nil, empty, single, multiple)
- [x] `make test` passes (all Go and UI tests)
- [ ] CI Unit Tests pass
- [ ] CI Lint passes

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)