### PR TITLE
feat(ui): display K8s events and container status on deployment status tab

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -344,19 +344,22 @@ export function DeploymentDetailPage({
                               {pod.containerStatuses && pod.containerStatuses.length > 0 && (
                                 <div className="ml-4 space-y-1">
                                   <p className="text-xs text-muted-foreground">Containers:</p>
-                                  {pod.containerStatuses.map((cs) => (
-                                    <div key={cs.name} className="flex items-center gap-2 text-xs font-mono">
+                                  {pod.containerStatuses.map((cs) => {
+                                    // Terminated containers are green for normal completion (no error reason),
+                                    // red only when an error reason is present or restarts indicate failure.
+                                    const terminatedIsError = cs.state === 'terminated' && isContainerError(cs)
+                                    const badgeClass =
+                                      cs.state === 'running'
+                                        ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent text-xs'
+                                        : cs.state === 'waiting'
+                                          ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 border-transparent text-xs'
+                                          : terminatedIsError
+                                            ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200 border-transparent text-xs'
+                                            : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent text-xs'
+                                    return (
+                                    <div key={cs.name} className="flex items-center gap-2 text-xs font-mono flex-wrap">
                                       <span className="text-foreground">{cs.name}</span>
-                                      <Badge
-                                        data-testid="container-state-badge"
-                                        className={
-                                          cs.state === 'running'
-                                            ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent text-xs'
-                                            : cs.state === 'waiting'
-                                              ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 border-transparent text-xs'
-                                              : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200 border-transparent text-xs'
-                                        }
-                                      >
+                                      <Badge data-testid="container-state-badge" className={badgeClass}>
                                         {cs.state}
                                       </Badge>
                                       {cs.reason && (
@@ -369,8 +372,14 @@ export function DeploymentDetailPage({
                                           — {cs.message}
                                         </span>
                                       )}
+                                      {cs.image && (
+                                        <span className="text-muted-foreground truncate max-w-sm" title={cs.image}>
+                                          {cs.image}
+                                        </span>
+                                      )}
                                     </div>
-                                  ))}
+                                    )
+                                  })}
                                 </div>
                               )}
                             </div>

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -86,7 +86,11 @@ function formatEventAge(event: Event): string {
   return age
 }
 
-/** Error reasons for containers in waiting or terminated states. */
+/**
+ * Known error reasons for containers in waiting or terminated states.
+ * Normal transient reasons like ContainerCreating and PodInitializing are
+ * excluded so they are not visually highlighted as errors during startup.
+ */
 const CONTAINER_ERROR_REASONS = new Set([
   'ImagePullBackOff',
   'ErrImagePull',
@@ -95,13 +99,14 @@ const CONTAINER_ERROR_REASONS = new Set([
   'InvalidImageName',
   'CreateContainerConfigError',
   'RunContainerError',
+  'OOMKilled',
 ])
 
 /** Returns true if the container status represents an error condition. */
 function isContainerError(cs: ContainerStatus): boolean {
-  if (cs.state === 'waiting' && cs.reason) return true
+  if (CONTAINER_ERROR_REASONS.has(cs.reason)) return true
   if (cs.state === 'terminated' && cs.restartCount > 0) return true
-  return CONTAINER_ERROR_REASONS.has(cs.reason)
+  return false
 }
 
 function DeploymentDetailRoute() {

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -36,9 +36,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { ArrowLeft, CheckCircle2, Copy, XCircle } from 'lucide-react'
+import { ArrowLeft, CheckCircle2, Copy, Info, TriangleAlert, XCircle } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import type { EnvVar } from '@/gen/holos/console/v1/deployments_pb'
+import type { EnvVar, Event, ContainerStatus } from '@/gen/holos/console/v1/deployments_pb'
 import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useGetDeploymentRenderPreview, useUpdateDeployment, useDeleteDeployment } from '@/queries/deployments'
 import { makeProjectScope } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
@@ -56,6 +56,53 @@ export const Route = createFileRoute('/_authenticated/projects/$projectName/depl
   }),
   component: DeploymentDetailRoute,
 })
+
+/**
+ * Converts a protobuf Timestamp to a human-readable relative age string.
+ * Matches kubectl describe output style: "45s", "3m", "28m", "2h", "3d".
+ */
+function relativeAge(timestamp: { seconds: bigint; nanos: number } | undefined): string {
+  if (!timestamp) return ''
+  const nowMs = Date.now()
+  const thenMs = Number(timestamp.seconds) * 1000
+  const diffS = Math.floor((nowMs - thenMs) / 1000)
+  if (diffS < 0) return '0s'
+  if (diffS < 60) return `${diffS}s`
+  if (diffS < 3600) return `${Math.floor(diffS / 60)}m`
+  if (diffS < 86400) return `${Math.floor(diffS / 3600)}h`
+  return `${Math.floor(diffS / 86400)}d`
+}
+
+/**
+ * Formats the age column for an event, including count if > 1.
+ * Example: "3m (x4 over 28m)" or just "28m" for count=1.
+ */
+function formatEventAge(event: Event): string {
+  const age = relativeAge(event.lastSeen)
+  if (event.count > 1) {
+    const totalSpan = relativeAge(event.firstSeen)
+    return `${age} (x${event.count} over ${totalSpan})`
+  }
+  return age
+}
+
+/** Error reasons for containers in waiting or terminated states. */
+const CONTAINER_ERROR_REASONS = new Set([
+  'ImagePullBackOff',
+  'ErrImagePull',
+  'CrashLoopBackOff',
+  'CreateContainerError',
+  'InvalidImageName',
+  'CreateContainerConfigError',
+  'RunContainerError',
+])
+
+/** Returns true if the container status represents an error condition. */
+function isContainerError(cs: ContainerStatus): boolean {
+  if (cs.state === 'waiting' && cs.reason) return true
+  if (cs.state === 'terminated' && cs.restartCount > 0) return true
+  return CONTAINER_ERROR_REASONS.has(cs.reason)
+}
 
 function DeploymentDetailRoute() {
   const { projectName, deploymentName } = Route.useParams()
@@ -280,13 +327,47 @@ export function DeploymentDetailPage({
                     {status.pods.length > 0 && (
                       <div>
                         <p className="text-sm text-muted-foreground mb-2">Pods</p>
-                        <div className="space-y-1">
+                        <div className="space-y-3">
                           {status.pods.map((pod) => (
-                            <div key={pod.name} className="flex items-center gap-3 text-sm font-mono">
-                              <span>{pod.name}</span>
-                              <Badge variant="outline" className="text-xs">{pod.phase}</Badge>
-                              {pod.ready && <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent text-xs">Ready</Badge>}
-                              {pod.restartCount > 0 && <span className="text-muted-foreground text-xs">{pod.restartCount} restarts</span>}
+                            <div key={pod.name} className="space-y-1">
+                              <div className="flex items-center gap-3 text-sm font-mono">
+                                <span>{pod.name}</span>
+                                <Badge variant="outline" className="text-xs">{pod.phase}</Badge>
+                                {pod.ready && <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent text-xs">Ready</Badge>}
+                                {pod.restartCount > 0 && <span className="text-muted-foreground text-xs">{pod.restartCount} restarts</span>}
+                              </div>
+                              {pod.containerStatuses && pod.containerStatuses.length > 0 && (
+                                <div className="ml-4 space-y-1">
+                                  <p className="text-xs text-muted-foreground">Containers:</p>
+                                  {pod.containerStatuses.map((cs) => (
+                                    <div key={cs.name} className="flex items-center gap-2 text-xs font-mono">
+                                      <span className="text-foreground">{cs.name}</span>
+                                      <Badge
+                                        data-testid="container-state-badge"
+                                        className={
+                                          cs.state === 'running'
+                                            ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent text-xs'
+                                            : cs.state === 'waiting'
+                                              ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 border-transparent text-xs'
+                                              : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200 border-transparent text-xs'
+                                        }
+                                      >
+                                        {cs.state}
+                                      </Badge>
+                                      {cs.reason && (
+                                        <span className={isContainerError(cs) ? 'text-yellow-600 dark:text-yellow-500' : 'text-muted-foreground'}>
+                                          {cs.reason}
+                                        </span>
+                                      )}
+                                      {cs.message && (
+                                        <span className="text-muted-foreground truncate max-w-md" title={cs.message}>
+                                          — {cs.message}
+                                        </span>
+                                      )}
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
                             </div>
                           ))}
                         </div>
@@ -295,6 +376,52 @@ export function DeploymentDetailPage({
                   </div>
                 ) : (
                   <p className="text-sm text-muted-foreground">No status available.</p>
+                )}
+              </div>
+
+              {/* Events section — between Pods and Environment Variables */}
+              <div className="space-y-4">
+                <h3 className="text-sm font-medium">Events</h3>
+                <Separator />
+                {status && status.events && status.events.length > 0 ? (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-8"></TableHead>
+                        <TableHead>Reason</TableHead>
+                        <TableHead>Age</TableHead>
+                        <TableHead>Source</TableHead>
+                        <TableHead>Message</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {status.events.map((evt, idx) => (
+                        <TableRow key={idx}>
+                          <TableCell className="w-8 pr-0">
+                            {evt.type === 'Warning' ? (
+                              <TriangleAlert data-testid="event-warning-icon" className="h-4 w-4 text-yellow-600 dark:text-yellow-500 shrink-0" />
+                            ) : (
+                              <Info data-testid="event-normal-icon" className="h-4 w-4 text-muted-foreground shrink-0" />
+                            )}
+                          </TableCell>
+                          <TableCell className={evt.type === 'Warning' ? 'text-yellow-600 dark:text-yellow-500 font-medium text-sm' : 'text-sm'}>
+                            {evt.reason}
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
+                            {formatEventAge(evt)}
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {evt.source}
+                          </TableCell>
+                          <TableCell className="text-sm max-w-md truncate" title={evt.message}>
+                            {evt.message}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No events.</p>
                 )}
               </div>
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -918,6 +918,55 @@ describe('DeploymentDetailPage', () => {
       expect(runningBadge.className).toMatch(/green/)
     })
 
+    it('shows container image', () => {
+      ;(useGetDeployment as Mock).mockReturnValue({ data: mockDeployment, isPending: false, error: null })
+      ;(useGetDeploymentStatus as Mock).mockReturnValue({ data: mockStatusWithEvents, isPending: false, error: null })
+      ;(useGetDeploymentLogs as Mock).mockReturnValue({ data: mockLogs, isPending: false, error: null })
+      ;(useUpdateDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, reset: vi.fn() })
+      ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+      ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
+      ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: mockPreview, isPending: false, error: null })
+      ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+      render(<DeploymentDetailPage />)
+      // The container's image should be displayed
+      expect(screen.getByText('ghcr.io/org/app:bad')).toBeInTheDocument()
+    })
+
+    it('terminated container with no error reason gets green badge', () => {
+      const terminatedNormalStatus = {
+        ...mockStatus,
+        pods: [
+          {
+            name: 'job-pod-1',
+            phase: 'Succeeded',
+            ready: false,
+            restartCount: 0,
+            containerStatuses: [
+              { name: 'worker', state: 'terminated', reason: 'Completed', message: '', image: 'ghcr.io/org/worker:v1', ready: false, restartCount: 0, startedAt: ts('2025-01-15T10:00:00Z') },
+            ],
+            events: [],
+          },
+        ],
+      }
+      ;(useGetDeployment as Mock).mockReturnValue({ data: mockDeployment, isPending: false, error: null })
+      ;(useGetDeploymentStatus as Mock).mockReturnValue({ data: terminatedNormalStatus, isPending: false, error: null })
+      ;(useGetDeploymentLogs as Mock).mockReturnValue({ data: mockLogs, isPending: false, error: null })
+      ;(useUpdateDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, reset: vi.fn() })
+      ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+      ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
+      ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: mockPreview, isPending: false, error: null })
+      ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+      render(<DeploymentDetailPage />)
+      const terminatedBadge = screen.getByText(/terminated/i, { selector: '[data-testid="container-state-badge"]' })
+      // Completed (normal exit) should get green, not red
+      expect(terminatedBadge.className).toMatch(/green/)
+      expect(terminatedBadge.className).not.toMatch(/red/)
+    })
+
     it('does not render container section when containerStatuses is empty', () => {
       setupMocks()
       render(<DeploymentDetailPage />)

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -77,7 +77,86 @@ const mockStatus = {
     { type: 'Progressing', status: 'True', reason: 'NewReplicaSetAvailable', message: '' },
   ],
   pods: [
-    { name: 'api-7d8f9b6c4-xk2m3', phase: 'Running', ready: true, restartCount: 0 },
+    { name: 'api-7d8f9b6c4-xk2m3', phase: 'Running', ready: true, restartCount: 0, containerStatuses: [], events: [] },
+  ],
+  events: [],
+}
+
+/** Creates a Timestamp-like object for protobuf. */
+function ts(isoStr: string) {
+  const ms = new Date(isoStr).getTime()
+  return { seconds: BigInt(Math.floor(ms / 1000)), nanos: 0, toDate: () => new Date(isoStr) }
+}
+
+const mockStatusWithEvents = {
+  ...mockStatus,
+  events: [
+    {
+      type: 'Warning',
+      reason: 'Failed',
+      message: 'Failed to pull image "ghcr.io/org/app:bad": rpc error',
+      source: 'kubelet',
+      count: 4,
+      firstSeen: ts('2025-01-15T10:00:00Z'),
+      lastSeen: ts('2025-01-15T10:28:00Z'),
+      involvedObjectName: 'api-7d8f9b6c4-xk2m3',
+    },
+    {
+      type: 'Normal',
+      reason: 'Scheduled',
+      message: 'Successfully assigned default/api-7d8f9b6c4-xk2m3',
+      source: 'default-scheduler',
+      count: 1,
+      firstSeen: ts('2025-01-15T10:00:00Z'),
+      lastSeen: ts('2025-01-15T10:00:00Z'),
+      involvedObjectName: 'api-7d8f9b6c4-xk2m3',
+    },
+  ],
+  pods: [
+    {
+      name: 'api-7d8f9b6c4-xk2m3',
+      phase: 'Pending',
+      ready: false,
+      restartCount: 2,
+      containerStatuses: [
+        {
+          name: 'app',
+          state: 'waiting',
+          reason: 'ImagePullBackOff',
+          message: 'Failed to pull "ghcr.io/org/app:bad"',
+          image: 'ghcr.io/org/app:bad',
+          ready: false,
+          restartCount: 2,
+          startedAt: undefined,
+        },
+      ],
+      events: [],
+    },
+  ],
+}
+
+const mockStatusWithHealthyContainers = {
+  ...mockStatus,
+  pods: [
+    {
+      name: 'api-7d8f9b6c4-xk2m3',
+      phase: 'Running',
+      ready: true,
+      restartCount: 0,
+      containerStatuses: [
+        {
+          name: 'app',
+          state: 'running',
+          reason: '',
+          message: '',
+          image: 'ghcr.io/org/api:v1.2.3',
+          ready: true,
+          restartCount: 0,
+          startedAt: ts('2025-01-15T10:00:00Z'),
+        },
+      ],
+      events: [],
+    },
   ],
 }
 
@@ -711,6 +790,182 @@ describe('DeploymentDetailPage', () => {
       render(<DeploymentDetailPage />)
       await user.click(screen.getByRole('tab', { name: /logs/i }))
       expect(screen.getByLabelText(/previous/i)).toBeInTheDocument()
+    })
+  })
+
+  // ── Events table tests ──────────────────────────────────────────────────
+
+  describe('Events section', () => {
+    function setupWithEvents() {
+      ;(useGetDeployment as Mock).mockReturnValue({ data: mockDeployment, isPending: false, error: null })
+      ;(useGetDeploymentStatus as Mock).mockReturnValue({ data: mockStatusWithEvents, isPending: false, error: null })
+      ;(useGetDeploymentLogs as Mock).mockReturnValue({ data: mockLogs, isPending: false, error: null })
+      ;(useUpdateDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, reset: vi.fn() })
+      ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+      ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
+      ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: mockPreview, isPending: false, error: null })
+      ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+    }
+
+    it('renders events table with correct columns', () => {
+      setupWithEvents()
+      render(<DeploymentDetailPage />)
+      expect(screen.getByText('Events')).toBeInTheDocument()
+      expect(screen.getByText('Reason')).toBeInTheDocument()
+      expect(screen.getByText('Message')).toBeInTheDocument()
+      expect(screen.getByText('Source')).toBeInTheDocument()
+    })
+
+    it('renders warning events with warning styling', () => {
+      setupWithEvents()
+      render(<DeploymentDetailPage />)
+      // The Warning event row should contain the reason and message
+      expect(screen.getByText('Failed')).toBeInTheDocument()
+      expect(screen.getByText(/Failed to pull image/)).toBeInTheDocument()
+      // Check that the warning icon is present (AlertTriangle / TriangleAlert)
+      const warningRow = screen.getByText('Failed').closest('tr')
+      expect(warningRow).not.toBeNull()
+      // Warning rows should have a distinguishing visual treatment
+      const warningIcon = warningRow!.querySelector('[data-testid="event-warning-icon"]')
+      expect(warningIcon).toBeInTheDocument()
+    })
+
+    it('renders normal events without warning styling', () => {
+      setupWithEvents()
+      render(<DeploymentDetailPage />)
+      expect(screen.getByText('Scheduled')).toBeInTheDocument()
+      expect(screen.getByText(/Successfully assigned/)).toBeInTheDocument()
+      const normalRow = screen.getByText('Scheduled').closest('tr')
+      expect(normalRow).not.toBeNull()
+      const normalIcon = normalRow!.querySelector('[data-testid="event-normal-icon"]')
+      expect(normalIcon).toBeInTheDocument()
+    })
+
+    it('shows event count for events with count > 1', () => {
+      setupWithEvents()
+      render(<DeploymentDetailPage />)
+      // The warning event has count=4, should show "x4"
+      expect(screen.getByText(/x4/)).toBeInTheDocument()
+    })
+
+    it('shows event source', () => {
+      setupWithEvents()
+      render(<DeploymentDetailPage />)
+      expect(screen.getByText('kubelet')).toBeInTheDocument()
+      expect(screen.getByText('default-scheduler')).toBeInTheDocument()
+    })
+
+    it('shows "No events" when events array is empty', () => {
+      setupMocks()
+      render(<DeploymentDetailPage />)
+      expect(screen.getByText(/no events/i)).toBeInTheDocument()
+    })
+  })
+
+  // ── Container status tests ──────────────────────────────────────────────
+
+  describe('Container status section', () => {
+    function setupWithContainerStatus() {
+      ;(useGetDeployment as Mock).mockReturnValue({ data: mockDeployment, isPending: false, error: null })
+      ;(useGetDeploymentStatus as Mock).mockReturnValue({ data: mockStatusWithEvents, isPending: false, error: null })
+      ;(useGetDeploymentLogs as Mock).mockReturnValue({ data: mockLogs, isPending: false, error: null })
+      ;(useUpdateDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, reset: vi.fn() })
+      ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+      ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
+      ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: mockPreview, isPending: false, error: null })
+      ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+    }
+
+    it('renders container name and state', () => {
+      setupWithContainerStatus()
+      render(<DeploymentDetailPage />)
+      expect(screen.getByText('app')).toBeInTheDocument()
+      expect(screen.getByText(/waiting/i)).toBeInTheDocument()
+    })
+
+    it('renders container reason and message for error state', () => {
+      setupWithContainerStatus()
+      render(<DeploymentDetailPage />)
+      expect(screen.getByText('ImagePullBackOff')).toBeInTheDocument()
+    })
+
+    it('highlights containers in error state', () => {
+      setupWithContainerStatus()
+      render(<DeploymentDetailPage />)
+      // The container in waiting state with error reason should have error styling
+      const badge = screen.getByText(/waiting/i)
+      // waiting + error reason = yellow/amber badge
+      expect(badge.className).toMatch(/yellow|amber|destructive/)
+    })
+
+    it('renders healthy container state with green badge', () => {
+      ;(useGetDeployment as Mock).mockReturnValue({ data: mockDeployment, isPending: false, error: null })
+      ;(useGetDeploymentStatus as Mock).mockReturnValue({ data: mockStatusWithHealthyContainers, isPending: false, error: null })
+      ;(useGetDeploymentLogs as Mock).mockReturnValue({ data: mockLogs, isPending: false, error: null })
+      ;(useUpdateDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, reset: vi.fn() })
+      ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+      ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
+      ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: mockPreview, isPending: false, error: null })
+      ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+      render(<DeploymentDetailPage />)
+      const runningBadge = screen.getByText(/running/i, { selector: '[data-testid="container-state-badge"]' })
+      expect(runningBadge.className).toMatch(/green/)
+    })
+
+    it('does not render container section when containerStatuses is empty', () => {
+      setupMocks()
+      render(<DeploymentDetailPage />)
+      // With empty containerStatuses, no "Containers:" label should appear
+      expect(screen.queryByText(/containers:/i)).not.toBeInTheDocument()
+    })
+
+    it('renders multiple pods with different container states', () => {
+      const multiPodStatus = {
+        ...mockStatus,
+        events: [],
+        pods: [
+          {
+            name: 'api-pod-1',
+            phase: 'Running',
+            ready: true,
+            restartCount: 0,
+            containerStatuses: [
+              { name: 'app', state: 'running', reason: '', message: '', image: 'ghcr.io/org/api:v1', ready: true, restartCount: 0, startedAt: ts('2025-01-15T10:00:00Z') },
+            ],
+            events: [],
+          },
+          {
+            name: 'api-pod-2',
+            phase: 'Pending',
+            ready: false,
+            restartCount: 3,
+            containerStatuses: [
+              { name: 'app', state: 'waiting', reason: 'CrashLoopBackOff', message: 'back-off', image: 'ghcr.io/org/api:v1', ready: false, restartCount: 3, startedAt: undefined },
+            ],
+            events: [],
+          },
+        ],
+      }
+      ;(useGetDeployment as Mock).mockReturnValue({ data: mockDeployment, isPending: false, error: null })
+      ;(useGetDeploymentStatus as Mock).mockReturnValue({ data: multiPodStatus, isPending: false, error: null })
+      ;(useGetDeploymentLogs as Mock).mockReturnValue({ data: mockLogs, isPending: false, error: null })
+      ;(useUpdateDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, reset: vi.fn() })
+      ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
+      ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
+      ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: mockPreview, isPending: false, error: null })
+      ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+      render(<DeploymentDetailPage />)
+      expect(screen.getByText('api-pod-1')).toBeInTheDocument()
+      expect(screen.getByText('api-pod-2')).toBeInTheDocument()
+      expect(screen.getByText('CrashLoopBackOff')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add Events table section to the deployment status tab showing Kubernetes events with type icons (warning/normal), reason, relative age with count, source, and message
- Extend pod rows with container status details showing state badges (running=green, waiting=yellow, terminated=red), reason, and message for error diagnosis
- Add utility functions for relative time computation and container error detection
- Add 11 new UI tests covering events table rendering, warning vs normal styling, empty states, container status rendering, error highlighting, and multi-pod scenarios
- Events section appears between Pods and Environment Variables in the status tab layout

Closes #904

## Test plan
- [x] `make test` passes — 897 tests across 55 test files
- [x] Events table renders with correct columns (type icon, Reason, Age, Source, Message)
- [x] Warning events show amber icon and text; Normal events show muted icon
- [x] Event count > 1 displays "xN over Xm" like kubectl describe
- [x] Empty events state shows "No events." message
- [x] Container status renders state badge, reason, and message
- [x] Error containers (waiting with reason) are visually highlighted
- [x] Multiple pods with different container states render correctly

Generated with [Claude Code](https://claude.com/claude-code)