### PR TITLE
feat(console): extract output.url in render pipeline and surface via GetDeploymentRenderPreview

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -870,12 +870,14 @@ func (h *Handler) GetDeploymentRenderPreview(
 	// Extract structured JSON fields from the grouped result if render succeeded.
 	var defaultsJSON, platformInputJSON, projectInputJSON *string
 	var platformResourcesStructJSON, projectResourcesStructJSON *string
+	var output *consolev1.DeploymentOutput
 	if grouped != nil {
 		defaultsJSON = grouped.DefaultsJSON
 		platformInputJSON = grouped.PlatformInputJSON
 		projectInputJSON = grouped.ProjectInputJSON
 		platformResourcesStructJSON = grouped.PlatformResourcesStructJSON
 		projectResourcesStructJSON = grouped.ProjectResourcesStructJSON
+		output = deploymentOutputFromJSON(ctx, project, name, grouped.OutputJSON)
 	}
 
 	return connect.NewResponse(&consolev1.GetDeploymentRenderPreviewResponse{
@@ -893,7 +895,37 @@ func (h *Handler) GetDeploymentRenderPreview(
 		ProjectInputJson:               projectInputJSON,
 		PlatformResourcesStructuredJson: platformResourcesStructJSON,
 		ProjectResourcesStructuredJson:  projectResourcesStructJSON,
+		Output:                          output,
 	}), nil
+}
+
+// deploymentOutputFromJSON unmarshals the evaluated `output` CUE section JSON
+// into a DeploymentOutput proto message. Returns nil when outputJSON is nil,
+// points to empty content, or cannot be parsed as JSON. A malformed OutputJSON
+// is treated as non-fatal: a warning is logged and the handler leaves the
+// response field unset rather than erroring the RPC. A valid but empty JSON
+// object (e.g. `{}`) produces a non-nil DeploymentOutput with zero values so
+// the frontend — not the backend — decides whether to render.
+func deploymentOutputFromJSON(ctx context.Context, project, name string, outputJSON *string) *consolev1.DeploymentOutput {
+	if outputJSON == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(*outputJSON)
+	if raw == "" {
+		return nil
+	}
+	var parsed struct {
+		Url string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		slog.WarnContext(ctx, "failed to unmarshal OutputJSON into DeploymentOutput",
+			slog.String("project", project),
+			slog.String("name", name),
+			slog.Any("error", err),
+		)
+		return nil
+	}
+	return &consolev1.DeploymentOutput{Url: parsed.Url}
 }
 
 // checkProjectAccess verifies that the user has the given permission via project cascade grants.

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -97,6 +97,10 @@ type stubRenderer struct {
 	called       bool
 	lastPlatform v1alpha2.PlatformInput
 	lastProject  v1alpha2.ProjectInput
+	// outputJSON, when non-nil, is copied onto GroupedResources.OutputJSON in
+	// the RenderGrouped* methods so tests can simulate a template producing an
+	// `output` block.
+	outputJSON *string
 }
 
 func (s *stubRenderer) Render(_ context.Context, _ string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
@@ -117,14 +121,14 @@ func (s *stubRenderer) RenderGrouped(_ context.Context, _ string, platform v1alp
 	s.called = true
 	s.lastPlatform = platform
 	s.lastProject = project
-	return &GroupedResources{Project: s.resources}, s.err
+	return &GroupedResources{Project: s.resources, OutputJSON: s.outputJSON}, s.err
 }
 
 func (s *stubRenderer) RenderGroupedWithAncestorTemplates(_ context.Context, _ string, _ []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
 	s.called = true
 	s.lastPlatform = platform
 	s.lastProject = project
-	return &GroupedResources{Project: s.resources}, s.err
+	return &GroupedResources{Project: s.resources, OutputJSON: s.outputJSON}, s.err
 }
 
 // stubApplier implements ResourceApplier for tests.
@@ -1217,6 +1221,112 @@ func TestHandler_GetDeploymentRenderPreview(t *testing.T) {
 			t.Errorf("expected cue_project_input to contain image, got: %q", resp.Msg.CueProjectInput)
 		}
 	})
