### PR TITLE
fix(orgs): seed org default role grants before folder/project

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -263,8 +263,9 @@ func (s *Server) Serve(ctx context.Context) error {
 		orgGrantResolver := organizations.NewOrgGrantResolver(orgsK8s)
 		projectsK8s := projects.NewK8sClient(k8sClientset, nsResolver)
 		folderPrefix := nsResolver.NamespacePrefix + nsResolver.FolderPrefix
+		foldersAdapter := &folders.FolderCreatorAdapter{K8s: foldersK8s}
 		orgsHandler := organizations.NewHandler(orgsK8s, projectsK8s, s.cfg.DisableOrgCreation, s.cfg.OrgCreatorUsers, s.cfg.OrgCreatorRoles).
-			WithFolderCreator(foldersK8s, foldersK8s, folderPrefix)
+			WithFolderCreator(foldersAdapter, foldersK8s, folderPrefix)
 		orgsPath, orgsHTTPHandler := consolev1connect.NewOrganizationServiceHandler(orgsHandler, protectedInterceptors)
 		mux.Handle(orgsPath, orgsHTTPHandler)
 

--- a/console/folders/handler.go
+++ b/console/folders/handler.go
@@ -240,7 +240,7 @@ func (h *Handler) CreateFolder(
 	const maxCreateRetries = 3
 	for attempt := range maxCreateRetries + 1 {
 		_, err = h.k8s.CreateFolder(ctx, name, req.Msg.DisplayName, req.Msg.Description,
-			req.Msg.Organization, parentNs, claims.Email, shareUsers, shareRoles)
+			req.Msg.Organization, parentNs, claims.Email, shareUsers, shareRoles, nil, nil)
 		if err == nil {
 			break
 		}

--- a/console/folders/k8s.go
+++ b/console/folders/k8s.go
@@ -114,10 +114,16 @@ func (c *K8sClient) NamespaceExists(ctx context.Context, nsName string) (bool, e
 // CreateFolder creates a new namespace with folder labels and annotations.
 // parentNs is the Kubernetes namespace name of the immediate parent (org or folder).
 // org is the root organization name.
+//
+// defaultShareUsers and defaultShareRoles, when non-empty, are written as the
+// folder's default-share-users/default-share-roles annotations so the cascade
+// continues to descendants. They are ordinarily empty; the seeded default
+// folder flow in organizations.Handler.CreateOrganization populates them when
+// populate_defaults=true.
 func (c *K8sClient) CreateFolder(
 	ctx context.Context,
 	name, displayName, description, org, parentNs, creatorEmail string,
-	shareUsers, shareRoles []secrets.AnnotationGrant,
+	shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant,
 ) (*corev1.Namespace, error) {
 	nsName := c.Resolver.FolderNamespace(name)
 	slog.DebugContext(ctx, "creating folder in kubernetes",
@@ -137,6 +143,20 @@ func (c *K8sClient) CreateFolder(
 	annotations := map[string]string{
 		v1alpha2.AnnotationShareUsers: string(usersJSON),
 		v1alpha2.AnnotationShareRoles: string(rolesJSON),
+	}
+	if len(defaultShareUsers) > 0 {
+		defaultUsersJSON, err := json.Marshal(defaultShareUsers)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling default-share-users: %w", err)
+		}
+		annotations[v1alpha2.AnnotationDefaultShareUsers] = string(defaultUsersJSON)
+	}
+	if len(defaultShareRoles) > 0 {
+		defaultRolesJSON, err := json.Marshal(defaultShareRoles)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling default-share-roles: %w", err)
+		}
+		annotations[v1alpha2.AnnotationDefaultShareRoles] = string(defaultRolesJSON)
 	}
 	if displayName != "" {
 		annotations[v1alpha2.AnnotationDisplayName] = displayName
@@ -335,6 +355,39 @@ func GetDefaultShareUsers(ns *corev1.Namespace) ([]secrets.AnnotationGrant, erro
 // GetDefaultShareRoles parses the default-share-roles annotation from a namespace.
 func GetDefaultShareRoles(ns *corev1.Namespace) ([]secrets.AnnotationGrant, error) {
 	return parseGrantAnnotation(ns, v1alpha2.AnnotationDefaultShareRoles)
+}
+
+// FolderCreatorAdapter adapts the folders K8sClient to satisfy the
+// organizations.FolderCreator interface. It mirrors
+// projects.ProjectCreatorAdapter so that the organizations package can create
+// the seeded default folder through the folders package without importing the
+// folders Handler directly.
+type FolderCreatorAdapter struct {
+	K8s *K8sClient
+}
+
+// CreateFolder creates a folder namespace, forwarding both active and default
+// share grants so that the seeded default folder inherits the org's default
+// role grants and propagates them as its own default-share cascade (matching
+// the ancestor-default-share merge done by folders.Handler.CreateFolder).
+func (a *FolderCreatorAdapter) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	return a.K8s.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+}
+
+// DeleteFolder delegates to the K8sClient.
+func (a *FolderCreatorAdapter) DeleteFolder(ctx context.Context, name string) error {
+	return a.K8s.DeleteFolder(ctx, name)
+}
+
+// NamespaceExists delegates to the K8sClient.
+func (a *FolderCreatorAdapter) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
+	return a.K8s.NamespaceExists(ctx, nsName)
+}
+
+// GetFolder delegates to the K8sClient so the adapter can also satisfy
+// organizations.FolderLister in test and production wiring.
+func (a *FolderCreatorAdapter) GetFolder(ctx context.Context, name string) (*corev1.Namespace, error) {
+	return a.K8s.GetFolder(ctx, name)
 }
 
 func parseGrantAnnotation(ns *corev1.Namespace, key string) ([]secrets.AnnotationGrant, error) {

--- a/console/folders/k8s_test.go
+++ b/console/folders/k8s_test.go
@@ -132,7 +132,7 @@ func TestCreateFolder_CreatesNamespaceWithLabels(t *testing.T) {
 	k8s := NewK8sClient(fakeClient, testResolver())
 
 	shareUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
-	result, err := k8s.CreateFolder(context.Background(), "eng", "Engineering", "Eng team", "acme", "holos-org-acme", "alice@example.com", shareUsers, nil)
+	result, err := k8s.CreateFolder(context.Background(), "eng", "Engineering", "Eng team", "acme", "holos-org-acme", "alice@example.com", shareUsers, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -30,8 +30,13 @@ type ProjectLister interface {
 // FolderCreator creates and deletes a folder namespace. Used by CreateOrganization to
 // auto-create the default folder without importing the folders package directly.
 // DeleteFolder is needed for rollback when later steps of org creation fail.
+//
+// CreateFolder accepts both active (shareUsers/shareRoles) and default
+// (defaultShareUsers/defaultShareRoles) grants so that the seeded default folder
+// inherits the org's default role grants via the same merge logic
+// folders.Handler.CreateFolder applies to user-initiated folder creates.
 type FolderCreator interface {
-	CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
+	CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
 	DeleteFolder(ctx context.Context, name string) error
 	NamespaceExists(ctx context.Context, nsName string) (bool, error)
 }
@@ -340,6 +345,13 @@ func (h *Handler) CreateOrganization(
 // createDefaultFolder generates an identifier from the display name and creates
 // the folder namespace as a direct child of the organization. Returns the folder
 // identifier (slug).
+//
+// When the org carries default-share grants (seeded via seedOrgDefaultSharing
+// when populate_defaults=true), those grants are merged into the folder's
+// active grants and copied as the folder's own default-share grants, mirroring
+// the ancestor-default-share merge that folders.Handler.CreateFolder applies
+// for user-initiated folder creation. This ensures the seeded default folder
+// inherits the org's default Owner/Editor/Viewer role grants.
 func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (string, error) {
 	exists := func(ctx context.Context, nsName string) (bool, error) {
 		return h.folderCreator.NamespaceExists(ctx, nsName)
@@ -349,8 +361,22 @@ func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName,
 		return "", fmt.Errorf("generating folder identifier: %w", err)
 	}
 
+	// Read the org namespace so we can propagate any default-share grants
+	// (seeded earlier via seedOrgDefaultSharing when populate_defaults=true)
+	// into the default folder. When populate_defaults is false the org has
+	// no default-share annotations and these slices will be empty, which
+	// preserves the existing behaviour.
+	orgNs, err := h.k8s.GetOrganization(ctx, orgName)
+	if err != nil {
+		return "", fmt.Errorf("looking up org for default folder: %w", err)
+	}
+	orgDefaultUsers, _ := GetDefaultShareUsers(orgNs)
+	orgDefaultRoles, _ := GetDefaultShareRoles(orgNs)
+	folderShareUsers := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareUsers...), orgDefaultUsers...))
+	folderShareRoles := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareRoles...), orgDefaultRoles...))
+
 	orgNsName := h.k8s.resolver.OrgNamespace(orgName)
-	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, shareUsers, shareRoles); err != nil {
+	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, folderShareUsers, folderShareRoles, orgDefaultUsers, orgDefaultRoles); err != nil {
 		return "", fmt.Errorf("creating folder namespace: %w", err)
 	}
 	return folderName, nil

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -233,6 +233,26 @@ func (h *Handler) CreateOrganization(
 		return nil, mapK8sError(err)
 	}
 
+	// Seed org default role grants (Owner, Editor, Viewer) onto the org
+	// namespace *before* creating the default folder or project. This ensures
+	// the default folder and default project inherit the correct org-level
+	// default role grants via GetOrgDefaultGrants().
+	if req.Msg.GetPopulateDefaults() {
+		if err := h.seedOrgDefaultSharing(ctx, req.Msg.Name); err != nil {
+			slog.ErrorContext(ctx, "seeding org default role grants failed, rolling back org",
+				slog.String("organization", req.Msg.Name),
+				slog.Any("error", err),
+			)
+			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
+				slog.ErrorContext(ctx, "org rollback after default-sharing seed failure failed",
+					slog.String("organization", req.Msg.Name),
+					slog.Any("error", delErr),
+				)
+			}
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("seeding org default role grants: %w", err))
+		}
+	}
+
 	// Auto-create the default folder as an immediate child of the org.
 	// folderName is hoisted so the seed-defaults rollback can also delete
 	// the folder namespace (Kubernetes namespaces are flat — deleting the
@@ -348,6 +368,38 @@ func (h *Handler) rollbackFolder(ctx context.Context, folderName string) {
 			slog.Any("error", delErr),
 		)
 	}
