### PR TITLE
fix(console): send id_token instead of access_token for OIDC auth

### DIFF
--- a/frontend/src/lib/auth/AuthProvider.tsx
+++ b/frontend/src/lib/auth/AuthProvider.tsx
@@ -82,7 +82,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [userManager])
 
   useEffect(() => {
-    tokenRef.current = user?.access_token ?? null
+    tokenRef.current = user?.id_token ?? null
   }, [user])
 
   const login = useCallback(

--- a/frontend/src/lib/auth/AuthProvider.tsx
+++ b/frontend/src/lib/auth/AuthProvider.tsx
@@ -17,7 +17,6 @@ export interface AuthContextValue {
   isAuthenticated: boolean
   login: (returnTo?: string) => Promise<void>
   logout: () => Promise<void>
-  getAccessToken: () => string | null
   refreshTokens: () => Promise<void>
   lastRefreshStatus: 'idle' | 'success' | 'error'
   lastRefreshTime: Date | null
@@ -111,8 +110,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [userManager])
 
-  const getAccessToken = useCallback(() => user?.access_token ?? null, [user])
-
   const refreshTokens = useCallback(async () => {
     try {
       setLastRefreshStatus('idle')
@@ -140,13 +137,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isAuthenticated: !!user && !user.expired,
       login,
       logout,
-      getAccessToken,
       refreshTokens,
       lastRefreshStatus,
       lastRefreshTime,
       lastRefreshError,
     }),
-    [user, isLoading, error, login, logout, getAccessToken, refreshTokens, lastRefreshStatus, lastRefreshTime, lastRefreshError],
+    [user, isLoading, error, login, logout, refreshTokens, lastRefreshStatus, lastRefreshTime, lastRefreshError],
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/lib/transport.test.ts
+++ b/frontend/src/lib/transport.test.ts
@@ -18,7 +18,7 @@ function makeMockRequest(headers?: Record<string, string>): MockRequest {
   return { header: h } as unknown as MockRequest
 }
 
-function makeMockResponse(token?: string): MockResponse {
+function makeMockResponse(): MockResponse {
   return {} as unknown as MockResponse
 }
 

--- a/frontend/src/lib/transport.test.ts
+++ b/frontend/src/lib/transport.test.ts
@@ -52,28 +52,35 @@ describe('readStoredToken', () => {
     expect(readStoredToken()).toBeNull()
   })
 
-  it('returns the access_token from a valid oidc.user entry', () => {
+  it('returns the id_token from a valid oidc.user entry', () => {
     const futureExp = Math.floor(Date.now() / 1000) + 3600
     sessionStorage.setItem(
       'oidc.user:https://localhost:8443/dex:holos-console',
-      JSON.stringify({ access_token: 'valid-token-abc', expires_at: futureExp }),
+      JSON.stringify({
+        id_token: 'valid-id-token-abc',
+        access_token: 'valid-access-token-xyz',
+        expires_at: futureExp,
+      }),
     )
-    expect(readStoredToken()).toBe('valid-token-abc')
+    expect(readStoredToken()).toBe('valid-id-token-abc')
   })
 
   it('returns null when the stored token is expired', () => {
     const pastExp = Math.floor(Date.now() / 1000) - 60
     sessionStorage.setItem(
       'oidc.user:https://localhost:8443/dex:holos-console',
-      JSON.stringify({ access_token: 'expired-token', expires_at: pastExp }),
+      JSON.stringify({ id_token: 'expired-token', expires_at: pastExp }),
     )
     expect(readStoredToken()).toBeNull()
   })
 
-  it('returns null when access_token is missing from the stored entry', () => {
+  it('returns null when id_token is missing from the stored entry', () => {
     sessionStorage.setItem(
       'oidc.user:https://localhost:8443/dex:holos-console',
-      JSON.stringify({ expires_at: Math.floor(Date.now() / 1000) + 3600 }),
+      JSON.stringify({
+        access_token: 'only-access',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
     )
     expect(readStoredToken()).toBeNull()
   })
@@ -106,6 +113,33 @@ describe('createAuthInterceptor', () => {
     expect(next).toHaveBeenCalledTimes(1)
   })
 
+  it('attaches id_token (not access_token) as Bearer when sessionStorage has both', async () => {
+    // Seed sessionStorage with both an id_token and a different access_token,
+    // then pick up what readStoredToken selects. The Bearer header must carry
+    // the ID token, because the backend verifies aud == client_id (an
+    // ID-token property) and would reject the access token.
+    sessionStorage.setItem(
+      'oidc.user:https://localhost:8443/dex:holos-console',
+      JSON.stringify({
+        id_token: 'the-id-token',
+        access_token: 'the-access-token',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    )
+    try {
+      tokenRef.current = readStoredToken()
+      const interceptor = createAuthInterceptor()
+      const req = makeMockRequest()
+      const next = vi.fn().mockResolvedValue(makeMockResponse())
+
+      await interceptor(next)(req)
+
+      expect(req.header.get('Authorization')).toBe('Bearer the-id-token')
+    } finally {
+      sessionStorage.clear()
+    }
+  })
+
   it('does not set Authorization header when tokenRef is null', async () => {
     tokenRef.current = null
     const interceptor = createAuthInterceptor()
@@ -121,7 +155,7 @@ describe('createAuthInterceptor', () => {
   it('retries request after successful signinSilent on 401', async () => {
     tokenRef.current = 'old-token'
     const freshToken = 'fresh-token'
-    const mockSigninSilent = vi.fn().mockResolvedValue({ access_token: freshToken })
+    const mockSigninSilent = vi.fn().mockResolvedValue({ id_token: freshToken })
     vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
 
     const interceptor = createAuthInterceptor()
@@ -143,6 +177,30 @@ describe('createAuthInterceptor', () => {
     expect(tokenRef.current).toBe(freshToken)
     // The retried request must carry the fresh token.
     expect(req.header.get('Authorization')).toBe(`Bearer ${freshToken}`)
+  })
+
+  it('renewToken refreshes the ID token on 401 (not the access token)', async () => {
+    // When signinSilent returns a fresh User with both tokens, the retry
+    // must carry the id_token, matching what the backend verifier expects.
+    tokenRef.current = 'old-token'
+    const mockSigninSilent = vi
+      .fn()
+      .mockResolvedValue({ id_token: 'new-id', access_token: 'new-access' })
+    vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
+
+    const interceptor = createAuthInterceptor()
+    const req = makeMockRequest()
+    const response = makeMockResponse()
+
+    const next = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('unauthenticated', Code.Unauthenticated))
+      .mockResolvedValueOnce(response)
+
+    await interceptor(next)(req)
+
+    expect(tokenRef.current).toBe('new-id')
+    expect(req.header.get('Authorization')).toBe('Bearer new-id')
   })
 
   it('propagates renewal error when signinSilent fails', async () => {
@@ -167,7 +225,7 @@ describe('createAuthInterceptor', () => {
   it('does not retry a second 401 (prevents retry loops)', async () => {
     tokenRef.current = 'old-token'
     const freshToken = 'fresh-token'
-    const mockSigninSilent = vi.fn().mockResolvedValue({ access_token: freshToken })
+    const mockSigninSilent = vi.fn().mockResolvedValue({ id_token: freshToken })
     vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
 
     const interceptor = createAuthInterceptor()
@@ -207,7 +265,7 @@ describe('createAuthInterceptor', () => {
     // signinSilent returns a promise that resolves after a tick so concurrent
     // calls overlap.
     const mockSigninSilent = vi.fn().mockImplementation(
-      () => new Promise<{ access_token: string }>((resolve) => setTimeout(() => resolve({ access_token: freshToken }), 0))
+      () => new Promise<{ id_token: string }>((resolve) => setTimeout(() => resolve({ id_token: freshToken }), 0))
     )
     vi.mocked(getUserManager).mockReturnValue({ signinSilent: mockSigninSilent } as never)
 

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -2,8 +2,11 @@ import { createConnectTransport } from '@connectrpc/connect-web'
 import { ConnectError, Code, type Interceptor } from '@connectrpc/connect'
 import { getUserManager } from '@/lib/auth/userManager'
 
-// readStoredToken reads the access token from sessionStorage synchronously at
-// module load time. oidc-client-ts stores the user object under a key matching
+// readStoredToken reads the ID token from sessionStorage synchronously at
+// module load time. The backend's OIDC verifier authenticates the end user by
+// their ID token (aud == client_id); access tokens are not accepted because
+// some IdPs (e.g. Keycloak) mint them with a different audience.
+// oidc-client-ts stores the user object under a key matching
 // "oidc.user:<authority>:<client_id>". Reading it here ensures tokenRef is
 // populated before any React effect runs, eliminating the timing race where
 // child query hooks fire before AuthProvider's useEffect sets the token.
@@ -13,17 +16,17 @@ export function readStoredToken(): string | null {
     if (!key) return null
     const raw = sessionStorage.getItem(key)
     if (!raw) return null
-    const data = JSON.parse(raw) as { access_token?: string; expires_at?: number }
-    if (!data?.access_token) return null
+    const data = JSON.parse(raw) as { id_token?: string; expires_at?: number }
+    if (!data?.id_token) return null
     // Treat expired tokens as absent; silent renew in AuthProvider will fix them.
     if (data.expires_at && data.expires_at * 1000 < Date.now()) return null
-    return data.access_token
+    return data.id_token
   } catch {
     return null
   }
 }
 
-// Shared mutable ref for the current access token.
+// Shared mutable ref for the current ID token.
 // Initialized synchronously from sessionStorage so that the very first RPC
 // request (before any React effect runs) already carries the correct token for
 // returning authenticated users. AuthProvider keeps this current on
@@ -43,11 +46,11 @@ async function renewToken(): Promise<string> {
   renewalPromise = (async () => {
     const userManager = getUserManager()
     const user = await userManager.signinSilent()
-    if (!user?.access_token) {
-      throw new Error('signinSilent returned no access token')
+    if (!user?.id_token) {
+      throw new Error('signinSilent returned no id token')
     }
-    tokenRef.current = user.access_token
-    return user.access_token
+    tokenRef.current = user.id_token
+    return user.id_token
   })()
   try {
     return await renewalPromise

--- a/frontend/src/routes/_authenticated/-dev-tools.test.tsx
+++ b/frontend/src/routes/_authenticated/-dev-tools.test.tsx
@@ -49,7 +49,6 @@ function mockAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
     isLoading: false,
     login: vi.fn(),
     logout: vi.fn(),
-    getAccessToken: vi.fn(),
     refreshTokens: vi.fn(),
     lastRefreshStatus: 'idle' as const,
     lastRefreshTime: null,


### PR DESCRIPTION
## Summary

Fixes [HOL-525](https://linear.app/holos-run/issue/HOL-525/console-sends-access-token-instead-of-id-token-keycloak-aud-mismatch) — Keycloak `aud` mismatch breaks login.

- Frontend now attaches the OIDC **ID token** (not the access token) on every ConnectRPC request, so the backend's ID-token verifier accepts tokens from any spec-compliant OIDC provider.
- Root cause: backend's `LazyAuthInterceptor` in `console/rpc/auth.go` calls `provider.Verifier(&oidc.Config{ClientID: clientID})` which enforces `aud == clientID` — an ID-token property. Keycloak's default access token has `aud: ["account"]`, so verification failed. Dex happened to mint access tokens with `aud == client_id`, so the bug went latent there.
- No backend change. No IdP configuration change.

## Changes

| File | Change |
| -- | -- |
| `frontend/src/lib/transport.ts` | `readStoredToken` and `renewToken` now read `id_token` instead of `access_token` |
| `frontend/src/lib/auth/AuthProvider.tsx` | Effect syncs `tokenRef.current` from `user.id_token` |
| `frontend/src/lib/transport.test.ts` | Fixtures updated to include `id_token`; added explicit test that seeds both tokens and asserts the Bearer header is the ID token; added a silent-renew regression test |

### Docs not updated in this PR

The Linear plan references `docs/agents/authentication.md` and `docs/agents/ui-architecture.md`, but those files were removed from the repo in ddc60e0 ("move docs to project planning location"). The relocated docs in the planning vault should be updated in a follow-up.

## Test plan

- [x] `make test-ui` — 912 passed, including the new id_token tests in `transport.test.ts`
- [x] `make vet` — clean
- [ ] CI: `test`, `e2e`, `lint` (build+generate) all green
- [ ] Manual verification against Keycloak (`ci-holos-paas`): decoded Bearer JWT has `typ: "ID"` and `aud == client-id`; pod logs no longer show `expected audience ... got ["account"]`
- [ ] Manual verification against local Dex (`make run` + `make dev` + login as `admin/verysecret`): `GetTemplateDefaults` RPC succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)