+
+	t.Run("response.Output is nil when template has no output section", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc")
+		fakeClient := fake.NewClientset(ns, cm)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		// defaultHandler uses a stubRenderer with no outputJSON set, so the
+		// handler should see OutputJSON=nil and leave Output unset.
+		handler := defaultHandler(fakeClient, pr)
+
+		ctx := authedCtx("alice@example.com", nil)
+		req := connect.NewRequest(&consolev1.GetDeploymentRenderPreviewRequest{
+			Project: "my-project",
+			Name:    "web-app",
+		})
+		resp, err := handler.GetDeploymentRenderPreview(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Output != nil {
+			t.Errorf("expected response.Output to be nil when template has no output, got %+v", resp.Msg.Output)
+		}
+	})
+
+	t.Run("response.Output.Url is populated when template sets output.url", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc")
+		fakeClient := fake.NewClientset(ns, cm)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		k8s := NewK8sClient(fakeClient, testResolver())
+		outputJSON := `{"url":"https://web-app.example.com"}`
+		renderer := &stubRenderer{outputJSON: &outputJSON}
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, &stubApplier{})
+
+		ctx := authedCtx("alice@example.com", nil)
+		req := connect.NewRequest(&consolev1.GetDeploymentRenderPreviewRequest{
+			Project: "my-project",
+			Name:    "web-app",
+		})
+		resp, err := handler.GetDeploymentRenderPreview(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Output == nil {
+			t.Fatal("expected response.Output to be set, got nil")
+		}
+		if resp.Msg.Output.Url != "https://web-app.example.com" {
+			t.Errorf("expected Output.Url = https://web-app.example.com, got %q", resp.Msg.Output.Url)
+		}
+	})
+
+	t.Run("response.Output is set with empty Url when template declares output without url", func(t *testing.T) {
+		// Pitfall guard: `output: {}` produces an OutputJSON of `{}`; the
+		// backend must surface DeploymentOutput{Url: ""} (present-but-empty)
+		// and let the frontend decide whether to render.
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc")
+		fakeClient := fake.NewClientset(ns, cm)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		k8s := NewK8sClient(fakeClient, testResolver())
+		outputJSON := `{}`
+		renderer := &stubRenderer{outputJSON: &outputJSON}
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, &stubApplier{})
+
+		ctx := authedCtx("alice@example.com", nil)
+		req := connect.NewRequest(&consolev1.GetDeploymentRenderPreviewRequest{
+			Project: "my-project",
+			Name:    "web-app",
+		})
+		resp, err := handler.GetDeploymentRenderPreview(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.Msg.Output == nil {
+			t.Fatal("expected response.Output to be set (non-nil) for empty output block, got nil")
+		}
+		if resp.Msg.Output.Url != "" {
+			t.Errorf("expected Output.Url to be empty, got %q", resp.Msg.Output.Url)
+		}
+	})
+
+	t.Run("response.Output is nil when OutputJSON is not valid JSON", func(t *testing.T) {
+		// Malformed OutputJSON must not fail the RPC; the handler logs a
+		// warning and leaves Output unset.
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc")
+		fakeClient := fake.NewClientset(ns, cm)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		k8s := NewK8sClient(fakeClient, testResolver())
+		bad := `not json`
+		renderer := &stubRenderer{outputJSON: &bad}
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, &stubApplier{})
+
+		ctx := authedCtx("alice@example.com", nil)
+		req := connect.NewRequest(&consolev1.GetDeploymentRenderPreviewRequest{
+			Project: "my-project",
+			Name:    "web-app",
+		})
+		resp, err := handler.GetDeploymentRenderPreview(ctx, req)
+		if err != nil {
+			t.Fatalf("expected no error for malformed OutputJSON, got %v", err)
+		}
+		if resp.Msg.Output != nil {
+			t.Errorf("expected response.Output to be nil for malformed OutputJSON, got %+v", resp.Msg.Output)
+		}
+	})
 }
 
 // stubAncestorTemplateProvider implements AncestorTemplateProvider for tests.