+}
+
+// defaultOrgRoleGrants returns the standard three-role default grant list
+// (Owner, Editor, Viewer) with no start restriction and no expiration. The
+// principal for each grant is the lowercase role name (e.g. "owner") — role
+// grants treat the role string as both the principal and the role. These are
+// seeded onto new organizations when populate_defaults=true so that the
+// default folder and default project inherit sensible org-level defaults via
+// GetOrgDefaultGrants() in projects/resolver.go.
+func defaultOrgRoleGrants() []secrets.AnnotationGrant {
+	return []secrets.AnnotationGrant{
+		{Principal: roleAnnotationString(rbac.RoleOwner), Role: roleAnnotationString(rbac.RoleOwner)},
+		{Principal: roleAnnotationString(rbac.RoleEditor), Role: roleAnnotationString(rbac.RoleEditor)},
+		{Principal: roleAnnotationString(rbac.RoleViewer), Role: roleAnnotationString(rbac.RoleViewer)},
+	}
+}
+
+// seedOrgDefaultSharing patches the org namespace with the standard default
+// role grants (Owner, Editor, Viewer). It writes only the
+// AnnotationDefaultShareRoles annotation — default user grants are left
+// untouched so the non-populate_defaults path is preserved.
+func (h *Handler) seedOrgDefaultSharing(ctx context.Context, orgName string) error {
+	if _, err := h.k8s.UpdateOrganizationDefaultRoleGrants(ctx, orgName, defaultOrgRoleGrants()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// roleAnnotationString converts a proto Role enum to the lowercase annotation
+// string (e.g. ROLE_OWNER -> "owner") used by secrets.AnnotationGrant.Role.
+func roleAnnotationString(r rbac.Role) string {
+	return strings.ToLower(strings.TrimPrefix(r.String(), "ROLE_"))
 }
 
 // seedDefaults creates example resources for the new organization:

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -53,7 +53,7 @@ type TemplateSeeder interface {
 // pattern as FolderCreator. DeleteProject is needed for rollback when later
 // seeding steps fail.
 type ProjectCreator interface {
-	CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error
+	CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error
 	DeleteProject(ctx context.Context, name string) error
 	NamespaceExists(ctx context.Context, nsName string) (bool, error)
 }
@@ -442,7 +442,16 @@ func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail string
 		return fmt.Errorf("generating project identifier: %w", err)
 	}
 
-	if err := h.projectCreator.CreateProject(ctx, projectName, projectDisplayName, "", orgName, parentNs, creatorEmail, shareUsers, shareRoles); err != nil {
+	// Read the org's default sharing grants (seeded earlier via
+	// seedOrgDefaultSharing) and merge them into the project's grants, mirroring
+	// the production path in projects.Handler.CreateProject. Also copy them as
+	// the project's default sharing so new secrets inherit them.
+	orgDefaultUsers, _ := GetDefaultShareUsers(orgNs)
+	orgDefaultRoles, _ := GetDefaultShareRoles(orgNs)
+	projectShareUsers := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareUsers...), orgDefaultUsers...))
+	projectShareRoles := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareRoles...), orgDefaultRoles...))
+
+	if err := h.projectCreator.CreateProject(ctx, projectName, projectDisplayName, "", orgName, parentNs, creatorEmail, projectShareUsers, projectShareRoles, orgDefaultUsers, orgDefaultRoles); err != nil {
 		return fmt.Errorf("creating default project: %w", err)
 	}
 

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -1242,7 +1242,7 @@ type k8sProjectCreator struct {
 	createErr error
 }
 
