### PR TITLE
feat(render): remove namespace restriction from CUE render pipeline

### DIFF
--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -693,6 +693,9 @@ func walkNamespacedResources(namespacedValue cue.Value, fieldPath string) ([]uns
 	}
 	for nsIter.Next() {
 		nsKey := nsIter.Selector().Unquoted()
+		if nsKey == "" {
+			return nil, fmt.Errorf("%s: empty namespace key is not allowed", fieldPath)
+		}
 		kindIter, err := nsIter.Value().Fields()
 		if err != nil {
 			return nil, fmt.Errorf("iterating Kind keys under %s/%s: %w", fieldPath, nsKey, err)

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -271,7 +271,7 @@ func evaluateWithOrgTemplates(deploymentCUE string, orgTemplateCUESources []stri
 		return nil, fmt.Errorf("deployment template must define 'projectResources.namespacedResources' (structured output format required)")
 	}
 
-	return evaluateStructured(unified, platform.Namespace, true)
+	return evaluateStructured(unified, true)
 }
 
 // evaluate performs synchronous CUE template evaluation.
@@ -331,7 +331,7 @@ func evaluate(cueSource string, platform v1alpha2.PlatformInput, project v1alpha
 	}
 
 	// Project-level render: do not read platformResources (ADR 016 Decision 8).
-	return evaluateStructured(unified, platform.Namespace, false)
+	return evaluateStructured(unified, false)
 }
 
 // evaluateWithCueInput performs synchronous CUE template evaluation using a raw
@@ -339,7 +339,6 @@ func evaluate(cueSource string, platform v1alpha2.PlatformInput, project v1alpha
 // "input" (user-provided values) and "platform" (trusted backend values) at the
 // top level.  The template source and input are compiled together so that
 // cross-references (e.g. input.name used in the template) resolve correctly.
-// The expected namespace is derived from platform.namespace in the unified value.
 func evaluateWithCueInput(cueSource, cueInput string) ([]unstructured.Unstructured, error) {
 	cueCtx := cuecontext.New()
 
@@ -365,18 +364,8 @@ func evaluateWithCueInput(cueSource, cueInput string) ([]unstructured.Unstructur
 		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
 	}
 
-	// Extract the expected namespace from the unified platform value.
-	nsValue := unified.LookupPath(cue.ParsePath("platform.namespace"))
-	if nsValue.Err() != nil || !nsValue.Exists() {
-		return nil, fmt.Errorf("cue_input must provide a 'platform.namespace' field")
-	}
-	expectedNamespace, err := nsValue.String()
-	if err != nil {
-		return nil, fmt.Errorf("platform.namespace must be a concrete string: %w", err)
-	}
-
 	// Preview mode reads both collections (ADR 016 Decision 8).
-	return evaluateStructured(unified, expectedNamespace, true)
+	return evaluateStructured(unified, true)
 }
 
 // evaluateGrouped performs synchronous CUE template evaluation and returns
@@ -425,7 +414,7 @@ func evaluateGrouped(cueSource string, platform v1alpha2.PlatformInput, project 
 	}
 
 	// Project-level render: do not read platformResources (ADR 016 Decision 8).
-	return evaluateStructuredGrouped(unified, platform.Namespace, false)
+	return evaluateStructuredGrouped(unified, false)
 }
 
 // evaluateWithOrgTemplatesGrouped performs synchronous CUE template evaluation
@@ -475,7 +464,7 @@ func evaluateWithOrgTemplatesGrouped(deploymentCUE string, orgTemplateCUESources
 		return nil, fmt.Errorf("deployment template must define 'projectResources.namespacedResources' (structured output format required)")
 	}
 
-	return evaluateStructuredGrouped(unified, platform.Namespace, true)
+	return evaluateStructuredGrouped(unified, true)
 }
 
 // evaluateWithCueInputGrouped performs synchronous CUE template evaluation using
@@ -496,17 +485,8 @@ func evaluateWithCueInputGrouped(cueSource, cueInput string) (*GroupedResources,
 		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
 	}
 
-	nsValue := unified.LookupPath(cue.ParsePath("platform.namespace"))
-	if nsValue.Err() != nil || !nsValue.Exists() {
-		return nil, fmt.Errorf("cue_input must provide a 'platform.namespace' field")
-	}
-	expectedNamespace, err := nsValue.String()
-	if err != nil {
-		return nil, fmt.Errorf("platform.namespace must be a concrete string: %w", err)
-	}
-
 	// Preview mode reads both collections (ADR 016 Decision 8).