@@ -1260,7 +1370,7 @@ func (r *trackingDeploymentRenderer) RenderGrouped(_ context.Context, _ string, 
 	r.calledRenderGrouped = true
 	r.lastPlatform = platform
 	r.lastProject = project
-	return &GroupedResources{Project: r.resources}, r.err
+	return &GroupedResources{Project: r.resources, OutputJSON: r.outputJSON}, r.err
 }
 
 func (r *trackingDeploymentRenderer) RenderGroupedWithAncestorTemplates(_ context.Context, _ string, sources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
@@ -1268,7 +1378,7 @@ func (r *trackingDeploymentRenderer) RenderGroupedWithAncestorTemplates(_ contex
 	r.lastAncestorSources = sources
 	r.lastPlatform = platform
 	r.lastProject = project
-	return &GroupedResources{Project: r.resources}, r.err
+	return &GroupedResources{Project: r.resources, OutputJSON: r.outputJSON}, r.err
 }
 
 func TestRenderResourcesWithAncestorProvider(t *testing.T) {

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -48,6 +48,11 @@ type GroupedResources struct {
 	ProjectInputJSON            *string
 	PlatformResourcesStructJSON *string
 	ProjectResourcesStructJSON  *string
+	// OutputJSON carries the JSON-serialized `output` section of the unified
+	// CUE value (ResourceSetSpec.output). Nil when the template has no
+	// `output` block or the section is non-concrete. Present-but-empty
+	// (e.g. `{}`) is preserved so the frontend can decide whether to render.
+	OutputJSON *string
 }
 
 // CueRenderer evaluates CUE templates with deployment parameters.
@@ -510,7 +515,7 @@ func extractCuePathJSON(unified cue.Value, cuePath string) (*string, error) {
 	return &s, nil
 }
 
-// populateStructuredJSON extracts the five structured JSON sections from the
+// populateStructuredJSON extracts the structured JSON sections from the
 // unified CUE value and sets the corresponding fields on the GroupedResources.
 // Extraction errors are logged but do not fail the render.
 func populateStructuredJSON(unified cue.Value, gr *GroupedResources) {
@@ -523,6 +528,7 @@ func populateStructuredJSON(unified cue.Value, gr *GroupedResources) {
 		{"input", &gr.ProjectInputJSON},
 		{"platformResources", &gr.PlatformResourcesStructJSON},
 		{"projectResources", &gr.ProjectResourcesStructJSON},
+		{"output", &gr.OutputJSON},
 	}
 	for _, p := range paths {
 		val, err := extractCuePathJSON(unified, p.cuePath)

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -2666,6 +2666,102 @@ func TestEvaluateStructuredGrouped(t *testing.T) {
 	})
 }
 
+// templateWithOutput declares an `output` block with a concrete URL so the
+// render pipeline can extract and surface it via OutputJSON.
+const templateWithOutput = `
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:   string
+	namespace: string
+}
+
+output: {
+	url: "https://example.com"
+}
+
+projectResources: {
+	namespacedResources: (platform.namespace): {
+		Deployment: (input.name): {
+			apiVersion: "apps/v1"
+			kind:       "Deployment"
+			metadata: {
+				name:      input.name
+				namespace: platform.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+					"app.kubernetes.io/name":       input.name
+				}
+			}
+			spec: {
+				selector: matchLabels: "app.kubernetes.io/name": input.name
+				template: {
+					metadata: labels: "app.kubernetes.io/name": input.name
+					spec: containers: [{
+						name:  input.name
+						image: input.image + ":" + input.tag
+					}]
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// templateWithEmptyOutput declares an `output` block without a concrete url so
+// the render pipeline should extract an empty JSON object. This verifies the
+// pitfall noted in HOL-545: `output: {}` must surface as a present but empty
+// DeploymentOutput, not be filtered out by the backend.
+const templateWithEmptyOutput = `
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:   string
+	namespace: string
+}
+
+output: {}
+
+projectResources: {
+	namespacedResources: (platform.namespace): {
+		Deployment: (input.name): {
+			apiVersion: "apps/v1"
+			kind:       "Deployment"
+			metadata: {
+				name:      input.name
+				namespace: platform.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+					"app.kubernetes.io/name":       input.name
+				}
+			}
+			spec: {
+				selector: matchLabels: "app.kubernetes.io/name": input.name
+				template: {
+					metadata: labels: "app.kubernetes.io/name": input.name
+					spec: containers: [{
+						name:  input.name
+						image: input.image + ":" + input.tag
+					}]
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
 // templateWithDefaults includes a defaults block so structured JSON extraction
 // can verify it is populated.
 const templateWithDefaults = `
@@ -2946,6 +3042,71 @@ func TestStructuredJSONExtraction(t *testing.T) {
 			if !json.Valid([]byte(*val)) {
 				t.Errorf("%s is not valid JSON: %s", name, *val)
 			}
+		}
+	})
+
+	t.Run("template without output leaves OutputJSON nil", func(t *testing.T) {
+		grouped, err := renderer.RenderGrouped(context.Background(),
+			validTemplate,
+			defaultPlatform(namespace),
+			defaultProject(),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if grouped.OutputJSON != nil {
+			t.Errorf("expected OutputJSON to be nil for template without output, got %q", *grouped.OutputJSON)
+		}
+	})
+
+	t.Run("template with output.url populates OutputJSON with the URL", func(t *testing.T) {
+		grouped, err := renderer.RenderGrouped(context.Background(),
+			templateWithOutput,
+			defaultPlatform(namespace),
+			defaultProject(),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if grouped.OutputJSON == nil {
+			t.Fatal("expected OutputJSON to be set for template with output.url, got nil")
+		}
+		if !json.Valid([]byte(*grouped.OutputJSON)) {
+			t.Fatalf("OutputJSON is not valid JSON: %s", *grouped.OutputJSON)
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(*grouped.OutputJSON), &out); err != nil {
+			t.Fatalf("failed to unmarshal OutputJSON: %v", err)
+		}
+		if out["url"] != "https://example.com" {
+			t.Errorf("expected output.url = https://example.com, got %v", out["url"])
+		}
+	})
+
+	t.Run("template with empty output block still populates OutputJSON", func(t *testing.T) {
+		// Pitfall guard: `output: {}` is a present-but-empty section; the backend
+		// must not filter it out. The frontend decides whether to render.
+		grouped, err := renderer.RenderGrouped(context.Background(),
+			templateWithEmptyOutput,
+			defaultPlatform(namespace),
+			defaultProject(),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if grouped.OutputJSON == nil {
+			t.Fatal("expected OutputJSON to be set for template with empty output block, got nil")
+		}
+		if !json.Valid([]byte(*grouped.OutputJSON)) {
+			t.Fatalf("OutputJSON is not valid JSON: %s", *grouped.OutputJSON)
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(*grouped.OutputJSON), &out); err != nil {
+			t.Fatalf("failed to unmarshal OutputJSON: %v", err)
+		}
+		// url key should not be present when it's not set in the template.
+		if _, ok := out["url"]; ok {
+			t.Errorf("expected no url key in OutputJSON for empty output, got %v", out["url"])
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Phase 2 of the HOL-543 plan (Phase 1 HOL-544 already merged).

- Add `OutputJSON *string` to `GroupedResources` and extend `populateStructuredJSON` so the render pipeline extracts the CUE `output` section through the existing `extractCuePathJSON` helper.
- In `GetDeploymentRenderPreview`, unmarshal `grouped.OutputJSON` into `*consolev1.DeploymentOutput` via a local anonymous struct and set it on the response. Malformed JSON logs a warning and leaves the field unset rather than erroring the RPC.
- Preserve the present-but-empty case: `output: {}` produces a non-nil `DeploymentOutput{Url: ""}` so the frontend decides whether to render.
- Extend `stubRenderer`/`trackingDeploymentRenderer` with an `outputJSON` field so handler tests can simulate templates with/without an `output` block.
- Table-driven tests in `render_test.go` cover absent, populated, and empty-but-present OutputJSON. Table-driven tests in `handler_test.go` cover the four Output states on the response (nil / populated url / empty url / malformed JSON).

Fixes HOL-545

## Test plan

- [x] `go test ./console/deployments/ -run TestStructuredJSONExtraction -count=1 -v` (new OutputJSON subtests pass; existing five sections pass)
- [x] `go test ./console/deployments/ -run TestHandler_GetDeploymentRenderPreview -count=1 -v` (four new Output subtests pass)
- [x] `go test ./... -count=1` (all Go packages pass)
- [x] `make test` (Go + frontend: 912 frontend tests pass; all Go packages pass)
- [x] `make vet` (clean)
- [ ] Local E2E not run; no k3d cluster in this environment. Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)