### PR TITLE
test(orgs): lock in default project inherits org default role grants

### DIFF
--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -1746,6 +1746,73 @@ func TestCreateOrganization_SeedsDefaultRoleGrants(t *testing.T) {
 		}
 	})
 
+	t.Run("seeded default project inherits Owner/Editor/Viewer default role grants", func(t *testing.T) {
+		// Locks in the ordering guarantee from plan #919: because the org
+		// namespace's default-share-roles annotation is written *before*
+		// the default project is created, the seeded default project's
+		// own default-share-roles annotation must contain exactly the
+		// three standard grants (Owner, Editor, Viewer) with empty start
+		// and expiration, inherited via the project resolver's
+		// ancestor-default merge.
+		ts := &mockTemplateSeeder{}
+		handler := newTestHandlerWithOpts(testHandlerOpts{
+			withFolderCreator:  true,
+			withDefaultsSeeder: true,
+			templateSeeder:     ts,
+		})
+		ctx := contextWithClaims("alice@example.com")
+		populateDefaults := true
+
+		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
+			Name:             "project-inherits-org",
+			DisplayName:      "Project Inherits Org",
+			PopulateDefaults: &populateDefaults,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		pc := handler.projectCreator.(*k8sProjectCreator)
+		projectNsName := pc.resolver.ProjectNamespace(ts.seededProjectName)
+		projectNs, err := pc.client.CoreV1().Namespaces().Get(context.Background(), projectNsName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected default project namespace %q to exist, got %v", projectNsName, err)
+		}
+
+		raw, ok := projectNs.Annotations[v1alpha2.AnnotationDefaultShareRoles]
+		if !ok {
+			t.Fatalf("expected annotation %q on seeded default project namespace", v1alpha2.AnnotationDefaultShareRoles)
+		}
+		var grants []secrets.AnnotationGrant
+		if err := json.Unmarshal([]byte(raw), &grants); err != nil {
+			t.Fatalf("parsing default-share-roles annotation on project: %v", err)
+		}
+		if len(grants) != 3 {
+			t.Fatalf("expected 3 default role grants on seeded project, got %d (%v)", len(grants), grants)
+		}
+
+		byRole := make(map[string]secrets.AnnotationGrant, 3)
+		for _, g := range grants {
+			byRole[g.Role] = g
+		}
+		for _, role := range []string{"owner", "editor", "viewer"} {
+			g, ok := byRole[role]
+			if !ok {
+				t.Errorf("expected a default grant for role %q on project namespace, none found", role)
+				continue
+			}
+			if g.Principal != role {
+				t.Errorf("expected principal %q for project default role %q grant, got %q", role, role, g.Principal)
+			}
+			if g.Nbf != nil {
+				t.Errorf("expected no start restriction (nbf) for project default role %q grant, got %v", role, *g.Nbf)
+			}
+			if g.Exp != nil {
+				t.Errorf("expected no expiration (exp) for project default role %q grant, got %v", role, *g.Exp)
+			}
+		}
+	})
+
 	t.Run("default role grants are written before default folder creation", func(t *testing.T) {
 		// Use a FolderCreator that records whether the
 		// default-share-roles annotation was present on the org namespace


### PR DESCRIPTION
## Summary
- Add a `TestCreateOrganization_SeedsDefaultRoleGrants` subtest that asserts the seeded default project's namespace carries exactly three `AnnotationDefaultShareRoles` grants — Owner, Editor, Viewer — each with matching Principal and empty Nbf/Exp, after `CreateOrganization(populate_defaults=true)`.
- Tightens the existing len==3 check on the project's default-share-roles with explicit role-identity and zero-start/expiration assertions, closing the observability gap that let the original ordering bug (#920) slip in.
- Uses the existing `k8s.io/client-go/kubernetes/fake` harness and `secrets.AnnotationGrant` decode pattern already established in this file. No production code changes.

Part of plan #919. Backend ordering fix landed in #923; these tests reflect current main behavior.

Closes #921

## Test plan
- [x] `go test ./console/organizations/ -run TestCreateOrganization_SeedsDefaultRoleGrants -v -count=1` passes
- [x] `make test` passes (Go + UI)
- [ ] CI Unit Tests / Lint pass
- Local E2E was not run (no k3d cluster available). Relying on CI E2E check. The change is test-only in a Go package with no UI/RPC surface, so E2E is not relevant per the repo heuristic.

Generated with [Claude Code](https://claude.com/claude-code)

Agent: holos-console-agent-2