### PR TITLE
chore(hol-560): harmonize TemplatePolicy audit logs, docs, negative test

### DIFF
--- a/console/templatepolicies/handler.go
+++ b/console/templatepolicies/handler.go
@@ -4,16 +4,37 @@
 // and LinkableTemplate (HOL-554/HOL-555). The handler:
 //
 //   - Rejects project-scope storage outright so a project owner cannot tamper
-//     with the very policy the platform means to constrain them with
-//     (HOL-554 storage-isolation design note).
+//     with the very policy the platform means to constrain them with. See
+//     storage-isolation guardrail below.
 //   - Stores policies as ConfigMaps in the folder or organization namespace
 //     with the console.holos.run/resource-type=template-policy label and a
 //     JSON-serialized rules annotation.
-//   - Enforces RBAC through the new TemplatePolicyCascadePerms table using the
-//     PERMISSION_TEMPLATE_POLICIES_* permissions.
+//   - Enforces RBAC through the TemplatePolicyCascadePerms table using the
+//     PERMISSION_TEMPLATE_POLICIES_* permissions, so WRITE/DELETE/ADMIN can
+//     only be granted at organization or folder scope.
 //
-// Render-time integration (treating REQUIRE rules as the only source of forced
-// templates) lands in HOL-557.
+// # Storage-isolation guardrail (HOL-554)
+//
+// TemplatePolicy ConfigMaps and any applied-render-set state live exclusively
+// in folder or organization namespaces. They must NEVER be stored in a
+// project namespace because project owners have namespace-scoped write access
+// to their project namespace and could otherwise tamper with the very policy
+// the platform means to constrain them with. Storage-isolation is enforced
+// at three layers:
+//
+//  1. Proto contract: CreateTemplatePolicyRequest and UpdateTemplatePolicyRequest
+//     both carry a TemplateScopeRef; validatePolicyScopeRef rejects
+//     TEMPLATE_SCOPE_PROJECT directly.
+//  2. Handler validation: extractPolicyScope rejects project scope with a
+//     specific error message naming the project namespace.
+//  3. K8s client: namespaceForScope in k8s.go re-derives the namespace via
+//     the resolver and asserts it does not classify as a project namespace,
+//     catching any bug that routed a project scope through validation.
+//
+// Render-time integration (treating REQUIRE rules as the only source of
+// forced templates) is tracked by HOL-557. Until that lands, the existing
+// annotation-driven `mandatory` flag on Template ConfigMaps continues to
+// drive auto-inclusion at render time; see console/templates/k8s.go.
 package templatepolicies
 
 import (
@@ -118,12 +139,16 @@ func (h *Handler) ListTemplatePolicies(
 		policies = append(policies, configMapToPolicy(&cms[i], scope, scopeName))
 	}
 
+	// HOL-560: audit shape harmonized with console/folders/handler.go. List and
+	// read paths include the caller email alongside sub so security review can
+	// pivot on either identifier.
 	slog.InfoContext(ctx, "template policies listed",
 		slog.String("action", "template_policy_list"),
 		slog.String("resource_type", auditResourceType),
 		slog.String("scope", scope.String()),
 		slog.String("scopeName", scopeName),
 		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
 		slog.Int("count", len(policies)),
 	)
 
@@ -165,6 +190,7 @@ func (h *Handler) GetTemplatePolicy(
 		slog.String("scopeName", scopeName),
 		slog.String("name", name),
 		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
 	)
 
 	return connect.NewResponse(&consolev1.GetTemplatePolicyResponse{

--- a/console/templatepolicies/handler_test.go
+++ b/console/templatepolicies/handler_test.go
@@ -49,24 +49,58 @@ func walkGoFiles(t *testing.T, root string, visit func(path, body string)) error
 // per-user role grants for the organization passed to its constructor; folder
 // lookups use stubFolderGrantResolver instead so tests can verify the handler
 // picks the right cascade source.
+//
+// The resolver supports two modes. When perScope is non-nil it is consulted
+// first and keyed by the org scope_name — this lets a single test install
+// different grants for different scopes (e.g. seed an "owner" grant only on
+// the project namespace while keeping folder / org namespaces empty). The
+// fall-through fields users and roles preserve the simpler "one grant set for
+// all scopes" behaviour the rest of the tests rely on.
 type stubOrgGrantResolver struct {
-	users map[string]string
-	roles map[string]string
-	err   error
+	users    map[string]string
+	roles    map[string]string
+	perScope map[string]stubGrant
+	err      error
 }
 
-func (s *stubOrgGrantResolver) GetOrgGrants(_ context.Context, _ string) (map[string]string, map[string]string, error) {
-	return s.users, s.roles, s.err
+// stubGrant is a (users, roles) pair keyed by scope name in the per-scope
+// variants of the grant-resolver stubs.
+type stubGrant struct {
+	users map[string]string
+	roles map[string]string
+}
+
+func (s *stubOrgGrantResolver) GetOrgGrants(_ context.Context, scopeName string) (map[string]string, map[string]string, error) {
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+	if s.perScope != nil {
+		if g, ok := s.perScope[scopeName]; ok {
+			return g.users, g.roles, nil
+		}
+		return map[string]string{}, map[string]string{}, nil
+	}
+	return s.users, s.roles, nil
 }
 
 type stubFolderGrantResolver struct {
-	users map[string]string
-	roles map[string]string
-	err   error
+	users    map[string]string
+	roles    map[string]string
+	perScope map[string]stubGrant
+	err      error
 }
 
-func (s *stubFolderGrantResolver) GetFolderGrants(_ context.Context, _ string) (map[string]string, map[string]string, error) {
-	return s.users, s.roles, s.err
+func (s *stubFolderGrantResolver) GetFolderGrants(_ context.Context, scopeName string) (map[string]string, map[string]string, error) {
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+	if s.perScope != nil {
+		if g, ok := s.perScope[scopeName]; ok {
+			return g.users, g.roles, nil
+		}
+		return map[string]string{}, map[string]string{}, nil
+	}
+	return s.users, s.roles, nil
 }
 
 // fakeTemplateResolver implements TemplateExistsResolver. The err field is
@@ -782,7 +816,7 @@ func stringContains(haystack, needle string) bool {
 // called out by HOL-554 AC "A negative test in HOL-560 verifies a project-owner
 // role cannot mutate any policy ConfigMap or policy-enforcement annotation."
 //
-// The scenario: a user holds an owner grant only on a project (typical PaaS
+// The scenario: a user holds an owner grant *only* on a project (typical PaaS
 // customer-persona grant) and has NO grant at any ancestor folder or
 // organization. The TemplatePolicyService handler must refuse every mutation
 // path at every reachable scope, so there is no way for such a user to create,
@@ -792,23 +826,65 @@ func stringContains(haystack, needle string) bool {
 // PermissionDenied because the folder / org grant resolver carries no grant
 // for this user).
 //
+// To make the test a genuine regression guard rather than a trivially-passing
+// "unauthenticated user is denied" check, the grant resolvers are wired to
+// return an actual "owner" grant for the user — but only under the project
+// scope name. If a future refactor accidentally routes folder / org RBAC
+// checks through the project-scope grant table (or otherwise elevates
+// project-scoped ownership to folder/org writes on TemplatePolicy), the folder
+// / org cases below would flip from PermissionDenied to success and this test
+// would fail. Keeping the folder and org perScope maps empty for the queried
+// scope names ("payments", "acme") proves the existing handler does NOT
+// consult project grants when authorizing folder/org policy mutations.
+//
+// The user also carries a project-scoped role claim ("project-owner") in
+// their JWT-like Claims.Roles. No folder / org shareRoles map contains that
+// claim, so BestRoleFromGrants must not elevate the user via the role claim.
+// A regression that made folder / org shareRoles contain project-level role
+// mappings would again fail this test.
+//
 // This closes the loop on the HOL-554 storage-isolation guardrail: storage is
 // restricted to folder / org namespaces by construction (project scope is
 // rejected up front), and write access to those namespaces is gated by the
 // TemplatePolicyCascadePerms table which never awards WRITE / DELETE to a
 // project-scoped grant. The test asserts both halves.
 func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
-	// Org and folder resolvers return empty grants: the "project owner" user
-	// has no grant at any ancestor scope. This mirrors the real production
-	// wiring in which org / folder grant resolvers consult the
-	// org- / folder-namespace ShareUsers annotations only; a project-only
-	// grant would not appear in those maps.
+	const projectOwnerEmail = "project-owner@example.com"
+	const projectScopeName = "billing-web"
+	const folderScopeName = "payments"
+	const orgScopeName = "acme"
+	const projectOwnerRoleClaim = "project-owner"
+
+	// Simulate a genuine project-owner grant. The org and folder resolvers
+	// are per-scope-keyed: for the folder and org scope names queried by
+	// the handler below (payments / acme) they return empty grants, so the
+	// TemplatePolicyCascadePerms lookup yields RoleUnspecified and denies.
+	// For the project scope name (billing-web) the resolvers *do* carry a
+	// real owner grant — the handler must never reach this entry because
+	// TemplatePolicyService does not authorize writes against the project
+	// scope. If a regression ever wired checkFolderAccess or checkOrgAccess
+	// to the project scope (or extended the project scope grant into folder
+	// / org cascade tables), the test cases below would begin to succeed
+	// and this test would fail, catching the regression.
+	orgResolver := &stubOrgGrantResolver{
+		perScope: map[string]stubGrant{
+			orgScopeName:     {users: map[string]string{}, roles: map[string]string{}},
+			projectScopeName: {users: map[string]string{projectOwnerEmail: "owner"}},
+		},
+	}
+	folderResolver := &stubFolderGrantResolver{
+		perScope: map[string]stubGrant{
+			folderScopeName:  {users: map[string]string{}, roles: map[string]string{}},
+			projectScopeName: {users: map[string]string{projectOwnerEmail: "owner"}},
+		},
+	}
+
 	fakeClient := fake.NewClientset()
 	r := newTestResolver()
 	k := NewK8sClient(fakeClient, r)
 	h := NewHandler(k, r).
-		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{}}).
-		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{}})
+		WithOrgGrantResolver(orgResolver).
+		WithFolderGrantResolver(folderResolver)
 
 	// Seed a legitimate folder-scope policy so the Delete / Update cases have
 	// something to attempt to mutate. Seed directly via the k8s client so the
@@ -834,9 +910,10 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 		t.Fatalf("seeding folder-scope policy: %v", err)
 	}
 
-	// authedCtx with no roles — the user's only production grant is an
-	// "owner" role at project scope, which the handler does not consult.
-	ctx := authedCtx("project-owner@example.com", nil)
+	// The user carries a project-owner role claim in their JWT-style
+	// Claims.Roles. Folder / org shareRoles maps are empty, so the role
+	// claim must not grant access at those scopes.
+	ctx := authedCtx(projectOwnerEmail, []string{projectOwnerRoleClaim})
 
 	type mutation struct {
 		name    string

--- a/console/templatepolicies/handler_test.go
+++ b/console/templatepolicies/handler_test.go
@@ -777,3 +777,176 @@ func stringContains(haystack, needle string) bool {
 	}
 	return false
 }
+
+// TestProjectOwnerCannotMutatePolicy is the storage-isolation negative test
+// called out by HOL-554 AC "A negative test in HOL-560 verifies a project-owner
+// role cannot mutate any policy ConfigMap or policy-enforcement annotation."
+//
+// The scenario: a user holds an owner grant only on a project (typical PaaS
+// customer-persona grant) and has NO grant at any ancestor folder or
+// organization. The TemplatePolicyService handler must refuse every mutation
+// path at every reachable scope, so there is no way for such a user to create,
+// update, or delete a policy — regardless of whether they aim the request at
+// their own project namespace (rejected as InvalidArgument by the proto /
+// scope guard) or at the owning folder / organization namespace (rejected as
+// PermissionDenied because the folder / org grant resolver carries no grant
+// for this user).
+//
+// This closes the loop on the HOL-554 storage-isolation guardrail: storage is
+// restricted to folder / org namespaces by construction (project scope is
+// rejected up front), and write access to those namespaces is gated by the
+// TemplatePolicyCascadePerms table which never awards WRITE / DELETE to a
+// project-scoped grant. The test asserts both halves.
+func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
+	// Org and folder resolvers return empty grants: the "project owner" user
+	// has no grant at any ancestor scope. This mirrors the real production
+	// wiring in which org / folder grant resolvers consult the
+	// org- / folder-namespace ShareUsers annotations only; a project-only
+	// grant would not appear in those maps.
+	fakeClient := fake.NewClientset()
+	r := newTestResolver()
+	k := NewK8sClient(fakeClient, r)
+	h := NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{}})
+
+	// Seed a legitimate folder-scope policy so the Delete / Update cases have
+	// something to attempt to mutate. Seed directly via the k8s client so the
+	// creation is not itself gated by RBAC.
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "require-httproute",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:         "Require HTTPRoute",
+				v1alpha2.AnnotationDescription:         "Force HTTPRoute for every project",
+				v1alpha2.AnnotationCreatorEmail:        "platform@example.com",
+				v1alpha2.AnnotationTemplatePolicyRules: `[]`,
+			},
+		},
+	}
+	if _, err := fakeClient.CoreV1().ConfigMaps("holos-fld-payments").Create(context.Background(), existing, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seeding folder-scope policy: %v", err)
+	}
+
+	// authedCtx with no roles — the user's only production grant is an
+	// "owner" role at project scope, which the handler does not consult.
+	ctx := authedCtx("project-owner@example.com", nil)
+
+	type mutation struct {
+		name    string
+		run     func() error
+		wantErr connect.Code
+	}
+	cases := []mutation{
+		{
+			name: "Create at folder scope (no folder grant)",
+			run: func() error {
+				_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+					Scope:  newFolderScope("payments"),
+					Policy: basicPolicy(newFolderScope("payments")),
+				}))
+				return err
+			},
+			wantErr: connect.CodePermissionDenied,
+		},
+		{
+			name: "Create at organization scope (no org grant)",
+			run: func() error {
+				_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+					Scope:  newOrgScope("acme"),
+					Policy: basicPolicy(newOrgScope("acme")),
+				}))
+				return err
+			},
+			wantErr: connect.CodePermissionDenied,
+		},
+		{
+			name: "Create targeting project namespace (storage-isolation rejection)",
+			run: func() error {
+				_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+					Scope:  newProjectScope("billing-web"),
+					Policy: basicPolicy(newProjectScope("billing-web")),
+				}))
+				return err
+			},
+			wantErr: connect.CodeInvalidArgument,
+		},
+		{
+			name: "Update folder-scope policy (no folder grant)",
+			run: func() error {
+				_, err := h.UpdateTemplatePolicy(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyRequest{
+					Scope: newFolderScope("payments"),
+					Policy: &consolev1.TemplatePolicy{
+						Name:     "require-httproute",
+						ScopeRef: newFolderScope("payments"),
+						Rules:    []*consolev1.TemplatePolicyRule{sampleRule()},
+					},
+				}))
+				return err
+			},
+			wantErr: connect.CodePermissionDenied,
+		},
+		{
+			name: "Delete folder-scope policy (no folder grant)",
+			run: func() error {
+				_, err := h.DeleteTemplatePolicy(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyRequest{
+					Scope: newFolderScope("payments"),
+					Name:  "require-httproute",
+				}))
+				return err
+			},
+			wantErr: connect.CodePermissionDenied,
+		},
+		{
+			name: "Delete targeting project namespace (storage-isolation rejection)",
+			run: func() error {
+				_, err := h.DeleteTemplatePolicy(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyRequest{
+					Scope: newProjectScope("billing-web"),
+					Name:  "any",
+				}))
+				return err
+			},
+			wantErr: connect.CodeInvalidArgument,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil {
+				t.Fatalf("expected error, got nil (project-owner must not be able to mutate policies)")
+			}
+			if got := connect.CodeOf(err); got != tc.wantErr {
+				t.Errorf("expected %v, got %v: %v", tc.wantErr, got, err)
+			}
+		})
+	}
+
+	// Belt-and-suspenders: after all the mutation attempts, the seeded
+	// ConfigMap in the folder namespace must still be unchanged — no rules
+	// annotation rewrite, no deletion. This catches any future regression in
+	// which a handler path accidentally writes before checkAccess.
+	after, err := fakeClient.CoreV1().ConfigMaps("holos-fld-payments").Get(context.Background(), "require-httproute", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("folder-scope policy unexpectedly missing after denied mutations: %v", err)
+	}
+	if got, want := after.Annotations[v1alpha2.AnnotationTemplatePolicyRules], `[]`; got != want {
+		t.Errorf("folder-scope policy rules annotation mutated by denied caller: got %q want %q", got, want)
+	}
+	if got, want := after.Annotations[v1alpha2.AnnotationCreatorEmail], "platform@example.com"; got != want {
+		t.Errorf("folder-scope policy creator annotation mutated by denied caller: got %q want %q", got, want)
+	}
+
+	// And no ConfigMap should have landed in any project namespace, even
+	// though one of the Create cases targeted TEMPLATE_SCOPE_PROJECT.
+	projectCms, _ := fakeClient.CoreV1().ConfigMaps("holos-prj-billing-web").List(context.Background(), metav1.ListOptions{})
+	if len(projectCms.Items) != 0 {
+		t.Errorf("expected zero ConfigMaps in project namespace, got %d", len(projectCms.Items))
+	}
+}

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -807,6 +807,15 @@ func (h *Handler) ListAncestorTemplates(
 // (mandatory AND enabled) UNION (enabled AND ref IN linkedRefs).
 // Results are returned in org→folders→project order for correct CUE unification.
 // If linkedRefs is nil, only mandatory+enabled templates are returned.
+//
+// Storage-isolation note (HOL-554): the traversal only visits ancestor
+// namespaces — organization and folder — and never reads templates from a
+// project namespace even when the project itself is the starting scope. Any
+// future migration to a dedicated policy resolver (tracked by HOL-557) must
+// preserve this invariant. TemplatePolicy ConfigMaps and applied-render-set
+// state live exclusively in folder/organization namespaces precisely because
+// project owners can write to their project namespace and would otherwise be
+// able to tamper with the constraints the platform is enforcing.
 func (h *Handler) collectAncestorTemplates(ctx context.Context, scope consolev1.TemplateScope, scopeName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]*consolev1.Template, error) {
 	if h.walker == nil {
 		return nil, nil

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -305,6 +305,16 @@ func (k *K8sClient) ListTemplatesInNamespace(ctx context.Context, ns string) ([]
 // is: (mandatory AND enabled) UNION (enabled AND ref IN linkedRefs).
 // Disabled templates are never included even when explicitly linked.
 // The result is deduplicated so a mandatory+explicitly-linked template appears once.
+//
+// Storage-isolation note (HOL-554): callers pass a specific namespace and this
+// helper operates purely on ConfigMaps in that namespace. A render-time policy
+// resolver (tracked by HOL-557) will eventually replace the mandatory-flag
+// mechanism with TemplatePolicy REQUIRE rules; when it does, the applied
+// render-set state it persists MUST live exclusively in folder or
+// organization namespaces (the same namespaces that store TemplatePolicy
+// ConfigMaps), never in project namespaces. Project owners have write access
+// to their own project namespace and must never be able to mutate
+// applied-render-set state from there.
 func (k *K8sClient) ListTemplateSourcesForRender(ctx context.Context, ns string, linkedRefs []linkedRef) ([]string, error) {
 	cms, err := k.ListTemplatesInNamespace(ctx, ns)
 	if err != nil {
@@ -366,6 +376,13 @@ type RenderHierarchyWalker interface {
 //
 // If the walker fails, the method degrades gracefully by returning an empty
 // source list (no error).
+//
+// Storage-isolation note (HOL-554): the walk deliberately skips the project
+// namespace (ancestors[0]) and only reads from folder and organization
+// namespaces. Templates, releases, and — once HOL-557 lands — TemplatePolicy
+// ConfigMaps and applied-render-set state all live exclusively in those
+// folder/org namespaces. The project namespace is reserved for the project
+// owner's own writes and must never be read as a source of render-set truth.
 func (k *K8sClient) ListAncestorTemplateSourcesForRender(ctx context.Context, projectNs string, linkedRefs []*consolev1.LinkedTemplateRef, walker RenderHierarchyWalker) ([]string, error) {
 	if walker == nil {
 		return nil, nil


### PR DESCRIPTION
## Summary

Phase 6 cleanup pass for HOL-554 (TemplatePolicy). This is a **best-effort** pass limited to work that is implementable on main — HOL-557 and HOL-559 are not merged, so several HOL-554 acceptance criteria remain blocked (see below).

- **Audit logging** — added `email` field to `ListTemplatePolicies` and `GetTemplatePolicy` audit lines in `console/templatepolicies/handler.go` so the audit shape (`action, resource_type, scope, scopeName, name, sub, email`) matches sibling services like `console/folders/handler.go`. Existing mutate paths already carried `email`.
- **Storage-isolation doc polish** — expanded the `console/templatepolicies` package doc comment with a dedicated "Storage-isolation guardrail (HOL-554)" section enumerating the three enforcement layers (proto contract, handler validation, K8s client re-classification). Also expanded doc comments on `collectAncestorTemplates`, `ListTemplateSourcesForRender`, and `ListAncestorTemplateSourcesForRender` so any future HOL-557 resolver integration must preserve the folder/org-only render-set storage rule.
- **Negative RBAC test** — added `TestProjectOwnerCannotMutatePolicy` to `console/templatepolicies/handler_test.go`. Asserts that a user whose only grant is project-scoped cannot Create/Update/Delete a policy at any scope (folder, org, or project namespace). Six sub-cases cover `PermissionDenied` (no folder/org grant) and `InvalidArgument` (project scope rejected up front), and the test re-reads the seeded ConfigMap after every denied mutation to guard against a regression that might write before `checkAccess`.

Fixes HOL-560

## Scope reduction and blocked ACs

HOL-560 was scoped as the final verification phase for HOL-554, but:

- **HOL-557** (Phase 3: render integration, resolver, `policyresolver/` package, `policy_drift` field on `DeploymentStatusSummary`/`Template`, `GetDeploymentPolicyState` / `GetProjectTemplatePolicyState` RPCs, drift store) is NOT on main. PR #966 is open with the `needs-human-review` label after three Codex review rounds.
- **HOL-559** (Phase 5: drift UI) was skipped because it depends on the HOL-557 proto/RPC surface.
- **HOL-561** (TemplatePolicy picker should include same-scope templates) was created during HOL-558 review and is out of scope here.

The following HOL-554 / HOL-560 ACs are BLOCKED on main and cannot be verified in this PR:

- [ ] `DeploymentService.GetDeploymentPolicyState emits an audit line with action=deployment_policy_read.` — Blocked: RPC does not exist on main.
- [ ] `Doc comments in console/policyresolver/ explicitly call out the storage-isolation rule from HOL-554.` — Blocked: `console/policyresolver/` package does not exist on main. The storage-isolation note was added to the existing integration points in `console/templates/` instead.
- [ ] Manual acceptance-criteria walkthrough (force template on all projects under an org, folder EXCLUDE rule, folder REQUIRE rule, hierarchical depth ≥ 2). — Blocked: HOL-557 render integration not on main.
- [ ] Drift indicator shows after a policy change and clears after Reconcile. — Blocked: HOL-557/559.
- [ ] Storage-isolation negative test sub-criteria that reference HOL-557-specific storage (per-folder render-state ConfigMap or folder-namespace annotation set). — The handler/RBAC-level portion of this AC IS covered in this PR via `TestProjectOwnerCannotMutatePolicy`; the HOL-557-specific storage portion remains blocked.

Pre-existing ACs already satisfied on main:

- [x] TemplatePolicyService RPCs emit slog audit lines matching the shared shape (now fully homogenous with folders handler after this PR).
- [x] Any temporary feature flags are removed / never existed (grep confirms no feature-flag gating of the policy engine).
- [x] CHANGELOG entry is moot — no CHANGELOG file in the repo.
- [x] Negative test: project-owner cannot mutate any policy ConfigMap (this PR).

## Test plan
- [x] `make generate && make test` — 977 frontend tests pass, all Go packages pass (`ok` on every package).
- [x] `go test -run TestProjectOwnerCannotMutatePolicy -v ./console/templatepolicies/` — PASS, all six sub-cases.
- [x] `make lint` — no new findings in touched files (27 pre-existing findings in unrelated packages).
- [ ] Do NOT merge until HOL-557 lands; the blocked ACs above should be re-verified at that point.

Generated with [Claude Code](https://claude.com/claude-code)