### PR TITLE
chore(HOL-547): tidy doc comments after deployment-output feature

### DIFF
--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -355,7 +355,10 @@
 	spec:     #ResourceSetSpec  @go(Spec)
 }
 
-// ResourceSetSpec groups the input and output sections of a ResourceSet.
+// ResourceSetSpec groups the top-level sections of a ResourceSet: defaults,
+// platformInput, projectInput (inputs), platformResources, projectResources
+// (generated K8s manifests), and the optional output section (values the
+// template publishes to the UI, such as the deployment URL).
 #ResourceSetSpec: {
 	// Defaults carries optional default values for ProjectInput fields.
 	// Template authors specify concrete values in the CUE template's defaults

--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -30,7 +30,10 @@ type ResourceSet struct {
 	Spec     ResourceSetSpec `json:"spec"     yaml:"spec"     cue:"spec"`
 }
 
-// ResourceSetSpec groups the input and output sections of a ResourceSet.
+// ResourceSetSpec groups the top-level sections of a ResourceSet: defaults,
+// platformInput, projectInput (inputs), platformResources, projectResources
+// (generated K8s manifests), and the optional output section (values the
+// template publishes to the UI, such as the deployment URL).
 type ResourceSetSpec struct {
 	// Defaults carries optional default values for ProjectInput fields.
 	// Template authors specify concrete values in the CUE template's defaults

--- a/frontend/src/gen/holos/console/v1/deployments_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/deployments_pb.d.ts
@@ -828,8 +828,11 @@ export declare const GetDeploymentStatusResponseSchema: GenMessage<GetDeployment
 
 /**
  * DeploymentStatusSummary is a lightweight status snapshot derived from the
- * live Deployment resource. Intended for listing contexts where returning
- * full pod and event detail would be too expensive.
+ * live Deployment resource, augmented with the template-authored output
+ * section (e.g. app URL) cached on the deployment ConfigMap annotation.
+ * Intended for listing contexts where returning full pod and event detail
+ * would be too expensive and re-running the CUE render pipeline per row
+ * would be wasteful.
  *
  * @generated from message holos.console.v1.DeploymentStatusSummary
  */

--- a/gen/holos/console/v1/deployments.pb.go
+++ b/gen/holos/console/v1/deployments.pb.go
@@ -1653,8 +1653,11 @@ func (x *GetDeploymentStatusResponse) GetStatus() *DeploymentStatus {
 }
 
 // DeploymentStatusSummary is a lightweight status snapshot derived from the
-// live Deployment resource. Intended for listing contexts where returning
-// full pod and event detail would be too expensive.
+// live Deployment resource, augmented with the template-authored output
+// section (e.g. app URL) cached on the deployment ConfigMap annotation.
+// Intended for listing contexts where returning full pod and event detail
+// would be too expensive and re-running the CUE render pipeline per row
+// would be wasteful.
 type DeploymentStatusSummary struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// phase is the current deployment phase.

--- a/proto/holos/console/v1/deployments.proto
+++ b/proto/holos/console/v1/deployments.proto
@@ -265,8 +265,11 @@ message GetDeploymentStatusResponse {
 }
 
 // DeploymentStatusSummary is a lightweight status snapshot derived from the
-// live Deployment resource. Intended for listing contexts where returning
-// full pod and event detail would be too expensive.
+// live Deployment resource, augmented with the template-authored output
+// section (e.g. app URL) cached on the deployment ConfigMap annotation.
+// Intended for listing contexts where returning full pod and event detail
+// would be too expensive and re-running the CUE render pipeline per row
+// would be wasteful.
 message DeploymentStatusSummary {
   // phase is the current deployment phase.
   DeploymentPhase phase = 1;


### PR DESCRIPTION
## Summary

Final cleanup phase for HOL-543 (deployment output/URL feature). Tightens two doc comments made stale by HOL-544..HOL-548:

- `ResourceSetSpec` now enumerates every top-level section (defaults, platformInput, projectInput, platformResources, projectResources, **output**) instead of the pre-feature "groups the input and output sections of a ResourceSet".
- `DeploymentStatusSummary` now explains that it is augmented with the template-authored output section cached on the deployment ConfigMap annotation, so readers of the proto understand why the summary carries `output` alongside replica/phase state.

`make generate` regenerated `schema_gen.cue`, `gen/holos/console/v1/deployments.pb.go`, and `frontend/src/gen/holos/console/v1/deployments_pb.d.ts` so doc comments flow through to generated code.

## Scope audit performed

- Grepped for `TODO|FIXME|XXX|PLACEHOLDER` across the repo (excluding `node_modules`); only matches were in `frontend/package-lock.json` (not source).
- Verified `make generate` is a no-op on a second run.
- Verified `make test` (Go + frontend) is green.
- Verified `make vet` is clean.
- `make lint` has 27 pre-existing issues in `console/resolver/resolver_test.go`, `console/templates/semver_test.go`, `console/secrets/handler_test.go`; these are present on main at 0e345a5 (before HOL-543 work started) and are out of scope for this ticket.
- No stale mocks or unused imports from HOL-544..HOL-548. `renderResources` is still referenced from `handler_test.go` for parity coverage with `renderResourcesGrouped` and is intentionally kept.
- No `docs/agents/deployment-service.md` exists in the repo; nothing to update there.

Fixes HOL-547

## Test plan

- [x] `make generate` — no diff after a clean run
- [x] `make test` — all Go packages and frontend vitest suite pass
- [x] `make vet` — clean
- [x] Reviewed doc comment changes land in generated CUE and protobuf descriptors

Local E2E was not run (no k3d cluster available in this environment). Relying on CI E2E check — which is unlikely to be relevant since this PR touches only doc comments.

Generated with [Claude Code](https://claude.com/claude-code)