-func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
+func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error {
 	if p.createErr != nil {
 		return p.createErr
 	}
@@ -1251,6 +1251,14 @@ func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName
 	annotations := map[string]string{
 		v1alpha2.AnnotationShareUsers: string(usersJSON),
 		v1alpha2.AnnotationShareRoles: string(rolesJSON),
+	}
+	if len(defaultShareUsers) > 0 {
+		defaultUsersJSON, _ := json.Marshal(defaultShareUsers)
+		annotations[v1alpha2.AnnotationDefaultShareUsers] = string(defaultUsersJSON)
+	}
+	if len(defaultShareRoles) > 0 {
+		defaultRolesJSON, _ := json.Marshal(defaultShareRoles)
+		annotations[v1alpha2.AnnotationDefaultShareRoles] = string(defaultRolesJSON)
 	}
 	if displayName != "" {
 		annotations[v1alpha2.AnnotationDisplayName] = displayName
@@ -1327,9 +1335,44 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 		// Verify the default project was created (check that at least one project namespace exists).
 		pc := handler.projectCreator.(*k8sProjectCreator)
 		projectNsName := pc.resolver.ProjectNamespace(ts.seededProjectName)
-		_, err = pc.client.CoreV1().Namespaces().Get(context.Background(), projectNsName, metav1.GetOptions{})
+		projectNs, err := pc.client.CoreV1().Namespaces().Get(context.Background(), projectNsName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected default project namespace %q to exist, got %v", projectNsName, err)
+		}
+
+		// Verify the seeded project inherited the org's default role grants
+		// (Owner, Editor, Viewer) both as its active role grants and as its
+		// own default role grants, mirroring projects.Handler.CreateProject.
+		rolesAnnotation := projectNs.Annotations[v1alpha2.AnnotationShareRoles]
+		if rolesAnnotation == "" {
+			t.Fatalf("expected share-roles annotation on project namespace")
+		}
+		var projectRoles []secrets.AnnotationGrant
+		if err := json.Unmarshal([]byte(rolesAnnotation), &projectRoles); err != nil {
+			t.Fatalf("invalid share-roles annotation: %v", err)
+		}
+		wantRoles := map[string]bool{"owner": false, "editor": false, "viewer": false}
+		for _, g := range projectRoles {
+			if _, ok := wantRoles[g.Role]; ok && g.Principal == g.Role {
+				wantRoles[g.Role] = true
+			}
+		}
+		for role, seen := range wantRoles {
+			if !seen {
+				t.Errorf("expected seeded project to inherit org default role grant %q", role)
+			}
+		}
+
+		defaultRolesAnnotation := projectNs.Annotations[v1alpha2.AnnotationDefaultShareRoles]
+		if defaultRolesAnnotation == "" {
+			t.Fatalf("expected default-share-roles annotation on project namespace")
+		}
+		var projectDefaultRoles []secrets.AnnotationGrant
+		if err := json.Unmarshal([]byte(defaultRolesAnnotation), &projectDefaultRoles); err != nil {
+			t.Fatalf("invalid default-share-roles annotation: %v", err)
+		}
+		if len(projectDefaultRoles) != 3 {
+			t.Errorf("expected 3 default role grants copied from org, got %d", len(projectDefaultRoles))
 		}
 	})
 

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -1522,6 +1522,194 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 	})
 }
 
