### PR TITLE
feat(deployments): deployment status informer cache

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 
 	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/deployments/statuscache"
 	"github.com/holos-run/holos-console/console/folders"
 	"github.com/holos-run/holos-console/console/oidc"
 	"github.com/holos-run/holos-console/console/organizations"
@@ -344,9 +345,18 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 		projectFolderResolver := projects.NewProjectFolderResolver(projectsK8s, nsWalker)
 		ancestorTemplateResolver := templates.NewAncestorTemplateResolver(templatesK8s, nsWalker)
+		// Deployment status informer cache: one shared watch per managed
+		// namespace (filtered by the managed-by label). The informer lifecycle
+		// is tied to the server context so it stops cleanly on shutdown. Cache
+		// misses are treated as "no data yet" by the handler.
+		deploymentStatusCache, err := statuscache.New(ctx, k8sClientset)
+		if err != nil {
+			return fmt.Errorf("failed to start deployment status cache: %w", err)
+		}
 		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templates.NewProjectScopedResolver(templatesK8s), &deployments.CueRenderer{}, deploymentsApplier).
 			WithAncestorWalker(projectFolderResolver).
-			WithAncestorTemplateProvider(ancestorTemplateResolver)
+			WithAncestorTemplateProvider(ancestorTemplateResolver).
+			WithStatusCache(deploymentStatusCache)
 		deploymentsPath, deploymentsHTTPHandler := consolev1connect.NewDeploymentServiceHandler(deploymentsHandler, protectedInterceptors)
 		mux.Handle(deploymentsPath, deploymentsHTTPHandler)
 	} else {

--- a/console/console.go
+++ b/console/console.go
@@ -345,13 +345,21 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 		projectFolderResolver := projects.NewProjectFolderResolver(projectsK8s, nsWalker)
 		ancestorTemplateResolver := templates.NewAncestorTemplateResolver(templatesK8s, nsWalker)
-		// Deployment status informer cache: one shared watch per managed
-		// namespace (filtered by the managed-by label). The informer lifecycle
-		// is tied to the server context so it stops cleanly on shutdown. Cache
-		// misses are treated as "no data yet" by the handler.
+		// Deployment status informer cache: one shared watch scoped to
+		// console-managed apps/v1.Deployment resources via the managed-by
+		// label. The informer lifecycle is tied to the server context so it
+		// stops cleanly on shutdown. Cache misses are treated as "no data
+		// yet" by the handler, so a failure to start the cache (transient
+		// API latency, missing watch RBAC, etc.) must not block startup:
+		// log and fall through to a no-op cache so the console continues to
+		// serve, just without status summaries until the operator fixes the
+		// underlying problem and restarts.
 		deploymentStatusCache, err := statuscache.New(ctx, k8sClientset)
 		if err != nil {
-			return fmt.Errorf("failed to start deployment status cache: %w", err)
+			slog.WarnContext(ctx, "deployment status cache unavailable, deployments will report UNSPECIFIED status",
+				slog.Any("error", err),
+			)
+			deploymentStatusCache = statuscache.NewNop()
 		}
 		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templates.NewProjectScopedResolver(templatesK8s), &deployments.CueRenderer{}, deploymentsApplier).
 			WithAncestorWalker(projectFolderResolver).

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/deployments/statuscache"
 	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
@@ -113,6 +114,7 @@ type Handler struct {
 	logReader                LogReader
 	ancestorWalker           AncestorWalker
 	ancestorTemplateProvider AncestorTemplateProvider
+	statusCache              statuscache.Cache
 }
 
 // NewHandler creates a DeploymentService handler.
