### PR TITLE
chore(orgs): cleanup stale docs and dead helper after plan #919

### DIFF
--- a/console/folders/k8s_test.go
+++ b/console/folders/k8s_test.go
@@ -33,19 +33,6 @@ func folderNS(name, org, parentNs string) *corev1.Namespace {
 	}
 }
 
-func orgNS(name string) *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holos-org-" + name,
-			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
-				v1alpha2.LabelOrganization: name,
-			},
-		},
-	}
-}
-
 func TestGetFolder_ReturnsFolder(t *testing.T) {
 	ns := folderNS("eng", "acme", "holos-org-acme")
 	fakeClient := fake.NewClientset(ns)

--- a/docs/agents/template-service.md
+++ b/docs/agents/template-service.md
@@ -23,13 +23,15 @@ The default template adds a `console.holos.run/deployer-email` annotation to all
 
 ## Org Seeding via `populate_defaults`
 
-When `CreateOrganization` is called with `populate_defaults: true`, the backend seeds example resources into the new org:
+When `CreateOrganization` is called with `populate_defaults: true`, the backend seeds example resources into the new org in the following order (issue #920 / plan #919):
 
-1. An org-level platform template (HTTPRoute ReferenceGrant, enabled) via `SeedOrgTemplate`
-2. A default project in the org's default folder
-3. An example project-level deployment template (go-httpbin) via `SeedProjectTemplate`
+1. The org namespace's `console.holos.run/default-share-roles` annotation is populated with the three standard role grants (Owner, Editor, Viewer — no `nbf`, no `exp`) *before* any folder or project is created. This ensures the seeded default folder and default project pick up the org-level default role grants via the ancestor-default-share merge.
+2. The default folder is created as a direct child of the org, inheriting the org's default role grants as both its active share grants and its own default-share cascade.
+3. An org-level platform template (HTTPRoute ReferenceGrant, enabled) via `SeedOrgTemplate`.
+4. A default project in the org's default folder, inheriting the org default role grants.
+5. An example project-level deployment template (go-httpbin) via `SeedProjectTemplate`.
 
-The frontend exposes this as a "Populate with example resources" checkbox in the Create Organization dialog.
+The frontend exposes this as a "Populate with example resources" checkbox in the Create Organization dialog. When `populate_defaults` is false or unset, the default-share-roles annotation is *not* written and the non-seeded code path is preserved.
 
 ## Mandatory and Enabled Flags
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -149,7 +149,7 @@ Organization creation is controlled by CLI flags (`--disable-org-creation`, `--o
 
 ## Organization Default Sharing
 
-Organizations can define **default sharing grants** that are automatically applied to new projects created within the organization. These defaults are stored as annotations on the organization namespace (`console.holos.run/default-share-users` and `console.holos.run/default-share-roles`) and are copied to the project namespace at creation time. Changing the defaults does not retroactively update existing projects.
+Organizations can define **default sharing grants** that are automatically applied to new folders and projects created within the organization. These defaults are stored as annotations on the organization namespace (`console.holos.run/default-share-users` and `console.holos.run/default-share-roles`) and are merged into descendant namespaces at creation time via the ancestor-default-share cascade. When `CreateOrganization` is called with `populate_defaults: true`, the backend seeds the three standard role grants (Owner, Editor, Viewer) into `console.holos.run/default-share-roles` *before* the default folder or default project is created, so the seeded descendants inherit them. Changing the defaults does not retroactively update existing folders or projects.
 
 ## Example: Organization with Project and Secrets
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -87,7 +87,7 @@ Organization grants have no cascade tables — they never cascade to projects or
 
 ## Metadata Annotations
 
-Metadata annotations are stored on organization and project Namespace resources:
+Metadata annotations are stored on organization, folder, and project Namespace resources:
 
 | Annotation | Resource | Description |
 |---|---|---|
@@ -105,8 +105,8 @@ Grants are stored as JSON annotations on Namespace and Secret resources:
 |---|---|---|
 | `console.holos.run/share-users` | `[{"principal":"email","role":"role","nbf":ts,"exp":ts}]` | Per-user grants |
 | `console.holos.run/share-roles` | `[{"principal":"role","role":"role","nbf":ts,"exp":ts}]` | Per-role grants |
-| `console.holos.run/default-share-users` | `[{"principal":"email","role":"role","nbf":ts,"exp":ts}]` | Default per-user grants applied to new projects in the org |
-| `console.holos.run/default-share-roles` | `[{"principal":"role","role":"role","nbf":ts,"exp":ts}]` | Default per-role grants applied to new projects in the org |
+| `console.holos.run/default-share-users` | `[{"principal":"email","role":"role","nbf":ts,"exp":ts}]` | Default per-user grants applied to new folders and projects within the organization (propagated via ancestor walk). Settable on organization or folder namespaces. |
+| `console.holos.run/default-share-roles` | `[{"principal":"role","role":"role","nbf":ts,"exp":ts}]` | Default per-role grants applied to new folders and projects within the organization (propagated via ancestor walk). Settable on organization or folder namespaces. |
 
 Each grant is a JSON object with:
 


### PR DESCRIPTION
## Summary

Final cleanup phase for plan #919 (default-sharing ordering fix).

- Rewrites `docs/agents/template-service.md` "Org Seeding via `populate_defaults`" to describe the new five-step ordering (seed `default-share-roles` first, then default folder, then org platform template, then default project, then project template) with a cross-reference to issue #920, and documents the `populate_defaults=false|unset` path.
- Updates the "Organization Default Sharing" paragraph in `docs/rbac.md` to cover folders in addition to projects, describe the seeded role-grants flow under `populate_defaults=true`, and note that changes to org defaults do not retroactively update existing descendants.
- Removes the unused `orgNS` test helper from `console/folders/k8s_test.go` (flagged by `golangci-lint` under `unused`; no callers).

Acceptance criteria from #922:
- [x] Comments in `console/organizations/handler.go` describing the old ordering — already reflect the new ordering (nothing to change).
- [x] Dead helpers removed — `orgNS` in `console/folders/k8s_test.go`.
- [x] `docs/agents/` references reviewed and updated (`template-service.md`).
- [x] `AGENTS.md` / guardrail docs reviewed — no invariant changed, no update required.
- [x] `make generate` — no proto/codegen drift.
- [x] `go test ./console/organizations/... ./console/folders/... ./console/projects/...` passes.

`make lint` was already failing on `origin/main` with 28 pre-existing errcheck/staticcheck/unused findings unrelated to plan #919; this PR does not introduce new findings and removes one (`unused: orgNS`).

Closes #922
Part of plan #919

## Test plan
- [x] `go test ./console/organizations/...` passes
- [x] `go test ./console/folders/...` passes
- [x] `go test ./console/projects/...` passes
- [x] `make generate` clean
- [ ] CI: Unit Tests, Lint, E2E Tests

> Local E2E was not run (no k3d cluster available). This change is docs + test-helper only; relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)