### PR TITLE
feat(templates): implement GetTemplateDefaults handler and add defaults to examples

### DIFF
--- a/console/templates/defaults_test.go
+++ b/console/templates/defaults_test.go
@@ -205,6 +205,98 @@ defaults: {
 		}
 	})
 
+	t.Run("example_httpbin.cue extracts concrete defaults (ADR 027 regression)", func(t *testing.T) {
+		// Regression guard: the shipped example_httpbin.cue must carry a
+		// top-level `defaults` block whose fields ExtractDefaults can surface
+		// intact. Issue #925 documented the prior state where the example
+		// expressed defaults only via inline `*value | _` markers on `input`,
+		// which produced zero extractable defaults at the RPC layer. This
+		// assertion keeps the example aligned with ADR 027 section 7.
+		d, err := ExtractDefaults(ExampleHttpbinTemplate)
+		if err != nil {
+			t.Fatalf("expected no error extracting defaults from ExampleHttpbinTemplate, got %v", err)
+		}
+		if d == nil {
+			t.Fatal("expected non-nil TemplateDefaults from ExampleHttpbinTemplate — ADR 027 requires example templates to expose a defaults block")
+		}
+		if d.Name != "httpbin" {
+			t.Errorf("expected name 'httpbin', got %q", d.Name)
+		}
+		if d.Image != "ghcr.io/mccutchen/go-httpbin" {
+			t.Errorf("expected image 'ghcr.io/mccutchen/go-httpbin', got %q", d.Image)
+		}
+		if d.Tag != "2.21.0" {
+			t.Errorf("expected tag '2.21.0', got %q", d.Tag)
+		}
+		if d.Port != 8080 {
+			t.Errorf("expected port 8080, got %d", d.Port)
+		}
+		if d.Description != "A simple HTTP Request & Response Service" {
+			t.Errorf("expected description 'A simple HTTP Request & Response Service', got %q", d.Description)
+		}
+		// command and args are deliberately unset so the frontend keeps
+		// exercising the empty-slice path.
+		if len(d.Command) != 0 {
+			t.Errorf("expected empty command, got %v", d.Command)
+		}
+		if len(d.Args) != 0 {
+			t.Errorf("expected empty args, got %v", d.Args)
+		}
+	})
+
+	t.Run("issue #925 before-fix example (inline-only defaults) extracts nothing", func(t *testing.T) {
+		// The exact CUE shape issue #925 called out as broken: defaults
+		// expressed only through inline `*value | _` markers on `input` and
+		// no top-level `defaults` block. ExtractDefaults walks the `defaults`
+		// path only, so it must return nil on this input.
+		cueSource := `
+input: #ProjectInput & {
+    name:  =~"^[a-z][a-z0-9-]*$"
+    image: string | *"ghcr.io/mccutchen/go-httpbin"
+    tag:   string | *"2.21.0"
+    port:  >0 & <=65535 | *8080
+}
+`
+		d, err := ExtractDefaults(cueSource)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if d != nil {
+			t.Fatalf("expected nil — inline `*` defaults on input must NOT be extracted (ADR 027); got %+v", d)
+		}
+	})
+
+	t.Run("issue #925 after-fix example (top-level defaults block) extracts values", func(t *testing.T) {
+		// The matching "after" shape from issue #925: the same template now
+		// declares a top-level `defaults` block mirroring the inline values.
+		// ExtractDefaults must surface those values verbatim.
+		cueSource := `
+defaults: #ProjectInput & {
+    name:        "httpbin"
+    image:       "ghcr.io/mccutchen/go-httpbin"
+    tag:         "2.21.0"
+    port:        8080
+    description: "A simple HTTP Request & Response Service"
+}
+input: #ProjectInput & {
+    name:  *defaults.name | (string & =~"^[a-z][a-z0-9-]*$")
+    image: *defaults.image | _
+    tag:   *defaults.tag | _
+    port:  *defaults.port | (>0 & <=65535)
+}
+`
+		d, err := ExtractDefaults(cueSource)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if d == nil {
+			t.Fatal("expected non-nil TemplateDefaults")
+		}
+		if d.Name != "httpbin" || d.Image != "ghcr.io/mccutchen/go-httpbin" || d.Tag != "2.21.0" || d.Port != 8080 || d.Description != "A simple HTTP Request & Response Service" {
+			t.Errorf("expected full httpbin defaults, got %+v", d)
+		}
+	})
+
 	t.Run("typed defaults with one non-concrete field extracts concrete fields", func(t *testing.T) {
 		// A template using #ProjectInput & { ... } with one non-concrete field
 		// should still extract all the concrete fields.

--- a/console/templates/example_httpbin.cue
+++ b/console/templates/example_httpbin.cue
@@ -7,11 +7,25 @@
 
 // Use generated type definitions from api/v1alpha2 (prepended by renderer).
 // Additional CUE constraints narrow the generated types for this template.
+
+// defaults declares the template's default values as concrete CUE data.
+// The backend reads this block (via ExtractDefaults) to pre-fill the Create
+// Deployment form. See ADR 027 for the authoritative pre-fill behavior.
+// NOTE: `command` and `args` are intentionally unset so the frontend's
+// empty-slice handling path stays exercised by this example.
+defaults: #ProjectInput & {
+	name:        "httpbin"
+	image:       "ghcr.io/mccutchen/go-httpbin"
+	tag:         "2.21.0"
+	port:        8080
+	description: "A simple HTTP Request & Response Service"
+}
+
 input: #ProjectInput & {
-	name:  =~"^[a-z][a-z0-9-]*$" // DNS label
-	image: string | *"ghcr.io/mccutchen/go-httpbin"
-	tag:   string | *"2.21.0"
-	port:  >0 & <=65535 | *8080
+	name:  *defaults.name | (string & =~"^[a-z][a-z0-9-]*$") // DNS label
+	image: *defaults.image | _
+	tag:   *defaults.tag | _
+	port:  *defaults.port | (>0 & <=65535)
 }
 platform: #PlatformInput
 

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -213,6 +213,84 @@ func (h *Handler) GetTemplate(
 	}), nil
 }
 