@@ -140,6 +142,16 @@ func (h *Handler) WithAncestorWalker(aw AncestorWalker) *Handler {
 // the full ancestor chain (org + folders) at render time.
 func (h *Handler) WithAncestorTemplateProvider(atp AncestorTemplateProvider) *Handler {
 	h.ancestorTemplateProvider = atp
+	return h
+}
+
+// WithStatusCache configures the handler with a shared-informer-backed cache
+// of apps/v1 Deployment status. When set, the listing hot path and
+// GetDeploymentStatusSummary RPC read from the local cache instead of issuing
+// direct API calls. A nil cache means the handler falls back to UNSPECIFIED
+// status summaries (no data yet).
+func (h *Handler) WithStatusCache(c statuscache.Cache) *Handler {
+	h.statusCache = c
 	return h
 }
 

--- a/console/deployments/statuscache/cache.go
+++ b/console/deployments/statuscache/cache.go
@@ -56,13 +56,20 @@ type Cache interface {
 }
 
 // nopCache is returned when no kubernetes.Interface is available (for
-// example, when the console runs in dummy-secret-only mode). Summary always
-// reports a miss so callers degrade to UNSPECIFIED status without panicking.
+// example, when the console runs in dummy-secret-only mode), and also serves
+// as a safe fallback when the real informer cannot be started (missing RBAC,
+// transient API unavailability). Summary always reports a miss so callers
+// degrade to UNSPECIFIED status without panicking.
 type nopCache struct{}
 
 func (nopCache) Summary(string, string) (*consolev1.DeploymentStatusSummary, bool) {
 	return nil, false
 }
+
+// NewNop returns a Cache that always reports misses. It is intended as a
+// fallback when New fails to start a live informer but the console must keep
+// serving.
+func NewNop() Cache { return nopCache{} }
 
 // informerCache is the live implementation, backed by a SharedInformerFactory
 // scoped to console-managed Deployments.

--- a/console/deployments/statuscache/cache.go
+++ b/console/deployments/statuscache/cache.go
@@ -18,6 +18,7 @@ package statuscache
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,16 @@ import (
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
+
+// initialSyncTimeout bounds how long New will wait for the initial informer
+// LIST/WATCH to complete before returning an error. Without this bound, a
+// missing RBAC rule or a transiently unavailable API server would hang
+// console startup until the server context is cancelled, preventing the HTTP
+// listener from ever opening. The bound is deliberately short: status data
+// is non-essential for console startup and the cache returns (nil, false) on
+// misses anyway, so callers are free to fall back to UNSPECIFIED until the
+// cache catches up.
+const initialSyncTimeout = 10 * time.Second
 
 // managedByLabelSelector limits the watch to Deployments labeled as managed
 // by the console, matching the labels the deployments renderer applies to
@@ -83,9 +94,18 @@ func New(ctx context.Context, client kubernetes.Interface) (Cache, error) {
 	_ = depInformer.Informer()
 
 	factory.Start(ctx.Done())
-	synced := factory.WaitForCacheSync(ctx.Done())
+
+	// Bound the initial sync with a derived context so startup fails fast if
+	// the watch never establishes (missing RBAC, unreachable API server, etc.)
+	// rather than hanging until the server context is cancelled.
+	syncCtx, syncCancel := context.WithTimeout(ctx, initialSyncTimeout)
+	defer syncCancel()
+	synced := factory.WaitForCacheSync(syncCtx.Done())
 	for informerType, ok := range synced {
 		if !ok {
+			if err := syncCtx.Err(); err != nil {
+				return nil, fmt.Errorf("statuscache: informer %v did not sync within %s: %w", informerType, initialSyncTimeout, err)
+			}
 			return nil, fmt.Errorf("statuscache: informer %v failed to sync", informerType)
 		}
 	}
@@ -147,11 +167,14 @@ func summaryFromDeployment(dep *appsv1.Deployment) *consolev1.DeploymentStatusSu
 		}
 	}
 
+	// A deployment with desired==0 that Kubernetes marks Available=True is a
+	// legitimate steady state (e.g. intentionally scaled to zero): do not
+	// penalize it by forcing PENDING.
 	phase := consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING
 	switch {
 	case replicaFailure, progressingFalse:
 		phase = consolev1.DeploymentPhase_DEPLOYMENT_PHASE_FAILED
-	case available && ready == desired && desired > 0:
+	case available && ready == desired:
 		phase = consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING
 	}
 

--- a/console/deployments/statuscache/cache.go
+++ b/console/deployments/statuscache/cache.go
@@ -1,0 +1,167 @@
+// Package statuscache provides a shared-informer-backed read-only cache of
+// apps/v1 Deployment status, exposing a lightweight DeploymentStatusSummary
+// projection for the DeploymentService listing hot path.
+//
+// Only apps/v1.Deployment is watched. No pod, replicaset, event, or
+// configmap informers are added. All reads come from the local cache via a
+// lister; there is no fallback to the API server. Callers treat a cache miss
+// as "no data yet" and render the status column as UNSPECIFIED.
+//
+// Scope: the informer is filtered to resources labeled with
+// app.kubernetes.io/managed-by=console.holos.run. The console creates the
+// underlying apps/v1 Deployment by applying a rendered manifest whose labels
+// include that managed-by value, so this selector bounds the watch to console
+// managed deployments across all namespaces rather than enumerating managed
+// namespaces up front.
+package statuscache
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// managedByLabelSelector limits the watch to Deployments labeled as managed
+// by the console, matching the labels the deployments renderer applies to
+// rendered resources.
+var managedByLabelSelector = v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue
+
+// Cache exposes a read-only projection of apps/v1 Deployment status keyed by
+// (namespace, name).
+type Cache interface {
+	// Summary returns the lightweight status projection for the Deployment
+	// identified by (ns, name). The second return value is false on a cache
+	// miss (including when the cache is not backed by a live cluster).
+	Summary(ns, name string) (*consolev1.DeploymentStatusSummary, bool)
+}
+
+// nopCache is returned when no kubernetes.Interface is available (for
+// example, when the console runs in dummy-secret-only mode). Summary always
+// reports a miss so callers degrade to UNSPECIFIED status without panicking.
+type nopCache struct{}
+
+func (nopCache) Summary(string, string) (*consolev1.DeploymentStatusSummary, bool) {
+	return nil, false
+}
+
+// informerCache is the live implementation, backed by a SharedInformerFactory
+// scoped to console-managed Deployments.
+type informerCache struct {
+	lister appsv1listers.DeploymentLister
+}
+
+// New constructs a Cache. When client is nil (dummy-secret-only mode) the
+// returned cache is a no-op that always reports misses.
+//
+// When client is non-nil, a SharedInformerFactory is created with a label
+// selector tweak bounding the watch to console-managed Deployments. The
+// factory is started with ctx and its informers are stopped when ctx is
+// cancelled. New blocks until the deployment informer's cache has synced so
+// callers may immediately issue reads.
+func New(ctx context.Context, client kubernetes.Interface) (Cache, error) {
+	if client == nil {
+		return nopCache{}, nil
+	}
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		client,
+		0, // no resync: we rely on watch events for updates
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.LabelSelector = managedByLabelSelector
+		}),
+	)
+	depInformer := factory.Apps().V1().Deployments()
+	// Register the informer with the factory so Start picks it up.
+	_ = depInformer.Informer()
+
+	factory.Start(ctx.Done())
+	synced := factory.WaitForCacheSync(ctx.Done())
+	for informerType, ok := range synced {
+		if !ok {
+			return nil, fmt.Errorf("statuscache: informer %v failed to sync", informerType)
+		}
+	}
+	return &informerCache{lister: depInformer.Lister()}, nil
+}
+
+// Summary returns the DeploymentStatusSummary for the given (ns, name) if the
+// informer cache knows about the Deployment.
+func (c *informerCache) Summary(ns, name string) (*consolev1.DeploymentStatusSummary, bool) {
+	dep, err := c.lister.Deployments(ns).Get(name)
+	if err != nil || dep == nil {
+		return nil, false
+	}
+	return summaryFromDeployment(dep), true
+}
+
+// summaryFromDeployment projects an apps/v1.Deployment into the lightweight
+// DeploymentStatusSummary proto. Phase derivation rules (see issue #914):
+//
+//   - Available=True and ready == desired           -> RUNNING
+//   - ReplicaFailure=True or Progressing=False      -> FAILED
+//   - ready < desired (and none of the above)       -> PENDING
+//   - otherwise                                     -> PENDING (still settling)
+//
+// message is populated from the first FAILED-signaling condition so callers
+// can surface a terse cause (e.g. "quota exceeded"). When no such condition
+// exists, message is empty.
+func summaryFromDeployment(dep *appsv1.Deployment) *consolev1.DeploymentStatusSummary {
+	status := dep.Status
+	desired := status.Replicas
+	ready := status.ReadyReplicas
+
+	var (
+		available        bool
+		progressingFalse bool
+		replicaFailure   bool
+		failMessage      string
+	)
+	for _, c := range status.Conditions {
+		switch c.Type {
+		case appsv1.DeploymentAvailable:
+			if c.Status == corev1.ConditionTrue {
+				available = true
+			}
+		case appsv1.DeploymentProgressing:
+			if c.Status == corev1.ConditionFalse {
+				progressingFalse = true
+				if failMessage == "" {
+					failMessage = c.Message
+				}
+			}
+		case appsv1.DeploymentReplicaFailure:
+			if c.Status == corev1.ConditionTrue {
+				replicaFailure = true
+				if failMessage == "" {
+					failMessage = c.Message
+				}
+			}
+		}
+	}
+
+	phase := consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING
+	switch {
+	case replicaFailure, progressingFalse:
+		phase = consolev1.DeploymentPhase_DEPLOYMENT_PHASE_FAILED
+	case available && ready == desired && desired > 0:
+		phase = consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING
+	}
+
+	return &consolev1.DeploymentStatusSummary{
+		Phase:              phase,
+		ReadyReplicas:      ready,
+		DesiredReplicas:    desired,
+		AvailableReplicas:  status.AvailableReplicas,
+		UpdatedReplicas:    status.UpdatedReplicas,
+		ObservedGeneration: status.ObservedGeneration,
+		Message:            failMessage,
+	}
+}

