### PR TITLE
feat(ui): CueTemplateEditor empty state, pretty-print inputs, overflow fixes

### DIFF
--- a/frontend/src/components/cue-template-editor.test.tsx
+++ b/frontend/src/components/cue-template-editor.test.tsx
@@ -222,7 +222,7 @@ describe('CueTemplateEditor', () => {
       expect(screen.queryByText('all-resources')).not.toBeInTheDocument()
     })
 
-    it('renders only project section when platform resources are empty', async () => {
+    it('shows empty-state message when platform resources are empty but project resources exist', async () => {
       const user = userEvent.setup()
       ;(useRenderTemplate as Mock).mockReturnValue({
         data: {
@@ -245,14 +245,93 @@ describe('CueTemplateEditor', () => {
       )
       await user.click(screen.getByRole('tab', { name: /preview/i }))
 
-      // Should not show "Platform Resources" heading
-      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
-      // Should not show "Project Resources" heading (just shows "Rendered YAML")
-      expect(screen.queryByText('Project Resources')).not.toBeInTheDocument()
-      // Should show the label as "Rendered YAML"
-      expect(screen.getByText('Rendered YAML')).toBeInTheDocument()
-      // The content should be from projectResourcesYaml
-      expect(screen.getByLabelText('Rendered YAML')).toHaveTextContent('Deployment')
+      // Both headings should be shown
+      expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+      expect(screen.getByText('Project Resources')).toBeInTheDocument()
+      // Empty-state message replaces the platform YAML block
+      expect(screen.getByText('No platform resources rendered by this template.')).toBeInTheDocument()
+      // Project resources should be displayed
+      expect(screen.getByLabelText('Project Resources YAML')).toHaveTextContent('Deployment')
+    })
+
+    it('shows both Platform Resources and Project Resources headings when only project resources exist', async () => {
+      const user = userEvent.setup()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: {
+          renderedYaml: '',
+          renderedJson: '',
+          platformResourcesYaml: '',
+          platformResourcesJson: '',
+          projectResourcesYaml: 'apiVersion: v1\nkind: ConfigMap',
+          projectResourcesJson: '',
+        },
+        error: null,
+        isFetching: false,
+      })
+      render(
+        <CueTemplateEditor
+          cueTemplate="content"
+          onChange={vi.fn()}
+          scope={testScope}
+        />
+      )
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      // Both headings must always be present when hasPerCollectionFields is true
+      expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+      expect(screen.getByText('Project Resources')).toBeInTheDocument()
+      // Empty-state message for platform
+      expect(screen.getByText('No platform resources rendered by this template.')).toBeInTheDocument()
+      // Project content is shown
+      expect(screen.getByLabelText('Project Resources YAML')).toHaveTextContent('ConfigMap')
+    })
+
+    it('pretty-prints JSON default inputs in textareas', async () => {
+      const user = userEvent.setup()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: undefined,
+        error: null,
+        isFetching: false,
+      })
+      const compactJson = '{"name":"test","replicas":3}'
+      render(
+        <CueTemplateEditor
+          cueTemplate="content"
+          onChange={vi.fn()}
+          defaultPlatformInput={compactJson}
+          defaultProjectInput={compactJson}
+          scope={testScope}
+        />
+      )
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      const expectedPretty = JSON.stringify(JSON.parse(compactJson), null, 2)
+      expect(screen.getByRole('textbox', { name: /platform input/i })).toHaveValue(expectedPretty)
+      expect(screen.getByRole('textbox', { name: /project input/i })).toHaveValue(expectedPretty)
+    })
+
+    it('passes CUE default inputs through unchanged', async () => {
+      const user = userEvent.setup()
+      ;(useRenderTemplate as Mock).mockReturnValue({
+        data: undefined,
+        error: null,
+        isFetching: false,
+      })
+      const cueInput = 'name: "test"\nreplicas: 3'
+      render(
+        <CueTemplateEditor
+          cueTemplate="content"
+          onChange={vi.fn()}
+          defaultPlatformInput={cueInput}
+          defaultProjectInput={cueInput}
+          scope={testScope}
+        />
+      )
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      // CUE is not valid JSON, so it should pass through unchanged
+      expect(screen.getByRole('textbox', { name: /platform input/i })).toHaveValue(cueInput)
+      expect(screen.getByRole('textbox', { name: /project input/i })).toHaveValue(cueInput)
     })
 
     it('falls back to unified renderedYaml when no per-collection fields are present', async () => {

--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -66,6 +66,20 @@ function RenderStatusIndicator({ isStale, isRendering, hasError }: RenderStatusI
   )
 }
 
+/**
+ * prettyPrintJson attempts to parse the input as JSON and returns it
+ * pretty-printed with 2-space indent. If parsing fails (e.g. CUE syntax),
+ * the original string is returned unchanged.
+ */
+function prettyPrintJson(value: string): string {
+  if (!value) return value
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2)
+  } catch {
+    return value
+  }
+}
+
 export interface CueTemplateEditorProps {
   /** Current CUE template source */
   cueTemplate: string
@@ -104,8 +118,8 @@ export function CueTemplateEditor({
   linkedTemplates = [],
 }: CueTemplateEditorProps) {
   const [activeTab, setActiveTab] = useState('editor')
-  const [cuePlatformInput, setCuePlatformInput] = useState(defaultPlatformInput)
-  const [cueInput, setCueInput] = useState(defaultProjectInput)
+  const [cuePlatformInput, setCuePlatformInput] = useState(() => prettyPrintJson(defaultPlatformInput))
+  const [cueInput, setCueInput] = useState(() => prettyPrintJson(defaultProjectInput))
 
   const debouncedCueInput = useDebouncedValue(cueInput, 500)
   const debouncedCuePlatformInput = useDebouncedValue(cuePlatformInput, 500)
@@ -160,8 +174,8 @@ export function CueTemplateEditor({
           </div>
         )}
       </TabsContent>
-      <TabsContent value="preview" className="mt-4 space-y-4">
-        <div className="space-y-2">
+      <TabsContent value="preview" className="mt-4 space-y-4 min-w-0">
+        <div className="space-y-2 min-w-0">
           <Label htmlFor="cue-platform-input-editor">Platform Input</Label>
           <p className="text-xs text-muted-foreground">
             These values are set by the console at deployment time and include the authenticated user&apos;s OIDC claims.
@@ -172,10 +186,10 @@ export function CueTemplateEditor({
             value={cuePlatformInput}
             onChange={(e) => setCuePlatformInput(e.target.value)}
             rows={10}
-            className="font-mono text-sm field-sizing-normal max-h-64 overflow-y-auto"
+            className="font-mono text-sm field-sizing-normal max-h-64 overflow-y-auto overflow-x-auto"
           />
         </div>
-        <div className="space-y-2">
+        <div className="space-y-2 min-w-0">
           <Label htmlFor="cue-input-editor">Project Input (deployment parameters)</Label>
           <Textarea
             id="cue-input-editor"
@@ -183,12 +197,12 @@ export function CueTemplateEditor({
             value={cueInput}
             onChange={(e) => setCueInput(e.target.value)}
             rows={6}
-            className="font-mono text-sm field-sizing-normal max-h-48 overflow-y-auto"
+            className="font-mono text-sm field-sizing-normal max-h-48 overflow-y-auto overflow-x-auto"
           />
         </div>
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Label>{hasPerCollectionFields && platformResourcesYaml ? 'Platform Resources' : 'Rendered YAML'}</Label>
+            <Label>{hasPerCollectionFields ? 'Platform Resources' : 'Rendered YAML'}</Label>
             <RenderStatusIndicator isStale={isStale} isRendering={isRendering} hasError={!!renderError} />
           </div>
           {renderError ? (
@@ -197,22 +211,22 @@ export function CueTemplateEditor({
             </Alert>
           ) : hasPerCollectionFields ? (
             <>
-              {platformResourcesYaml && (
+              {platformResourcesYaml ? (
                 <pre
                   aria-label="Platform Resources YAML"
-                  className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre"
+                  className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre max-w-full"
                 >
                   {platformResourcesYaml}
                 </pre>
+              ) : (
+                <p className="text-sm text-muted-foreground">No platform resources rendered by this template.</p>
               )}
-              {platformResourcesYaml && (
-                <div className="flex items-center gap-2 pt-2">
-                  <Label>Project Resources</Label>
-                </div>
-              )}
+              <div className="flex items-center gap-2 pt-2">
+                <Label>Project Resources</Label>
+              </div>
               <pre
-                aria-label={platformResourcesYaml ? 'Project Resources YAML' : 'Rendered YAML'}
-                className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre"
+                aria-label="Project Resources YAML"
+                className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre max-w-full"
               >
                 {projectResourcesYaml}
               </pre>
@@ -220,7 +234,7 @@ export function CueTemplateEditor({
           ) : (
             <pre
               aria-label="Rendered YAML"
-              className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre"
+              className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre max-w-full"
             >
               {renderedYaml ?? ''}
             </pre>

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -645,7 +645,7 @@ describe('DeploymentDetailPage', () => {
       expect(screen.getByLabelText('Project Resources YAML')).toHaveTextContent('Deployment')
     })
 
-    it('shows only project section when platform resources are empty', async () => {
+    it('shows empty-state message when platform resources are empty but project resources exist', async () => {
       const user = userEvent.setup()
       setupMocks()
       ;(useRenderTemplate as Mock).mockReturnValue({
@@ -664,8 +664,10 @@ describe('DeploymentDetailPage', () => {
       await user.click(screen.getByRole('tab', { name: /template/i }))
       await user.click(screen.getByRole('tab', { name: /preview/i }))
 
-      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
-      expect(screen.getByText('Rendered YAML')).toBeInTheDocument()
+      expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+      expect(screen.getByText('Project Resources')).toBeInTheDocument()
+      expect(screen.getByText('No platform resources rendered by this template.')).toBeInTheDocument()
+      expect(screen.getByLabelText('Project Resources YAML')).toHaveTextContent('Service')
     })
 
     it('falls back to unified renderedYaml when no per-collection fields present', async () => {


### PR DESCRIPTION
## Summary
- Always show "Platform Resources" heading when per-collection fields are present, with an explicit empty-state message ("No platform resources rendered by this template.") when platformResourcesYaml is empty
- Always show "Project Resources" heading alongside platform resources (previously gated on platformResourcesYaml being truthy)
- Pretty-print JSON default inputs in preview textareas via a prettyPrintJson() helper (CUE values pass through unchanged)
- Add overflow containment: min-w-0 on preview TabsContent and textarea parents, max-w-full on all pre blocks, overflow-x-auto on textareas

Closes #897

## Test plan
- [x] Regression test: empty-state message shown when platformResourcesYaml is empty but projectResourcesYaml exists
- [x] Regression test: both Platform Resources and Project Resources headings shown when only project resources exist
- [x] Test: JSON default inputs are pretty-printed in textareas
- [x] Test: CUE default inputs pass through unchanged
- [x] Updated downstream deployment detail page test to verify new empty-state behavior
- [x] All 879 UI tests pass (make test-ui)
- [x] All Go tests pass (make test-go)

Generated with [Claude Code](https://claude.com/claude-code)