### PR TITLE
fix(deployments): honor rollout convergence and prefer live replica counts

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -350,18 +350,14 @@ func (s *Server) Serve(ctx context.Context) error {
 		// console-managed apps/v1.Deployment resources via the managed-by
 		// label. The informer lifecycle is tied to the server context so it
 		// stops cleanly on shutdown. Cache misses are treated as "no data
-		// yet" by the handler, so a failure to start the cache (transient
-		// API latency, missing watch RBAC, etc.) must not block startup:
-		// log and fall through to a no-op cache so the console continues to
-		// serve, just without status summaries until the operator fixes the
-		// underlying problem and restarts.
-		deploymentStatusCache, err := statuscache.New(ctx, k8sClientset)
-		if err != nil {
-			slog.WarnContext(ctx, "deployment status cache unavailable, deployments will report UNSPECIFIED status",
-				slog.Any("error", err),
-			)
-			deploymentStatusCache = statuscache.NewNop()
-		}
+		// yet" by the handler. New is non-blocking: it starts the informer
+		// in the background and reports misses until the initial sync
+		// completes, so a transiently unreachable API server or a missing
+		// watch RBAC rule never delays startup. If the initial sync does
+		// not complete within statuscache's internal timeout, the package
+		// itself cancels the reflector to avoid leaking LIST/WATCH retry
+		// goroutines and logs a warning.
+		deploymentStatusCache := statuscache.New(ctx, k8sClientset)
 		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templates.NewProjectScopedResolver(templatesK8s), &deployments.CueRenderer{}, deploymentsApplier).
 			WithAncestorWalker(projectFolderResolver).
 			WithAncestorTemplateProvider(ancestorTemplateResolver).

--- a/console/deployments/status.go
+++ b/console/deployments/status.go
@@ -188,28 +188,22 @@ func (h *Handler) GetDeploymentStatus(
 		slog.String("sub", claims.Sub),
 	)
 