--- a/console/deployments/statuscache/cache_test.go
+++ b/console/deployments/statuscache/cache_test.go
@@ -107,6 +107,17 @@ func TestCacheSummary(t *testing.T) {
 			wantReady: 0,
 		},
 		{
+			name: "running: scaled to zero is a steady state",
+			dep: buildDeployment("p-alpha", "idle", 0, 0, 0, 0, 1, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentAvailable, corev1.ConditionTrue, "MinimumReplicasAvailable", "ok"),
+			}, ""),
+			ns:        "p-alpha",
+			lookup:    "idle",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING,
+			wantReady: 0,
+		},
+		{
 			name:      "miss: unknown deployment",
 			dep:       buildDeployment("p-alpha", "web", 1, 1, 1, 1, 1, nil, ""),
 			ns:        "p-alpha",

--- a/console/deployments/statuscache/cache_test.go
+++ b/console/deployments/statuscache/cache_test.go
@@ -1,0 +1,173 @@
+package statuscache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// buildDeployment returns an apps/v1 Deployment with the given status fields
+// and conditions wired up for test table entries.
+func buildDeployment(ns, name string, desired, ready, available, updated int32, generation int64, conditions []appsv1.DeploymentCondition, message string) *appsv1.Deployment {
+	_ = message // message is derived from conditions by Summary()
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Generation: generation,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "console.holos.run",
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:           desired,
+			ReadyReplicas:      ready,
+			AvailableReplicas:  available,
+			UpdatedReplicas:    updated,
+			ObservedGeneration: generation,
+			Conditions:         conditions,
+		},
+	}
+}
+
+func cond(t appsv1.DeploymentConditionType, s corev1.ConditionStatus, reason, message string) appsv1.DeploymentCondition {
+	return appsv1.DeploymentCondition{Type: t, Status: s, Reason: reason, Message: message}
+}
+
+func TestCacheSummary(t *testing.T) {
+	tests := []struct {
+		name      string
+		dep       *appsv1.Deployment
+		ns        string
+		lookup    string
+		wantFound bool
+		wantPhase consolev1.DeploymentPhase
+		wantReady int32
+	}{
+		{
+			name: "running: Available=True and ready==desired",
+			dep: buildDeployment("p-alpha", "web", 3, 3, 3, 3, 1, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentAvailable, corev1.ConditionTrue, "MinimumReplicasAvailable", "ok"),
+				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "done"),
+			}, ""),
+			ns:        "p-alpha",
+			lookup:    "web",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING,
+			wantReady: 3,
+		},
+		{
+			name: "failed: ReplicaFailure=True",
+			dep: buildDeployment("p-alpha", "broken", 3, 0, 0, 0, 1, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentReplicaFailure, corev1.ConditionTrue, "FailedCreate", "quota exceeded"),
+				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "ReplicaSetUpdated", "progress"),
+			}, ""),
+			ns:        "p-alpha",
+			lookup:    "broken",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_FAILED,
+			wantReady: 0,
+		},
+		{
+			name: "failed: Progressing=False",
+			dep: buildDeployment("p-alpha", "stalled", 3, 0, 0, 0, 1, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentProgressing, corev1.ConditionFalse, "ProgressDeadlineExceeded", "timed out"),
+			}, ""),
+			ns:        "p-alpha",
+			lookup:    "stalled",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_FAILED,
+			wantReady: 0,
+		},
+		{
+			name: "pending: ready<desired and progressing",
+			dep: buildDeployment("p-alpha", "starting", 3, 1, 1, 2, 1, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "ReplicaSetUpdated", "progress"),
+			}, ""),
+			ns:        "p-alpha",
+			lookup:    "starting",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING,
+			wantReady: 1,
+		},
+		{
+			name: "pending: no conditions yet, ready<desired",
+			dep: buildDeployment("p-alpha", "fresh", 2, 0, 0, 0, 1, nil, ""),
+			ns:        "p-alpha",
+			lookup:    "fresh",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING,
+			wantReady: 0,
+		},
+		{
+			name:      "miss: unknown deployment",
+			dep:       buildDeployment("p-alpha", "web", 1, 1, 1, 1, 1, nil, ""),
+			ns:        "p-alpha",
+			lookup:    "does-not-exist",
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			client := fake.NewClientset(tc.dep)
+			cache, err := New(ctx, client)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			got, ok := cache.Summary(tc.ns, tc.lookup)
+			if ok != tc.wantFound {
+				t.Fatalf("Summary(%q,%q) found=%v, want %v", tc.ns, tc.lookup, ok, tc.wantFound)
+			}
+			if !tc.wantFound {
+				if got != nil {
+					t.Fatalf("Summary miss: expected nil, got %+v", got)
+				}
+				return
+			}
+			if got.Phase != tc.wantPhase {
+				t.Errorf("phase = %v, want %v", got.Phase, tc.wantPhase)
+			}
+			if got.ReadyReplicas != tc.wantReady {
+				t.Errorf("readyReplicas = %d, want %d", got.ReadyReplicas, tc.wantReady)
+			}
+			if got.DesiredReplicas != tc.dep.Status.Replicas {
+				t.Errorf("desiredReplicas = %d, want %d", got.DesiredReplicas, tc.dep.Status.Replicas)
+			}
+			if got.AvailableReplicas != tc.dep.Status.AvailableReplicas {
+				t.Errorf("availableReplicas = %d, want %d", got.AvailableReplicas, tc.dep.Status.AvailableReplicas)
+			}
+			if got.UpdatedReplicas != tc.dep.Status.UpdatedReplicas {
+				t.Errorf("updatedReplicas = %d, want %d", got.UpdatedReplicas, tc.dep.Status.UpdatedReplicas)
+			}
+			if got.ObservedGeneration != tc.dep.Status.ObservedGeneration {
+				t.Errorf("observedGeneration = %d, want %d", got.ObservedGeneration, tc.dep.Status.ObservedGeneration)
+			}
+		})
+	}
+}
+
+func TestCacheNilClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	cache, err := New(ctx, nil)
+	if err != nil {
+		t.Fatalf("New(nil): %v", err)
+	}
+	got, ok := cache.Summary("any", "thing")
+	if ok || got != nil {
+		t.Fatalf("expected (nil, false) for nil-client cache, got (%v, %v)", got, ok)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/cel-go v0.26.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -129,6 +130,7 @@ require (
 	github.com/petermattis/goid v0.0.0-20251121121749-a11dd1a45f9a // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect


### PR DESCRIPTION
## Summary

- Add `console/deployments/statuscache` package: shared-informer-backed read-only cache of `apps/v1.Deployment` status, scoped to console-managed deployments via the `app.kubernetes.io/managed-by=console.holos.run` label selector. Only `apps/v1.Deployment` is watched — no pod, replicaset, event, or configmap informers.
- Expose `Cache.Summary(ns, name) (*consolev1.DeploymentStatusSummary, bool)`. Phase is derived from `Available`/`Progressing`/`ReplicaFailure` conditions per #914 rules. Cache miss returns `(nil, false)`.
- Handle nil `kubernetes.Interface` (dummy-secret-only mode) cleanly via a `nopCache` that always reports misses.
- Wire the cache into `console.Serve` next to `k8sClientset`; the informer lifecycle is tied to the server context.
- Thread the cache into `deployments.Handler` via a new `WithStatusCache` option. The handler accepts but does not yet call the cache — that is the next sub-issue (#915).

## Scope rationale

The issue asked for a scope justification. The console applies a `app.kubernetes.io/managed-by=console.holos.run` label to every rendered manifest (see `api/v1alpha2/annotations.go` and `console/deployments/k8s.go`). Filtering the informer by that label covers the intended watch surface (console-managed deployments across all namespaces the console can see) without having to enumerate managed namespaces at startup and without pulling in unrelated deployments.

Closes #914

Parent: #912. Previous sub-issue #913 (proto + `GetDeploymentStatusSummary` RPC) already merged.

## Test plan

- [x] `go test ./console/deployments/statuscache/...` — table-driven cases for RUNNING / FAILED (ReplicaFailure / ProgressingFalse) / PENDING (with and without conditions) / cache miss / nil-client no-op
- [x] `make test` — all 899 UI + Go tests pass
- [x] `golangci-lint run ./console/deployments/statuscache/...` — 0 issues
- [ ] CI: Unit Tests, Lint

> Local E2E was not run (no k3d cluster available). Changed files are Go-only (new statuscache package, handler wiring, console wiring); no frontend routes, components, or OIDC touched, so E2E is not relevant per the decision table. Relying on CI.

Generated with [Claude Code](https://claude.com/claude-code)