### PR TITLE
feat(frontend): render real deployment status on listing page

### DIFF
--- a/frontend/src/components/phase-badge.test.tsx
+++ b/frontend/src/components/phase-badge.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import {
+  DeploymentPhase,
+  DeploymentStatusSummarySchema,
+  type DeploymentStatusSummary,
+} from '@/gen/holos/console/v1/deployments_pb'
+import { PhaseBadge } from './phase-badge'
+
+function makeSummary(partial: Partial<DeploymentStatusSummary> = {}): DeploymentStatusSummary {
+  return create(DeploymentStatusSummarySchema, {
+    phase: DeploymentPhase.UNSPECIFIED,
+    readyReplicas: 0,
+    desiredReplicas: 0,
+    availableReplicas: 0,
+    updatedReplicas: 0,
+    observedGeneration: 0n,
+    message: '',
+    ...partial,
+  })
+}
+
+describe('PhaseBadge', () => {
+  it('renders running badge with replica count when desiredReplicas > 0', () => {
+    render(
+      <PhaseBadge
+        summary={makeSummary({ phase: DeploymentPhase.RUNNING, readyReplicas: 2, desiredReplicas: 3 })}
+      />,
+    )
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('2/3')).toBeInTheDocument()
+  })
+
+  it('renders pending badge with replica count', () => {
+    render(
+      <PhaseBadge
+        summary={makeSummary({ phase: DeploymentPhase.PENDING, readyReplicas: 0, desiredReplicas: 1 })}
+      />,
+    )
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+    expect(screen.getByText('0/1')).toBeInTheDocument()
+  })
+
+  it('renders failed badge with replica count', () => {
+    render(
+      <PhaseBadge
+        summary={makeSummary({ phase: DeploymentPhase.FAILED, readyReplicas: 0, desiredReplicas: 1 })}
+      />,
+    )
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('0/1')).toBeInTheDocument()
+  })
+
+  it('renders succeeded badge with replica count', () => {
+    render(
+      <PhaseBadge
+        summary={makeSummary({ phase: DeploymentPhase.SUCCEEDED, readyReplicas: 1, desiredReplicas: 1 })}
+      />,
+    )
+    expect(screen.getByText('Succeeded')).toBeInTheDocument()
+    expect(screen.getByText('1/1')).toBeInTheDocument()
+  })
+
+  it('omits replica count when desiredReplicas is zero', () => {
+    render(
+      <PhaseBadge
+        summary={makeSummary({ phase: DeploymentPhase.RUNNING, readyReplicas: 0, desiredReplicas: 0 })}
+      />,
+    )
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.queryByText('0/0')).not.toBeInTheDocument()
+  })
+
+  it('renders Unknown when summary is missing and no fallback', () => {
+    render(<PhaseBadge />)
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+  })
+
+  it('renders fallback phase when summary is missing', () => {
+    render(<PhaseBadge fallbackPhase={DeploymentPhase.PENDING} />)
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+    // no replica count when there is no summary
+    expect(screen.queryByText(/\d+\/\d+/)).not.toBeInTheDocument()
+  })
+
+  it('renders unknown branch when summary.phase is UNSPECIFIED and no replicas', () => {
+    render(<PhaseBadge summary={makeSummary({ phase: DeploymentPhase.UNSPECIFIED })} />)
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/phase-badge.tsx
+++ b/frontend/src/components/phase-badge.tsx
@@ -1,0 +1,59 @@
+import { Badge } from '@/components/ui/badge'
+import { DeploymentPhase, type DeploymentStatusSummary } from '@/gen/holos/console/v1/deployments_pb'
+
+/**
+ * DeploymentStatus is the minimal shape PhaseBadge needs to render.
+ * Accepts either the full status_summary message or undefined/missing.
+ */
+export interface PhaseBadgeProps {
+  /** Lightweight status snapshot, typically from deployment.statusSummary. */
+  summary?: DeploymentStatusSummary
+  /**
+   * Fallback phase used only when summary is entirely absent. When provided,
+   * renders a bare badge without replica count. Prefer passing summary.
+   */
+  fallbackPhase?: DeploymentPhase
+}
+
+function phaseBadge(phase: DeploymentPhase) {
+  switch (phase) {
+    case DeploymentPhase.RUNNING:
+      return <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent">Running</Badge>
+    case DeploymentPhase.PENDING:
+      return <Badge className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 border-transparent">Pending</Badge>
+    case DeploymentPhase.FAILED:
+      return <Badge variant="destructive">Failed</Badge>
+    case DeploymentPhase.SUCCEEDED:
+      return <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border-transparent">Succeeded</Badge>
+    default:
+      return <Badge variant="outline">Unknown</Badge>
+  }
+}
+
+/**
+ * PhaseBadge renders a deployment phase badge, optionally with a
+ * ready/desired replica count (e.g. "Running 2/3") when summary is present
+ * and desired_replicas > 0.
+ *
+ * - If summary is provided, phase is taken from summary.phase and the replica
+ *   count is shown inline when desired_replicas > 0.
+ * - If summary is absent, fallbackPhase is rendered (defaults to the Unknown
+ *   branch when both are absent).
+ */
+export function PhaseBadge({ summary, fallbackPhase }: PhaseBadgeProps) {
+  if (!summary) {
+    return phaseBadge(fallbackPhase ?? DeploymentPhase.UNSPECIFIED)
+  }
+  const badge = phaseBadge(summary.phase)
+  if (summary.desiredReplicas > 0) {
+    return (
+      <span className="inline-flex items-center gap-2">
+        {badge}
+        <span className="font-mono text-sm text-muted-foreground">
+          {summary.readyReplicas}/{summary.desiredReplicas}
+        </span>
+      </span>
+    )
+  }
+  return badge
+}

--- a/frontend/src/queries/deployments.ts
+++ b/frontend/src/queries/deployments.ts
@@ -86,6 +86,29 @@ function deploymentStatusKey(project: string, name: string) {
   return ['deployments', 'status', project, name] as const
 }
 
+function deploymentStatusSummaryKey(project: string, name: string) {
+  return ['deployments', 'status-summary', project, name] as const
+}
+
+export function useGetDeploymentStatusSummary(
+  project: string,
+  name: string,
+  options?: { refetchInterval?: number },
+) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(DeploymentService, transport), [transport])
+  return useQuery({
+    queryKey: deploymentStatusSummaryKey(project, name),
+    queryFn: async () => {
+      const response = await client.getDeploymentStatusSummary({ project, name })
+      return response.summary
+    },
+    enabled: isAuthenticated && !!project && !!name,
+    refetchInterval: options?.refetchInterval,
+  })
+}
+
 function deploymentLogsKey(project: string, name: string, container?: string, tailLines?: number, previous?: boolean) {
   return ['deployments', 'logs', project, name, container, tailLines, previous] as const
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
@@ -29,11 +29,34 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { DeploymentPhase } from '@/gen/holos/console/v1/deployments_pb'
+import { DeploymentPhase, type DeploymentStatusSummary } from '@/gen/holos/console/v1/deployments_pb'
 import { DeploymentsPage } from './index'
 
-function makeDeployment(name: string, image = 'ghcr.io/org/app', tag = 'v1.0.0', phase = DeploymentPhase.RUNNING) {
-  return { name, project: 'test-project', image, tag, template: 'web-app', displayName: '', description: '', phase, message: '' }
+function makeSummary(
+  phase: DeploymentPhase,
+  readyReplicas = 0,
+  desiredReplicas = 0,
+): DeploymentStatusSummary {
+  return {
+    $typeName: 'holos.console.v1.DeploymentStatusSummary',
+    phase,
+    readyReplicas,
+    desiredReplicas,
+    availableReplicas: readyReplicas,
+    updatedReplicas: readyReplicas,
+    observedGeneration: 0n,
+    message: '',
+  }
+}
+
+function makeDeployment(
+  name: string,
+  image = 'ghcr.io/org/app',
+  tag = 'v1.0.0',
+  phase = DeploymentPhase.RUNNING,
+  statusSummary?: DeploymentStatusSummary,
+) {
+  return { name, project: 'test-project', image, tag, template: 'web-app', displayName: '', description: '', phase, message: '', statusSummary }
 }
 
 function setupMocks(
@@ -81,6 +104,56 @@ describe('DeploymentsPage', () => {
     setupMocks([makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0', DeploymentPhase.FAILED)])
     render(<DeploymentsPage />)
     expect(screen.getByText(/failed/i)).toBeInTheDocument()
+  })
+
+  it('renders Running badge with ready/desired replicas from status_summary', () => {
+    setupMocks([
+      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0', DeploymentPhase.UNSPECIFIED,
+        makeSummary(DeploymentPhase.RUNNING, 2, 3)),
+    ])
+    render(<DeploymentsPage />)
+    expect(screen.getByText(/running/i)).toBeInTheDocument()
+    expect(screen.getByText('2/3')).toBeInTheDocument()
+  })
+
+  it('renders Pending badge with replica count from status_summary', () => {
+    setupMocks([
+      makeDeployment('worker', 'ghcr.io/org/wrk', 'latest', DeploymentPhase.UNSPECIFIED,
+        makeSummary(DeploymentPhase.PENDING, 0, 1)),
+    ])
+    render(<DeploymentsPage />)
+    expect(screen.getByText(/pending/i)).toBeInTheDocument()
+    expect(screen.getByText('0/1')).toBeInTheDocument()
+  })
+
+  it('renders Failed badge with replica count from status_summary', () => {
+    setupMocks([
+      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0', DeploymentPhase.UNSPECIFIED,
+        makeSummary(DeploymentPhase.FAILED, 0, 1)),
+    ])
+    render(<DeploymentsPage />)
+    expect(screen.getByText(/failed/i)).toBeInTheDocument()
+    expect(screen.getByText('0/1')).toBeInTheDocument()
+  })
+
+  it('renders Unknown only when status_summary is missing', () => {
+    setupMocks([
+      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0', DeploymentPhase.UNSPECIFIED /* no summary */),
+    ])
+    render(<DeploymentsPage />)
+    expect(screen.getByText(/unknown/i)).toBeInTheDocument()
+    // No replica count rendered when summary is missing.
+    expect(screen.queryByText(/^\d+\/\d+$/)).not.toBeInTheDocument()
+  })
+
+  it('omits replica count when desired_replicas is zero', () => {
+    setupMocks([
+      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0', DeploymentPhase.UNSPECIFIED,
+        makeSummary(DeploymentPhase.RUNNING, 0, 0)),
+    ])
+    render(<DeploymentsPage />)
+    expect(screen.getByText(/running/i)).toBeInTheDocument()
+    expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
 
   it('shows empty state when no deployments', () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -3,7 +3,6 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -24,7 +23,7 @@ import {
 } from '@/components/ui/table'
 import { Trash2 } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { DeploymentPhase } from '@/gen/holos/console/v1/deployments_pb'
+import { PhaseBadge } from '@/components/phase-badge'
 import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 
@@ -145,7 +144,10 @@ export function DeploymentsPage({ projectName: propProjectName }: { projectName?
                     <TableCell className="font-mono text-sm">{deployment.image}</TableCell>
                     <TableCell className="font-mono text-sm">{deployment.tag}</TableCell>
                     <TableCell>
-                      <PhaseBadge phase={deployment.phase} />
+                      <PhaseBadge
+                        summary={deployment.statusSummary}
+                        fallbackPhase={deployment.phase}
+                      />
                     </TableCell>
                     <TableCell className="text-right">
                       {canDelete && (
@@ -190,17 +192,3 @@ export function DeploymentsPage({ projectName: propProjectName }: { projectName?
   )
 }
 
-function PhaseBadge({ phase }: { phase: DeploymentPhase }) {
-  switch (phase) {
-    case DeploymentPhase.RUNNING:
-      return <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-transparent">Running</Badge>
-    case DeploymentPhase.PENDING:
-      return <Badge className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 border-transparent">Pending</Badge>
-    case DeploymentPhase.FAILED:
-      return <Badge variant="destructive">Failed</Badge>
-    case DeploymentPhase.SUCCEEDED:
-      return <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border-transparent">Succeeded</Badge>
-    default:
-      return <Badge variant="outline">Unknown</Badge>
-  }
-}


### PR DESCRIPTION
## Summary

- Extract PhaseBadge into `frontend/src/components/phase-badge.tsx` and make it consume the new `DeploymentStatusSummary` message (phase + ready/desired replicas).
- Deployments listing page now reads `deployment.statusSummary`, rendering e.g. `Running 2/3` and only falling back to `deployment.phase` / `Unknown` when the summary is genuinely missing.
- Add `useGetDeploymentStatusSummary` query hook wrapping the new `GetDeploymentStatusSummary` RPC for single-row refresh.
- Add 8 Vitest + RTL unit tests for `PhaseBadge` and 5 new cases on the listing page covering running-with-replicas, pending, failed, missing summary (Unknown), and `desired_replicas == 0`.

Parent: #912 — sub-issue following #913 (proto), #914 (informer cache), #915 (handlers wired).

Closes #916

## Test plan

- [x] `make generate` succeeds.
- [x] `make test` — 912 tests pass (56 files).
- [x] ESLint clean on touched files.
- [ ] Local E2E not run (no k3d cluster available in this agent environment). Relying on CI E2E check.
- [ ] CI Unit Tests, Lint, and E2E Tests green on PR.

Agent slot: holos-console-agent-1

Generated with [Claude Code](https://claude.com/claude-code)