### PR TITLE
feat(ui): create page preview empty state, overflow fixes, and cleanup

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
@@ -215,6 +215,90 @@ describe('Linking UI regression — CreateTemplatePage', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Create page inline preview tests
+// ---------------------------------------------------------------------------
+
+describe('Create page inline preview — empty state and headings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useListLinkableTemplates as Mock).mockReturnValue({ data: [], isPending: false })
+    setupCreateMocks(Role.OWNER)
+  })
+
+  it('shows "Platform Resources" heading with empty-state message when platformResourcesJson is empty but projectResourcesJson is non-empty', async () => {
+    const user = userEvent.setup()
+    ;(useRenderTemplate as Mock).mockReturnValue({
+      data: {
+        platformResourcesJson: '',
+        projectResourcesJson: '{"kind":"Deployment"}',
+        renderedJson: '',
+      },
+      error: null,
+      isLoading: false,
+      isError: false,
+    })
+    render(<CreateTemplatePage />)
+
+    // Open preview
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    // Both headings should be present
+    expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+    expect(screen.getByText('Project Resources')).toBeInTheDocument()
+    // Empty-state message for platform
+    expect(screen.getByText('No platform resources rendered by this template.')).toBeInTheDocument()
+    // Project resources should be displayed
+    expect(screen.getByLabelText('Project Resources JSON')).toHaveTextContent('Deployment')
+  })
+
+  it('always shows "Project Resources" heading when per-collection fields are present (not "Rendered JSON")', async () => {
+    const user = userEvent.setup()
+    ;(useRenderTemplate as Mock).mockReturnValue({
+      data: {
+        platformResourcesJson: '{"kind":"ReferenceGrant"}',
+        projectResourcesJson: '{"kind":"Deployment"}',
+        renderedJson: '',
+      },
+      error: null,
+      isLoading: false,
+      isError: false,
+    })
+    render(<CreateTemplatePage />)
+
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+    expect(screen.getByText('Project Resources')).toBeInTheDocument()
+    expect(screen.queryByText('Rendered JSON')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Platform Resources JSON')).toHaveTextContent('ReferenceGrant')
+    expect(screen.getByLabelText('Project Resources JSON')).toHaveTextContent('Deployment')
+  })
+
+  it('shows "Project Resources" heading (not "Rendered JSON") when only project resources exist', async () => {
+    const user = userEvent.setup()
+    ;(useRenderTemplate as Mock).mockReturnValue({
+      data: {
+        platformResourcesJson: '',
+        projectResourcesJson: '{"kind":"ConfigMap"}',
+        renderedJson: '',
+      },
+      error: null,
+      isLoading: false,
+      isError: false,
+    })
+    render(<CreateTemplatePage />)
+
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+    expect(screen.getByText('Project Resources')).toBeInTheDocument()
+    expect(screen.queryByText('Rendered JSON')).not.toBeInTheDocument()
+    expect(screen.getByText('No platform resources rendered by this template.')).toBeInTheDocument()
+    expect(screen.getByLabelText('Project Resources JSON')).toHaveTextContent('ConfigMap')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Detail / edit page regression tests
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -475,7 +475,7 @@ describe('CreateTemplatePage', () => {
       expect(screen.getByLabelText('Project Resources JSON')).toHaveTextContent('Deployment')
     })
 
-    it('shows only project section when platform resources JSON is empty', () => {
+    it('shows empty-state message for platform and Project Resources heading when platform JSON is empty', () => {
       setupMocks(
         vi.fn().mockResolvedValue({}),
         {
@@ -487,9 +487,10 @@ describe('CreateTemplatePage', () => {
       render(<CreateTemplatePage />)
       fireEvent.click(screen.getByRole('button', { name: /preview/i }))
 
-      expect(screen.queryByText('Platform Resources')).not.toBeInTheDocument()
-      expect(screen.getByText('Rendered JSON')).toBeInTheDocument()
-      expect(screen.getByLabelText('Rendered JSON')).toHaveTextContent('Deployment')
+      expect(screen.getByText('Platform Resources')).toBeInTheDocument()
+      expect(screen.getByText('No platform resources rendered by this template.')).toBeInTheDocument()
+      expect(screen.getByText('Project Resources')).toBeInTheDocument()
+      expect(screen.getByLabelText('Project Resources JSON')).toHaveTextContent('Deployment')
     })
 
     it('falls back to unified renderedJson when no per-collection fields', () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -589,22 +589,22 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                   const hasPerCollection = !!(platformJson || projectJson)
                   if (hasPerCollection) {
                     return (
-                      <div className="space-y-3">
-                        {platformJson && (
-                          <>
-                            <Label>Platform Resources</Label>
-                            <pre
-                              aria-label="Platform Resources JSON"
-                              className="font-mono text-sm bg-muted p-3 rounded-md max-h-96 overflow-y-auto whitespace-pre-wrap break-all"
-                            >
-                              {platformJson}
-                            </pre>
-                          </>
+                      <div className="space-y-3 min-w-0">
+                        <Label>Platform Resources</Label>
+                        {platformJson ? (
+                          <pre
+                            aria-label="Platform Resources JSON"
+                            className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre max-w-full"
+                          >
+                            {platformJson}
+                          </pre>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">No platform resources rendered by this template.</p>
                         )}
-                        <Label>{platformJson ? 'Project Resources' : 'Rendered JSON'}</Label>
+                        <Label>Project Resources</Label>
                         <pre
-                          aria-label={platformJson ? 'Project Resources JSON' : 'Rendered JSON'}
-                          className="font-mono text-sm bg-muted p-3 rounded-md max-h-96 overflow-y-auto whitespace-pre-wrap break-all"
+                          aria-label="Project Resources JSON"
+                          className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre max-w-full"
                         >
                           {projectJson}
                         </pre>
@@ -613,7 +613,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
                   }
                   if (renderQuery.data.renderedJson) {
                     return (
-                      <pre className="font-mono text-sm bg-muted p-3 rounded-md max-h-96 overflow-y-auto whitespace-pre-wrap break-all">
+                      <pre className="font-mono text-sm bg-muted rounded-md p-4 overflow-auto whitespace-pre max-w-full">
                         {renderQuery.data.renderedJson}
                       </pre>
                     )

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -572,7 +572,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
               {previewOpen ? 'Hide Preview' : 'Preview'}
             </Button>
             {previewOpen && (
-              <div className="mt-2">
+              <div className="mt-2 min-w-0">
                 {renderQuery.isLoading && (
                   <p className="text-sm text-muted-foreground">Rendering...</p>
                 )}


### PR DESCRIPTION
## Summary

- Always show "Platform Resources" heading in the create page inline preview when per-collection fields are present, with an empty-state message ("No platform resources rendered by this template.") when platformResourcesJson is empty
- Always show "Project Resources" heading (previously showed "Rendered JSON" when platform was empty)
- Align CSS classes with CueTemplateEditor: `overflow-auto whitespace-pre max-w-full` instead of `whitespace-pre-wrap break-all`, consistent `p-4 rounded-md` styling
- Add `min-w-0` to preview container for flex overflow containment
- Add 3 new tests in `-linking-regression.test.tsx` covering empty-state and heading scenarios
- Update existing test in `-new.test.tsx` to match new behavior

Closes #898

## Test plan
- [x] `make test` passes with 885 tests (0 failures)
- [ ] Verify inline preview shows "Platform Resources" heading with empty-state message when no platform resources are rendered
- [ ] Verify "Project Resources" heading always appears (never "Rendered JSON") when per-collection fields are present
- [ ] Verify long JSON output does not push the page wider than the viewport

Generated with [Claude Code](https://claude.com/claude-code)