-	return evaluateStructuredGrouped(unified, expectedNamespace, true)
+	return evaluateStructuredGrouped(unified, true)
 }
 
 // extractCuePathJSON looks up a CUE path in the unified value and returns the
@@ -558,14 +538,18 @@ func populateStructuredJSON(unified cue.Value, gr *GroupedResources) {
 // value and returns validated Kubernetes resources partitioned into Platform and
 // Project groups. The logic mirrors evaluateStructured but collects resources
 // into separate slices instead of a single flat list.
-func evaluateStructuredGrouped(unified cue.Value, expectedNamespace string, readPlatformResources bool) (*GroupedResources, error) {
+//
+// There is no restriction on which namespaces resources may target. The
+// struct-key/metadata consistency check ensures internal consistency within the
+// template (ADR 026).
+func evaluateStructuredGrouped(unified cue.Value, readPlatformResources bool) (*GroupedResources, error) {
 	var projectResources []unstructured.Unstructured
 	var platformResources []unstructured.Unstructured
 
 	// Walk projectResources.namespacedResources: <namespace>.<Kind>.<name>
 	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
 	if namespacedValue.Err() == nil && namespacedValue.Exists() {
-		resources, err := walkNamespacedResources(namespacedValue, expectedNamespace, "projectResources.namespacedResources")
+		resources, err := walkNamespacedResources(namespacedValue, "projectResources.namespacedResources")
 		if err != nil {
 			return nil, err
 		}
@@ -594,7 +578,7 @@ func evaluateStructuredGrouped(unified cue.Value, expectedNamespace string, read
 	// Walk platformResources.namespacedResources
 	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
 	if platformNamespacedValue.Err() == nil && platformNamespacedValue.Exists() {
-		resources, err := walkNamespacedResources(platformNamespacedValue, expectedNamespace, "platformResources.namespacedResources")
+		resources, err := walkNamespacedResources(platformNamespacedValue, "platformResources.namespacedResources")
 		if err != nil {
 			return nil, err
 		}
@@ -637,13 +621,17 @@ func evaluateStructuredGrouped(unified cue.Value, expectedNamespace string, read
 // project template cannot produce platformResources. Organization and folder
 // level paths pass true to read both collections. This is a hard boundary
 // enforced in Go code, not in CUE.
-func evaluateStructured(unified cue.Value, expectedNamespace string, readPlatformResources bool) ([]unstructured.Unstructured, error) {
+//
+// There is no restriction on which namespaces resources may target. The
+// struct-key/metadata consistency check ensures internal consistency within the
+// template (ADR 026).
+func evaluateStructured(unified cue.Value, readPlatformResources bool) ([]unstructured.Unstructured, error) {
 	var result []unstructured.Unstructured
 
 	// Walk projectResources.namespacedResources: <namespace>.<Kind>.<name>
 	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
 	if namespacedValue.Err() == nil && namespacedValue.Exists() {
-		resources, err := walkNamespacedResources(namespacedValue, expectedNamespace, "projectResources.namespacedResources")
+		resources, err := walkNamespacedResources(namespacedValue, "projectResources.namespacedResources")
 		if err != nil {
 			return nil, err
 		}
@@ -668,7 +656,7 @@ func evaluateStructured(unified cue.Value, expectedNamespace string, readPlatfor
 	// skipped for project-level rendering).
 	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
 	if platformNamespacedValue.Err() == nil && platformNamespacedValue.Exists() {
-		resources, err := walkNamespacedResources(platformNamespacedValue, expectedNamespace, "platformResources.namespacedResources")
+		resources, err := walkNamespacedResources(platformNamespacedValue, "platformResources.namespacedResources")
 		if err != nil {
 			return nil, err
 		}
@@ -691,8 +679,12 @@ func evaluateStructured(unified cue.Value, expectedNamespace string, readPlatfor
 
 // walkNamespacedResources iterates a namespaced resource map of the form
 // <namespace>.<Kind>.<name> and returns validated Kubernetes resources.
-// All resources must reside in expectedNamespace.
-func walkNamespacedResources(namespacedValue cue.Value, expectedNamespace, fieldPath string) ([]unstructured.Unstructured, error) {
+//
+// The struct-key/metadata consistency check is enforced: metadata.namespace,
+// metadata.name, and kind must match their respective struct keys. There is no
+// restriction on which namespaces may appear — templates may produce resources
+// targeting any namespace (ADR 026).
+func walkNamespacedResources(namespacedValue cue.Value, fieldPath string) ([]unstructured.Unstructured, error) {
 	var result []unstructured.Unstructured
 
 	nsIter, err := namespacedValue.Fields()
@@ -731,12 +723,6 @@ func walkNamespacedResources(namespacedValue cue.Value, expectedNamespace, field
 				if u.GetName() != nameKey {
 					return nil, fmt.Errorf("%s/%s/%s/%s: metadata.name %q does not match struct key %q",
 						fieldPath, nsKey, kindKey, nameKey, u.GetName(), nameKey)
-				}
-
-				// Enforce project namespace constraint.
-				if u.GetNamespace() != expectedNamespace {
-					return nil, fmt.Errorf("%s resource %s/%s: namespace %q does not match project namespace %q",
-						fieldPath, u.GetKind(), u.GetName(), u.GetNamespace(), expectedNamespace)
 				}
 
 				// Run common resource validations.

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -71,7 +71,11 @@ projectResources: {
 }
 `
 
-// structuredCrossNamespaceTemplate tries to set metadata.namespace to a different value than the struct key.
+// structuredCrossNamespaceTemplate has a struct-key/metadata mismatch:
+// the struct key uses platform.namespace but metadata.namespace is hardcoded to
+// "other-namespace". This tests that the struct-key/metadata consistency check
+// catches the mismatch (the namespace restriction itself has been removed per
+// ADR 026).
 const structuredCrossNamespaceTemplate = `
 
 input: {
@@ -93,6 +97,206 @@ projectResources: {
 			metadata: {
 				name:      input.name
 				namespace: "other-namespace"
+				labels: "app.kubernetes.io/managed-by": "console.holos.run"
+			}
+			spec: {}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// multiNamespaceTemplate produces resources in two different namespaces:
+// a Deployment in the project namespace and an HTTPRoute in istio-ingress.
+// After removing the per-resource namespace restriction (ADR 026), this template
+// must render successfully.
+const multiNamespaceTemplate = `
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:          string
+	namespace:        string
+	gatewayNamespace: string
+}
+
+_labels: {
+	"app.kubernetes.io/name":       input.name
+	"app.kubernetes.io/managed-by": "console.holos.run"
+}
+
+projectResources: {
+	namespacedResources: {
+		(platform.namespace): {
+			Deployment: (input.name): {
+				apiVersion: "apps/v1"
+				kind:       "Deployment"
+				metadata: {
+					name:      input.name
+					namespace: platform.namespace
+					labels:    _labels
+				}
+				spec: {
+					selector: matchLabels: "app.kubernetes.io/name": input.name
+					template: {
+						metadata: labels: _labels
+						spec: containers: [{
+							name:  input.name
+							image: input.image + ":" + input.tag
+						}]
+					}
+				}
+			}
+		}
+		(platform.gatewayNamespace): {
+			HTTPRoute: (input.name): {
+				apiVersion: "gateway.networking.k8s.io/v1"
+				kind:       "HTTPRoute"
+				metadata: {
+					name:      input.name
+					namespace: platform.gatewayNamespace
+					labels:    _labels
+				}
+				spec: {
+					parentRefs: [{
+						group:     "gateway.networking.k8s.io"
+						kind:      "Gateway"
+						namespace: platform.gatewayNamespace
+						name:      "default"
+					}]
+					rules: [{
+						backendRefs: [{
+							name: input.name
+							port: 80
+						}]
+					}]
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// multiNamespacePlatformTemplate produces platform resources in two different
+// namespaces: a ServiceAccount in the project namespace and an HTTPRoute in
+// istio-ingress. Validates that platformResources also allows multi-namespace.
+const multiNamespacePlatformTemplate = `
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:          string
+	namespace:        string
+	gatewayNamespace: string
+}
+
+_labels: {
+	"app.kubernetes.io/name":       input.name
+	"app.kubernetes.io/managed-by": "console.holos.run"
+}
+
+projectResources: {
+	namespacedResources: (platform.namespace): {
+		Deployment: (input.name): {
+			apiVersion: "apps/v1"
+			kind:       "Deployment"
+			metadata: {
+				name:      input.name
+				namespace: platform.namespace
+				labels:    _labels
+			}
+			spec: {
+				selector: matchLabels: "app.kubernetes.io/name": input.name
+				template: {
+					metadata: labels: _labels
+					spec: containers: [{
+						name:  input.name
+						image: input.image + ":" + input.tag
+					}]
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+
+platformResources: {
+	namespacedResources: {
+		(platform.namespace): {
+			ServiceAccount: "platform-sa": {
+				apiVersion: "v1"
+				kind:       "ServiceAccount"
+				metadata: {
+					name:      "platform-sa"
+					namespace: platform.namespace
+					labels:    _labels
+				}
+			}
+		}
+		(platform.gatewayNamespace): {
+			HTTPRoute: (input.name + "-route"): {
+				apiVersion: "gateway.networking.k8s.io/v1"
+				kind:       "HTTPRoute"
+				metadata: {
+					name:      input.name + "-route"
+					namespace: platform.gatewayNamespace
+					labels:    _labels
+				}
+				spec: {
+					parentRefs: [{
+						group:     "gateway.networking.k8s.io"
+						kind:      "Gateway"
+						namespace: platform.gatewayNamespace
+						name:      "default"
+					}]
+					rules: [{
+						backendRefs: [{
+							name: input.name
+							port: 80
+						}]
+					}]
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// structKeyMismatchTemplate has a struct key that does not match
+// metadata.namespace — the struct key is "wrong-ns" but metadata.namespace is
+// the project namespace. This must still be rejected by the struct-key/metadata
+// consistency check even after the namespace restriction is removed.
+const structKeyMismatchTemplate = `
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:   string
+	namespace: string
+}
+
+projectResources: {
+	namespacedResources: "wrong-ns": {
+		Deployment: (input.name): {
+			apiVersion: "apps/v1"
+			kind:       "Deployment"
+			metadata: {
+				name:      input.name
+				namespace: platform.namespace
 				labels: "app.kubernetes.io/managed-by": "console.holos.run"
 			}
 			spec: {}
@@ -224,7 +428,10 @@ platformResources: {
 }
 `
 
-// crossNamespaceTemplate tries to write into a different namespace using structured output.
+// crossNamespaceTemplate has a struct-key/metadata mismatch: the struct key
+// uses platform.namespace but metadata.namespace is "other-namespace". This
+// tests the struct-key consistency check (the namespace restriction itself was
+// removed per ADR 026).
 const crossNamespaceTemplate = `
 
 input: {
@@ -430,10 +637,13 @@ func TestCueRenderer_Render(t *testing.T) {
 		}
 	})
 
-	t.Run("cross-namespace resource rejected", func(t *testing.T) {
+	t.Run("struct-key metadata namespace mismatch rejected", func(t *testing.T) {
 		_, err := renderer.Render(context.Background(), crossNamespaceTemplate, defaultPlatform(namespace), defaultProject())
 		if err == nil {
-			t.Fatal("expected error for cross-namespace resource")
+			t.Fatal("expected error for struct-key/metadata namespace mismatch")
+		}
+		if !strings.Contains(err.Error(), "does not match struct key") {
+			t.Errorf("expected 'does not match struct key' error, got: %v", err)
 		}
 	})
 
@@ -940,13 +1150,16 @@ func TestCueRenderer_StructuredOutput(t *testing.T) {
 		}
 	})
 
-	t.Run("structured template rejects cross-namespace resources", func(t *testing.T) {
+	t.Run("structured template rejects struct-key metadata namespace mismatch", func(t *testing.T) {
 		_, err := renderer.Render(context.Background(), structuredCrossNamespaceTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "web-app", Image: "nginx", Tag: "1.25", Port: 8080},
 		)
 		if err == nil {
-			t.Fatal("expected error for cross-namespace resource")
+			t.Fatal("expected error for struct-key/metadata namespace mismatch")
+		}
+		if !strings.Contains(err.Error(), "does not match struct key") {
+			t.Errorf("expected 'does not match struct key' error, got: %v", err)
 		}
 	})
 
@@ -2701,6 +2914,163 @@ func TestStructuredJSONExtraction(t *testing.T) {
 			if !json.Valid([]byte(*val)) {
 				t.Errorf("%s is not valid JSON: %s", name, *val)
 			}
+		}
+	})
+}
+
+// TestCueRenderer_MultiNamespaceResources verifies that templates producing
+// resources in multiple namespaces render successfully after the removal of the
+// per-resource namespace restriction (ADR 026). The struct-key/metadata
+// consistency check is preserved.
+func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
+	renderer := &CueRenderer{}
+	namespace := "prj-my-project"
+
+	t.Run("project resources spanning multiple namespaces render successfully", func(t *testing.T) {
+		platform := v1alpha2.PlatformInput{
+			Project:          "my-project",
+			Namespace:        namespace,
+			GatewayNamespace: "istio-ingress",
+		}
+		project := v1alpha2.ProjectInput{
+			Name:  "web-app",
+			Image: "nginx",
+			Tag:   "1.25",
+			Port:  8080,
+		}
+		resources, err := renderer.Render(context.Background(), multiNamespaceTemplate, platform, project)
+		if err != nil {
+			t.Fatalf("expected no error for multi-namespace template, got %v", err)
+		}
+		// Expect 2 resources: Deployment in project namespace, HTTPRoute in istio-ingress.
+		if len(resources) != 2 {
+			t.Fatalf("expected 2 resources, got %d: %v", len(resources), resourceKinds(resources))
+		}
+		nsSet := make(map[string]bool)
+		kindSet := make(map[string]bool)
+		for _, r := range resources {
+			nsSet[r.GetNamespace()] = true
+			kindSet[r.GetKind()] = true
+		}
+		if !nsSet[namespace] {
+			t.Errorf("expected resource in namespace %q", namespace)
+		}
+		if !nsSet["istio-ingress"] {
+			t.Error("expected resource in namespace 'istio-ingress'")
+		}
+		if !kindSet["Deployment"] {
+			t.Error("expected Deployment resource")
+		}
+		if !kindSet["HTTPRoute"] {
+			t.Error("expected HTTPRoute resource")
+		}
+	})
+
+	t.Run("platform resources spanning multiple namespaces render successfully", func(t *testing.T) {
+		platform := v1alpha2.PlatformInput{
+			Project:          "my-project",
+			Namespace:        namespace,
+			GatewayNamespace: "istio-ingress",
+		}
+		project := v1alpha2.ProjectInput{
+			Name:  "web-app",
+			Image: "nginx",
+			Tag:   "1.25",
+			Port:  8080,
+		}
+		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
+			multiNamespacePlatformTemplate,
+			nil,
+			platform, project,
+		)
+		if err != nil {
+			t.Fatalf("expected no error for multi-namespace platform template, got %v", err)
+		}
+		// Expect 3 resources: Deployment in project ns, ServiceAccount in project ns,
+		// HTTPRoute in istio-ingress.
+		if len(resources) != 3 {
+			t.Fatalf("expected 3 resources, got %d: %v", len(resources), resourceKinds(resources))
+		}
+		nsSet := make(map[string]bool)
+		for _, r := range resources {
+			nsSet[r.GetNamespace()] = true
+		}
+		if !nsSet[namespace] {
+			t.Errorf("expected resource in namespace %q", namespace)
+		}
+		if !nsSet["istio-ingress"] {
+			t.Error("expected resource in namespace 'istio-ingress'")
+		}
+	})
+
+	t.Run("struct-key metadata mismatch still rejected", func(t *testing.T) {
+		_, err := renderer.Render(context.Background(), structKeyMismatchTemplate,
+			defaultPlatform(namespace), defaultProject())
+		if err == nil {
+			t.Fatal("expected error for struct-key/metadata namespace mismatch")
+		}
+		if !strings.Contains(err.Error(), "does not match struct key") {
+			t.Errorf("expected 'does not match struct key' error, got: %v", err)
+		}
+	})
+
+	t.Run("grouped render with multi-namespace project resources", func(t *testing.T) {
+		platform := v1alpha2.PlatformInput{
+			Project:          "my-project",
+			Namespace:        namespace,
+			GatewayNamespace: "istio-ingress",
+		}
+		project := v1alpha2.ProjectInput{
+			Name:  "web-app",
+			Image: "nginx",
+			Tag:   "1.25",
+			Port:  8080,
+		}
+		grouped, err := renderer.RenderGrouped(context.Background(),
+			multiNamespaceTemplate, platform, project)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(grouped.Project) != 2 {
+			t.Fatalf("expected 2 project resources, got %d: %v",
+				len(grouped.Project), resourceKinds(grouped.Project))
+		}
+		nsSet := make(map[string]bool)
+		for _, r := range grouped.Project {
+			nsSet[r.GetNamespace()] = true
+		}
+		if !nsSet[namespace] || !nsSet["istio-ingress"] {
+			t.Errorf("expected resources in both %q and 'istio-ingress', got namespaces: %v", namespace, nsSet)
+		}
+	})
+
+	t.Run("grouped render with multi-namespace platform resources", func(t *testing.T) {
+		platform := v1alpha2.PlatformInput{
+			Project:          "my-project",
+			Namespace:        namespace,
+			GatewayNamespace: "istio-ingress",
+		}
+		project := v1alpha2.ProjectInput{
+			Name:  "web-app",
+			Image: "nginx",
+			Tag:   "1.25",
+			Port:  8080,
+		}
+		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+			multiNamespacePlatformTemplate, nil, platform, project)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(grouped.Platform) != 2 {
+			t.Fatalf("expected 2 platform resources, got %d: %v",
+				len(grouped.Platform), resourceKinds(grouped.Platform))
+		}
+		nsSet := make(map[string]bool)
+		for _, r := range grouped.Platform {
+			nsSet[r.GetNamespace()] = true
+		}
+		if !nsSet[namespace] || !nsSet["istio-ingress"] {
+			t.Errorf("expected platform resources in both %q and 'istio-ingress', got namespaces: %v", namespace, nsSet)
 		}
 	})
 }

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -272,6 +272,38 @@ platformResources: {
 }
 `
 
+// emptyNamespaceKeyTemplate uses an empty string as the namespace struct key.
+// This must be rejected because namespaced resources require a non-empty namespace.
+const emptyNamespaceKeyTemplate = `
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:   string
+	namespace: string
+}
+
+projectResources: {
+	namespacedResources: "": {
+		Deployment: (input.name): {
+			apiVersion: "apps/v1"
+			kind:       "Deployment"
+			metadata: {
+				name:      input.name
+				namespace: ""
+				labels: "app.kubernetes.io/managed-by": "console.holos.run"
+			}
+			spec: {}
+		}
+	}
+	clusterResources: {}
+}
+`
+
 // structKeyMismatchTemplate has a struct key that does not match
 // metadata.namespace — the struct key is "wrong-ns" but metadata.namespace is
 // the project namespace. This must still be rejected by the struct-key/metadata
@@ -3011,6 +3043,17 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "does not match struct key") {
 			t.Errorf("expected 'does not match struct key' error, got: %v", err)
+		}
+	})
+
+	t.Run("empty namespace key rejected", func(t *testing.T) {
+		_, err := renderer.Render(context.Background(), emptyNamespaceKeyTemplate,
+			defaultPlatform(namespace), defaultProject())
+		if err == nil {
+			t.Fatal("expected error for empty namespace key")
+		}
+		if !strings.Contains(err.Error(), "empty namespace key") {
+			t.Errorf("expected 'empty namespace key' error, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Remove per-resource namespace enforcement from `walkNamespacedResources()` — templates can now produce resources targeting any Kubernetes namespace (ADR 026)
- Remove `expectedNamespace` parameter from `evaluateStructured()`, `evaluateStructuredGrouped()`, and all callers
- Remove namespace extraction from `evaluateWithCueInput()` and `evaluateWithCueInputGrouped()` that was only used for the removed check
- Preserve struct-key/metadata consistency check (metadata.namespace must match the CUE struct key)
- Preserve kind allowlist and managed-by label validation
- Add multi-namespace test coverage: project resources and platform resources spanning multiple namespaces
- Add explicit struct-key/metadata mismatch test
- Update existing cross-namespace tests to verify struct-key consistency instead of namespace restriction

Closes #887

## Test plan

- [x] `make test` passes (all Go tests and 876 UI tests)
- [x] Multi-namespace project resources render successfully (Deployment in project ns + HTTPRoute in istio-ingress)
- [x] Multi-namespace platform resources render successfully
- [x] Struct-key/metadata mismatch still rejected
- [x] Existing tests updated and passing

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

_Agent slot: agent-2_