### PR TITLE
feat(frontend): render deployment output URL on Status tab

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -36,7 +36,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { ArrowLeft, CheckCircle2, Copy, Info, TriangleAlert, XCircle } from 'lucide-react'
+import { ArrowLeft, CheckCircle2, Copy, ExternalLink, Info, TriangleAlert, XCircle } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import type { EnvVar, Event, ContainerStatus } from '@/gen/holos/console/v1/deployments_pb'
 import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useGetDeploymentRenderPreview, useUpdateDeployment, useDeleteDeployment } from '@/queries/deployments'
@@ -302,6 +302,30 @@ export function DeploymentDetailPage({
               <div className="space-y-4">
                 <h3 className="text-sm font-medium">Status</h3>
                 <Separator />
+                {/*
+                  App URL row — surfaces the template-authored deployment URL
+                  from the render preview (`output.url`). Rendered only when
+                  the preview has resolved with a non-empty URL; while the
+                  preview is pending, `preview` is undefined so nothing
+                  renders (deliberate: avoids a flash on first load).
+                */}
+                {!isPreviewPending && preview?.output?.url ? (
+                  <div
+                    data-testid="deployment-output-url"
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <span className="text-muted-foreground w-36 shrink-0">App URL</span>
+                    <a
+                      href={preview.output.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 underline-offset-4 hover:underline break-all"
+                    >
+                      <span className="font-mono">{preview.output.url}</span>
+                      <ExternalLink aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+                    </a>
+                  </div>
+                ) : null}
                 {status ? (
                   <div className="space-y-3">
                     <div className="flex items-center gap-2 text-sm">

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -109,6 +109,22 @@ function isContainerError(cs: ContainerStatus): boolean {
   return false
 }
 
+/**
+ * Returns true only when `value` parses as a URL with an http: or https:
+ * scheme. Used to guard rendering of template-authored URLs (such as
+ * `output.url` from the render preview) into anchor hrefs so that unsafe
+ * schemes like `javascript:`, `data:`, `vbscript:`, and `file:` never
+ * reach the DOM. Parse failures (malformed URLs) also return false.
+ */
+export function isSafeHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 function DeploymentDetailRoute() {
   const { projectName, deploymentName } = Route.useParams()
   return <DeploymentDetailPage projectName={projectName} deploymentName={deploymentName} />
@@ -305,11 +321,14 @@ export function DeploymentDetailPage({
                 {/*
                   App URL row — surfaces the template-authored deployment URL
                   from the render preview (`output.url`). Rendered only when
-                  the preview has resolved with a non-empty URL; while the
-                  preview is pending, `preview` is undefined so nothing
-                  renders (deliberate: avoids a flash on first load).
+                  the preview has resolved with a non-empty URL that parses
+                  as an http:/https: URL. Non-HTTP(S) schemes (including
+                  javascript:, data:, vbscript:, file:) are dropped so they
+                  cannot reach an anchor href and execute script on click.
+                  While the preview is pending, `preview` is undefined so
+                  nothing renders (deliberate: avoids a flash on first load).
                 */}
-                {!isPreviewPending && preview?.output?.url ? (
+                {!isPreviewPending && preview?.output?.url && isSafeHttpUrl(preview.output.url) ? (
                   <div
                     data-testid="deployment-output-url"
                     className="flex items-center gap-2 text-sm"

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -1080,5 +1080,47 @@ describe('DeploymentDetailPage', () => {
       expect(screen.queryByTestId('deployment-output-url')).not.toBeInTheDocument()
       expect(screen.queryByText(/^App URL$/i)).not.toBeInTheDocument()
     })
+
+    // Security: the render preview carries template-authored data. A malicious
+    // or buggy template could set `output.url` to a scheme like `javascript:`,
+    // `data:`, `vbscript:`, or `file:`. Rendering such a value into an anchor
+    // href would let a click execute script or load attacker-controlled content
+    // in the console UI context. The component must validate the URL scheme
+    // and drop the row entirely when the scheme is not http: or https:.
+    it.each([
+      ['javascript: scheme', 'javascript:alert(1)'],
+      ['data: scheme', 'data:text/html,<script>alert(1)</script>'],
+      ['vbscript: scheme', 'vbscript:msgbox(1)'],
+      ['file: scheme', 'file:///etc/passwd'],
+      ['malformed URL', 'not a url'],
+      ['mailto: scheme', 'mailto:user@example.com'],
+    ])('does not render the App URL link for unsafe or malformed URLs (%s)', (_label, url) => {
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: { ...mockPreview, output: { url } },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      expect(screen.queryByTestId('deployment-output-url')).not.toBeInTheDocument()
+      expect(screen.queryByText(/^App URL$/i)).not.toBeInTheDocument()
+      // Also verify the raw value is not leaked into any href attribute.
+      const anchors = document.querySelectorAll('a')
+      anchors.forEach((a) => {
+        expect(a.getAttribute('href')).not.toBe(url)
+      })
+    })
+
+    it('renders the App URL link for an http: scheme', () => {
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: { ...mockPreview, output: { url: 'http://example.com/app' } },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      const link = screen.getByRole('link', { name: /http:\/\/example\.com\/app/ })
+      expect(link.getAttribute('href')).toBe('http://example.com/app')
+    })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -168,6 +168,7 @@ const mockPreview = {
   cueProjectInput: 'input: {\n  name: "api"\n  image: "ghcr.io/org/api"\n  tag: "v1.2.3"\n  port: 8080\n}',
   renderedYaml: 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: api\n',
   renderedJson: '[]',
+  output: undefined as { url: string } | undefined,
 }
 
 function setupMocks(userRole = Role.OWNER) {
@@ -1015,6 +1016,69 @@ describe('DeploymentDetailPage', () => {
       expect(screen.getByText('api-pod-1')).toBeInTheDocument()
       expect(screen.getByText('api-pod-2')).toBeInTheDocument()
       expect(screen.getByText('CrashLoopBackOff')).toBeInTheDocument()
+    })
+  })
+
+  // ── Output URL row tests ─────────────────────────────────────────────────
+  //
+  // The Status tab surfaces the template-authored deployment URL from the
+  // render preview response (`output.url`). The URL row is visible when the
+  // preview has resolved and `output.url` is a non-empty string; otherwise
+  // nothing is rendered. This mirrors the acceptance criteria on HOL-546.
+
+  describe('Output URL row', () => {
+    it('renders an App URL link when preview.output.url is a non-empty string', async () => {
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: { ...mockPreview, output: { url: 'https://example.com/app' } },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      const link = await screen.findByRole('link', { name: /https:\/\/example\.com\/app/ })
+      expect(link).toBeInTheDocument()
+      expect(link.getAttribute('href')).toBe('https://example.com/app')
+      expect(link.getAttribute('target')).toBe('_blank')
+      const rel = link.getAttribute('rel') ?? ''
+      expect(rel).toContain('noopener')
+      expect(rel).toContain('noreferrer')
+      expect(screen.getByText(/^App URL$/i)).toBeInTheDocument()
+    })
+
+    it('does not render the App URL row when preview.output is undefined', () => {
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: { ...mockPreview, output: undefined },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      expect(screen.queryByTestId('deployment-output-url')).not.toBeInTheDocument()
+      expect(screen.queryByText(/^App URL$/i)).not.toBeInTheDocument()
+    })
+
+    it('does not render the App URL row when preview.output.url is an empty string', () => {
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: { ...mockPreview, output: { url: '' } },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      expect(screen.queryByTestId('deployment-output-url')).not.toBeInTheDocument()
+      expect(screen.queryByText(/^App URL$/i)).not.toBeInTheDocument()
+    })
+
+    it('does not render the App URL row while the preview query is pending', () => {
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: undefined,
+        isPending: true,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      expect(screen.queryByTestId('deployment-output-url')).not.toBeInTheDocument()
+      expect(screen.queryByText(/^App URL$/i)).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Read `preview.output?.url` from the existing `useGetDeploymentRenderPreview` query on the deployment detail page.
- Render an "App URL" row at the top of the Status tab (above Replicas) when the URL is a non-empty string; anchor opens in a new tab with `rel="noopener noreferrer"`.
- Render nothing for the URL row when `output` is undefined, `output.url` is an empty string, or the preview query is still pending — keeps the Status tab stable on first load.
- Extend Vitest coverage: new describe block with four cases (URL present, URL absent, URL empty, preview pending); existing `useGetDeploymentRenderPreview` mock shape widened with optional `output` field.
- Phase 3 of HOL-543. Depends on the backend work that merged in HOL-544 (proto / schema) and HOL-545 (pipeline wiring).

Fixes HOL-546

## Test plan

- [x] `cd frontend && npx vitest run '-$deploymentName.test.tsx'` — all 71 tests pass (4 new)
- [x] `cd frontend && npm test -- --run` — 916 tests pass across 56 files
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd frontend && npx eslint` on modified files — no new errors (one pre-existing warning on an unrelated useEffect)
- [ ] Manually confirm in a running console that a template publishing a URL shows the "App URL" row on the Status tab, that the link opens in a new tab, and that deployments without a URL show no row

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)