### PR TITLE
docs(adr): ADR 027 authoritative template defaults pre-fill (#926)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Before making changes, review `CONTRIBUTING.md` for commit message requirements.
 - [Linking UI](docs/agents/guardrail-linking-ui.md) — Linked templates section must always render on create and edit pages.
 - [CI Check Names](docs/agents/guardrail-ci-check-names.md) — Use actual GitHub Actions names: "Unit Tests", "Lint", "E2E Tests" — not lowercase shorthand.
 - [Pages Over Modals](docs/agents/guardrail-pages-over-modals.md) — Create and update UIs use dedicated route pages, not modals; modals only for brief confirmations and lightweight actions.
-- [Template Defaults Pre-Fill](docs/agents/guardrail-template-defaults.md) — Per-field CUE defaults extraction and frontend pre-fill; non-concrete fields must not drop concrete siblings.
+- [Template Defaults Pre-Fill](docs/agents/guardrail-template-defaults.md) — Explicit `GetTemplateDefaults` RPC, single `isPristine` boolean, Load defaults button, and mandatory `defaults` block in example templates (ADR 027).
 
 ## Planning & Execution
 

--- a/docs/adrs/018-cue-template-default-values.md
+++ b/docs/adrs/018-cue-template-default-values.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Superseded by [ADR 027](027-template-defaults-prefill.md).
+
+See ADR 027 for the authoritative Create Deployment form pre-fill behavior; the schema decisions below (the `defaults` block, the `input` field wiring, and `ResourceSetSpec.Defaults`) are still in effect.
 
 ## Context
 

--- a/docs/adrs/025-per-field-defaults-extraction.md
+++ b/docs/adrs/025-per-field-defaults-extraction.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Superseded by [ADR 027](027-template-defaults-prefill.md).
+
+See ADR 027 for the authoritative Create Deployment form pre-fill behavior; the per-field extraction correctness rule below is still honored by the backend extractor.
 
 ## Context
 

--- a/docs/adrs/027-template-defaults-prefill.md
+++ b/docs/adrs/027-template-defaults-prefill.md
@@ -1,0 +1,207 @@
+# ADR 027: Authoritative Template Defaults Pre-Fill Behavior
+
+## Status
+
+Accepted
+
+Supersedes [ADR 018](018-cue-template-default-values.md) and
+[ADR 025](025-per-field-defaults-extraction.md) for the purpose of defining the
+Create Deployment form pre-fill behavior. The schema decisions in ADR 018 (the
+`defaults` block, the `input` field, the `Defaults *ProjectInput` field on
+`ResourceSetSpec`) and the per-field extraction correctness rule from ADR 025
+remain in effect — this ADR layers the authoritative pre-fill protocol on top
+of that foundation.
+
+## Decision
+
+This ADR is the single source of truth for how the Create Deployment form
+pre-fills fields from a selected deployment template. All future work, docs, and
+reviews reference only ADR 027.
+
+### 1. Dedicated `TemplateService.GetTemplateDefaults` RPC
+
+A dedicated RPC, `TemplateService.GetTemplateDefaults`, returns the
+`TemplateDefaults` for a given template. The frontend calls this RPC:
+
+- Every time the user selects a template in the Create Deployment form.
+- Every time the user clicks the **Load defaults** button.
+
+The frontend never reads defaults from any other source for the purpose of
+pre-filling the form.
+
+### 2. `Template.defaults` remains in list/get responses (compat only)
+
+`ListTemplates` and `GetTemplate` responses continue to carry an embedded
+`Template.defaults` field populated by the backend's `ExtractDefaults` path
+(unchanged from ADR 025). This is preserved purely so the proto contract stays
+additive and existing clients do not break.
+
+**The Create Deployment form ignores the embedded `Template.defaults` field.**
+Pre-fill relies exclusively on the explicit `GetTemplateDefaults` RPC so the
+behavior is consistently testable via MSW/Vitest mocks and there is exactly one
+code path that can regress.
+
+### 3. Pristine tracking rule
+
+The form tracks a single boolean, `isPristine`:
+
+- It starts **`true`** when the form mounts.
+- It flips to **`false`** on any user edit of a defaultable field.
+- It is reset to **`true`** by:
+  - The **Load defaults** button (after the RPC resolves and overwrites fields).
+  - A successful pre-fill on template selection (when the form was already
+    pristine and the RPC response was applied).
+
+### 4. Selection rule
+
+On every template change the frontend issues `GetTemplateDefaults`:
+
+- **If `isPristine` is `true`**: the response overwrites all defaultable form
+  fields with the returned values. `isPristine` stays `true`.
+- **If `isPristine` is `false`**: the response is cached but **no fields are
+  overwritten**. The user's in-progress edits are preserved.
+
+This rule guarantees that switching templates on a clean form always produces
+the new template's defaults, while a form with user edits is never silently
+clobbered when the template changes.
+
+### 5. Load defaults button
+
+The **Load defaults** button:
+
+- Always overwrites all defaultable fields, regardless of `isPristine`.
+- Re-issues `GetTemplateDefaults` (no stale cache) so the user sees the
+  template's current authored defaults.
+- Resets `isPristine` to `true` after applying the response.
+
+### 6. Defaultable fields list
+
+The defaultable fields, enumerated exactly once in this ADR, are:
+
+1. `displayName`
+2. `name` (slug)
+3. `description`
+4. `image`
+5. `tag`
+6. `port`
+7. `command`
+8. `args`
+9. `env`
+
+The guardrail (`docs/agents/guardrail-template-defaults.md`) references this
+list by pointer only. The frontend holds the only code-level copy of this list
+as a constant (populated in phase 3); any divergence between the ADR list and
+the frontend constant is a bug.
+
+### 7. Example-template invariant
+
+Every shipped example deployment template **MUST** declare a top-level
+`defaults: #ProjectInput & { ... }` block with concrete values that mirror the
+inline `input` defaults. For example:
+
+```cue
+defaults: #ProjectInput & {
+    name:        "httpbin"
+    displayName: "httpbin"
+    description: "A simple HTTP Request & Response Service"
+    image:       "ghcr.io/mccutchen/go-httpbin"
+    tag:         "2.21.0"
+    port:        8080
+}
+
+input: #ProjectInput & {
+    name:        *defaults.name        | _
+    displayName: *defaults.displayName | _
+    description: *defaults.description | _
+    image:       *defaults.image       | _
+    tag:         *defaults.tag         | _
+    port:        *defaults.port        | _
+}
+```
+
+**Inline `*` defaults on the `input` field are NOT extracted.** This is a
+deliberate simplification: the top-level `defaults` block is the single
+authoring surface for form pre-fill. A template that expresses defaults only
+through inline `*value | _` markers on `input` will produce **no**
+extractable defaults and the form will not pre-fill, even though the template
+renders correctly. This trap has bitten every prior attempt — the example
+templates looked self-documenting but produced no extractable defaults at the
+RPC layer.
+
+Reviewers must reject any example template that omits the `defaults` block or
+that drifts the `defaults` values out of sync with the inline `input` defaults.
+
+## Why This Has Regressed
+
+This behavior has regressed multiple times across the ADR 018 and ADR 025
+iterations. The recurring failure modes:
+
+1. **Frontend read from the embedded `Template.defaults` field** directly in
+   the form component. This path was subject to list-cache staleness and was
+   painful to mock in component tests. The explicit `GetTemplateDefaults` RPC
+   makes the call site obvious and the mock surface small.
+
+2. **Pristine tracking was implicit** — the form inferred "user has edited"
+   from diffing current values against defaults, which was fragile across
+   template switches. The single explicit `isPristine` boolean, flipped by user
+   edits and reset only by pre-fill events, is both simpler and easier to
+   assert in tests.
+
+3. **The Load defaults button was missing or overloaded.** Users who wanted to
+   reset the form to a template's defaults had no safe escape hatch after
+   editing. The dedicated button, which always overwrites and re-issues the
+   RPC, is now a first-class affordance.
+
+4. **Example templates relied on inline `*` defaults only.** Per-field
+   extraction (ADR 025) walks the `defaults` block; inline `input` defaults
+   are never visited. A template missing the `defaults` block produces no
+   pre-fill values. This ADR makes the `defaults` block mandatory for all
+   example templates and forbids the inline-only pattern.
+
+## Consequences
+
+### Positive
+
+- **Single source of truth.** One ADR describes the complete pre-fill
+  behavior. Future authors reference only this document.
+
+- **Explicit RPC boundary.** `GetTemplateDefaults` is the single call site for
+  form pre-fill. MSW/Vitest mocks have one endpoint to stub, and regressions
+  have one place to surface.
+
+- **Deterministic pristine semantics.** The `isPristine` boolean is easy to
+  reason about in both code and tests; its transitions are exhaustively
+  enumerated above.
+
+- **User-edit preservation.** A user who has started editing the form is never
+  silently overwritten by a template change. The Load defaults button provides
+  the explicit override.
+
+- **Proto stays additive.** `Template.defaults` remains in list/get responses
+  for backwards compatibility, so older generated clients continue to compile
+  and deserialize. The new RPC is purely additive.
+
+### Negative
+
+- **Two backend code paths** (`ExtractDefaults` serving both
+  `Template.defaults` and `GetTemplateDefaults`) for the transition period.
+  The duplication is trivial (both call the same extractor) and acceptable.
+
+- **Extra RPC round-trip on template selection.** The form issues one
+  `GetTemplateDefaults` call per template change rather than reading from the
+  already-fetched `ListTemplates` response. The latency cost is negligible
+  (single-template CUE evaluation is millisecond-scale) and is the price of a
+  testable, explicit boundary.
+
+## References
+
+- [ADR 018: CUE Template Default Values](018-cue-template-default-values.md) —
+  superseded for pre-fill behavior; its schema decisions (the `defaults`
+  block, `input` field wiring, `ResourceSetSpec.Defaults`) remain in effect.
+- [ADR 025: Per-Field CUE Defaults Extraction](025-per-field-defaults-extraction.md) —
+  superseded for pre-fill behavior; its per-field extraction correctness rule
+  remains in effect on the backend extractor.
+- [Guardrail: Template Defaults Pre-Fill](../agents/guardrail-template-defaults.md) —
+  enforcement surface for this ADR.
+- [Parent plan: #925](https://github.com/holos-run/holos-console/issues/925)
+- [This ADR's implementation issue: #926](https://github.com/holos-run/holos-console/issues/926)

--- a/docs/agents/guardrail-template-defaults.md
+++ b/docs/agents/guardrail-template-defaults.md
@@ -25,7 +25,7 @@ The **Load defaults** button always overwrites all defaultable fields, re-issues
 
 ### Defaultable Fields
 
-The defaultable fields are enumerated in [ADR 027 §6](../adrs/027-template-defaults-prefill.md): `displayName`, `name` (slug), `description`, `image`, `tag`, `port`, `command`, `args`, `env`. The frontend holds the only code-level copy of this list as a constant; reference the ADR list rather than adding a second copy elsewhere.
+The defaultable fields are enumerated in [ADR 027 §6](../adrs/027-template-defaults-prefill.md). The frontend holds the only code-level copy of this list as a constant; do not add a second copy here or anywhere else.
 
 ### Example-Template Invariant
 

--- a/docs/agents/guardrail-template-defaults.md
+++ b/docs/agents/guardrail-template-defaults.md
@@ -1,73 +1,63 @@
 # Guardrail: Template Defaults Pre-Fill
 
-**The backend must extract each `ProjectInput` field independently from the CUE `defaults` block (per-field extraction). The frontend must pre-fill all Create Deployment form fields from the extracted `TemplateDefaults` when a template is selected.** A non-concrete field must not prevent extraction of concrete siblings. All pre-filled fields must update when the user switches templates.
+**Authority:** [ADR 027](../adrs/027-template-defaults-prefill.md) is the single source of truth. This guardrail enforces ADR 027. If this document and ADR 027 disagree, ADR 027 wins and this document must be corrected.
 
-## Rationale
+## Rule
 
-This feature has regressed multiple times. The original implementation (ADR 018) used whole-block `MarshalJSON()` on the entire `defaults` CUE value. If any single field was non-concrete (e.g., `env: _`), the marshal call failed for the entire value and silently dropped all defaults -- even fields like `name`, `image`, and `tag` that were perfectly concrete. ADR 025 replaced this with per-field extraction to eliminate the silent data loss.
+The Create Deployment form pre-fills defaultable fields exclusively via the explicit `TemplateService.GetTemplateDefaults` RPC. It **never** reads from the embedded `Template.defaults` field on `ListTemplates` / `GetTemplate` responses. The form tracks a single `isPristine` boolean, issues `GetTemplateDefaults` on every template selection and every **Load defaults** click, and overwrites fields only when pristine (or when the user clicks Load defaults).
 
-On the frontend side, `handleTemplateChange` in the Create Deployment form must map every `TemplateDefaults` field to its corresponding form field. Missing a field means the form shows stale values from a previously selected template or empty values when the template intended to provide defaults.
+### Pristine Tracking
 
-## Enforcement
+- `isPristine` starts **`true`** on mount.
+- It flips to **`false`** on any user edit of a defaultable field.
+- It is reset to **`true`** by a successful pre-fill on selection and by the **Load defaults** button.
 
-### Backend
+### Selection Rule
 
-`console/templates/defaults_test.go` includes a "mixed concrete and non-concrete fields" test case that verifies concrete fields are extracted while non-concrete fields are silently omitted:
+On every template change, the frontend calls `GetTemplateDefaults`.
 
-```go
-t.Run("mixed concrete and non-concrete fields returns partial defaults", func(t *testing.T) {
-    cueSource := `
-defaults: #ProjectInput & {
-    name:  "httpbin"
-    image: string  // non-concrete — constrained but no value
-    tag:   "2.21.0"
-    port:  8080
-}
-`
-    d, err := ExtractDefaults(cueSource)
-    // ... asserts name="httpbin", image="", tag="2.21.0", port=8080
-})
-```
+- If `isPristine` is `true`, the response overwrites all defaultable form fields.
+- If `isPristine` is `false`, the response is cached and **no fields are overwritten**.
 
-### Frontend
+### Load Defaults Button
 
-`frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx` includes comprehensive defaults pre-fill regression tests (added in issue #853):
+The **Load defaults** button always overwrites all defaultable fields, re-issues the RPC (no stale cache), and resets `isPristine` to `true`.
 
-- `selecting a template with full defaults pre-fills all form fields` -- verifies every field is populated
-- `selecting a different template updates all fields to new defaults` -- verifies switching templates replaces all values
-- `selecting a template with partial defaults leaves other fields at default values` -- verifies missing defaults do not corrupt other fields
+### Defaultable Fields
 
-CI fails if either the backend extraction or the frontend pre-fill regresses.
+The defaultable fields are enumerated in [ADR 027 §6](../adrs/027-template-defaults-prefill.md): `displayName`, `name` (slug), `description`, `image`, `tag`, `port`, `command`, `args`, `env`. The frontend holds the only code-level copy of this list as a constant; reference the ADR list rather than adding a second copy elsewhere.
 
-## Common Failure Mode
+### Example-Template Invariant
 
-Reverting `ExtractDefaults()` in `console/templates/defaults.go` to whole-block `MarshalJSON()` on the entire `defaults` value instead of per-field extraction. This causes all defaults to silently disappear when any single field is non-concrete.
+Every shipped example deployment template **MUST** declare a top-level `defaults: #ProjectInput & { ... }` block with concrete values that mirror the inline `input` defaults.
 
-On the frontend, omitting a field from the `handleTemplateChange` callback means that field retains its value from a previously selected template instead of updating to the new template's default.
+**Inline `*value | _` defaults on the `input` field are NOT extracted.** A template that expresses defaults only through inline markers will produce no pre-fill values even though it renders correctly. The `defaults` block is the single authoring surface for form pre-fill. Reviewers must reject any example template that omits `defaults` or drifts its values away from the inline `input` defaults.
 
 ## Triggers
 
 Apply this rule when:
 
-- Editing `console/templates/defaults.go` (backend extraction logic)
-- Editing `frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx` (the `handleTemplateChange` callback)
-- Adding new fields to the `TemplateDefaults` proto message in `proto/holos/console/v1/templates.proto`
-- Adding new fields to `ProjectInput` in `api/v1alpha2/types.go` that should have default values
-- Resolving merge conflicts in any of the above files
+- Editing the Create Deployment form (`frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx`) or the template-change / load-defaults handlers.
+- Adding or modifying the `GetTemplateDefaults` RPC, the `TemplateDefaults` proto message, or `ProjectInput` fields that should be pre-filled.
+- Authoring or editing an example deployment template (the `defaults` block is required).
+- Editing `console/templates/defaults.go` or the server-side `GetTemplateDefaults` handler.
+- Resolving merge conflicts in any of the above files.
 
 ## Incorrect Patterns
 
 | Pattern | Why it is wrong |
 |---------|-----------------|
-| `defaultsVal.MarshalJSON()` on the whole `defaults` value | One non-concrete field drops all defaults silently |
-| `handleTemplateChange` that does not set every `TemplateDefaults` field | Stale values persist from previously selected template |
-| Removing the "mixed concrete and non-concrete" backend test | The per-field extraction regression guard must stay |
-| Removing the frontend defaults pre-fill regression tests | The form pre-fill regression guard must stay |
-| Using `json.Unmarshal` on the entire defaults block into `ProjectInput` | Same whole-block failure mode as `MarshalJSON()` |
+| Reading `Template.defaults` from a `ListTemplates` / `GetTemplate` response to pre-fill the form | ADR 027 requires the explicit `GetTemplateDefaults` RPC; embedded `Template.defaults` is compat-only |
+| Skipping the `GetTemplateDefaults` call on Load defaults (re-using a cached response) | Load defaults must re-issue the RPC to reflect the template's current authored values |
+| Inferring "user has edited" by diffing form values against defaults | The pristine rule is a single explicit boolean; implicit inference has regressed multiple times |
+| Overwriting fields on template change when `isPristine` is `false` | The selection rule preserves in-progress user edits unless Load defaults is clicked |
+| Shipping an example template that relies on inline `*value | _` markers without a `defaults` block | Inline defaults are not extracted; the form will silently show no pre-fill |
+| Adding a second copy of the defaultable fields list anywhere other than the frontend constant | ADR 027 is the only enumeration; duplicate lists drift silently |
 
 ## Related
 
-- [Template Service](template-service.md) -- Deployment Defaults section describes the extraction mechanism
-- [Guardrail: Template Fields](guardrail-template-fields.md) -- New proto fields must propagate through defaults extraction
-- [ADR 018: CUE Template Default Values](../adrs/018-cue-template-default-values.md) -- Original design for the `defaults` block
-- [ADR 025: Per-Field CUE Defaults Extraction](../adrs/025-per-field-defaults-extraction.md) -- Per-field extraction design replacing whole-block marshaling
+- [ADR 027: Authoritative Template Defaults Pre-Fill Behavior](../adrs/027-template-defaults-prefill.md) — this guardrail's authority.
+- [ADR 018: CUE Template Default Values](../adrs/018-cue-template-default-values.md) — superseded for pre-fill behavior; schema decisions still in effect.
+- [ADR 025: Per-Field CUE Defaults Extraction](../adrs/025-per-field-defaults-extraction.md) — superseded for pre-fill behavior; extraction correctness rule still honored.
+- [Template Service](template-service.md)
+- [Guardrail: Template Fields](guardrail-template-fields.md)


### PR DESCRIPTION
## Summary

Phase 1 of #925 — docs only. Publishes ADR 027 as the single source of truth for how the Create Deployment form pre-fills from deployment templates, and supersedes ADRs 018 and 025 for that purpose.

- New `docs/adrs/027-template-defaults-prefill.md` (status Accepted), Decision first and "Why this has regressed" second. Enumerates the dedicated `TemplateService.GetTemplateDefaults` RPC, the compat-only role of embedded `Template.defaults`, the `isPristine` rule, the selection rule, the Load defaults button, the defaultable fields list (`displayName`, `name`, `description`, `image`, `tag`, `port`, `command`, `args`, `env`), and the example-template invariant mandating a top-level `defaults: #ProjectInput & { ... }` block with concrete values mirroring inline `input` defaults. Explicitly forbids extracting defaults from inline `*` markers.
- `docs/adrs/018-cue-template-default-values.md` status header updated to "Superseded by ADR 027" with a one-sentence pointer; file stays in place because its schema decisions still apply.
- `docs/adrs/025-per-field-defaults-extraction.md` status header updated to "Superseded by ADR 027" with a one-sentence pointer; file stays in place because its per-field extraction correctness rule still applies.
- `docs/agents/guardrail-template-defaults.md` rewritten against ADR 027.
- `AGENTS.md` link description updated to the new one-line summary.
- `docs/adrs/revoked/README.md` intentionally not modified (018 and 025 are superseded, not revoked).
- `docs/agents/cue-template-guide.md` does not exist in this tree, so per the issue it is skipped (no new doc created).

Subsequent phases (proto #927, backend #928, frontend #929, example templates #930) can now cite ADR 027 in their commit messages and PR bodies.

Closes #926

## Test plan

- [x] `docs/adrs/027-template-defaults-prefill.md` present
- [x] ADR 018 and ADR 025 status headers show "Superseded by ADR 027" with a pointer sentence
- [x] Guardrail and AGENTS.md link line reference ADR 027
- [x] `docs/adrs/revoked/README.md` unchanged
- [ ] No code changes — CI Unit Tests / Lint / E2E are unaffected by this docs-only PR (relying on CI to confirm)

> Local E2E was not run (docs-only change; no code paths exercised). Relying on CI.

Agent slot: `holos-console-agent-3`

Generated with [Claude Code](https://claude.com/claude-code)