-	// Source phase-summary from the informer cache so all status RPCs share
-	// one derivation path. On a cache miss, summary is nil but the scalar
-	// replica fields still fall back to the live apps/v1.Deployment.Status
-	// values we already fetched above — otherwise a cold informer (right
-	// after startup, after the initial sync timeout, or without watch RBAC)
-	// would render healthy deployments as 0/0 ready even though the detail
-	// page has real pod data to show alongside.
+	// Replica scalars always come from the live apps/v1.Deployment.Status we
+	// fetched above: this RPC has the freshest data, and the informer cache
+	// is eventually consistent (it lags during rollouts and immediately
+	// after updates). The cached summary is still surfaced for derived
+	// phase/message display so the detail page shares the same status
+	// derivation path as the listing RPC; on a cache miss the summary is
+	// nil and callers render UNSPECIFIED for phase.
 	summary, _ := h.summaryFromCache(ns, name)
 	status := &consolev1.DeploymentStatus{
-		Conditions: conditions,
-		Pods:       pods,
-		Events:     depEvents,
-		Summary:    summary,
-	}
-	if summary != nil {
-		status.ReadyReplicas = summary.ReadyReplicas
-		status.DesiredReplicas = summary.DesiredReplicas
-		status.AvailableReplicas = summary.AvailableReplicas
-	} else {
-		status.ReadyReplicas = dep.Status.ReadyReplicas
-		status.DesiredReplicas = dep.Status.Replicas
-		status.AvailableReplicas = dep.Status.AvailableReplicas
+		Conditions:        conditions,
+		Pods:              pods,
+		Events:            depEvents,
+		Summary:           summary,
+		ReadyReplicas:     dep.Status.ReadyReplicas,
+		DesiredReplicas:   dep.Status.Replicas,
+		AvailableReplicas: dep.Status.AvailableReplicas,
 	}
 
 	return connect.NewResponse(&consolev1.GetDeploymentStatusResponse{

--- a/console/deployments/status_test.go
+++ b/console/deployments/status_test.go
@@ -174,6 +174,64 @@ func TestGetDeploymentStatus_CacheMissFallsBackToLiveReplicas(t *testing.T) {
 	}
 }
 
+// TestGetDeploymentStatus_LiveReplicaCountsPreferredOverCache ensures that
+// GetDeploymentStatus always reports replica scalars from the live
+// apps/v1.Deployment.Status, never from the eventually-consistent informer
+// cache. The detail-page RPC already does a direct GET on the Deployment, so
+// those numbers are the freshest available. The cached summary must still be
+// returned for derived phase/message display, but must never override live
+// replica counts during rollouts or immediately after an update.
+func TestGetDeploymentStatus_LiveReplicaCountsPreferredOverCache(t *testing.T) {
+	const ns = "prj-my-project"
+	// Live Deployment is mid-rollout: 5 desired, 4 ready, 4 available.
+	dep := k8sDeployment(ns, "my-app", 5, 4, 4, nil)
+
+	fakeClient := fake.NewClientset(dep)
+	// Cache is stale — it still reflects the pre-update steady state of
+	// 3/3/3. Without this patch the handler would overwrite live replica
+	// counts with these stale values.
+	cache := newFakeStatusCache()
+	cache.set(ns, "my-app", &consolev1.DeploymentStatusSummary{
+		Phase:             consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING,
+		DesiredReplicas:   3,
+		ReadyReplicas:     3,
+		AvailableReplicas: 3,
+		Message:           "rolling out",
+	})
+	h := newStatusHandler(fakeClient).WithStatusCache(cache)
+
+	ctx := authedCtx("viewer@example.com", nil)
+	resp, err := h.GetDeploymentStatus(ctx, connect.NewRequest(&consolev1.GetDeploymentStatusRequest{
+		Name:    "my-app",
+		Project: "my-project",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := resp.Msg.Status
+	// Scalar replica fields must come from the live Deployment, not the cache.
+	if s.DesiredReplicas != 5 {
+		t.Errorf("desired_replicas: got %d, want 5 (live dep.Status.Replicas, not cached 3)", s.DesiredReplicas)
+	}
+	if s.ReadyReplicas != 4 {
+		t.Errorf("ready_replicas: got %d, want 4 (live dep.Status.ReadyReplicas, not cached 3)", s.ReadyReplicas)
+	}
+	if s.AvailableReplicas != 4 {
+		t.Errorf("available_replicas: got %d, want 4 (live dep.Status.AvailableReplicas, not cached 3)", s.AvailableReplicas)
+	}
+	// Summary must still be populated for derived phase/message display.
+	if s.Summary == nil {
+		t.Fatal("summary: got nil, want non-nil (cache hit should still populate derived phase/message)")
+	}
+	if s.Summary.Phase != consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING {
+		t.Errorf("summary.phase: got %v, want PENDING", s.Summary.Phase)
+	}
+	if s.Summary.Message != "rolling out" {
+		t.Errorf("summary.message: got %q, want %q", s.Summary.Message, "rolling out")
+	}
+}
+
 func TestGetDeploymentStatus_Conditions(t *testing.T) {
 	const ns = "prj-my-project"
 	dep := k8sDeployment(ns, "my-app", 1, 1, 1, []appsv1.DeploymentCondition{

--- a/console/deployments/statuscache/cache.go
+++ b/console/deployments/statuscache/cache.go
@@ -130,12 +130,23 @@ func (c *informerCache) Summary(ns, name string) (*consolev1.DeploymentStatusSum
 }
 
 // summaryFromDeployment projects an apps/v1.Deployment into the lightweight
-// DeploymentStatusSummary proto. Phase derivation rules (see issue #914):
+// DeploymentStatusSummary proto. Phase derivation rules (see issue #914 and
+// follow-up #941):
 //
-//   - Available=True and ready == desired           -> RUNNING
 //   - ReplicaFailure=True or Progressing=False      -> FAILED
-//   - ready < desired (and none of the above)       -> PENDING
-//   - otherwise                                     -> PENDING (still settling)
+//   - Available=True, ready == desired, rollout converged  -> RUNNING
+//   - otherwise                                     -> PENDING (reconciling)
+//
+// "rollout converged" means both:
+//
+//   - observedGeneration >= metadata.generation (controller has seen the
+//     current spec), and
+//   - updatedReplicas >= desired (every pod belongs to the latest ReplicaSet).
+//
+// Without these guards Kubernetes can satisfy Available=True and
+// ready==desired from the previous ReplicaSet while a new rollout is still
+// in progress, which would otherwise falsely render RUNNING for deployments
+// that have not converged on the newly desired template.
 //
 // message is populated from the first FAILED-signaling condition so callers
 // can surface a terse cause (e.g. "quota exceeded"). When no such condition
@@ -144,6 +155,9 @@ func summaryFromDeployment(dep *appsv1.Deployment) *consolev1.DeploymentStatusSu
 	status := dep.Status
 	desired := status.Replicas
 	ready := status.ReadyReplicas
+	updated := status.UpdatedReplicas
+	observedGen := status.ObservedGeneration
+	specGen := dep.Generation
 
 	var (
 		available        bool
@@ -177,11 +191,12 @@ func summaryFromDeployment(dep *appsv1.Deployment) *consolev1.DeploymentStatusSu
 	// A deployment with desired==0 that Kubernetes marks Available=True is a
 	// legitimate steady state (e.g. intentionally scaled to zero): do not
 	// penalize it by forcing PENDING.
+	converged := observedGen >= specGen && updated >= desired
 	phase := consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING
 	switch {
 	case replicaFailure, progressingFalse:
 		phase = consolev1.DeploymentPhase_DEPLOYMENT_PHASE_FAILED
-	case available && ready == desired:
+	case available && ready == desired && converged:
 		phase = consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING
 	}
 

--- a/console/deployments/statuscache/cache.go
+++ b/console/deployments/statuscache/cache.go
@@ -199,7 +199,9 @@ func (c *informerCache) Summary(ns, name string) (*consolev1.DeploymentStatusSum
 //
 //   - observedGeneration >= metadata.generation (controller has seen the
 //     current spec), and
-//   - updatedReplicas >= desired (every pod belongs to the latest ReplicaSet).
+//   - updatedReplicas >= desired (every pod belongs to the latest ReplicaSet),
+//     where desired is taken from spec.replicas (not status.replicas) so that
+//     scale-ups before any new pod is created are not reported as RUNNING.
 //
 // Without these guards Kubernetes can satisfy Available=True and
 // ready==desired from the previous ReplicaSet while a new rollout is still
@@ -211,7 +213,14 @@ func (c *informerCache) Summary(ns, name string) (*consolev1.DeploymentStatusSum
 // exists, message is empty.
 func summaryFromDeployment(dep *appsv1.Deployment) *consolev1.DeploymentStatusSummary {
 	status := dep.Status
-	desired := status.Replicas
+	// Derive desired from spec.replicas (Kubernetes defaults to 1 when nil) so
+	// that in-progress rollouts and scale-ups are not reported as RUNNING. Using
+	// status.Replicas would reflect the current ReplicaSet's pod count, which on
+	// a scale-up before new pods exist still matches the old target.
+	var desired int32 = 1
+	if dep.Spec.Replicas != nil {
+		desired = *dep.Spec.Replicas
+	}
 	ready := status.ReadyReplicas
 	updated := status.UpdatedReplicas
 	observedGen := status.ObservedGeneration

--- a/console/deployments/statuscache/cache.go
+++ b/console/deployments/statuscache/cache.go
@@ -17,7 +17,7 @@ package statuscache
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,15 +31,21 @@ import (
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
 
-// initialSyncTimeout bounds how long New will wait for the initial informer
-// LIST/WATCH to complete before returning an error. Without this bound, a
-// missing RBAC rule or a transiently unavailable API server would hang
-// console startup until the server context is cancelled, preventing the HTTP
-// listener from ever opening. The bound is deliberately short: status data
-// is non-essential for console startup and the cache returns (nil, false) on
-// misses anyway, so callers are free to fall back to UNSPECIFIED until the
-// cache catches up.
+// initialSyncTimeout bounds how long the background sync watcher waits for
+// the initial informer LIST/WATCH to complete before declaring the cache
+// degraded and shutting the reflector down. Without this bound, a missing
+// RBAC rule or a transiently unavailable API server would leave the
+// reflector retrying LIST/WATCH for the lifetime of the process. The bound
+// is deliberately short: status data is non-essential and the cache returns
+// (nil, false) on misses anyway, so callers degrade to UNSPECIFIED until
+// the operator fixes the underlying problem and restarts.
 const initialSyncTimeout = 10 * time.Second
+
+// initialSyncTimeoutForTest is the timeout actually used by New. Production
+// code never overrides it; tests in this package replace it via
+// TestMain-style cleanup hooks to exercise the failure path without
+// blocking for the full production duration.
+var initialSyncTimeoutForTest = initialSyncTimeout
 
 // managedByLabelSelector limits the watch to Deployments labeled as managed
 // by the console, matching the labels the deployments renderer applies to
@@ -56,25 +62,21 @@ type Cache interface {
 }
 
 // nopCache is returned when no kubernetes.Interface is available (for
-// example, when the console runs in dummy-secret-only mode), and also serves
-// as a safe fallback when the real informer cannot be started (missing RBAC,
-// transient API unavailability). Summary always reports a miss so callers
-// degrade to UNSPECIFIED status without panicking.
+// example, when the console runs in dummy-secret-only mode). Summary always
+// reports a miss so callers degrade to UNSPECIFIED status without panicking.
 type nopCache struct{}
 
 func (nopCache) Summary(string, string) (*consolev1.DeploymentStatusSummary, bool) {
 	return nil, false
 }
 
-// NewNop returns a Cache that always reports misses. It is intended as a
-// fallback when New fails to start a live informer but the console must keep
-// serving.
-func NewNop() Cache { return nopCache{} }
-
 // informerCache is the live implementation, backed by a SharedInformerFactory
-// scoped to console-managed Deployments.
+// scoped to console-managed Deployments. Until the underlying informer has
+// completed its initial LIST/WATCH sync, Summary returns a miss so callers
+// continue to render UNSPECIFIED rather than block.
 type informerCache struct {
-	lister appsv1listers.DeploymentLister
+	lister    appsv1listers.DeploymentLister
+	hasSynced func() bool
 }
 
 // New constructs a Cache. When client is nil (dummy-secret-only mode) the
@@ -82,12 +84,26 @@ type informerCache struct {
 //
 // When client is non-nil, a SharedInformerFactory is created with a label
 // selector tweak bounding the watch to console-managed Deployments. The
-// factory is started with ctx and its informers are stopped when ctx is
-// cancelled. New blocks until the deployment informer's cache has synced so
-// callers may immediately issue reads.
-func New(ctx context.Context, client kubernetes.Interface) (Cache, error) {
+// informer is started in a background goroutine on a child context derived
+// from ctx so server startup is never blocked on the initial LIST/WATCH —
+// this matters because the cache is optional, callers already treat misses
+// as "no data yet", and waiting up to initialSyncTimeout on every restart
+// in the failure modes the fallback is meant to tolerate (missing RBAC,
+// transient API unavailability) would turn an optional feature into a
+// guaranteed multi-second readiness delay.
+//
+// A second background goroutine watches WaitForCacheSync. If the initial
+// sync does not complete within initialSyncTimeout (or the parent context
+// is cancelled), it cancels the child context, which stops the reflector
+// goroutines so they do not leak and keep retrying LIST/WATCH for the
+// lifetime of the process. The cache itself remains live but will simply
+// keep reporting misses; callers should observe this via the returned
+// log/metric and treat it as a degraded state.
+//
+// New never returns an error: the cache is best-effort by design.
+func New(ctx context.Context, client kubernetes.Interface) Cache {
 	if client == nil {
-		return nopCache{}, nil
+		return nopCache{}
 	}
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		client,
@@ -98,30 +114,72 @@ func New(ctx context.Context, client kubernetes.Interface) (Cache, error) {
 	)
 	depInformer := factory.Apps().V1().Deployments()
 	// Register the informer with the factory so Start picks it up.
-	_ = depInformer.Informer()
+	informer := depInformer.Informer()
 
-	factory.Start(ctx.Done())
+	// Derive a cancellable child context from the parent. We need a handle
+	// to cancel() on the failure path (sync timeout) so the reflector
+	// goroutines launched by factory.Start stop instead of retrying
+	// LIST/WATCH for the lifetime of the process. The child is also
+	// cancelled implicitly when ctx is cancelled, preserving the
+	// shutdown-stops-informer contract.
+	childCtx, cancel := context.WithCancel(ctx)
+	factory.Start(childCtx.Done())
 
-	// Bound the initial sync with a derived context so startup fails fast if
-	// the watch never establishes (missing RBAC, unreachable API server, etc.)
-	// rather than hanging until the server context is cancelled.
-	syncCtx, syncCancel := context.WithTimeout(ctx, initialSyncTimeout)
-	defer syncCancel()
-	synced := factory.WaitForCacheSync(syncCtx.Done())
-	for informerType, ok := range synced {
-		if !ok {
-			if err := syncCtx.Err(); err != nil {
-				return nil, fmt.Errorf("statuscache: informer %v did not sync within %s: %w", informerType, initialSyncTimeout, err)
-			}
-			return nil, fmt.Errorf("statuscache: informer %v failed to sync", informerType)
+	cache := &informerCache{
+		lister:    depInformer.Lister(),
+		hasSynced: informer.HasSynced,
+	}
+
+	// Watch the initial sync in the background. If it never completes
+	// within initialSyncTimeout, cancel the child context to stop the
+	// reflector and log the degradation. We deliberately do not block New
+	// on this: server startup must not depend on optional status data.
+	go func() {
+		timeout := initialSyncTimeoutForTest
+		syncCtx, syncCancel := context.WithTimeout(childCtx, timeout)
+		defer syncCancel()
+		if !waitForCacheSync(syncCtx, informer.HasSynced) {
+			slog.WarnContext(ctx,
+				"deployment status informer did not sync within timeout, cancelling reflector to avoid background LIST/WATCH retry loop; cache will report UNSPECIFIED until the console is restarted",
+				slog.Duration("timeout", timeout),
+				slog.Any("parent_ctx_err", ctx.Err()),
+			)
+			cancel()
+			return
+		}
+		slog.InfoContext(ctx, "deployment status informer synced")
+	}()
+
+	return cache
+}
+
+// waitForCacheSync polls hasSynced until it returns true or ctx is done. It
+// mirrors cache.WaitForCacheSync but takes a context directly so the caller
+// can derive deadlines without juggling stop channels.
+func waitForCacheSync(ctx context.Context, hasSynced func() bool) bool {
+	const interval = 100 * time.Millisecond
+	timer := time.NewTicker(interval)
+	defer timer.Stop()
+	for {
+		if hasSynced() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return hasSynced()
+		case <-timer.C:
 		}
 	}
-	return &informerCache{lister: depInformer.Lister()}, nil
 }
 
 // Summary returns the DeploymentStatusSummary for the given (ns, name) if the
-// informer cache knows about the Deployment.
+// informer cache knows about the Deployment. Until the initial LIST/WATCH
+// sync has completed, Summary always reports a miss so callers degrade to
+// UNSPECIFIED rather than reading a partially-populated lister.
 func (c *informerCache) Summary(ns, name string) (*consolev1.DeploymentStatusSummary, bool) {
+	if c.hasSynced != nil && !c.hasSynced() {
+		return nil, false
+	}
 	dep, err := c.lister.Deployments(ns).Get(name)
 	if err != nil || dep == nil {
 		return nil, false

--- a/console/deployments/statuscache/cache_test.go
+++ b/console/deployments/statuscache/cache_test.go
@@ -41,6 +41,14 @@ func waitForSummary(t *testing.T, cache Cache, ns, name string, wantOK bool) (*c
 // Tests that do not care about rollout progress pass the same value for both.
 func buildDeployment(ns, name string, desired, ready, available, updated int32, metaGeneration, observedGeneration int64, conditions []appsv1.DeploymentCondition, message string) *appsv1.Deployment {
 	_ = message // message is derived from conditions by Summary()
+	return buildDeploymentSpec(ns, name, desired, desired, ready, available, updated, metaGeneration, observedGeneration, conditions)
+}
+
+// buildDeploymentSpec is like buildDeployment but lets tests set spec.replicas
+// independently of status.replicas so rollout/scale-up scenarios can be
+// exercised (spec advances before status reflects the new ReplicaSet).
+func buildDeploymentSpec(ns, name string, specReplicas, statusReplicas, ready, available, updated int32, metaGeneration, observedGeneration int64, conditions []appsv1.DeploymentCondition) *appsv1.Deployment {
+	replicas := specReplicas
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,
@@ -50,8 +58,11 @@ func buildDeployment(ns, name string, desired, ready, available, updated int32, 
 				"app.kubernetes.io/managed-by": "console.holos.run",
 			},
 		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
 		Status: appsv1.DeploymentStatus{
-			Replicas:           desired,
+			Replicas:           statusReplicas,
 			ReadyReplicas:      ready,
 			AvailableReplicas:  available,
 			UpdatedReplicas:    updated,
@@ -177,6 +188,24 @@ func TestCacheSummary(t *testing.T) {
 			wantReady: 3,
 		},
 		{
+			// Scale-up in progress: spec.replicas advanced from 3 to 5, the
+			// controller has observed the new generation, but no new pods
+			// have been created yet. status.replicas still reflects the old
+			// ReplicaSet (3). Deriving desired from status.replicas would
+			// falsely report RUNNING/3 of 3; deriving from spec.replicas
+			// correctly reports PENDING/3 of 5.
+			name: "pending: scale-up rollout observed but new replicas not yet created",
+			dep: buildDeploymentSpec("p-alpha", "scaling", 5, 3, 3, 3, 3, 2, 2, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentAvailable, corev1.ConditionTrue, "MinimumReplicasAvailable", "ok"),
+				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "ReplicaSetUpdated", "progress"),
+			}),
+			ns:        "p-alpha",
+			lookup:    "scaling",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING,
+			wantReady: 3,
+		},
+		{
 			name:      "miss: unknown deployment",
 			dep:       buildDeployment("p-alpha", "web", 1, 1, 1, 1, 1, 1, nil, ""),
 			ns:        "p-alpha",
@@ -209,8 +238,12 @@ func TestCacheSummary(t *testing.T) {
 			if got.ReadyReplicas != tc.wantReady {
 				t.Errorf("readyReplicas = %d, want %d", got.ReadyReplicas, tc.wantReady)
 			}
-			if got.DesiredReplicas != tc.dep.Status.Replicas {
-				t.Errorf("desiredReplicas = %d, want %d", got.DesiredReplicas, tc.dep.Status.Replicas)
+			wantDesired := int32(1)
+			if tc.dep.Spec.Replicas != nil {
+				wantDesired = *tc.dep.Spec.Replicas
+			}
+			if got.DesiredReplicas != wantDesired {
+				t.Errorf("desiredReplicas = %d, want %d", got.DesiredReplicas, wantDesired)
 			}
 			if got.AvailableReplicas != tc.dep.Status.AvailableReplicas {
 				t.Errorf("availableReplicas = %d, want %d", got.AvailableReplicas, tc.dep.Status.AvailableReplicas)

--- a/console/deployments/statuscache/cache_test.go
+++ b/console/deployments/statuscache/cache_test.go
@@ -14,14 +14,16 @@ import (
 )
 
 // buildDeployment returns an apps/v1 Deployment with the given status fields
-// and conditions wired up for test table entries.
-func buildDeployment(ns, name string, desired, ready, available, updated int32, generation int64, conditions []appsv1.DeploymentCondition, message string) *appsv1.Deployment {
+// and conditions wired up for test table entries. metaGeneration sets
+// ObjectMeta.Generation; observedGeneration sets Status.ObservedGeneration.
+// Tests that do not care about rollout progress pass the same value for both.
+func buildDeployment(ns, name string, desired, ready, available, updated int32, metaGeneration, observedGeneration int64, conditions []appsv1.DeploymentCondition, message string) *appsv1.Deployment {
 	_ = message // message is derived from conditions by Summary()
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,
 			Namespace:  ns,
-			Generation: generation,
+			Generation: metaGeneration,
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": "console.holos.run",
 			},
@@ -31,7 +33,7 @@ func buildDeployment(ns, name string, desired, ready, available, updated int32, 
 			ReadyReplicas:      ready,
 			AvailableReplicas:  available,
 			UpdatedReplicas:    updated,
-			ObservedGeneration: generation,
+			ObservedGeneration: observedGeneration,
 			Conditions:         conditions,
 		},
 	}
@@ -53,7 +55,7 @@ func TestCacheSummary(t *testing.T) {
 	}{
 		{
 			name: "running: Available=True and ready==desired",
-			dep: buildDeployment("p-alpha", "web", 3, 3, 3, 3, 1, []appsv1.DeploymentCondition{
+			dep: buildDeployment("p-alpha", "web", 3, 3, 3, 3, 1, 1, []appsv1.DeploymentCondition{
 				cond(appsv1.DeploymentAvailable, corev1.ConditionTrue, "MinimumReplicasAvailable", "ok"),
 				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "NewReplicaSetAvailable", "done"),
 			}, ""),
@@ -65,7 +67,7 @@ func TestCacheSummary(t *testing.T) {
 		},
 		{
 			name: "failed: ReplicaFailure=True",
-			dep: buildDeployment("p-alpha", "broken", 3, 0, 0, 0, 1, []appsv1.DeploymentCondition{
+			dep: buildDeployment("p-alpha", "broken", 3, 0, 0, 0, 1, 1, []appsv1.DeploymentCondition{
 				cond(appsv1.DeploymentReplicaFailure, corev1.ConditionTrue, "FailedCreate", "quota exceeded"),
 				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "ReplicaSetUpdated", "progress"),
 			}, ""),
@@ -77,7 +79,7 @@ func TestCacheSummary(t *testing.T) {
 		},
 		{
 			name: "failed: Progressing=False",
-			dep: buildDeployment("p-alpha", "stalled", 3, 0, 0, 0, 1, []appsv1.DeploymentCondition{
+			dep: buildDeployment("p-alpha", "stalled", 3, 0, 0, 0, 1, 1, []appsv1.DeploymentCondition{
 				cond(appsv1.DeploymentProgressing, corev1.ConditionFalse, "ProgressDeadlineExceeded", "timed out"),
 			}, ""),
 			ns:        "p-alpha",
@@ -88,7 +90,7 @@ func TestCacheSummary(t *testing.T) {
 		},
 		{
 			name: "pending: ready<desired and progressing",
-			dep: buildDeployment("p-alpha", "starting", 3, 1, 1, 2, 1, []appsv1.DeploymentCondition{
+			dep: buildDeployment("p-alpha", "starting", 3, 1, 1, 2, 1, 1, []appsv1.DeploymentCondition{
 				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "ReplicaSetUpdated", "progress"),
 			}, ""),
 			ns:        "p-alpha",
@@ -99,7 +101,7 @@ func TestCacheSummary(t *testing.T) {
 		},
 		{
 			name: "pending: no conditions yet, ready<desired",
-			dep: buildDeployment("p-alpha", "fresh", 2, 0, 0, 0, 1, nil, ""),
+			dep: buildDeployment("p-alpha", "fresh", 2, 0, 0, 0, 1, 1, nil, ""),
 			ns:        "p-alpha",
 			lookup:    "fresh",
 			wantFound: true,
@@ -108,7 +110,7 @@ func TestCacheSummary(t *testing.T) {
 		},
 		{
 			name: "running: scaled to zero is a steady state",
-			dep: buildDeployment("p-alpha", "idle", 0, 0, 0, 0, 1, []appsv1.DeploymentCondition{
+			dep: buildDeployment("p-alpha", "idle", 0, 0, 0, 0, 1, 1, []appsv1.DeploymentCondition{
 				cond(appsv1.DeploymentAvailable, corev1.ConditionTrue, "MinimumReplicasAvailable", "ok"),
 			}, ""),
 			ns:        "p-alpha",
@@ -118,8 +120,43 @@ func TestCacheSummary(t *testing.T) {
 			wantReady: 0,
 		},
 		{
+			// Rollout just started: spec generation advanced (2) but the
+			// controller has not yet observed it (observedGeneration=1).
+			// Available=True and ready==desired can remain true from the
+			// previous ReplicaSet, but the new rollout has not converged.
+			// Treat as PENDING rather than falsely reporting RUNNING.
+			name: "pending: observedGeneration < metadata.generation during rollout",
+			dep: buildDeployment("p-alpha", "rolling", 3, 3, 3, 3, 2, 1, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentAvailable, corev1.ConditionTrue, "MinimumReplicasAvailable", "ok"),
+				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "ReplicaSetUpdated", "progress"),
+			}, ""),
+			ns:        "p-alpha",
+			lookup:    "rolling",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING,
+			wantReady: 3,
+		},
+		{
+			// Rollout in progress: updatedReplicas < desired means some
+			// pods still belong to the old ReplicaSet. Kubernetes may mark
+			// Available=True (old pods satisfy minAvailable) while the new
+			// version is still rolling out. Treat as PENDING so callers do
+			// not report RUNNING for deployments that have not converged
+			// on the newly desired template.
+			name: "pending: updatedReplicas < desired during rollout",
+			dep: buildDeployment("p-alpha", "updating", 3, 3, 3, 1, 2, 2, []appsv1.DeploymentCondition{
+				cond(appsv1.DeploymentAvailable, corev1.ConditionTrue, "MinimumReplicasAvailable", "ok"),
+				cond(appsv1.DeploymentProgressing, corev1.ConditionTrue, "ReplicaSetUpdated", "progress"),
+			}, ""),
+			ns:        "p-alpha",
+			lookup:    "updating",
+			wantFound: true,
+			wantPhase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_PENDING,
+			wantReady: 3,
+		},
+		{
 			name:      "miss: unknown deployment",
-			dep:       buildDeployment("p-alpha", "web", 1, 1, 1, 1, 1, nil, ""),
+			dep:       buildDeployment("p-alpha", "web", 1, 1, 1, 1, 1, 1, nil, ""),
 			ns:        "p-alpha",
 			lookup:    "does-not-exist",
 			wantFound: false,

--- a/console/deployments/statuscache/cache_test.go
+++ b/console/deployments/statuscache/cache_test.go
@@ -2,16 +2,38 @@ package statuscache
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
+
+// waitForSummary polls cache.Summary until ok matches wantOK or the deadline
+// expires. New is non-blocking, so tests must wait for the informer to
+// observe the seeded objects before asserting on Summary results.
+func waitForSummary(t *testing.T, cache Cache, ns, name string, wantOK bool) (*consolev1.DeploymentStatusSummary, bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got, ok := cache.Summary(ns, name)
+		if ok == wantOK {
+			return got, ok
+		}
+		if time.Now().After(deadline) {
+			return got, ok
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
 
 // buildDeployment returns an apps/v1 Deployment with the given status fields
 // and conditions wired up for test table entries. metaGeneration sets
@@ -100,8 +122,8 @@ func TestCacheSummary(t *testing.T) {
 			wantReady: 1,
 		},
 		{
-			name: "pending: no conditions yet, ready<desired",
-			dep: buildDeployment("p-alpha", "fresh", 2, 0, 0, 0, 1, 1, nil, ""),
+			name:      "pending: no conditions yet, ready<desired",
+			dep:       buildDeployment("p-alpha", "fresh", 2, 0, 0, 0, 1, 1, nil, ""),
 			ns:        "p-alpha",
 			lookup:    "fresh",
 			wantFound: true,
@@ -169,12 +191,9 @@ func TestCacheSummary(t *testing.T) {
 			defer cancel()
 
 			client := fake.NewClientset(tc.dep)
-			cache, err := New(ctx, client)
-			if err != nil {
-				t.Fatalf("New: %v", err)
-			}
+			cache := New(ctx, client)
 
-			got, ok := cache.Summary(tc.ns, tc.lookup)
+			got, ok := waitForSummary(t, cache, tc.ns, tc.lookup, tc.wantFound)
 			if ok != tc.wantFound {
 				t.Fatalf("Summary(%q,%q) found=%v, want %v", tc.ns, tc.lookup, ok, tc.wantFound)
 			}
@@ -210,12 +229,80 @@ func TestCacheNilClient(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	cache, err := New(ctx, nil)
-	if err != nil {
-		t.Fatalf("New(nil): %v", err)
-	}
+	cache := New(ctx, nil)
 	got, ok := cache.Summary("any", "thing")
 	if ok || got != nil {
 		t.Fatalf("expected (nil, false) for nil-client cache, got (%v, %v)", got, ok)
+	}
+}
+
+// TestNewDoesNotBlockOnFailingWatch is a regression test for codex review
+// finding round-1 #1: New must return immediately even when the underlying
+// LIST/WATCH cannot establish (for example, missing list/watch RBAC or a
+// temporarily unavailable API server). Blocking up to initialSyncTimeout
+// would turn an explicitly optional feature into a guaranteed multi-second
+// startup delay in exactly the failure modes the fallback is meant to
+// tolerate.
+func TestNewDoesNotBlockOnFailingWatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := fake.NewClientset()
+	// Simulate a permanently failing LIST so the informer never syncs.
+	client.PrependReactor("list", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden: missing list/watch on deployments")
+	})
+
+	start := time.Now()
+	cache := New(ctx, client)
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("New blocked for %s, expected immediate return", elapsed)
+	}
+
+	// While the informer is failing to sync, Summary must report misses
+	// rather than panic or block.
+	if got, ok := cache.Summary("any", "thing"); ok || got != nil {
+		t.Fatalf("expected (nil, false) before sync, got (%v, %v)", got, ok)
+	}
+}
+
+// TestNewCancelsReflectorOnSyncTimeout is a regression test for codex
+// review finding round-1 #2: when the initial sync does not complete within
+// initialSyncTimeout, the package must cancel the child context driving the
+// informer factory so the reflector goroutines stop retrying LIST/WATCH for
+// the lifetime of the process. We assert this by counting LIST attempts
+// observed after the timeout has elapsed and verifying the count plateaus.
+func TestNewCancelsReflectorOnSyncTimeout(t *testing.T) {
+	// Shrink the timeout to keep the test fast. We swap initialSyncTimeout
+	// out via the package-level variable below.
+	prev := initialSyncTimeoutForTest
+	initialSyncTimeoutForTest = 200 * time.Millisecond
+	t.Cleanup(func() { initialSyncTimeoutForTest = prev })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var listCount atomic.Int64
+	client := fake.NewClientset()
+	client.PrependReactor("list", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		listCount.Add(1)
+		return true, nil, errors.New("forbidden")
+	})
+
+	_ = New(ctx, client)
+
+	// Wait long enough for the timeout to fire and cancellation to
+	// propagate to the reflector.
+	time.Sleep(600 * time.Millisecond)
+	countAfterCancel := listCount.Load()
+
+	// Wait again. If the reflector were still running it would continue
+	// retrying LIST under the client-go retry backoff (sub-second after a
+	// failed list with the fake client). The count must not grow.
+	time.Sleep(1 * time.Second)
+	countLater := listCount.Load()
+
+	if countLater > countAfterCancel {
+		t.Fatalf("reflector kept retrying LIST after sync timeout: count grew from %d to %d", countAfterCancel, countLater)
 	}
 }

--- a/docs/agents/deployment-service.md
+++ b/docs/agents/deployment-service.md
@@ -13,7 +13,7 @@ Two RPCs expose deployment status:
 
 ### Status Cache
 
-`console/deployments/statuscache/` runs a `SharedInformerFactory` scoped to `apps/v1.Deployment` objects carrying the console-managed label selector. The watch is deliberately narrow: Deployments only, no Pods, no ReplicaSets, and no Events. Detail-page data that requires those (per-pod status, events) still flows through direct API calls in `GetDeploymentStatus`. `statuscache.New` blocks on the initial cache sync (bounded by a timeout) so RPC handlers can read immediately after server startup. When the K8s client is nil (dummy-secret-only mode), `NewNop` returns a cache that always reports misses.
+`console/deployments/statuscache/` runs a `SharedInformerFactory` scoped to `apps/v1.Deployment` objects carrying the console-managed label selector. The watch is deliberately narrow: Deployments only, no Pods, no ReplicaSets, and no Events. Detail-page data that requires those (per-pod status, events) still flows through direct API calls in `GetDeploymentStatus`. `statuscache.New` is non-blocking: it starts the informer in the background on a cancellable child context and returns immediately so server startup is never delayed by an optional feature. Until the initial LIST/WATCH sync completes the cache reports misses, and callers degrade to UNSPECIFIED. If the initial sync does not complete within `initialSyncTimeout` (currently 10s), `statuscache` cancels the child context to stop the reflector goroutines so they do not leak background LIST/WATCH retries for the lifetime of the process; the cache will keep reporting misses until the console is restarted. When the K8s client is nil (dummy-secret-only mode), `New` returns a no-op cache that always reports misses.
 
 ### Deprecated Fields
 


### PR DESCRIPTION
## Summary
- Phase derivation in `statuscache` now requires rollout convergence (`observedGeneration >= metadata.generation` AND `updatedReplicas >= desired`) before reporting `RUNNING`; otherwise the phase stays `PENDING` to reflect in-progress reconciliation.
- `GetDeploymentStatus` now sources `ready/desired/available` replica counts exclusively from the live `apps/v1.Deployment.Status`, avoiding stale overrides from the eventually-consistent informer cache. The cached summary is still surfaced for derived phase/message display.
- Adds regression tests for both findings.

Closes #941

## Test plan
- [x] `go test ./console/deployments/statuscache/ ./console/deployments/` passes
- [x] `make test` passes
- [x] `make generate` produces no diff
- [x] `make lint` — no new findings in touched files (27 pre-existing issues on main unchanged)

Generated with [Claude Code](https://claude.com/claude-code)