### PR TITLE
fix(templates): preserve all fields in partial update handlers

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -99,6 +99,8 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
         displayName: template?.displayName,
         description: template?.description,
         cueTemplate,
+        mandatory: template?.mandatory,
+        enabled: template?.enabled,
       })
       toast.success('Saved')
     } catch (err) {
@@ -122,7 +124,13 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
 
   const handleSaveDescription = async () => {
     try {
-      await updateMutation.mutateAsync({ description: draftDescription })
+      await updateMutation.mutateAsync({
+        description: draftDescription,
+        cueTemplate,
+        displayName: template?.displayName,
+        mandatory: template?.mandatory,
+        enabled: template?.enabled,
+      })
       toast.success('Saved')
       setDescEditOpen(false)
     } catch (err) {
@@ -150,7 +158,15 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
           const vc = draftVersionConstraints.get(key) ?? ''
           return { scope: parsed.scope, scopeName: parsed.scopeName, name: parsed.name, versionConstraint: vc } as LinkedTemplateRef
         })
-      await updateMutation.mutateAsync({ linkedTemplates, updateLinkedTemplates: true })
+      await updateMutation.mutateAsync({
+        linkedTemplates,
+        updateLinkedTemplates: true,
+        cueTemplate,
+        displayName: template?.displayName,
+        description: template?.description,
+        mandatory: template?.mandatory,
+        enabled: template?.enabled,
+      })
       toast.success('Saved')
       setLinkedEditOpen(false)
     } catch (err) {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
@@ -102,7 +102,9 @@ const mockTemplate = {
   displayName: 'Web App',
   description: 'Standard web application',
   cueTemplate: '// cue template content',
-  linkedTemplates: [] as Array<{ name: string; scope: number; scopeName: string }>,
+  mandatory: true,
+  enabled: true,
+  linkedTemplates: [] as Array<{ name: string; scope: number; scopeName: string; versionConstraint?: string }>,
 }
 
 // ---------------------------------------------------------------------------
@@ -283,6 +285,130 @@ describe('Linking UI regression — DeploymentTemplateDetailPage', () => {
           expect.objectContaining({ name: 'reference-grant', scope: 1, scopeName: 'default' }),
         ]),
       )
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Partial-update regression tests
+//
+// These tests ensure that each save handler passes ALL current field values to
+// the mutation, preventing any field from being silently zeroed out.
+// See https://github.com/holos-run/holos-console/issues/895
+// ---------------------------------------------------------------------------
+
+describe('Partial-update regression — DeploymentTemplateDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('handleSaveLinkedTemplates preserves all fields', () => {
+    it('passes cueTemplate, displayName, description, mandatory, and enabled alongside linkedTemplates', async () => {
+      const user = userEvent.setup()
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
+      setupDetailMocks(Role.OWNER, {
+        cueTemplate: '// existing content',
+        displayName: 'My Template',
+        description: 'My description',
+        mandatory: true,
+        enabled: true,
+      })
+      ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync, isPending: false })
+
+      render(<DeploymentTemplateDetailPage />)
+
+      // Open the linked templates dialog
+      await user.click(screen.getByRole('button', { name: /edit linked platform templates/i }))
+      const dialog = screen.getByRole('dialog')
+
+      // Toggle a non-mandatory template
+      const httpbinCheckbox = within(dialog).getByRole('checkbox', { name: /httpbin platform/i })
+      await user.click(httpbinCheckbox)
+
+      // Click Save
+      await user.click(within(dialog).getByRole('button', { name: /save/i }))
+
+      expect(mutateAsync).toHaveBeenCalledTimes(1)
+      const callArgs = mutateAsync.mock.calls[0][0]
+      // Must include CUE template content (not empty string)
+      expect(callArgs.cueTemplate).toBe('// existing content')
+      expect(callArgs.displayName).toBe('My Template')
+      expect(callArgs.description).toBe('My description')
+      expect(callArgs.mandatory).toBe(true)
+      expect(callArgs.enabled).toBe(true)
+      // Must still include linkedTemplates and updateLinkedTemplates
+      expect(callArgs.updateLinkedTemplates).toBe(true)
+      expect(callArgs.linkedTemplates).toBeDefined()
+    })
+  })
+
+  describe('handleSaveDescription preserves all fields', () => {
+    it('passes cueTemplate, displayName, mandatory, and enabled alongside description', async () => {
+      const user = userEvent.setup()
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
+      setupDetailMocks(Role.OWNER, {
+        cueTemplate: '// existing content',
+        displayName: 'My Template',
+        description: 'Original description',
+        mandatory: true,
+        enabled: true,
+      })
+      ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync, isPending: false })
+
+      render(<DeploymentTemplateDetailPage />)
+
+      // Open the description edit dialog
+      await user.click(screen.getByRole('button', { name: /edit description/i }))
+      const dialog = screen.getByRole('dialog')
+
+      // Change description text
+      const textarea = within(dialog).getByRole('textbox', { name: /description/i })
+      await user.clear(textarea)
+      await user.type(textarea, 'Updated description')
+
+      // Click Save
+      await user.click(within(dialog).getByRole('button', { name: /save/i }))
+
+      expect(mutateAsync).toHaveBeenCalledTimes(1)
+      const callArgs = mutateAsync.mock.calls[0][0]
+      // Must include CUE template content (not empty string)
+      expect(callArgs.cueTemplate).toBe('// existing content')
+      expect(callArgs.displayName).toBe('My Template')
+      expect(callArgs.description).toBe('Updated description')
+      expect(callArgs.mandatory).toBe(true)
+      expect(callArgs.enabled).toBe(true)
+    })
+  })
+
+  describe('handleSave preserves all fields', () => {
+    it('passes mandatory and enabled alongside cueTemplate, displayName, and description', async () => {
+      const user = userEvent.setup()
+      const mutateAsync = vi.fn().mockResolvedValue({})
+      ;(useListLinkableTemplates as Mock).mockReturnValue({ data: allLinkable, isPending: false })
+      setupDetailMocks(Role.OWNER, {
+        cueTemplate: '// existing content',
+        displayName: 'My Template',
+        description: 'My description',
+        mandatory: true,
+        enabled: true,
+      })
+      ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync, isPending: false })
+
+      render(<DeploymentTemplateDetailPage />)
+
+      // The Save button is inside the CueTemplateEditor — click it
+      const saveButton = screen.getByRole('button', { name: /^save$/i })
+      await user.click(saveButton)
+
+      expect(mutateAsync).toHaveBeenCalledTimes(1)
+      const callArgs = mutateAsync.mock.calls[0][0]
+      expect(callArgs.cueTemplate).toBe('// existing content')
+      expect(callArgs.displayName).toBe('My Template')
+      expect(callArgs.description).toBe('My description')
+      expect(callArgs.mandatory).toBe(true)
+      expect(callArgs.enabled).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Fix `handleSave` to pass `mandatory` and `enabled` fields alongside `cueTemplate`, `displayName`, and `description`
- Fix `handleSaveDescription` to pass `cueTemplate` (from local state), `displayName`, `mandatory`, and `enabled` alongside `description`
- Fix `handleSaveLinkedTemplates` to pass `cueTemplate` (from local state), `displayName`, `description`, `mandatory`, and `enabled` alongside `linkedTemplates`
- Add three regression tests verifying each handler passes all current field values to `mutateAsync`

The root cause was that `useUpdateTemplate` builds a full `Template` message for every call -- any field not provided defaults to its zero value (`''` for strings, `false` for booleans). The backend handler always overwrites all fields, so omitting a field silently zeros it out.

Closes #895

## Test plan

- [x] 3 new regression tests pass (partial-update preservation)
- [x] All 25 tests in `-linking-regression.test.tsx` pass
- [x] Full UI test suite passes (879 tests, 55 files)
- [x] Go test suite passes

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)

---
*Agent: agent-3*