### PR TITLE
fix(orgs): stop copying org defaults onto seeded default folder

### DIFF
--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -348,10 +348,13 @@ func (h *Handler) CreateOrganization(
 //
 // When the org carries default-share grants (seeded via seedOrgDefaultSharing
 // when populate_defaults=true), those grants are merged into the folder's
-// active grants and copied as the folder's own default-share grants, mirroring
-// the ancestor-default-share merge that folders.Handler.CreateFolder applies
-// for user-initiated folder creation. This ensures the seeded default folder
-// inherits the org's default Owner/Editor/Viewer role grants.
+// active grants only. The folder is NOT given its own default-share
+// annotations — descendants created under this folder pick up the current org
+// defaults dynamically via the ancestor walk performed by
+// folders.Handler.collectAncestorDefaultShares and
+// projects.ProjectGrantResolver.GetDefaultGrants. Persisting a snapshot on the
+// folder itself would cause later changes to org default sharing to be
+// shadowed by stale folder defaults.
 func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (string, error) {
 	exists := func(ctx context.Context, nsName string) (bool, error) {
 		return h.folderCreator.NamespaceExists(ctx, nsName)
@@ -376,7 +379,10 @@ func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName,
 	folderShareRoles := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareRoles...), orgDefaultRoles...))
 
 	orgNsName := h.k8s.resolver.OrgNamespace(orgName)
-	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, folderShareUsers, folderShareRoles, orgDefaultUsers, orgDefaultRoles); err != nil {
+	// Pass nil for the folder's own default-share grants. Descendants resolve
+	// the org defaults dynamically via the ancestor walk, so persisting a copy
+	// here would cause stale defaults to shadow future org changes.
+	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, folderShareUsers, folderShareRoles, nil, nil); err != nil {
 		return "", fmt.Errorf("creating folder namespace: %w", err)
 	}
 	return folderName, nil

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -1422,16 +1422,15 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 			}
 		}
 
-		folderDefaultRolesAnnotation := folderNs.Annotations[v1alpha2.AnnotationDefaultShareRoles]
-		if folderDefaultRolesAnnotation == "" {
-			t.Fatalf("expected default-share-roles annotation on folder namespace")
+		// The seeded default folder must NOT carry its own default-share-*
+		// annotations. Descendants pick up the current org defaults dynamically
+		// via the ancestor walk, so persisting a snapshot on the folder would
+		// shadow later org-level changes. See issue #933.
+		if v, ok := folderNs.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
+			t.Errorf("expected no %q annotation on seeded default folder, got %q", v1alpha2.AnnotationDefaultShareRoles, v)
 		}
-		var folderDefaultRoles []secrets.AnnotationGrant
-		if err := json.Unmarshal([]byte(folderDefaultRolesAnnotation), &folderDefaultRoles); err != nil {
-			t.Fatalf("invalid default-share-roles annotation on folder: %v", err)
-		}
-		if len(folderDefaultRoles) != 3 {
-			t.Errorf("expected 3 default role grants copied from org onto folder, got %d", len(folderDefaultRoles))
+		if v, ok := folderNs.Annotations[v1alpha2.AnnotationDefaultShareUsers]; ok {
+			t.Errorf("expected no %q annotation on seeded default folder, got %q", v1alpha2.AnnotationDefaultShareUsers, v)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- `createDefaultFolder` in `console/organizations/handler.go` no longer persists the org's default-share grants onto the seeded default folder's own `default-share-*` annotations.
- Org default grants are still merged into the folder's active `share-users` / `share-roles` grants, so the default folder still inherits Owner/Editor/Viewer initially.
- Descendants created under the seeded default folder now pick up the current org defaults dynamically via the ancestor walk (`folders.Handler.collectAncestorDefaultShares`, `projects.ProjectGrantResolver.GetDefaultGrants`).
- Previously, a stale snapshot on the folder could shadow later changes to org default sharing for descendants; this removes that divergence from the normal `folders.Handler.CreateFolder` path.

Closes #933

## Test plan
- [x] `go test ./console/organizations/...` passes
- [x] `go test ./console/folders/... ./console/projects/...` passes
- [x] Existing `TestCreateOrganization_PopulateDefaults` updated to assert the seeded folder has NO `default-share-*` annotations while the seeded project (a descendant) still receives the org defaults via the ancestor walk

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Agent slot: holos-console-agent-2

Generated with [Claude Code](https://claude.com/claude-code)