+// GetTemplateDefaults returns the defaults block evaluated from a template's
+// CUE source. It is the single authoritative source for Create Deployment form
+// pre-fill (see ADR 027). Inline `*` defaults declared on `input` fields are
+// NOT read — only the top-level `defaults` CUE block is considered.
+//
+// Behavior:
+//   - For non-project scopes the response is an empty TemplateDefaults message
+//     (defaults are a project-scope concept per ADR 027). Returning an empty
+//     message rather than an error lets the UI call this RPC uniformly.
+//   - For project-scope templates without a `defaults` block (or with all
+//     non-concrete fields) the response is an empty TemplateDefaults message.
+//   - Missing templates return CodeNotFound; callers lacking read permission
+//     on the scope receive CodePermissionDenied (mirrors GetTemplate).
+func (h *Handler) GetTemplateDefaults(
+	ctx context.Context,
+	req *connect.Request[consolev1.GetTemplateDefaultsRequest],
+) (*connect.Response[consolev1.GetTemplateDefaultsResponse], error) {
+	scope, scopeName, err := extractScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	name := req.Msg.GetName()
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesRead); err != nil {
+		return nil, err
+	}
+
+	// Defaults are a project-scope concept (ADR 027). For org/folder scopes,
+	// return an empty TemplateDefaults so the UI can call uniformly without
+	// special-casing scope.
+	if scope != consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT {
+		return connect.NewResponse(&consolev1.GetTemplateDefaultsResponse{
+			Defaults: &consolev1.TemplateDefaults{},
+		}), nil
+	}
+
+	cm, err := h.k8s.GetTemplate(ctx, scope, scopeName, name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	cueSource := cm.Data[CueTemplateKey]
+	extracted, err := ExtractDefaults(cueSource)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to extract template defaults",
+			slog.String("scope", scope.String()),
+			slog.String("scopeName", scopeName),
+			slog.String("name", name),
+			slog.Any("error", err),
+		)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to extract template defaults: %w", err))
+	}
+	if extracted == nil {
+		extracted = &consolev1.TemplateDefaults{}
+	}
+
+	slog.InfoContext(ctx, "template defaults read",
+		slog.String("action", "template_defaults_read"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("name", name),
+		slog.String("sub", claims.Sub),
+	)
+
+	return connect.NewResponse(&consolev1.GetTemplateDefaultsResponse{
+		Defaults: extracted,
+	}), nil
+}
+
 // CreateTemplate creates a new template at the given scope.
 func (h *Handler) CreateTemplate(
 	ctx context.Context,

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
@@ -1012,6 +1013,261 @@ func TestRenderTemplateStructuredJSON(t *testing.T) {
 		}
 		if resp.Msg.PlatformInputJson != nil {
 			t.Errorf("expected PlatformInputJson to be nil, got %q", *resp.Msg.PlatformInputJson)
+		}
+	})
+}
+
+// TestGetTemplateDefaults covers the handler behavior required by ADR 027 and
+// the acceptance criteria on issue #928: RBAC parity with GetTemplate, empty
+// responses for missing-defaults and non-project scopes, and CodeNotFound for
+// missing templates.
+func TestGetTemplateDefaults(t *testing.T) {
+	const project = "my-project"
+	const org = "acme"
+	const ownerEmail = "platform@localhost"
+	const strangerEmail = "stranger@localhost"
+
+	httpbinCue := `
+defaults: #ProjectInput & {
+    name:        "httpbin"
+    image:       "ghcr.io/mccutchen/go-httpbin"
+    tag:         "2.21.0"
+    port:        8080
+    description: "A simple HTTP Request & Response Service"
+}
+input: #ProjectInput & {
+    name:  *defaults.name | (string & =~"^[a-z][a-z0-9-]*$")
+    image: *defaults.image | _
+    tag:   *defaults.tag | _
+    port:  *defaults.port | (>0 & <=65535)
+}
+`
+	bareCue := `
+input: #ProjectInput & {
+    name: string
+}
+`
+
+	type want struct {
+		wantErr  bool
+		wantCode connect.Code
+		// expected concrete fields on a success response; zero values mean
+		// "assert this field is zero" (empty response).
+		expectName        string
+		expectImage       string
+		expectTag         string
+		expectPort        int32
+		expectDescription string
+	}
+
+	tests := []struct {
+		name        string
+		email       string
+		scope       *consolev1.TemplateScopeRef
+		tmplName    string
+		cueTemplate string // if non-empty, seeded as a project-scope template with this name
+		orgTmpl     string // if non-empty, seeded as an org-scope template with tmplName in org namespace
+		want        want
+	}{
+		{
+			name:        "project-scope template with defaults block returns populated TemplateDefaults",
+			email:       ownerEmail,
+			scope:       projectScopeRef(project),
+			tmplName:    "httpbin",
+			cueTemplate: httpbinCue,
+			want: want{
+				expectName:        "httpbin",
+				expectImage:       "ghcr.io/mccutchen/go-httpbin",
+				expectTag:         "2.21.0",
+				expectPort:        8080,
+				expectDescription: "A simple HTTP Request & Response Service",
+			},
+		},
+		{
+			name:        "project-scope template without defaults block returns empty TemplateDefaults",
+			email:       ownerEmail,
+			scope:       projectScopeRef(project),
+			tmplName:    "bare",
+			cueTemplate: bareCue,
+			want:        want{}, // all zero values — empty TemplateDefaults, no error
+		},
+		{
+			name:     "missing project-scope template returns CodeNotFound",
+			email:    ownerEmail,
+			scope:    projectScopeRef(project),
+			tmplName: "does-not-exist",
+			want: want{
+				wantErr:  true,
+				wantCode: connect.CodeNotFound,
+			},
+		},
+		{
+			name:     "org-scope template returns empty TemplateDefaults (defaults are project-scope only)",
+			email:    ownerEmail,
+			scope:    orgScopeRef(org),
+			tmplName: "org-tmpl",
+			orgTmpl:  httpbinCue, // even with a defaults block, org scope returns empty
+			want:     want{},
+		},
+		{
+			name:        "caller without permission returns CodePermissionDenied",
+			email:       strangerEmail,
+			scope:       projectScopeRef(project),
+			tmplName:    "httpbin",
+			cueTemplate: httpbinCue,
+			want: want{
+				wantErr:  true,
+				wantCode: connect.CodePermissionDenied,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Seed namespaces for both project and org scopes so handlers can
+			// resolve either hierarchy.
+			objs := []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prj-" + project}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "org-" + org}},
+			}
+			if tt.cueTemplate != "" {
+				objs = append(objs, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.tmplName,
+						Namespace: "prj-" + project,
+						Labels: map[string]string{
+							v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+						},
+					},
+					Data: map[string]string{
+						CueTemplateKey: tt.cueTemplate,
+					},
+				})
+			}
+			if tt.orgTmpl != "" {
+				objs = append(objs, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.tmplName,
+						Namespace: "org-" + org,
+						Labels: map[string]string{
+							v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+						},
+					},
+					Data: map[string]string{
+						CueTemplateKey: tt.orgTmpl,
+					},
+				})
+			}
+			fakeClient := fake.NewClientset(objs...)
+
+			// Owner has read/write on both scopes; stranger has no grants.
+			shareUsers := map[string]string{ownerEmail: "owner"}
+
+			r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+			k8s := NewK8sClient(fakeClient, r)
+			handler := NewHandler(k8s, r, &stubRenderer{})
+			handler.WithProjectGrantResolver(&stubProjectGrantResolver{users: shareUsers})
+			handler.WithOrgGrantResolver(&stubOrgGrantResolver{users: shareUsers})
+
+			ctx := authedCtx(tt.email, nil)
+			resp, err := handler.GetTemplateDefaults(ctx, connect.NewRequest(&consolev1.GetTemplateDefaultsRequest{
+				Scope: tt.scope,
+				Name:  tt.tmplName,
+			}))
+
+			if tt.want.wantErr {
+				if err == nil {
+					t.Fatalf("expected error with code %v, got nil", tt.want.wantCode)
+				}
+				if connect.CodeOf(err) != tt.want.wantCode {
+					t.Fatalf("expected code %v, got %v (%v)", tt.want.wantCode, connect.CodeOf(err), err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if resp == nil || resp.Msg == nil {
+				t.Fatal("expected non-nil response")
+			}
+			if resp.Msg.Defaults == nil {
+				t.Fatal("expected non-nil Defaults on response (empty message, never nil pointer)")
+			}
+			d := resp.Msg.Defaults
+			if d.Name != tt.want.expectName {
+				t.Errorf("Name: expected %q, got %q", tt.want.expectName, d.Name)
+			}
+			if d.Image != tt.want.expectImage {
+				t.Errorf("Image: expected %q, got %q", tt.want.expectImage, d.Image)
+			}
+			if d.Tag != tt.want.expectTag {
+				t.Errorf("Tag: expected %q, got %q", tt.want.expectTag, d.Tag)
+			}
+			if d.Port != tt.want.expectPort {
+				t.Errorf("Port: expected %d, got %d", tt.want.expectPort, d.Port)
+			}
+			if d.Description != tt.want.expectDescription {
+				t.Errorf("Description: expected %q, got %q", tt.want.expectDescription, d.Description)
+			}
+		})
+	}
+}
+
+// TestGetTemplateDefaultsValidation verifies request-level input validation
+// that is independent of RBAC or storage state.
+func TestGetTemplateDefaultsValidation(t *testing.T) {
+	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+	k8s := NewK8sClient(fake.NewClientset(), r)
+	handler := NewHandler(k8s, r, &stubRenderer{})
+	handler.WithProjectGrantResolver(&stubProjectGrantResolver{})
+	handler.WithOrgGrantResolver(&stubOrgGrantResolver{})
+
+	t.Run("empty name returns CodeInvalidArgument", func(t *testing.T) {
+		_, err := handler.GetTemplateDefaults(
+			authedCtx("anyone@localhost", nil),
+			connect.NewRequest(&consolev1.GetTemplateDefaultsRequest{
+				Scope: projectScopeRef("p"),
+				Name:  "",
+			}),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected CodeInvalidArgument, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("missing claims returns CodeUnauthenticated", func(t *testing.T) {
+		_, err := handler.GetTemplateDefaults(
+			context.Background(),
+			connect.NewRequest(&consolev1.GetTemplateDefaultsRequest{
+				Scope: projectScopeRef("p"),
+				Name:  "foo",
+			}),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeUnauthenticated {
+			t.Errorf("expected CodeUnauthenticated, got %v", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("missing scope returns CodeInvalidArgument", func(t *testing.T) {
+		_, err := handler.GetTemplateDefaults(
+			authedCtx("anyone@localhost", nil),
+			connect.NewRequest(&consolev1.GetTemplateDefaultsRequest{
+				Scope: nil,
+				Name:  "foo",
+			}),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("expected CodeInvalidArgument, got %v", connect.CodeOf(err))
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Implements ADR 027 phase 3 (backend half) for plan #925:

- Adds `Handler.GetTemplateDefaults` in `console/templates/handler.go`. Mirrors `GetTemplate` for scope resolution and `PermissionTemplatesRead` RBAC; returns `CodeNotFound` for missing templates, `CodePermissionDenied` for unauthorized callers. Non-project scopes and project templates without a `defaults` block return an empty `TemplateDefaults` message (never nil, never an error) so the UI can call uniformly. `ExtractDefaults` is reused verbatim — inline `*` defaults on `input` stay intentionally unreadable per ADR 027 section 7.
- Adds a top-level `defaults: #ProjectInput & { ... }` block to `console/templates/example_httpbin.cue` and rewires `input` via `*defaults.field | _`. Adds `description`; leaves `command` and `args` unset so the frontend's empty-slice path stays exercised. `example_httpbin_platform.cue` is not modified — it is org-scope (defaults are project-scope only). `default_template.cue` already complied and is unchanged.
- Table-driven handler tests (`TestGetTemplateDefaults`, `TestGetTemplateDefaultsValidation`) cover populated/empty defaults, NotFound, org-scope empty response, PermissionDenied, and input validation.
- `TestExtractDefaults` gains three cases: the shipped `ExampleHttpbinTemplate` regression guard, plus the exact inline-only (before) and authored-defaults (after) CUE shapes from issue #925.

Closes #928

## Test plan
- [x] `go test ./console/templates/... -count=1` passes
- [x] `go test ./console/deployments/... -run TestCueRenderer_HttpbinExample -count=1` passes (example template still renders)
- [x] `make test` — 899/899 frontend + full Go suite green
- [x] `make lint` — 28 pre-existing issues on `origin/main`, none introduced by this patch
- [ ] CI Unit Tests + Lint + E2E

Generated with [Claude Code](https://claude.com/claude-code) · agent-3