+// TestCreateOrganization_SeedsDefaultRoleGrants verifies the org namespace's
+// AnnotationDefaultShareRoles is populated with the three standard role
+// grants (Owner, Editor, Viewer) *before* the default folder and default
+// project are created when populate_defaults=true.
+func TestCreateOrganization_SeedsDefaultRoleGrants(t *testing.T) {
+	t.Run("populate_defaults=true writes Owner/Editor/Viewer default role grants", func(t *testing.T) {
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := true
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "seeded-org",
+			DisplayName:      "Seeded Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Read the org namespace back and inspect the default-share-roles annotation.
+		ns, err := handler.k8s.GetOrganization(context.Background(), "seeded-org")
+		if err != nil {
+			t.Fatalf("fetching org namespace: %v", err)
+		}
+		raw, ok := ns.Annotations[v1alpha2.AnnotationDefaultShareRoles]
+		if !ok {
+			t.Fatalf("expected annotation %q to be set", v1alpha2.AnnotationDefaultShareRoles)
+		}
+		var grants []secrets.AnnotationGrant
+		if err := json.Unmarshal([]byte(raw), &grants); err != nil {
+			t.Fatalf("parsing default-share-roles annotation: %v", err)
+		}
+		if len(grants) != 3 {
+			t.Fatalf("expected 3 grants, got %d (%v)", len(grants), grants)
+		}
+
+		byRole := make(map[string]secrets.AnnotationGrant, 3)
+		for _, g := range grants {
+			byRole[g.Role] = g
+		}
+		for _, role := range []string{"owner", "editor", "viewer"} {
+			g, ok := byRole[role]
+			if !ok {
+				t.Errorf("expected a grant for role %q, none found", role)
+				continue
+			}
+			if g.Principal != role {
+				t.Errorf("expected principal %q for role %q grant, got %q", role, role, g.Principal)
+			}
+			if g.Nbf != nil {
+				t.Errorf("expected no start restriction (nbf) for role %q grant, got %v", role, *g.Nbf)
+			}
+			if g.Exp != nil {
+				t.Errorf("expected no expiration (exp) for role %q grant, got %v", role, *g.Exp)
+			}
+		}
+
+		// Also verify default-share-users was NOT set (spec: role grants only).
+		if _, userDefaultsSet := ns.Annotations[v1alpha2.AnnotationDefaultShareUsers]; userDefaultsSet {
+			t.Errorf("expected annotation %q to be unset, but it was present", v1alpha2.AnnotationDefaultShareUsers)
+		}
+	})
+
+	t.Run("populate_defaults=false does not seed default role grants", func(t *testing.T) {
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := false
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "no-seed-defaults-org",
+			DisplayName:      "No Seed Defaults Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		ns, err := handler.k8s.GetOrganization(context.Background(), "no-seed-defaults-org")
+		if err != nil {
+			t.Fatalf("fetching org namespace: %v", err)
+		}
+		if v, ok := ns.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
+			t.Errorf("expected annotation %q to be unset when populate_defaults=false, got %q", v1alpha2.AnnotationDefaultShareRoles, v)
+		}
+	})
+
+	t.Run("populate_defaults unset does not seed default role grants", func(t *testing.T) {
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:        "unset-defaults-org",
+			DisplayName: "Unset Defaults Org",
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		ns, err := handler.k8s.GetOrganization(context.Background(), "unset-defaults-org")
+		if err != nil {
+			t.Fatalf("fetching org namespace: %v", err)
+		}
+		if v, ok := ns.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
+			t.Errorf("expected annotation %q to be unset when populate_defaults is unset, got %q", v1alpha2.AnnotationDefaultShareRoles, v)
+		}
+	})
+
+	t.Run("default role grants are written before default folder creation", func(t *testing.T) {
+		// Use a FolderCreator that records whether the
+		// default-share-roles annotation was present on the org namespace
+		// at the moment CreateFolder was invoked. This verifies the
+		// ordering guarantee (annotation-before-folder) described in the
+		// spec: "annotations must be visible on the org namespace
+		// *before* any folder/project creation call runs".
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		fc := handler.folderCreator.(*k8sFolderCreator)
+
+		orderingProbe := &orderingFolderCreator{inner: fc, k8s: handler.k8s}
+		// Swap in the probe as the FolderCreator (leaving FolderLister intact).
+		folderPrefix := handler.folderPrefix
+		handler.WithFolderCreator(orderingProbe, fc, folderPrefix)
+
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := true
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "ordering-org",
+			DisplayName:      "Ordering Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if !orderingProbe.seenDefaultRolesAnnotation {
+			t.Errorf("expected default-share-roles annotation to be visible on the org namespace before CreateFolder was called")
+		}
+	})
+}
+
+// orderingFolderCreator wraps a FolderCreator and records, at the moment
+// CreateFolder is invoked, whether the org namespace already carries the
+// default-share-roles annotation. Used to assert the ordering invariant
+// from issue #920.
+type orderingFolderCreator struct {
+	inner                      FolderCreator
+	k8s                        *K8sClient
+	seenDefaultRolesAnnotation bool
+}
+
+func (o *orderingFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	ns, err := o.k8s.GetOrganization(ctx, org)
+	if err == nil && ns.Annotations != nil {
+		if _, ok := ns.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
+			o.seenDefaultRolesAnnotation = true
+		}
+	}
+	return o.inner.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles)
+}
+
+func (o *orderingFolderCreator) DeleteFolder(ctx context.Context, name string) error {
+	return o.inner.DeleteFolder(ctx, name)
+}
+
+func (o *orderingFolderCreator) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
+	return o.inner.NamespaceExists(ctx, nsName)
+}
+
 // ---- Helpers ----
 
 func assertUnauthenticated(t *testing.T, err error) {

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -106,18 +106,26 @@ func newTestHandlerWithOpts(opts testHandlerOpts, namespaces ...*corev1.Namespac
 type k8sFolderCreator struct {
 	client   *fake.Clientset
 	resolver *resolver.Resolver
-	createFn func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
+	createFn func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
 }
 
-func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	if f.createFn != nil {
-		return f.createFn(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles)
+		return f.createFn(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	}
 	usersJSON, _ := json.Marshal(shareUsers)
 	rolesJSON, _ := json.Marshal(shareRoles)
 	annotations := map[string]string{
 		v1alpha2.AnnotationShareUsers: string(usersJSON),
 		v1alpha2.AnnotationShareRoles: string(rolesJSON),
+	}
+	if len(defaultShareUsers) > 0 {
+		defaultUsersJSON, _ := json.Marshal(defaultShareUsers)
+		annotations[v1alpha2.AnnotationDefaultShareUsers] = string(defaultUsersJSON)
+	}
+	if len(defaultShareRoles) > 0 {
+		defaultRolesJSON, _ := json.Marshal(defaultShareRoles)
+		annotations[v1alpha2.AnnotationDefaultShareRoles] = string(defaultRolesJSON)
 	}
 	if displayName != "" {
 		annotations[v1alpha2.AnnotationDisplayName] = displayName
@@ -1018,7 +1026,7 @@ func TestCreateOrganization_RollbackOnFolderFailure(t *testing.T) {
 	failFC := &k8sFolderCreator{
 		client:   fakeClient,
 		resolver: r,
-		createFn: func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+		createFn: func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 			return nil, fmt.Errorf("simulated folder creation failure")
 		},
 	}
@@ -1373,6 +1381,57 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 		}
 		if len(projectDefaultRoles) != 3 {
 			t.Errorf("expected 3 default role grants copied from org, got %d", len(projectDefaultRoles))
+		}
+
+		// Verify the seeded default folder inherited the org's default role
+		// grants on both share-roles and default-share-roles, analogous to
+		// the project assertions above. This guards against regressions of
+		// the bootstrap path skipping the ancestor-default-share merge.
+		fc := handler.folderCreator.(*k8sFolderCreator)
+		orgNsForFolder, err := handler.k8s.GetOrganization(context.Background(), "seed-org")
+		if err != nil {
+			t.Fatalf("failed to get org namespace: %v", err)
+		}
+		folderName := orgNsForFolder.Annotations[v1alpha2.AnnotationDefaultFolder]
+		if folderName == "" {
+			t.Fatalf("expected default folder annotation on org namespace")
+		}
+		folderNsName := fc.resolver.FolderNamespace(folderName)
+		folderNs, err := fc.client.CoreV1().Namespaces().Get(context.Background(), folderNsName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected default folder namespace %q to exist, got %v", folderNsName, err)
+		}
+
+		folderRolesAnnotation := folderNs.Annotations[v1alpha2.AnnotationShareRoles]
+		if folderRolesAnnotation == "" {
+			t.Fatalf("expected share-roles annotation on folder namespace")
+		}
+		var folderRoles []secrets.AnnotationGrant
+		if err := json.Unmarshal([]byte(folderRolesAnnotation), &folderRoles); err != nil {
+			t.Fatalf("invalid share-roles annotation on folder: %v", err)
+		}
+		wantFolderRoles := map[string]bool{"owner": false, "editor": false, "viewer": false}
+		for _, g := range folderRoles {
+			if _, ok := wantFolderRoles[g.Role]; ok && g.Principal == g.Role {
+				wantFolderRoles[g.Role] = true
+			}
+		}
+		for role, seen := range wantFolderRoles {
+			if !seen {
+				t.Errorf("expected seeded default folder to inherit org default role grant %q on share-roles", role)
+			}
+		}
+
+		folderDefaultRolesAnnotation := folderNs.Annotations[v1alpha2.AnnotationDefaultShareRoles]
+		if folderDefaultRolesAnnotation == "" {
+			t.Fatalf("expected default-share-roles annotation on folder namespace")
+		}
+		var folderDefaultRoles []secrets.AnnotationGrant
+		if err := json.Unmarshal([]byte(folderDefaultRolesAnnotation), &folderDefaultRoles); err != nil {
+			t.Fatalf("invalid default-share-roles annotation on folder: %v", err)
+		}
+		if len(folderDefaultRoles) != 3 {
+			t.Errorf("expected 3 default role grants copied from org onto folder, got %d", len(folderDefaultRoles))
 		}
 	})
 
@@ -1735,14 +1794,14 @@ type orderingFolderCreator struct {
 	seenDefaultRolesAnnotation bool
 }
 
-func (o *orderingFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (o *orderingFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	ns, err := o.k8s.GetOrganization(ctx, org)
 	if err == nil && ns.Annotations != nil {
 		if _, ok := ns.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
 			o.seenDefaultRolesAnnotation = true
 		}
 	}
-	return o.inner.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles)
+	return o.inner.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 }
 
 func (o *orderingFolderCreator) DeleteFolder(ctx context.Context, name string) error {

--- a/console/organizations/k8s.go
+++ b/console/organizations/k8s.go
@@ -237,6 +237,29 @@ func GetDefaultShareRoles(ns *corev1.Namespace) ([]secrets.AnnotationGrant, erro
 	return parseGrantAnnotation(ns, v1alpha2.AnnotationDefaultShareRoles)
 }
 
+// UpdateOrganizationDefaultRoleGrants writes only the
+// AnnotationDefaultShareRoles annotation on an organization namespace,
+// leaving AnnotationDefaultShareUsers untouched. Used when seeding the
+// default role grants (Owner/Editor/Viewer) at org-create time.
+func (c *K8sClient) UpdateOrganizationDefaultRoleGrants(ctx context.Context, name string, defaultRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	slog.DebugContext(ctx, "updating organization default role grants in kubernetes",
+		slog.String("name", name),
+	)
+	ns, err := c.GetOrganization(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	rolesJSON, err := json.Marshal(defaultRoles)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling default-share-roles: %w", err)
+	}
+	ns.Annotations[v1alpha2.AnnotationDefaultShareRoles] = string(rolesJSON)
+	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+}
+
 // UpdateOrganizationDefaultSharing updates the default sharing annotations on an organization namespace.
 func (c *K8sClient) UpdateOrganizationDefaultSharing(ctx context.Context, name string, defaultUsers, defaultRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	slog.DebugContext(ctx, "updating organization default sharing in kubernetes",

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -373,16 +373,16 @@ func (c *K8sClient) UpdateProjectDefaultSharing(ctx context.Context, name string
 }
 
 // ProjectCreatorAdapter adapts the projects K8sClient to satisfy the
-// organizations.ProjectCreator interface. The adapter drops the
-// defaultShareUsers/defaultShareRoles parameters that are not needed for
-// the populate_defaults seeding flow.
+// organizations.ProjectCreator interface.
 type ProjectCreatorAdapter struct {
 	K8s *K8sClient
 }
 
-// CreateProject creates a project namespace without default sharing grants.
-func (a *ProjectCreatorAdapter) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
-	_, err := a.K8s.CreateProject(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, nil, nil)
+// CreateProject creates a project namespace, forwarding default sharing grants
+// so that seeded default projects inherit org-level defaults, mirroring the
+// production path in projects.Handler.CreateProject.
+func (a *ProjectCreatorAdapter) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error {
+	_, err := a.K8s.CreateProject(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- In `console/organizations/handler.go`, reorder `CreateOrganization` so that when `populate_defaults=true`, the org namespace's `AnnotationDefaultShareRoles` is seeded with the three standard role grants (Owner, Editor, Viewer — no start restriction, no expiration) *before* the default folder and default project are created.
- Factor a shared helper `seedOrgDefaultSharing` + `defaultOrgRoleGrants` in the organizations handler, and a new `K8sClient.UpdateOrganizationDefaultRoleGrants` method that writes only the `default-share-roles` annotation (leaving `default-share-users` untouched, per spec).
- On failure, roll back the org namespace using the same pattern as the other `CreateOrganization` rollback paths.
- Preserve existing behavior when `populate_defaults=false` or unset — no default role grants are written.
- Add unit tests covering populate_defaults=true/false/unset and an ordering probe that verifies the `default-share-roles` annotation is visible on the org namespace *before* `CreateFolder` is invoked.

Closes #920

Part of plan #919 (Phase 1).

## Test plan
- [x] `go test ./console/organizations/...`
- [x] `make test` (full Go + UI suite)
- [ ] CI: Unit Tests, Lint, E2E Tests

> Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check. This change is backend-only (no UI, no RPC surface changes) so E2E relevance is low, but the CI check will still run.

Generated with [Claude Code](https://claude.com/claude-code)