### PR TITLE
refactor(deployments): collapse CueRenderer to one Render entry point

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -207,12 +207,24 @@ func (h *Handler) renderResources(ctx context.Context, project, cueSource string
 // renderResourcesGrouped mirrors renderResources but returns resources grouped
 // by origin (platform vs project). Used by GetDeploymentRenderPreview to populate
 // the per-collection response fields.
+//
+// When an AncestorTemplateProvider is configured this is an
+// organization/folder-level render (ReadPlatformResources=true) even when the
+// ancestor chain returns zero sources, so a deployment template authored with
+// its own platformResources still emits them. When no provider is configured
+// we fall back to a project-level render (ADR 016 Decision 8).
 func (h *Handler) renderResourcesGrouped(ctx context.Context, project, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) (*GroupedResources, error) {
 	var ancestorSources []string
+	readPlatformResources := false
 	if sources, ok := h.resolveAncestorTemplateSources(ctx, project, linkedRefs); ok {
 		ancestorSources = sources
+		readPlatformResources = true
 	}
-	return h.renderer.Render(ctx, cueSource, ancestorSources, RenderInputs{Platform: platform, Project: projectInput})
+	return h.renderer.Render(ctx, cueSource, ancestorSources, RenderInputs{
+		Platform:              platform,
+		Project:               projectInput,
+		ReadPlatformResources: readPlatformResources,
+	})
 }
 
 // ListDeployments returns all deployments in a project.

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -60,17 +60,12 @@ const DefaultGatewayNamespace = "istio-ingress"
 
 // Renderer evaluates CUE templates with deployment parameters.
 type Renderer interface {
-	Render(ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error)
-	// RenderWithAncestorTemplates unifies one or more ancestor (organization- and
-	// folder-level) template CUE sources with the deployment template before
-	// filling in platform and project inputs.
-	RenderWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error)
-	// RenderGrouped evaluates the CUE template and returns resources grouped by
-	// origin (platform vs project). Project-level path: platform group is empty.
-	RenderGrouped(ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error)
-	// RenderGroupedWithAncestorTemplates evaluates the deployment template unified
-	// with ancestor templates and returns resources grouped by origin.
-	RenderGroupedWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error)
+	// Render evaluates the deployment template unified with zero or more
+	// ancestor template CUE sources and the provided inputs, returning
+	// resources grouped by origin (platform vs project). When
+	// ancestorSources is empty this is a project-level render and
+	// platformResources is not read (ADR 016 Decision 8).
+	Render(ctx context.Context, cueSource string, ancestorSources []string, inputs RenderInputs) (*GroupedResources, error)
 }
 
 // AncestorWalker resolves the folder ancestry for a project namespace.
@@ -192,33 +187,32 @@ func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project st
 // The effective template set at render time is the union of mandatory+enabled
 // templates and the explicitly linked enabled templates (ADR 019).
 //
-// When no AncestorTemplateProvider is configured, falls back to Render
-// (deployment template only, no platform template unification).
+// When no AncestorTemplateProvider is configured, falls back to a plain
+// project-level render (deployment template only, no platform template
+// unification).
+//
+// This helper flattens the grouped render result into a single list. Callers
+// that need the per-origin split should use renderResourcesGrouped.
 func (h *Handler) renderResources(ctx context.Context, project, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) ([]unstructured.Unstructured, error) {
-	if sources, ok := h.resolveAncestorTemplateSources(ctx, project, linkedRefs); ok {
-		if len(sources) > 0 {
-			return h.renderer.RenderWithAncestorTemplates(ctx, cueSource, sources, platform, projectInput)
-		}
-		return h.renderer.Render(ctx, cueSource, platform, projectInput)
+	grouped, err := h.renderResourcesGrouped(ctx, project, cueSource, platform, projectInput, linkedRefs)
+	if err != nil {
+		return nil, err
 	}
-
-	// No AncestorTemplateProvider configured; render without platform templates.
-	return h.renderer.Render(ctx, cueSource, platform, projectInput)
+	combined := make([]unstructured.Unstructured, 0, len(grouped.Platform)+len(grouped.Project))
+	combined = append(combined, grouped.Platform...)
+	combined = append(combined, grouped.Project...)
+	return combined, nil
 }
 
 // renderResourcesGrouped mirrors renderResources but returns resources grouped
 // by origin (platform vs project). Used by GetDeploymentRenderPreview to populate
 // the per-collection response fields.
 func (h *Handler) renderResourcesGrouped(ctx context.Context, project, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) (*GroupedResources, error) {
+	var ancestorSources []string
 	if sources, ok := h.resolveAncestorTemplateSources(ctx, project, linkedRefs); ok {
-		if len(sources) > 0 {
-			return h.renderer.RenderGroupedWithAncestorTemplates(ctx, cueSource, sources, platform, projectInput)
-		}
-		return h.renderer.RenderGrouped(ctx, cueSource, platform, projectInput)
+		ancestorSources = sources
 	}
-
-	// No AncestorTemplateProvider configured; render without platform templates.
-	return h.renderer.RenderGrouped(ctx, cueSource, platform, projectInput)
+	return h.renderer.Render(ctx, cueSource, ancestorSources, RenderInputs{Platform: platform, Project: projectInput})
 }
 
 // ListDeployments returns all deployments in a project.

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -97,38 +97,22 @@ type stubRenderer struct {
 	called       bool
 	lastPlatform v1alpha2.PlatformInput
 	lastProject  v1alpha2.ProjectInput
-	// outputJSON, when non-nil, is copied onto GroupedResources.OutputJSON in
-	// the RenderGrouped* methods so tests can simulate a template producing an
-	// `output` block.
+	// outputJSON, when non-nil, is copied onto GroupedResources.OutputJSON so
+	// tests can simulate a template producing an `output` block.
 	outputJSON *string
 }
 
-func (s *stubRenderer) Render(_ context.Context, _ string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
+// Render implements Renderer for tests. The stub returns a GroupedResources
+// whose Project group carries the stubbed resources; callers that care about
+// the Platform group can wrap the stub.
+func (s *stubRenderer) Render(_ context.Context, _ string, _ []string, inputs RenderInputs) (*GroupedResources, error) {
 	s.called = true
-	s.lastPlatform = platform
-	s.lastProject = project
-	return s.resources, s.err
-}
-
-func (s *stubRenderer) RenderWithAncestorTemplates(_ context.Context, _ string, _ []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
-	s.called = true
-	s.lastPlatform = platform
-	s.lastProject = project
-	return s.resources, s.err
-}
-
-func (s *stubRenderer) RenderGrouped(_ context.Context, _ string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
-	s.called = true
-	s.lastPlatform = platform
-	s.lastProject = project
-	return &GroupedResources{Project: s.resources, OutputJSON: s.outputJSON}, s.err
-}
-
-func (s *stubRenderer) RenderGroupedWithAncestorTemplates(_ context.Context, _ string, _ []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
-	s.called = true
-	s.lastPlatform = platform
-	s.lastProject = project
-	return &GroupedResources{Project: s.resources, OutputJSON: s.outputJSON}, s.err
+	s.lastPlatform = inputs.Platform
+	s.lastProject = inputs.Project
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &GroupedResources{Project: s.resources, OutputJSON: s.outputJSON}, nil
 }
 
 // stubApplier implements ResourceApplier for tests.
@@ -1341,44 +1325,34 @@ func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Con
 	return s.sources, s.err
 }
 
-// trackingDeploymentRenderer extends stubRenderer to track which method was called.
+// trackingDeploymentRenderer extends stubRenderer to record whether Render
+// was called with ancestor sources. After the render-path collapse (HOL-563)
+// the renderer exposes exactly one entry point, so the "was this the ancestor
+// path" question is answered by inspecting lastAncestorSources rather than
+// by counting separate method calls.
 type trackingDeploymentRenderer struct {
 	stubRenderer
-	calledRender                    bool
-	calledRenderWithAncestor        bool
-	calledRenderGrouped             bool
-	calledRenderGroupedWithAncestor bool
-	lastAncestorSources             []string
+	calledRender        bool
+	lastAncestorSources []string
 }
 
-func (r *trackingDeploymentRenderer) Render(_ context.Context, _ string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
+func (r *trackingDeploymentRenderer) Render(_ context.Context, _ string, ancestorSources []string, inputs RenderInputs) (*GroupedResources, error) {
 	r.calledRender = true
-	r.lastPlatform = platform
-	r.lastProject = project
-	return r.resources, r.err
+	r.lastAncestorSources = ancestorSources
+	r.lastPlatform = inputs.Platform
+	r.lastProject = inputs.Project
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &GroupedResources{Project: r.resources, OutputJSON: r.outputJSON}, nil
 }
 
-func (r *trackingDeploymentRenderer) RenderWithAncestorTemplates(_ context.Context, _ string, sources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
-	r.calledRenderWithAncestor = true
-	r.lastAncestorSources = sources
-	r.lastPlatform = platform
-	r.lastProject = project
-	return r.resources, r.err
-}
-
-func (r *trackingDeploymentRenderer) RenderGrouped(_ context.Context, _ string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
-	r.calledRenderGrouped = true
-	r.lastPlatform = platform
-	r.lastProject = project
-	return &GroupedResources{Project: r.resources, OutputJSON: r.outputJSON}, r.err
-}
-
-func (r *trackingDeploymentRenderer) RenderGroupedWithAncestorTemplates(_ context.Context, _ string, sources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
-	r.calledRenderGroupedWithAncestor = true
-	r.lastAncestorSources = sources
-	r.lastPlatform = platform
-	r.lastProject = project
-	return &GroupedResources{Project: r.resources, OutputJSON: r.outputJSON}, r.err
+// renderedWithAncestors reports whether the last Render call passed a
+// non-empty ancestor-sources slice. Tests use this to assert on which render
+// path was taken, replacing the pre-HOL-563 distinction between separate
+// "with ancestor" entry points and the plain Render.
+func (r *trackingDeploymentRenderer) renderedWithAncestors() bool {
+	return len(r.lastAncestorSources) > 0
 }
 
 func TestRenderResourcesWithAncestorProvider(t *testing.T) {
@@ -1401,8 +1375,11 @@ func TestRenderResourcesWithAncestorProvider(t *testing.T) {
 		if !atp.called {
 			t.Error("expected ancestor provider to be called")
 		}
-		if !renderer.calledRenderWithAncestor {
-			t.Error("expected RenderWithAncestorTemplates to be called")
+		if !renderer.calledRender {
+			t.Error("expected Render to be called")
+		}
+		if !renderer.renderedWithAncestors() {
+			t.Error("expected Render to be called with ancestor sources")
 		}
 		if len(renderer.lastAncestorSources) != 1 {
 			t.Fatalf("expected 1 ancestor source, got %d", len(renderer.lastAncestorSources))
@@ -1424,7 +1401,10 @@ func TestRenderResourcesWithAncestorProvider(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if !renderer.calledRender {
-			t.Error("expected plain Render to be called when no ancestor provider configured")
+			t.Error("expected Render to be called when no ancestor provider configured")
+		}
+		if renderer.renderedWithAncestors() {
+			t.Error("expected Render to be called without ancestor sources when no provider is configured")
 		}
 	})
 
@@ -1449,7 +1429,10 @@ func TestRenderResourcesWithAncestorProvider(t *testing.T) {
 		}
 		// Should fall back to plain render without platform templates.
 		if !renderer.calledRender {
-			t.Error("expected plain Render to be called after ancestor provider error")
+			t.Error("expected Render to be called after ancestor provider error")
+		}
+		if renderer.renderedWithAncestors() {
+			t.Error("expected Render to be called without ancestor sources after provider error")
 		}
 	})
 }
@@ -1474,8 +1457,11 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 		if !atp.called {
 			t.Error("expected ancestor provider to be called")
 		}
-		if !renderer.calledRenderGroupedWithAncestor {
-			t.Error("expected RenderGroupedWithAncestorTemplates to be called")
+		if !renderer.calledRender {
+			t.Error("expected Render to be called")
+		}
+		if !renderer.renderedWithAncestors() {
+			t.Error("expected Render to be called with ancestor sources")
 		}
 	})
 
@@ -1495,8 +1481,11 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !renderer.calledRenderGrouped {
-			t.Error("expected RenderGrouped (no ancestors) to be called")
+		if !renderer.calledRender {
+			t.Error("expected Render to be called")
+		}
+		if renderer.renderedWithAncestors() {
+			t.Error("expected Render to be called without ancestor sources when provider returns empty")
 		}
 	})
 }

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -59,9 +59,20 @@ type GroupedResources struct {
 // platform-side PlatformInput and the user-supplied ProjectInput. Both are
 // marshaled to JSON and unified with the template at the "platform" and
 // "input" CUE paths respectively.
+//
+// ReadPlatformResources selects the render level: true is the
+// organization/folder-level path (both platformResources and projectResources
+// are read), false is the project-level path (ADR 016 Decision 8: the
+// deployment template must not emit platformResources). This must be set
+// explicitly by the caller; the renderer never infers it from the contents of
+// ancestorSources, so org/folder-level renders with zero ancestor templates
+// still read platformResources from the deployment template (for example the
+// GetDeploymentRenderPreview path invoked on a project with no linked
+// templates).
 type RenderInputs struct {
-	Platform v1alpha2.PlatformInput
-	Project  v1alpha2.ProjectInput
+	Platform              v1alpha2.PlatformInput
+	Project               v1alpha2.ProjectInput
+	ReadPlatformResources bool
 }
 
 // CueRenderer evaluates CUE templates with deployment parameters.
@@ -71,9 +82,13 @@ type CueRenderer struct{}
 // template CUE sources and the provided inputs, returning resources grouped
 // by origin (platform vs project).
 //
-// When ancestorSources is empty this is a project-level render and
-// platformResources is not read (ADR 016 Decision 8); when ancestorSources is
-// non-empty both collections are read (organization/folder-level).
+// The render level (project vs organization/folder) is signaled explicitly by
+// inputs.ReadPlatformResources, not inferred from len(ancestorSources). A
+// project-level render (false) must not emit platformResources per ADR 016
+// Decision 8; an org/folder-level render (true) reads both collections even
+// when ancestorSources is empty (for example a deployment in a project with
+// no linked templates whose deployment template itself supplies
+// platformResources).
 //
 // The deployment template and any ancestor sources are concatenated before
 // compilation so ancestor templates can reference top-level identifiers
@@ -100,44 +115,6 @@ func (r *CueRenderer) Render(ctx context.Context, cueSource string, ancestorSour
 	}
 }
 
-// EvaluateGroupedCUE compiles and evaluates a pre-concatenated CUE source
-// document (template + any already-embedded raw CUE input) and returns the
-// rendered Kubernetes resources grouped by origin. This is the raw-CUE entry
-// point used by callers that assemble the full CUE document themselves (for
-// example, the templates preview path which receives CUE strings for
-// "platform" and "input" from the client, or the mandatory-template applier
-// which marshals its own inputs to CUE).
-//
-// When readPlatformResources is true the renderer reads both
-// platformResources and projectResources; when false only projectResources is
-// read (per ADR 016 Decision 8 the project-level path must not emit
-// platformResources).
-//
-// This helper exists so the unified evaluation core lives in one place; the
-// raw-CUE call sites in the templates package will be removed in later phases
-// (see HOL-562).
-func EvaluateGroupedCUE(ctx context.Context, combinedCUESource string, readPlatformResources bool) (*GroupedResources, error) {
-	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
-	defer cancel()
-
-	type result struct {
-		grouped *GroupedResources
-		err     error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		grouped, err := evaluateCueInput(combinedCUESource, readPlatformResources)
-		ch <- result{grouped, err}
-	}()
-
-	select {
-	case <-evalCtx.Done():
-		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
-	case res := <-ch:
-		return res.grouped, res.err
-	}
-}
-
 // evaluateWithInputs performs synchronous CUE template evaluation with
 // structured Platform and Project inputs. The deployment template is
 // concatenated with any ancestor sources before compilation so ancestor
@@ -147,9 +124,10 @@ func EvaluateGroupedCUE(ctx context.Context, combinedCUESource string, readPlatf
 // #Claims, etc.
 //
 // Inputs are encoded as JSON and unified at the "input" (project) and
-// "platform" paths. When ancestorSources is empty the render is project-level
-// and platformResources is not read (ADR 016 Decision 8); otherwise both
-// collections are read.
+// "platform" paths. inputs.ReadPlatformResources selects the render level:
+// false is the project-level path (platformResources not read, ADR 016
+// Decision 8); true is the org/folder-level path (both collections read)
+// regardless of whether ancestorSources is empty.
 func evaluateWithInputs(cueSource string, ancestorSources []string, inputs RenderInputs) (*GroupedResources, error) {
 	cueCtx := cuecontext.New()
 
@@ -195,36 +173,7 @@ func evaluateWithInputs(cueSource string, ancestorSources []string, inputs Rende
 		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' (structured output format required)")
 	}
 
-	readPlatformResources := len(ancestorSources) > 0
-	return evaluateStructuredGrouped(unified, readPlatformResources)
-}
-
-// evaluateCueInput performs synchronous CUE template evaluation of a
-// pre-concatenated source document. The caller is responsible for assembling
-// the full CUE document (template plus any raw-CUE "platform" / "input"
-// values). Generated schema definitions are prepended so templates can
-// reference #PlatformInput, #ProjectInput, etc.
-//
-// At least one of projectResources.namespacedResources or
-// platformResources.namespacedResources must exist (preview of a
-// platform-only template is permitted).
-func evaluateCueInput(cueSource string, readPlatformResources bool) (*GroupedResources, error) {
-	cueCtx := cuecontext.New()
-
-	combined := v1alpha2.GeneratedSchema + "\n" + cueSource
-	unified := cueCtx.CompileString(combined)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("invalid CUE template: %w", err)
-	}
-
-	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
-	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
-	if (namespacedValue.Err() != nil || !namespacedValue.Exists()) &&
-		(platformNamespacedValue.Err() != nil || !platformNamespacedValue.Exists()) {
-		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
-	}
-
-	return evaluateStructuredGrouped(unified, readPlatformResources)
+	return evaluateStructuredGrouped(unified, inputs.ReadPlatformResources)
 }
 
 // extractCuePathJSON looks up a CUE path in the unified value and returns the

--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -55,40 +55,30 @@ type GroupedResources struct {
 	OutputJSON *string
 }
 
+// RenderInputs carries the structured inputs every render needs: the trusted
+// platform-side PlatformInput and the user-supplied ProjectInput. Both are
+// marshaled to JSON and unified with the template at the "platform" and
+// "input" CUE paths respectively.
+type RenderInputs struct {
+	Platform v1alpha2.PlatformInput
+	Project  v1alpha2.ProjectInput
+}
+
 // CueRenderer evaluates CUE templates with deployment parameters.
 type CueRenderer struct{}
 
-// Render evaluates the CUE template with the given platform and project inputs and
-// returns a list of K8s resource manifests as unstructured objects.
-func (r *CueRenderer) Render(ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
-	// Enforce evaluation timeout.
-	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
-	defer cancel()
-
-	// Run evaluation in a goroutine so we can respect context cancellation.
-	type result struct {
-		resources []unstructured.Unstructured
-		err       error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		resources, err := evaluate(cueSource, platform, project)
-		ch <- result{resources, err}
-	}()
-
-	select {
-	case <-evalCtx.Done():
-		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
-	case res := <-ch:
-		return res.resources, res.err
-	}
-}
-
-// RenderGrouped evaluates the CUE template with the given platform and project
-// inputs and returns resources grouped by origin (platform vs project). This is
-// the project-level path: platformResources are not read (ADR 016 Decision 8),
-// so the Platform group will always be empty.
-func (r *CueRenderer) RenderGrouped(ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+// Render evaluates the CUE template unified with zero or more ancestor
+// template CUE sources and the provided inputs, returning resources grouped
+// by origin (platform vs project).
+//
+// When ancestorSources is empty this is a project-level render and
+// platformResources is not read (ADR 016 Decision 8); when ancestorSources is
+// non-empty both collections are read (organization/folder-level).
+//
+// The deployment template and any ancestor sources are concatenated before
+// compilation so ancestor templates can reference top-level identifiers
+// defined by the deployment template (input, platform, _labels, etc.).
+func (r *CueRenderer) Render(ctx context.Context, cueSource string, ancestorSources []string, inputs RenderInputs) (*GroupedResources, error) {
 	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
 	defer cancel()
 
@@ -98,7 +88,7 @@ func (r *CueRenderer) RenderGrouped(ctx context.Context, cueSource string, platf
 	}
 	ch := make(chan result, 1)
 	go func() {
-		grouped, err := evaluateGrouped(cueSource, platform, project)
+		grouped, err := evaluateWithInputs(cueSource, ancestorSources, inputs)
 		ch <- result{grouped, err}
 	}()
 
@@ -110,11 +100,23 @@ func (r *CueRenderer) RenderGrouped(ctx context.Context, cueSource string, platf
 	}
 }
 
-// RenderGroupedWithAncestorTemplates evaluates the deployment template unified
-// with zero or more ancestor template CUE sources and returns resources grouped
-// by origin (platform vs project). This is the org/folder-level path that reads
-// both platformResources and projectResources.
-func (r *CueRenderer) RenderGroupedWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+// EvaluateGroupedCUE compiles and evaluates a pre-concatenated CUE source
+// document (template + any already-embedded raw CUE input) and returns the
+// rendered Kubernetes resources grouped by origin. This is the raw-CUE entry
+// point used by callers that assemble the full CUE document themselves (for
+// example, the templates preview path which receives CUE strings for
+// "platform" and "input" from the client, or the mandatory-template applier
+// which marshals its own inputs to CUE).
+//
+// When readPlatformResources is true the renderer reads both
+// platformResources and projectResources; when false only projectResources is
+// read (per ADR 016 Decision 8 the project-level path must not emit
+// platformResources).
+//
+// This helper exists so the unified evaluation core lives in one place; the
+// raw-CUE call sites in the templates package will be removed in later phases
+// (see HOL-562).
+func EvaluateGroupedCUE(ctx context.Context, combinedCUESource string, readPlatformResources bool) (*GroupedResources, error) {
 	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
 	defer cancel()
 
@@ -124,7 +126,7 @@ func (r *CueRenderer) RenderGroupedWithAncestorTemplates(ctx context.Context, de
 	}
 	ch := make(chan result, 1)
 	go func() {
-		grouped, err := evaluateWithOrgTemplatesGrouped(deploymentCUE, ancestorTemplateCUESources, platform, project)
+		grouped, err := evaluateCueInput(combinedCUESource, readPlatformResources)
 		ch <- result{grouped, err}
 	}()
 
@@ -136,257 +138,32 @@ func (r *CueRenderer) RenderGroupedWithAncestorTemplates(ctx context.Context, de
 	}
 }
 
-// RenderGroupedWithCueInput evaluates the CUE template unified with a raw CUE
-// input string and returns resources grouped by origin (platform vs project).
-// This is the preview path that reads both collections (ADR 016 Decision 8).
-func (r *CueRenderer) RenderGroupedWithCueInput(ctx context.Context, cueSource, cueInput string) (*GroupedResources, error) {
-	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
-	defer cancel()
-
-	type result struct {
-		grouped *GroupedResources
-		err     error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		grouped, err := evaluateWithCueInputGrouped(cueSource, cueInput)
-		ch <- result{grouped, err}
-	}()
-
-	select {
-	case <-evalCtx.Done():
-		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
-	case res := <-ch:
-		return res.grouped, res.err
-	}
-}
-
-// RenderWithAncestorTemplates evaluates the deployment template unified with zero
-// or more ancestor template CUE sources (organization- and folder-level). Each
-// ancestor template is concatenated with the deployment template before filling in
-// the platform and project inputs. All templates can define values for both
-// projectResources and platformResources. The renderer reads both collections when
-// ancestor templates are present (organization/folder level).
-func (r *CueRenderer) RenderWithAncestorTemplates(ctx context.Context, deploymentCUE string, ancestorTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
-	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
-	defer cancel()
-
-	type result struct {
-		resources []unstructured.Unstructured
-		err       error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		resources, err := evaluateWithOrgTemplates(deploymentCUE, ancestorTemplateCUESources, platform, project)
-		ch <- result{resources, err}
-	}()
-
-	select {
-	case <-evalCtx.Done():
-		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
-	case res := <-ch:
-		return res.resources, res.err
-	}
-}
-
-// RenderWithCueInput evaluates the CUE template unified with a raw CUE input
-// string at the "input" path and returns a list of K8s resource manifests as
-// unstructured objects.  The cueInput must be valid CUE source that supplies
-// concrete values for the template parameters (including "namespace").
-func (r *CueRenderer) RenderWithCueInput(ctx context.Context, cueSource, cueInput string) ([]unstructured.Unstructured, error) {
-	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
-	defer cancel()
-
-	type result struct {
-		resources []unstructured.Unstructured
-		err       error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		resources, err := evaluateWithCueInput(cueSource, cueInput)
-		ch <- result{resources, err}
-	}()
-
-	select {
-	case <-evalCtx.Done():
-		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
-	case res := <-ch:
-		return res.resources, res.err
-	}
-}
-
-// evaluateWithOrgTemplates performs synchronous CUE template evaluation of a
-// deployment template unified with zero or more platform template CUE sources.
-// All CUE sources are concatenated before compilation so that platform templates
-// can reference top-level identifiers (input, platform, _labels, etc.) defined
-// by the deployment template.
-// All templates can define values for both projectResources and platformResources.
-// The renderer reads both collections at the organization/folder level (ADR 016).
-func evaluateWithOrgTemplates(deploymentCUE string, orgTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
+// evaluateWithInputs performs synchronous CUE template evaluation with
+// structured Platform and Project inputs. The deployment template is
+// concatenated with any ancestor sources before compilation so ancestor
+// templates can reference top-level identifiers (input, platform, _labels,
+// etc.) defined by the deployment template. Generated schema definitions are
+// always prepended so templates can reference #PlatformInput, #ProjectInput,
+// #Claims, etc.
+//
+// Inputs are encoded as JSON and unified at the "input" (project) and
+// "platform" paths. When ancestorSources is empty the render is project-level
+// and platformResources is not read (ADR 016 Decision 8); otherwise both
+// collections are read.
+func evaluateWithInputs(cueSource string, ancestorSources []string, inputs RenderInputs) (*GroupedResources, error) {
 	cueCtx := cuecontext.New()
 
-	// Prepend generated schema definitions and concatenate all CUE sources.
-	// Platform templates may reference identifiers defined in the deployment
-	// template (input, platform, _labels, etc.) as well as generated type
-	// definitions (#PlatformInput, #ProjectInput, etc.). Combining them into
-	// a single compilation unit allows those cross-references to resolve.
-	combined := v1alpha2.GeneratedSchema + "\n" + deploymentCUE
-	for _, orgTemplateSrc := range orgTemplateCUESources {
-		combined = combined + "\n" + orgTemplateSrc
+	combined := v1alpha2.GeneratedSchema + "\n" + cueSource
+	for _, src := range ancestorSources {
+		combined = combined + "\n" + src
 	}
 
-	unified := cueCtx.CompileString(combined)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("invalid CUE template (deployment + platform templates): %w", err)
-	}
-
-	// Encode project input as JSON then compile to a CUE value and unify at "input".
-	inputJSON, err := json.Marshal(project)
-	if err != nil {
-		return nil, fmt.Errorf("encoding project input: %w", err)
-	}
-	inputValue := cueCtx.CompileBytes(inputJSON)
-	if err := inputValue.Err(); err != nil {
-		return nil, fmt.Errorf("compiling project input: %w", err)
-	}
-
-	// Encode platform input as JSON then compile to a CUE value and unify at "platform".
-	platformJSON, err := json.Marshal(platform)
-	if err != nil {
-		return nil, fmt.Errorf("encoding platform input: %w", err)
-	}
-	platformValue := cueCtx.CompileBytes(platformJSON)
-	if err := platformValue.Err(); err != nil {
-		return nil, fmt.Errorf("compiling platform input: %w", err)
-	}
-
-	// Unify template with inputs.
-	unified = unified.FillPath(cue.ParsePath("input"), inputValue)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("unifying template with project input: %w", err)
-	}
-	unified = unified.FillPath(cue.ParsePath("platform"), platformValue)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("unifying template with platform input: %w", err)
-	}
-
-	// Require the structured output format: projectResources.namespacedResources must exist.
-	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
-	if namespacedValue.Err() != nil || !namespacedValue.Exists() {
-		return nil, fmt.Errorf("deployment template must define 'projectResources.namespacedResources' (structured output format required)")
-	}
-
-	return evaluateStructured(unified, true)
-}
-
-// evaluate performs synchronous CUE template evaluation.
-// Templates must use the structured output format under projectResources.
-// The platform input (project, namespace, claims) and project input (name, image,
-// tag, etc.) are encoded separately and unified with the template.
-// This is the project-level render path. Per ADR 016, the renderer does not read
-// platformResources from project-level templates.
-func evaluate(cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
-	cueCtx := cuecontext.New()
-
-	// Prepend generated schema definitions so templates can reference
-	// #PlatformInput, #ProjectInput, #Claims, etc.
-	fullSource := v1alpha2.GeneratedSchema + "\n" + cueSource
-
-	// Compile the template source.
-	tmpl := cueCtx.CompileString(fullSource)
-	if err := tmpl.Err(); err != nil {
-		return nil, fmt.Errorf("invalid CUE template: %w", err)
-	}
-
-	// Encode project input as JSON then compile to a CUE value and unify at "input".
-	inputJSON, err := json.Marshal(project)
-	if err != nil {
-		return nil, fmt.Errorf("encoding project input: %w", err)
-	}
-	inputValue := cueCtx.CompileBytes(inputJSON)
-	if err := inputValue.Err(); err != nil {
-		return nil, fmt.Errorf("compiling project input: %w", err)
-	}
-
-	// Encode platform input as JSON then compile to a CUE value and unify at "platform".
-	platformJSON, err := json.Marshal(platform)
-	if err != nil {
-		return nil, fmt.Errorf("encoding platform input: %w", err)
-	}
-	platformValue := cueCtx.CompileBytes(platformJSON)
-	if err := platformValue.Err(); err != nil {
-		return nil, fmt.Errorf("compiling platform input: %w", err)
-	}
-
-	// Unify template with the project input at the "input" path and platform input
-	// at the "platform" path.
-	unified := tmpl.FillPath(cue.ParsePath("input"), inputValue)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("unifying template with project input: %w", err)
-	}
-	unified = unified.FillPath(cue.ParsePath("platform"), platformValue)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("unifying template with platform input: %w", err)
-	}
-
-	// Require the structured output format: projectResources.namespacedResources must exist.
-	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
-	if namespacedValue.Err() != nil || !namespacedValue.Exists() {
-		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' (structured output format required)")
-	}
-
-	// Project-level render: do not read platformResources (ADR 016 Decision 8).
-	return evaluateStructured(unified, false)
-}
-
-// evaluateWithCueInput performs synchronous CUE template evaluation using a raw
-// CUE string as input.  The cueInput is a CUE document that provides both
-// "input" (user-provided values) and "platform" (trusted backend values) at the
-// top level.  The template source and input are compiled together so that
-// cross-references (e.g. input.name used in the template) resolve correctly.
-func evaluateWithCueInput(cueSource, cueInput string) ([]unstructured.Unstructured, error) {
-	cueCtx := cuecontext.New()
-
-	// Prepend generated schema definitions and compile the template source
-	// together with the CUE input document. Concatenating them in a single
-	// compilation unit allows the template to reference top-level identifiers
-	// (input.name, platform.namespace, etc.) and generated type definitions
-	// (#PlatformInput, #ProjectInput, etc.).
-	combined := v1alpha2.GeneratedSchema + "\n" + cueSource + "\n" + cueInput
 	unified := cueCtx.CompileString(combined)
 	if err := unified.Err(); err != nil {
 		return nil, fmt.Errorf("invalid CUE template: %w", err)
 	}
 
-	// Require the structured output format.
-	// Platform templates define platformResources.namespacedResources; project
-	// templates define projectResources.namespacedResources.  At minimum one of
-	// these must exist.  For platform template standalone preview we check for either.
-	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
-	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
-	if (namespacedValue.Err() != nil || !namespacedValue.Exists()) &&
-		(platformNamespacedValue.Err() != nil || !platformNamespacedValue.Exists()) {
-		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
-	}
-
-	// Preview mode reads both collections (ADR 016 Decision 8).
-	return evaluateStructured(unified, true)
-}
-
-// evaluateGrouped performs synchronous CUE template evaluation and returns
-// resources grouped by origin. This is the project-level path: platformResources
-// are not read (ADR 016 Decision 8), so Platform will always be empty.
-func evaluateGrouped(cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
-	cueCtx := cuecontext.New()
-
-	fullSource := v1alpha2.GeneratedSchema + "\n" + cueSource
-
-	tmpl := cueCtx.CompileString(fullSource)
-	if err := tmpl.Err(); err != nil {
-		return nil, fmt.Errorf("invalid CUE template: %w", err)
-	}
-
-	inputJSON, err := json.Marshal(project)
+	inputJSON, err := json.Marshal(inputs.Project)
 	if err != nil {
 		return nil, fmt.Errorf("encoding project input: %w", err)
 	}
@@ -395,58 +172,7 @@ func evaluateGrouped(cueSource string, platform v1alpha2.PlatformInput, project 
 		return nil, fmt.Errorf("compiling project input: %w", err)
 	}
 
-	platformJSON, err := json.Marshal(platform)
-	if err != nil {
-		return nil, fmt.Errorf("encoding platform input: %w", err)
-	}
-	platformValue := cueCtx.CompileBytes(platformJSON)
-	if err := platformValue.Err(); err != nil {
-		return nil, fmt.Errorf("compiling platform input: %w", err)
-	}
-
-	unified := tmpl.FillPath(cue.ParsePath("input"), inputValue)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("unifying template with project input: %w", err)
-	}
-	unified = unified.FillPath(cue.ParsePath("platform"), platformValue)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("unifying template with platform input: %w", err)
-	}
-
-	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
-	if namespacedValue.Err() != nil || !namespacedValue.Exists() {
-		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' (structured output format required)")
-	}
-
-	// Project-level render: do not read platformResources (ADR 016 Decision 8).
-	return evaluateStructuredGrouped(unified, false)
-}
-
-// evaluateWithOrgTemplatesGrouped performs synchronous CUE template evaluation
-// with org/folder templates and returns resources grouped by origin.
-func evaluateWithOrgTemplatesGrouped(deploymentCUE string, orgTemplateCUESources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
-	cueCtx := cuecontext.New()
-
-	combined := v1alpha2.GeneratedSchema + "\n" + deploymentCUE
-	for _, orgTemplateSrc := range orgTemplateCUESources {
-		combined = combined + "\n" + orgTemplateSrc
-	}
-
-	unified := cueCtx.CompileString(combined)
-	if err := unified.Err(); err != nil {
-		return nil, fmt.Errorf("invalid CUE template (deployment + platform templates): %w", err)
-	}
-
-	inputJSON, err := json.Marshal(project)
-	if err != nil {
-		return nil, fmt.Errorf("encoding project input: %w", err)
-	}
-	inputValue := cueCtx.CompileBytes(inputJSON)
-	if err := inputValue.Err(); err != nil {
-		return nil, fmt.Errorf("compiling project input: %w", err)
-	}
-
-	platformJSON, err := json.Marshal(platform)
+	platformJSON, err := json.Marshal(inputs.Platform)
 	if err != nil {
 		return nil, fmt.Errorf("encoding platform input: %w", err)
 	}
@@ -466,18 +192,26 @@ func evaluateWithOrgTemplatesGrouped(deploymentCUE string, orgTemplateCUESources
 
 	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
 	if namespacedValue.Err() != nil || !namespacedValue.Exists() {
-		return nil, fmt.Errorf("deployment template must define 'projectResources.namespacedResources' (structured output format required)")
+		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' (structured output format required)")
 	}
 
-	return evaluateStructuredGrouped(unified, true)
+	readPlatformResources := len(ancestorSources) > 0
+	return evaluateStructuredGrouped(unified, readPlatformResources)
 }
 
-// evaluateWithCueInputGrouped performs synchronous CUE template evaluation using
-// a raw CUE string as input and returns resources grouped by origin.
-func evaluateWithCueInputGrouped(cueSource, cueInput string) (*GroupedResources, error) {
+// evaluateCueInput performs synchronous CUE template evaluation of a
+// pre-concatenated source document. The caller is responsible for assembling
+// the full CUE document (template plus any raw-CUE "platform" / "input"
+// values). Generated schema definitions are prepended so templates can
+// reference #PlatformInput, #ProjectInput, etc.
+//
+// At least one of projectResources.namespacedResources or
+// platformResources.namespacedResources must exist (preview of a
+// platform-only template is permitted).
+func evaluateCueInput(cueSource string, readPlatformResources bool) (*GroupedResources, error) {
 	cueCtx := cuecontext.New()
 
-	combined := v1alpha2.GeneratedSchema + "\n" + cueSource + "\n" + cueInput
+	combined := v1alpha2.GeneratedSchema + "\n" + cueSource
 	unified := cueCtx.CompileString(combined)
 	if err := unified.Err(); err != nil {
 		return nil, fmt.Errorf("invalid CUE template: %w", err)
@@ -490,8 +224,7 @@ func evaluateWithCueInputGrouped(cueSource, cueInput string) (*GroupedResources,
 		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
 	}
 
-	// Preview mode reads both collections (ADR 016 Decision 8).
-	return evaluateStructuredGrouped(unified, true)
+	return evaluateStructuredGrouped(unified, readPlatformResources)
 }
 
 // extractCuePathJSON looks up a CUE path in the unified value and returns the
@@ -540,14 +273,29 @@ func populateStructuredJSON(unified cue.Value, gr *GroupedResources) {
 	}
 }
 
-// evaluateStructuredGrouped walks the structured output fields of a unified CUE
-// value and returns validated Kubernetes resources partitioned into Platform and
-// Project groups. The logic mirrors evaluateStructured but collects resources
-// into separate slices instead of a single flat list.
+// evaluateStructuredGrouped walks the structured output fields of a unified
+// CUE value and returns validated Kubernetes resources partitioned into
+// Platform and Project groups.
+//
+// It always reads projectResources (project-level resources):
+//
+//	projectResources.namespacedResources.<namespace>.<Kind>.<name>
+//	projectResources.clusterResources.<Kind>.<name>
+//
+// When readPlatformResources is true, it also reads platformResources
+// (organization/folder-level resources):
+//
+//	platformResources.namespacedResources.<namespace>.<Kind>.<name>
+//	platformResources.clusterResources.<Kind>.<name>
+//
+// Per ADR 016 Decision 8, the project-level render path passes false so that
+// a project template cannot produce platformResources. Organization and
+// folder level paths pass true to read both collections. This is a hard
+// boundary enforced in Go code, not in CUE.
 //
 // There is no restriction on which namespaces resources may target. The
-// struct-key/metadata consistency check ensures internal consistency within the
-// template (ADR 026).
+// struct-key/metadata consistency check ensures internal consistency within
+// the template (ADR 026).
 func evaluateStructuredGrouped(unified cue.Value, readPlatformResources bool) (*GroupedResources, error) {
 	var projectResources []unstructured.Unstructured
 	var platformResources []unstructured.Unstructured
@@ -607,80 +355,6 @@ func evaluateStructuredGrouped(unified cue.Value, readPlatformResources bool) (*
 	}
 	populateStructuredJSON(unified, gr)
 	return gr, nil
-}
-
-// evaluateStructured walks the structured output fields of a unified CUE value
-// and returns validated Kubernetes resources.
-//
-// It always reads projectResources (project-level resources):
-//
-//	projectResources.namespacedResources.<namespace>.<Kind>.<name>
-//	projectResources.clusterResources.<Kind>.<name>
-//
-// When readPlatformResources is true, it also reads platformResources
-// (organization/folder-level resources):
-//
-//	platformResources.namespacedResources.<namespace>.<Kind>.<name>
-//	platformResources.clusterResources.<Kind>.<name>
-//
-// Per ADR 016 Decision 8, the project-level render path passes false so that a
-// project template cannot produce platformResources. Organization and folder
-// level paths pass true to read both collections. This is a hard boundary
-// enforced in Go code, not in CUE.
-//
-// There is no restriction on which namespaces resources may target. The
-// struct-key/metadata consistency check ensures internal consistency within the
-// template (ADR 026).
-func evaluateStructured(unified cue.Value, readPlatformResources bool) ([]unstructured.Unstructured, error) {
-	var result []unstructured.Unstructured
-
-	// Walk projectResources.namespacedResources: <namespace>.<Kind>.<name>
-	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
-	if namespacedValue.Err() == nil && namespacedValue.Exists() {
-		resources, err := walkNamespacedResources(namespacedValue, "projectResources.namespacedResources")
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, resources...)
-	}
-
-	// Walk projectResources.clusterResources: <Kind>.<name>
-	clusterValue := unified.LookupPath(cue.ParsePath("projectResources.clusterResources"))
-	if clusterValue.Err() == nil && clusterValue.Exists() {
-		resources, err := walkClusterResources(clusterValue, "projectResources.clusterResources")
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, resources...)
-	}
-
-	if !readPlatformResources {
-		return result, nil
-	}
-
-	// Walk platformResources.namespacedResources (populated by organization/folder templates;
-	// skipped for project-level rendering).
-	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
-	if platformNamespacedValue.Err() == nil && platformNamespacedValue.Exists() {
-		resources, err := walkNamespacedResources(platformNamespacedValue, "platformResources.namespacedResources")
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, resources...)
-	}
-
-	// Walk platformResources.clusterResources (populated by organization/folder templates;
-	// skipped for project-level rendering).
-	platformClusterValue := unified.LookupPath(cue.ParsePath("platformResources.clusterResources"))
-	if platformClusterValue.Err() == nil && platformClusterValue.Exists() {
-		resources, err := walkClusterResources(platformClusterValue, "platformResources.clusterResources")
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, resources...)
-	}
-
-	return result, nil
 }
 
 // walkNamespacedResources iterates a namespaced resource map of the form

--- a/console/deployments/render_raw_cue.go
+++ b/console/deployments/render_raw_cue.go
@@ -1,0 +1,79 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+// EvaluateGroupedCUE compiles and evaluates a pre-concatenated CUE source
+// document (template + any already-embedded raw CUE input) and returns the
+// rendered Kubernetes resources grouped by origin. This is the raw-CUE entry
+// point used by callers that assemble the full CUE document themselves (for
+// example, the templates preview path which receives CUE strings for
+// "platform" and "input" from the client, or the mandatory-template applier
+// which marshals its own inputs to CUE).
+//
+// When readPlatformResources is true the renderer reads both
+// platformResources and projectResources; when false only projectResources is
+// read (per ADR 016 Decision 8 the project-level path must not emit
+// platformResources).
+//
+// This helper is a transitional raw-CUE entry point kept out of render.go so
+// that render.go exposes exactly one public render function
+// (CueRenderer.Render). The raw-CUE call sites in the templates package will
+// be removed in later phases (see HOL-562); when the last caller is gone,
+// this file and the helper it exports will be deleted.
+func EvaluateGroupedCUE(ctx context.Context, combinedCUESource string, readPlatformResources bool) (*GroupedResources, error) {
+	evalCtx, cancel := context.WithTimeout(ctx, renderTimeout)
+	defer cancel()
+
+	type result struct {
+		grouped *GroupedResources
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		grouped, err := evaluateCueInput(combinedCUESource, readPlatformResources)
+		ch <- result{grouped, err}
+	}()
+
+	select {
+	case <-evalCtx.Done():
+		return nil, fmt.Errorf("CUE template evaluation timed out after %s", renderTimeout)
+	case res := <-ch:
+		return res.grouped, res.err
+	}
+}
+
+// evaluateCueInput performs synchronous CUE template evaluation of a
+// pre-concatenated source document. The caller is responsible for assembling
+// the full CUE document (template plus any raw-CUE "platform" / "input"
+// values). Generated schema definitions are prepended so templates can
+// reference #PlatformInput, #ProjectInput, etc.
+//
+// At least one of projectResources.namespacedResources or
+// platformResources.namespacedResources must exist (preview of a
+// platform-only template is permitted).
+func evaluateCueInput(cueSource string, readPlatformResources bool) (*GroupedResources, error) {
+	cueCtx := cuecontext.New()
+
+	combined := v1alpha2.GeneratedSchema + "\n" + cueSource
+	unified := cueCtx.CompileString(combined)
+	if err := unified.Err(); err != nil {
+		return nil, fmt.Errorf("invalid CUE template: %w", err)
+	}
+
+	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
+	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
+	if (namespacedValue.Err() != nil || !namespacedValue.Exists()) &&
+		(platformNamespacedValue.Err() != nil || !platformNamespacedValue.Exists()) {
+		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
+	}
+
+	return evaluateStructuredGrouped(unified, readPlatformResources)
+}

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -636,7 +636,8 @@ func defaultProject() v1alpha2.ProjectInput {
 
 // renderFlat is a test helper that calls the unified Render and flattens the
 // grouped result into a single slice, preserving the "platform-then-project"
-// ordering historically emitted by the flat render paths.
+// ordering historically emitted by the flat render paths. This drives the
+// project-level render path (ReadPlatformResources=false).
 func renderFlat(r *CueRenderer, ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
 	grouped, err := r.Render(ctx, cueSource, nil, RenderInputs{Platform: platform, Project: project})
 	if err != nil {
@@ -646,19 +647,17 @@ func renderFlat(r *CueRenderer, ctx context.Context, cueSource string, platform 
 }
 
 // renderFlatWithAncestors is a test helper that calls the unified Render with
-// ancestor sources and flattens the grouped result into a single slice.
-//
-// The pre-HOL-563 API routed RenderWithAncestorTemplates through the org-level
-// evaluate path unconditionally, which reads both platformResources and
-// projectResources even when the caller supplied a nil ancestor-sources
-// slice. To preserve that test semantic with the new API (which uses
-// len(ancestorSources)>0 as the "org-level" signal), this helper substitutes
-// a single empty-source placeholder when the caller passes nil/empty. The
-// placeholder changes no CUE evaluation output (an empty string contributes
-// nothing to the concatenated document) but forces the renderer onto the
-// org-level path that reads both collections.
+// ancestor sources and flattens the grouped result into a single slice. It
+// drives the organization/folder-level render path
+// (ReadPlatformResources=true) regardless of whether the ancestor-sources
+// slice is empty, matching the pre-HOL-563 semantics of
+// RenderWithAncestorTemplates.
 func renderFlatWithAncestors(r *CueRenderer, ctx context.Context, cueSource string, ancestorSources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
-	grouped, err := r.Render(ctx, cueSource, ensureAncestorSources(ancestorSources), RenderInputs{Platform: platform, Project: project})
+	grouped, err := r.Render(ctx, cueSource, ancestorSources, RenderInputs{
+		Platform:              platform,
+		Project:               project,
+		ReadPlatformResources: true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -666,30 +665,20 @@ func renderFlatWithAncestors(r *CueRenderer, ctx context.Context, cueSource stri
 }
 
 // renderGrouped is a test helper that calls the unified Render without
-// ancestor sources (project-level render path).
+// ancestor sources (project-level render path; ReadPlatformResources=false).
 func renderGrouped(r *CueRenderer, ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
 	return r.Render(ctx, cueSource, nil, RenderInputs{Platform: platform, Project: project})
 }
 
 // renderGroupedWithAncestors is a test helper that calls the unified Render
-// with ancestor sources (organization/folder-level render path). See
-// renderFlatWithAncestors for why nil/empty ancestor slices are replaced
-// with a placeholder.
+// with ancestor sources and drives the organization/folder-level render path
+// (ReadPlatformResources=true), even when ancestorSources is empty.
 func renderGroupedWithAncestors(r *CueRenderer, ctx context.Context, cueSource string, ancestorSources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
-	return r.Render(ctx, cueSource, ensureAncestorSources(ancestorSources), RenderInputs{Platform: platform, Project: project})
-}
-
-// ensureAncestorSources returns a non-empty ancestor-sources slice so the
-// renderer takes the org-level path (reading both platformResources and
-// projectResources). When the caller already supplied sources they pass
-// through unchanged; when the caller supplied nil or an empty slice we
-// substitute a single empty-string source which contributes nothing to the
-// compiled CUE document.
-func ensureAncestorSources(ancestorSources []string) []string {
-	if len(ancestorSources) > 0 {
-		return ancestorSources
-	}
-	return []string{""}
+	return r.Render(ctx, cueSource, ancestorSources, RenderInputs{
+		Platform:              platform,
+		Project:               project,
+		ReadPlatformResources: true,
+	})
 }
 
 // flattenGrouped concatenates Platform resources followed by Project

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -634,12 +634,81 @@ func defaultProject() v1alpha2.ProjectInput {
 	}
 }
 
+// renderFlat is a test helper that calls the unified Render and flattens the
+// grouped result into a single slice, preserving the "platform-then-project"
+// ordering historically emitted by the flat render paths.
+func renderFlat(r *CueRenderer, ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
+	grouped, err := r.Render(ctx, cueSource, nil, RenderInputs{Platform: platform, Project: project})
+	if err != nil {
+		return nil, err
+	}
+	return flattenGrouped(grouped), nil
+}
+
+// renderFlatWithAncestors is a test helper that calls the unified Render with
+// ancestor sources and flattens the grouped result into a single slice.
+//
+// The pre-HOL-563 API routed RenderWithAncestorTemplates through the org-level
+// evaluate path unconditionally, which reads both platformResources and
+// projectResources even when the caller supplied a nil ancestor-sources
+// slice. To preserve that test semantic with the new API (which uses
+// len(ancestorSources)>0 as the "org-level" signal), this helper substitutes
+// a single empty-source placeholder when the caller passes nil/empty. The
+// placeholder changes no CUE evaluation output (an empty string contributes
+// nothing to the concatenated document) but forces the renderer onto the
+// org-level path that reads both collections.
+func renderFlatWithAncestors(r *CueRenderer, ctx context.Context, cueSource string, ancestorSources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
+	grouped, err := r.Render(ctx, cueSource, ensureAncestorSources(ancestorSources), RenderInputs{Platform: platform, Project: project})
+	if err != nil {
+		return nil, err
+	}
+	return flattenGrouped(grouped), nil
+}
+
+// renderGrouped is a test helper that calls the unified Render without
+// ancestor sources (project-level render path).
+func renderGrouped(r *CueRenderer, ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	return r.Render(ctx, cueSource, nil, RenderInputs{Platform: platform, Project: project})
+}
+
+// renderGroupedWithAncestors is a test helper that calls the unified Render
+// with ancestor sources (organization/folder-level render path). See
+// renderFlatWithAncestors for why nil/empty ancestor slices are replaced
+// with a placeholder.
+func renderGroupedWithAncestors(r *CueRenderer, ctx context.Context, cueSource string, ancestorSources []string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) (*GroupedResources, error) {
+	return r.Render(ctx, cueSource, ensureAncestorSources(ancestorSources), RenderInputs{Platform: platform, Project: project})
+}
+
+// ensureAncestorSources returns a non-empty ancestor-sources slice so the
+// renderer takes the org-level path (reading both platformResources and
+// projectResources). When the caller already supplied sources they pass
+// through unchanged; when the caller supplied nil or an empty slice we
+// substitute a single empty-string source which contributes nothing to the
+// compiled CUE document.
+func ensureAncestorSources(ancestorSources []string) []string {
+	if len(ancestorSources) > 0 {
+		return ancestorSources
+	}
+	return []string{""}
+}
+
+// flattenGrouped concatenates Platform resources followed by Project
+// resources, matching the historical ordering produced by the flat render
+// entry points (platform templates contributed platformResources first, then
+// the deployment template contributed projectResources).
+func flattenGrouped(g *GroupedResources) []unstructured.Unstructured {
+	out := make([]unstructured.Unstructured, 0, len(g.Platform)+len(g.Project))
+	out = append(out, g.Platform...)
+	out = append(out, g.Project...)
+	return out
+}
+
 func TestCueRenderer_Render(t *testing.T) {
 	renderer := &CueRenderer{}
 	namespace := "prj-my-project"
 
 	t.Run("valid template produces expected resources", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), validTemplate, defaultPlatform(namespace), defaultProject())
+		resources, err := renderFlat(renderer, context.Background(), validTemplate, defaultPlatform(namespace), defaultProject())
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -663,14 +732,14 @@ func TestCueRenderer_Render(t *testing.T) {
 	})
 
 	t.Run("invalid CUE syntax returns error", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), invalidCUETemplate, defaultPlatform(namespace), defaultProject())
+		_, err := renderFlat(renderer, context.Background(), invalidCUETemplate, defaultPlatform(namespace), defaultProject())
 		if err == nil {
 			t.Fatal("expected error for invalid CUE syntax")
 		}
 	})
 
 	t.Run("struct-key metadata namespace mismatch rejected", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), crossNamespaceTemplate, defaultPlatform(namespace), defaultProject())
+		_, err := renderFlat(renderer, context.Background(), crossNamespaceTemplate, defaultPlatform(namespace), defaultProject())
 		if err == nil {
 			t.Fatal("expected error for struct-key/metadata namespace mismatch")
 		}
@@ -680,14 +749,14 @@ func TestCueRenderer_Render(t *testing.T) {
 	})
 
 	t.Run("disallowed resource kind rejected", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), disallowedKindTemplate, defaultPlatform(namespace), defaultProject())
+		_, err := renderFlat(renderer, context.Background(), disallowedKindTemplate, defaultPlatform(namespace), defaultProject())
 		if err == nil {
 			t.Fatal("expected error for disallowed resource kind")
 		}
 	})
 
 	t.Run("missing managed-by label rejected", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), missingManagedByTemplate, defaultPlatform(namespace), defaultProject())
+		_, err := renderFlat(renderer, context.Background(), missingManagedByTemplate, defaultPlatform(namespace), defaultProject())
 		if err == nil {
 			t.Fatal("expected error for missing managed-by label")
 		}
@@ -696,14 +765,14 @@ func TestCueRenderer_Render(t *testing.T) {
 	t.Run("timeout enforced for slow evaluation", func(t *testing.T) {
 		// A valid template should not time out (5s limit, evaluation is fast).
 		ctx := context.Background()
-		_, err := renderer.Render(ctx, validTemplate, defaultPlatform(namespace), defaultProject())
+		_, err := renderFlat(renderer, ctx, validTemplate, defaultPlatform(namespace), defaultProject())
 		if err != nil {
 			t.Fatalf("fast template should not time out: %v", err)
 		}
 	})
 
 	t.Run("input values are available in template", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), validTemplate,
+		resources, err := renderFlat(renderer, context.Background(), validTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "my-app", Image: "myrepo/myapp", Tag: "v2.0.0", Port: 8080},
 		)
@@ -837,7 +906,7 @@ func TestCueRenderer_Env(t *testing.T) {
 	namespace := "prj-my-project"
 
 	t.Run("literal env var is passed to template", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), envTemplate,
+		resources, err := renderFlat(renderer, context.Background(), envTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "my-app", Image: "myrepo/myapp", Tag: "v1.0.0", Env: []v1alpha2.EnvVar{{Name: "FOO", Value: "bar"}}},
 		)
@@ -872,7 +941,7 @@ func TestCueRenderer_Env(t *testing.T) {
 	})
 
 	t.Run("empty env is omitted from template", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), envTemplate,
+		resources, err := renderFlat(renderer, context.Background(), envTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "my-app", Image: "myrepo/myapp", Tag: "v1.0.0", Port: 8080},
 		)
@@ -901,7 +970,7 @@ func TestCueRenderer_CommandArgs(t *testing.T) {
 	namespace := "prj-my-project"
 
 	t.Run("command and args are passed to template", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), commandArgsTemplate,
+		resources, err := renderFlat(renderer, context.Background(), commandArgsTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "my-app", Image: "myrepo/myapp", Tag: "v1.0.0", Command: []string{"/bin/sh", "-c"}, Args: []string{"echo hello"}},
 		)
@@ -930,7 +999,7 @@ func TestCueRenderer_CommandArgs(t *testing.T) {
 	})
 
 	t.Run("empty command and args are omitted", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), commandArgsTemplate,
+		resources, err := renderFlat(renderer, context.Background(), commandArgsTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "my-app", Image: "myrepo/myapp", Tag: "v1.0.0", Port: 8080},
 		)
@@ -1023,7 +1092,7 @@ func TestCueRenderer_Port(t *testing.T) {
 	namespace := "prj-my-project"
 
 	t.Run("explicit port is used in containerPort", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), portTemplate,
+		resources, err := renderFlat(renderer, context.Background(), portTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "my-app", Image: "myrepo/myapp", Tag: "v1.0.0", Port: 9090},
 		)
@@ -1066,7 +1135,7 @@ func TestCueRenderer_Port(t *testing.T) {
 	t.Run("default port 8080 is applied by Go when port is unset", func(t *testing.T) {
 		// The Go handler defaults Port to 8080 before calling the renderer.
 		// This test verifies that Port: 8080 (the default) renders correctly.
-		resources, err := renderer.Render(context.Background(), portTemplate,
+		resources, err := renderFlat(renderer, context.Background(), portTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "my-app", Image: "myrepo/myapp", Tag: "v1.0.0", Port: 8080},
 		)
@@ -1153,7 +1222,7 @@ func TestCueRenderer_StructuredOutput(t *testing.T) {
 	namespace := "prj-my-project"
 
 	t.Run("structured template produces expected resources", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), structuredTemplate,
+		resources, err := renderFlat(renderer, context.Background(), structuredTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "web-app", Image: "nginx", Tag: "1.25", Port: 8080},
 		)
@@ -1183,7 +1252,7 @@ func TestCueRenderer_StructuredOutput(t *testing.T) {
 	})
 
 	t.Run("structured template rejects struct-key metadata namespace mismatch", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), structuredCrossNamespaceTemplate,
+		_, err := renderFlat(renderer, context.Background(), structuredCrossNamespaceTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "web-app", Image: "nginx", Tag: "1.25", Port: 8080},
 		)
@@ -1196,7 +1265,7 @@ func TestCueRenderer_StructuredOutput(t *testing.T) {
 	})
 
 	t.Run("structured template rejects missing managed-by label", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), structuredMissingManagedByTemplate,
+		_, err := renderFlat(renderer, context.Background(), structuredMissingManagedByTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "web-app", Image: "nginx", Tag: "1.25", Port: 8080},
 		)
@@ -1206,7 +1275,7 @@ func TestCueRenderer_StructuredOutput(t *testing.T) {
 	})
 
 	t.Run("duplicate Kind/name with incompatible values causes CUE conflict", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), structuredDuplicateTemplate,
+		_, err := renderFlat(renderer, context.Background(), structuredDuplicateTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "web-app", Image: "nginx", Tag: "1.25", Port: 8080},
 		)
@@ -1244,7 +1313,7 @@ func TestCueRenderer_ClaimsPropagation(t *testing.T) {
 	}
 
 	t.Run("platform.claims.email appears in resource annotation", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), claimsAnnotationTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), claimsAnnotationTemplate, system, user)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -1261,7 +1330,7 @@ func TestCueRenderer_ClaimsPropagation(t *testing.T) {
 	t.Run("platform.namespace is used for namespace constraint not input.namespace", func(t *testing.T) {
 		// The claimsAnnotationTemplate uses platform.namespace (not input.namespace)
 		// for the namespaced struct key, confirming the split input architecture.
-		resources, err := renderer.Render(context.Background(), claimsAnnotationTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), claimsAnnotationTemplate, system, user)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -1400,7 +1469,7 @@ func TestCueRenderer_GatewayNamespace(t *testing.T) {
 				EmailVerified: true,
 			},
 		}
-		resources, err := renderer.Render(context.Background(), gatewayNamespaceTemplate, system, v1alpha2.ProjectInput{
+		resources, err := renderFlat(renderer, context.Background(), gatewayNamespaceTemplate, system, v1alpha2.ProjectInput{
 			Name:  "web-app",
 			Image: "nginx",
 			Tag:   "1.25",
@@ -1435,7 +1504,7 @@ func TestCueRenderer_GatewayNamespace(t *testing.T) {
 				EmailVerified: true,
 			},
 		}
-		resources, err := renderer.Render(context.Background(), gatewayNamespaceTemplate, system, v1alpha2.ProjectInput{
+		resources, err := renderFlat(renderer, context.Background(), gatewayNamespaceTemplate, system, v1alpha2.ProjectInput{
 			Name:  "web-app",
 			Image: "nginx",
 			Tag:   "1.25",
@@ -1632,7 +1701,7 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 	}
 
 	t.Run("platform template resources are included when unified with deployment template", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
+		resources, err := renderFlatWithAncestors(renderer, context.Background(),
 			deploymentTemplateForUnification,
 			[]string{systemUnificationTemplate},
 			system, user,
@@ -1663,7 +1732,7 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 	})
 
 	t.Run("no platform templates returns only deployment resources", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
+		resources, err := renderFlatWithAncestors(renderer, context.Background(),
 			deploymentTemplateForUnification,
 			nil,
 			system, user,
@@ -1682,7 +1751,7 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 	// ADR 016 key insight: any template at any level can define values in any
 	// collection. A platform template is not restricted to platformResources only.
 	t.Run("platform template contributing to projectResources is unified", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
+		resources, err := renderFlatWithAncestors(renderer, context.Background(),
 			deploymentTemplateForUnification,
 			[]string{systemProjectResourcesTemplate},
 			system, user,
@@ -1711,7 +1780,7 @@ func TestCueRenderer_OrgTemplateUnification(t *testing.T) {
 	// Validate that RenderWithAncestorTemplates returns resources from both
 	// projectResources and platformResources when a platform template defines both.
 	t.Run("platform template defining both collections returns all resources", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
+		resources, err := renderFlatWithAncestors(renderer, context.Background(),
 			deploymentTemplateForUnification,
 			[]string{systemBothCollectionsTemplate},
 			system, user,
@@ -1760,7 +1829,7 @@ func TestCueRenderer_LevelBasedResourceReading(t *testing.T) {
 	// Render() uses evaluate() — the project-level path. Per ADR 016, it must
 	// NOT read platformResources even if the template defines them.
 	t.Run("Render does not read platformResources (project-level boundary)", func(t *testing.T) {
-		resources, err := renderer.Render(context.Background(), systemOutputTemplate,
+		resources, err := renderFlat(renderer, context.Background(), systemOutputTemplate,
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
 			v1alpha2.ProjectInput{Name: "web-app", Image: "nginx", Tag: "1.25", Port: 8080},
 		)
@@ -1781,7 +1850,7 @@ func TestCueRenderer_LevelBasedResourceReading(t *testing.T) {
 	// RenderWithAncestorTemplates() uses evaluateWithOrgTemplates() — the
 	// org/folder level path. It must read BOTH projectResources and platformResources.
 	t.Run("RenderWithAncestorTemplates reads both projectResources and platformResources", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
+		resources, err := renderFlatWithAncestors(renderer, context.Background(),
 			systemOutputTemplate,
 			nil, // no additional platform templates; the deployment template itself defines platformResources
 			v1alpha2.PlatformInput{Project: "my-project", Namespace: namespace},
@@ -2065,7 +2134,7 @@ func TestCueRenderer_ClosedStructKindConstraint(t *testing.T) {
 	// resources: 3 project resources (Deployment, Service, ServiceAccount) from
 	// projectResources + 1 HTTPRoute from platformResources = 4 total.
 	t.Run("allowed kinds succeed", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(
+		resources, err := renderFlatWithAncestors(renderer,
 			context.Background(),
 			closedStructProjectTemplate,
 			[]string{closedStructOrgTemplate},
@@ -2098,7 +2167,7 @@ func TestCueRenderer_ClosedStructKindConstraint(t *testing.T) {
 	// closed struct error), matching the documented error:
 	//   projectResources.namespacedResources.<ns>.RoleBinding: field not allowed
 	t.Run("disallowed kind fails with CUE closed struct error", func(t *testing.T) {
-		_, err := renderer.RenderWithAncestorTemplates(
+		_, err := renderFlatWithAncestors(renderer,
 			context.Background(),
 			closedStructProjectTemplateForbidden,
 			[]string{closedStructOrgTemplate},
@@ -2183,7 +2252,7 @@ func TestCueRenderer_HttpbinExample(t *testing.T) {
 	// 3 project resources (ServiceAccount, Deployment, Service) from
 	// projectResources + 1 platform resource (HTTPRoute) from platformResources.
 	t.Run("templates render together producing 4 resources", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(
+		resources, err := renderFlatWithAncestors(renderer,
 			context.Background(),
 			projectTemplate,
 			[]string{platformTemplate},
@@ -2240,7 +2309,7 @@ projectResources: namespacedResources: (platform.namespace): {
 		// have a template that produces a disallowed kind alongside the allowed ones.
 		projectWithForbidden := projectTemplate + forbiddenAddition
 
-		_, err := renderer.RenderWithAncestorTemplates(
+		_, err := renderFlatWithAncestors(renderer,
 			context.Background(),
 			projectWithForbidden,
 			[]string{platformTemplate},
@@ -2259,7 +2328,7 @@ projectResources: namespacedResources: (platform.namespace): {
 	// Render with just the project template (no platform template) must produce
 	// exactly 3 resources: ServiceAccount, Deployment, Service.
 	t.Run("project template renders standalone producing 3 resources", func(t *testing.T) {
-		resources, err := renderer.Render(
+		resources, err := renderFlat(renderer,
 			context.Background(),
 			projectTemplate,
 			platform,
@@ -2369,7 +2438,7 @@ func TestCueRenderer_FoldersPropagation(t *testing.T) {
 			Tag:   "1.25",
 			Port:  8080,
 		}
-		resources, err := renderer.Render(context.Background(), foldersTemplate, platform, project)
+		resources, err := renderFlat(renderer, context.Background(), foldersTemplate, platform, project)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -2405,7 +2474,7 @@ func TestCueRenderer_FoldersPropagation(t *testing.T) {
 			Tag:   "1.25",
 			Port:  8080,
 		}
-		resources, err := renderer.Render(context.Background(), foldersTemplate, platform, project)
+		resources, err := renderFlat(renderer, context.Background(), foldersTemplate, platform, project)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -2473,7 +2542,7 @@ func TestCueRenderer_AncestorTemplateWalk(t *testing.T) {
 	}
 
 	t.Run("folder-level platform template unified with deployment template", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(
+		resources, err := renderFlatWithAncestors(renderer,
 			context.Background(),
 			deploymentTemplateForUnification,
 			[]string{folderPlatformTemplate},
@@ -2501,7 +2570,7 @@ func TestCueRenderer_AncestorTemplateWalk(t *testing.T) {
 	})
 
 	t.Run("multiple ancestor templates (org + folder) are all unified", func(t *testing.T) {
-		resources, err := renderer.RenderWithAncestorTemplates(
+		resources, err := renderFlatWithAncestors(renderer,
 			context.Background(),
 			deploymentTemplateForUnification,
 			[]string{systemUnificationTemplate, folderPlatformTemplate},
@@ -2538,7 +2607,7 @@ func TestEvaluateStructuredGrouped(t *testing.T) {
 	namespace := "prj-my-project"
 
 	t.Run("project-only template produces empty platform group", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			validTemplate,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -2560,7 +2629,7 @@ func TestEvaluateStructuredGrouped(t *testing.T) {
 	})
 
 	t.Run("template with both collections produces populated platform and project groups", func(t *testing.T) {
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			systemOutputTemplate,
 			nil, // deployment template itself defines platformResources
 			defaultPlatform(namespace),
@@ -2586,7 +2655,7 @@ func TestEvaluateStructuredGrouped(t *testing.T) {
 	})
 
 	t.Run("unified fields equal union of both groups", func(t *testing.T) {
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			systemOutputTemplate,
 			nil,
 			defaultPlatform(namespace),
@@ -2597,7 +2666,7 @@ func TestEvaluateStructuredGrouped(t *testing.T) {
 		}
 
 		// The flat render should return the same total count as Platform + Project.
-		flat, err := renderer.RenderWithAncestorTemplates(context.Background(),
+		flat, err := renderFlatWithAncestors(renderer, context.Background(),
 			systemOutputTemplate,
 			nil,
 			defaultPlatform(namespace),
@@ -2630,7 +2699,7 @@ func TestEvaluateStructuredGrouped(t *testing.T) {
 	})
 
 	t.Run("org template with closed struct produces grouped results", func(t *testing.T) {
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			closedStructProjectTemplate,
 			[]string{closedStructOrgTemplate},
 			v1alpha2.PlatformInput{
@@ -2821,7 +2890,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	namespace := "prj-my-project"
 
 	t.Run("template without defaults leaves DefaultsJSON nil", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			validTemplate,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -2835,7 +2904,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("template with defaults populates DefaultsJSON", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			templateWithDefaults,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -2860,7 +2929,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("PlatformInputJSON is populated", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			validTemplate,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -2884,7 +2953,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("ProjectInputJSON is populated", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			validTemplate,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -2908,7 +2977,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("ProjectResourcesStructJSON is populated for non-empty resources", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			validTemplate,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -2925,7 +2994,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("PlatformResourcesStructJSON is set for template with platform resources", func(t *testing.T) {
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			systemOutputTemplate,
 			nil,
 			defaultPlatform(namespace),
@@ -2946,7 +3015,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 		// validTemplate has no platformResources, but when rendered via the
 		// org-level path (readPlatformResources=true) the platformResources CUE
 		// path does not exist, so the field should be nil.
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			validTemplate,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -2965,7 +3034,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 		// emptyPlatformResourcesTemplate defines platformResources with empty
 		// namespacedResources and clusterResources sub-structs. The field should
 		// be non-nil because the CUE path exists and is concrete.
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			emptyPlatformResourcesTemplate,
 			nil,
 			defaultPlatform(namespace),
@@ -2996,7 +3065,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	t.Run("populated platformResources produces JSON", func(t *testing.T) {
 		// systemOutputTemplate defines platformResources with actual resources.
 		// Use the org-level render path which reads both collections.
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			systemOutputTemplate,
 			nil,
 			defaultPlatform(namespace),
@@ -3019,7 +3088,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("all structured JSON fields are valid JSON", func(t *testing.T) {
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			systemOutputTemplate,
 			nil,
 			defaultPlatform(namespace),
@@ -3046,7 +3115,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("template without output leaves OutputJSON nil", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			validTemplate,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -3060,7 +3129,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	})
 
 	t.Run("template with output.url populates OutputJSON with the URL", func(t *testing.T) {
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			templateWithOutput,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -3086,7 +3155,7 @@ func TestStructuredJSONExtraction(t *testing.T) {
 	t.Run("template with empty output block still populates OutputJSON", func(t *testing.T) {
 		// Pitfall guard: `output: {}` is a present-but-empty section; the backend
 		// must not filter it out. The frontend decides whether to render.
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			templateWithEmptyOutput,
 			defaultPlatform(namespace),
 			defaultProject(),
@@ -3131,7 +3200,7 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 			Tag:   "1.25",
 			Port:  8080,
 		}
-		resources, err := renderer.Render(context.Background(), multiNamespaceTemplate, platform, project)
+		resources, err := renderFlat(renderer, context.Background(), multiNamespaceTemplate, platform, project)
 		if err != nil {
 			t.Fatalf("expected no error for multi-namespace template, got %v", err)
 		}
@@ -3171,7 +3240,7 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 			Tag:   "1.25",
 			Port:  8080,
 		}
-		resources, err := renderer.RenderWithAncestorTemplates(context.Background(),
+		resources, err := renderFlatWithAncestors(renderer, context.Background(),
 			multiNamespacePlatformTemplate,
 			nil,
 			platform, project,
@@ -3197,7 +3266,7 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 	})
 
 	t.Run("struct-key metadata mismatch still rejected", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), structKeyMismatchTemplate,
+		_, err := renderFlat(renderer, context.Background(), structKeyMismatchTemplate,
 			defaultPlatform(namespace), defaultProject())
 		if err == nil {
 			t.Fatal("expected error for struct-key/metadata namespace mismatch")
@@ -3208,7 +3277,7 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 	})
 
 	t.Run("empty namespace key rejected", func(t *testing.T) {
-		_, err := renderer.Render(context.Background(), emptyNamespaceKeyTemplate,
+		_, err := renderFlat(renderer, context.Background(), emptyNamespaceKeyTemplate,
 			defaultPlatform(namespace), defaultProject())
 		if err == nil {
 			t.Fatal("expected error for empty namespace key")
@@ -3230,7 +3299,7 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 			Tag:   "1.25",
 			Port:  8080,
 		}
-		grouped, err := renderer.RenderGrouped(context.Background(),
+		grouped, err := renderGrouped(renderer, context.Background(),
 			multiNamespaceTemplate, platform, project)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -3260,7 +3329,7 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 			Tag:   "1.25",
 			Port:  8080,
 		}
-		grouped, err := renderer.RenderGroupedWithAncestorTemplates(context.Background(),
+		grouped, err := renderGroupedWithAncestors(renderer, context.Background(),
 			multiNamespacePlatformTemplate, nil, platform, project)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)

--- a/console/templates/apply.go
+++ b/console/templates/apply.go
@@ -155,12 +155,19 @@ func (a *MandatoryTemplateApplier) applyMandatoryFromNamespace(ctx context.Conte
 			return fmt.Errorf("encoding user input for template %q in %q: %w", cm.Name, ancestorNs, err)
 		}
 
-		combinedCUE := fmt.Sprintf("platform: %s\ninput: %s", string(platformJSON), string(userJSON))
+		combinedCUE := cueSource + "\n" + fmt.Sprintf("platform: %s\ninput: %s", string(platformJSON), string(userJSON))
 
-		resources, err := a.renderer.RenderWithCueInput(ctx, cueSource, combinedCUE)
+		// Mandatory templates are applied to the project namespace at project
+		// creation time. Ancestor templates are not unified here (this applier
+		// itself IS the ancestor-application path). Read both collections
+		// because mandatory templates typically define platformResources.
+		grouped, err := deployments.EvaluateGroupedCUE(ctx, combinedCUE, true)
 		if err != nil {
 			return fmt.Errorf("rendering mandatory template %q from %q for project %q: %w", cm.Name, ancestorNs, project, err)
 		}
+		resources := make([]unstructured.Unstructured, 0, len(grouped.Platform)+len(grouped.Project))
+		resources = append(resources, grouped.Platform...)
+		resources = append(resources, grouped.Project...)
 
 		if a.applier == nil {
 			slog.WarnContext(ctx, "no resource applier configured, skipping mandatory template apply",

--- a/console/templates/default_template_test.go
+++ b/console/templates/default_template_test.go
@@ -28,6 +28,20 @@ func defaultPlatformInput(namespace string) v1alpha2.PlatformInput {
 	}
 }
 
+// renderFlat calls the unified deployments.CueRenderer.Render and flattens
+// the grouped result into a single slice, preserving the "platform-first"
+// ordering historically produced by the flat render entry point.
+func renderFlat(r *deployments.CueRenderer, ctx context.Context, cueSource string, platform v1alpha2.PlatformInput, project v1alpha2.ProjectInput) ([]unstructured.Unstructured, error) {
+	grouped, err := r.Render(ctx, cueSource, nil, deployments.RenderInputs{Platform: platform, Project: project})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]unstructured.Unstructured, 0, len(grouped.Platform)+len(grouped.Project))
+	out = append(out, grouped.Platform...)
+	out = append(out, grouped.Project...)
+	return out, nil
+}
+
 // TestDefaultTemplate verifies that DefaultTemplate renders correctly through
 // the full CUE render pipeline including managed-by label validation.
 func TestDefaultTemplate(t *testing.T) {
@@ -41,7 +55,7 @@ func TestDefaultTemplate(t *testing.T) {
 		Port:  8080,
 	}
 
-	resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+	resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 	if err != nil {
 		t.Fatalf("default template render failed: %v", err)
 	}
@@ -109,7 +123,7 @@ func TestDefaultTemplate_CommandArgs(t *testing.T) {
 			Port:    8080,
 		}
 
-		resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 		if err != nil {
 			t.Fatalf("default template render failed: %v", err)
 		}
@@ -147,7 +161,7 @@ func TestDefaultTemplate_CommandArgs(t *testing.T) {
 			Port:  8080,
 		}
 
-		resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 		if err != nil {
 			t.Fatalf("default template render failed: %v", err)
 		}
@@ -190,7 +204,7 @@ func TestDefaultTemplate_EnvVars(t *testing.T) {
 			Tag:   "latest",
 			Port:  8080,
 		}
-		resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 		if err != nil {
 			t.Fatalf("render failed: %v", err)
 		}
@@ -222,7 +236,7 @@ func TestDefaultTemplate_EnvVars(t *testing.T) {
 			Env:   []v1alpha2.EnvVar{{Name: "FOO", Value: "bar"}},
 			Port:  8080,
 		}
-		resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 		if err != nil {
 			t.Fatalf("render failed: %v", err)
 		}
@@ -251,7 +265,7 @@ func TestDefaultTemplate_EnvVars(t *testing.T) {
 			Env:   []v1alpha2.EnvVar{{Name: "DB_PASS", SecretKeyRef: &v1alpha2.KeyRef{Name: "my-secret", Key: "password"}}},
 			Port:  8080,
 		}
-		resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 		if err != nil {
 			t.Fatalf("render failed: %v", err)
 		}
@@ -285,7 +299,7 @@ func TestDefaultTemplate_EnvVars(t *testing.T) {
 			Env:   []v1alpha2.EnvVar{{Name: "APP_MODE", ConfigMapKeyRef: &v1alpha2.KeyRef{Name: "my-config", Key: "mode"}}},
 			Port:  8080,
 		}
-		resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 		if err != nil {
 			t.Fatalf("render failed: %v", err)
 		}
@@ -323,7 +337,7 @@ func TestDefaultTemplate_EnvVars(t *testing.T) {
 			},
 			Port: 8080,
 		}
-		resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+		resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 		if err != nil {
 			t.Fatalf("render failed: %v", err)
 		}
@@ -358,7 +372,7 @@ func TestDefaultTemplate_StructuredOutput(t *testing.T) {
 		Port:  8080,
 	}
 
-	resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+	resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 	if err != nil {
 		t.Fatalf("default template render failed: %v", err)
 	}
@@ -422,7 +436,7 @@ func TestDefaultTemplate_DeployerEmailAnnotation(t *testing.T) {
 		Port:  8080,
 	}
 
-	resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+	resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 	if err != nil {
 		t.Fatalf("default template render failed: %v", err)
 	}
@@ -468,7 +482,7 @@ func TestDefaultTemplate_ClaimsEmailInAnnotation(t *testing.T) {
 				Tag:   "latest",
 				Port:  8080,
 			}
-			resources, err := renderer.Render(context.Background(), DefaultTemplate, system, user)
+			resources, err := renderFlat(renderer, context.Background(), DefaultTemplate, system, user)
 			if err != nil {
 				t.Fatalf("render failed: %v", err)
 			}

--- a/console/templates/render_adapter.go
+++ b/console/templates/render_adapter.go
@@ -9,64 +9,52 @@ import (
 	"github.com/holos-run/holos-console/console/deployments"
 )
 
-// CueRendererAdapter wraps deployments.CueRenderer to satisfy templates.Renderer.
-type CueRendererAdapter struct {
-	inner *deployments.CueRenderer
-}
+// CueRendererAdapter wraps deployments.EvaluateGroupedCUE to satisfy
+// templates.Renderer. The adapter assembles the full CUE source document
+// (template + ancestor sources + raw CUE inputs) on behalf of callers that
+// supply their inputs as raw CUE strings (e.g. the RenderTemplate preview
+// path). The raw-CUE call sites go away in later phases (see HOL-562).
+type CueRendererAdapter struct{}
 
-// NewCueRendererAdapter creates a Renderer backed by deployments.CueRenderer.
+// NewCueRendererAdapter creates a Renderer backed by the deployments-package
+// CUE evaluation core.
 func NewCueRendererAdapter() *CueRendererAdapter {
-	return &CueRendererAdapter{inner: &deployments.CueRenderer{}}
+	return &CueRendererAdapter{}
 }
 
 // Render evaluates cueTemplate unified with cuePlatformInput and cueInput and
 // returns the rendered Kubernetes resource manifests.
+//
+// The preview path reads both projectResources and platformResources so that
+// platform-template-only templates can be previewed (ADR 016 Decision 8 only
+// forbids project-level renders from emitting platformResources; that hard
+// boundary is enforced at the structured-input entry point in
+// deployments.CueRenderer.Render).
 func (a *CueRendererAdapter) Render(ctx context.Context, cueTemplate string, cuePlatformInput string, cueInput string) ([]RenderResource, error) {
-	combined := cuePlatformInput
-	if combined != "" && cueInput != "" {
-		combined = combined + "\n" + cueInput
-	} else if cueInput != "" {
-		combined = cueInput
-	}
-	resources, err := a.inner.RenderWithCueInput(ctx, cueTemplate, combined)
+	combined := combineCueSource(cueTemplate, nil, cuePlatformInput, cueInput)
+	grouped, err := deployments.EvaluateGroupedCUE(ctx, combined, true)
 	if err != nil {
 		return nil, err
 	}
-	return unstructuredToRenderResources(resources)
+	return unstructuredToRenderResources(flattenGroupedResources(grouped))
 }
 
 // RenderWithTemplateSources evaluates the template unified with zero or more
 // ancestor template CUE sources, then with the CUE input.
 func (a *CueRendererAdapter) RenderWithTemplateSources(ctx context.Context, cueTemplate string, templateSources []string, cuePlatformInput string, cueInput string) ([]RenderResource, error) {
-	combinedInput := cuePlatformInput
-	if combinedInput != "" && cueInput != "" {
-		combinedInput = combinedInput + "\n" + cueInput
-	} else if cueInput != "" {
-		combinedInput = cueInput
-	}
-	combined := cueTemplate
-	for _, src := range templateSources {
-		if src != "" {
-			combined = combined + "\n" + src
-		}
-	}
-	resources, err := a.inner.RenderWithCueInput(ctx, combined, combinedInput)
+	combined := combineCueSource(cueTemplate, templateSources, cuePlatformInput, cueInput)
+	grouped, err := deployments.EvaluateGroupedCUE(ctx, combined, true)
 	if err != nil {
 		return nil, err
 	}
-	return unstructuredToRenderResources(resources)
+	return unstructuredToRenderResources(flattenGroupedResources(grouped))
 }
 
 // RenderGrouped evaluates cueTemplate unified with cuePlatformInput and cueInput
 // and returns resources grouped by origin (platform vs project).
 func (a *CueRendererAdapter) RenderGrouped(ctx context.Context, cueTemplate string, cuePlatformInput string, cueInput string) (*GroupedRenderResources, error) {
-	combined := cuePlatformInput
-	if combined != "" && cueInput != "" {
-		combined = combined + "\n" + cueInput
-	} else if cueInput != "" {
-		combined = cueInput
-	}
-	grouped, err := a.inner.RenderGroupedWithCueInput(ctx, cueTemplate, combined)
+	combined := combineCueSource(cueTemplate, nil, cuePlatformInput, cueInput)
+	grouped, err := deployments.EvaluateGroupedCUE(ctx, combined, true)
 	if err != nil {
 		return nil, err
 	}
@@ -76,23 +64,44 @@ func (a *CueRendererAdapter) RenderGrouped(ctx context.Context, cueTemplate stri
 // RenderGroupedWithTemplateSources evaluates the template unified with ancestor
 // template CUE sources and returns resources grouped by origin.
 func (a *CueRendererAdapter) RenderGroupedWithTemplateSources(ctx context.Context, cueTemplate string, templateSources []string, cuePlatformInput string, cueInput string) (*GroupedRenderResources, error) {
-	combinedInput := cuePlatformInput
-	if combinedInput != "" && cueInput != "" {
-		combinedInput = combinedInput + "\n" + cueInput
-	} else if cueInput != "" {
-		combinedInput = cueInput
-	}
-	combinedTemplate := cueTemplate
-	for _, src := range templateSources {
-		if src != "" {
-			combinedTemplate = combinedTemplate + "\n" + src
-		}
-	}
-	grouped, err := a.inner.RenderGroupedWithCueInput(ctx, combinedTemplate, combinedInput)
+	combined := combineCueSource(cueTemplate, templateSources, cuePlatformInput, cueInput)
+	grouped, err := deployments.EvaluateGroupedCUE(ctx, combined, true)
 	if err != nil {
 		return nil, err
 	}
 	return groupedUnstructuredToRenderResources(grouped)
+}
+
+// combineCueSource concatenates the deployment template, any ancestor
+// template sources, and the raw-CUE platform/input documents into a single
+// compilation unit. Ancestor templates are appended after the deployment
+// template so they may reference top-level identifiers defined by the
+// deployment template; the raw-CUE inputs are appended last so they bind
+// values at the "platform" / "input" paths.
+func combineCueSource(cueTemplate string, templateSources []string, cuePlatformInput string, cueInput string) string {
+	combined := cueTemplate
+	for _, src := range templateSources {
+		if src != "" {
+			combined = combined + "\n" + src
+		}
+	}
+	if cuePlatformInput != "" {
+		combined = combined + "\n" + cuePlatformInput
+	}
+	if cueInput != "" {
+		combined = combined + "\n" + cueInput
+	}
+	return combined
+}
+
+// flattenGroupedResources concatenates the platform and project groups into a
+// single slice, preserving the "platform-first" ordering historically
+// produced by the flat render entry points.
+func flattenGroupedResources(g *deployments.GroupedResources) []unstructured.Unstructured {
+	out := make([]unstructured.Unstructured, 0, len(g.Platform)+len(g.Project))
+	out = append(out, g.Platform...)
+	out = append(out, g.Project...)
+	return out
 }
 
 // groupedUnstructuredToRenderResources converts GroupedResources from the


### PR DESCRIPTION
## Summary

Collapses the six public `CueRenderer` methods in `console/deployments/render.go` (`Render`, `RenderGrouped`, `RenderWithAncestorTemplates`, `RenderGroupedWithAncestorTemplates`, `RenderWithCueInput`, `RenderGroupedWithCueInput`) to a single `Render(ctx, cueSource, ancestorSources, inputs RenderInputs) (*GroupedResources, error)` entry point.

- **Grouped-vs-flat** is folded into the return type: `Render` always returns `*GroupedResources`; callers that need a flat list flatten it themselves (deployments handler does this in `renderResources`).
- **Ancestor-sources vs project-only** is folded into a parameter whose length signals the render level per ADR 016 Decision 8: empty slice -> project-level (platformResources not read); non-empty slice -> organization/folder-level (both collections read).
- **Raw-CUE input** is routed through a new package-level `EvaluateGroupedCUE` helper for the two remaining callers (`templates.CueRendererAdapter` and `templates.MandatoryTemplateApplier`); phase 3 of HOL-562 deletes both.

Also collapses the `deployments.Renderer` interface from four methods to one, updates `renderResources` / `renderResourcesGrouped` to forward to the unified `Render`, and consolidates the test stubs (`stubRenderer`, `trackingDeploymentRenderer`) onto the new single-method surface.

`render.go` drops from 821 lines to 495 (~40% reduction). The ticket's aspirational target was ~300 lines; the extra ~200 are the raw-CUE helper (`EvaluateGroupedCUE` + `evaluateCueInput`) that supports the two remaining callers until phase 3 deletes them, plus the existing walk/validate helpers.

Fixes HOL-563

## Test plan

- [x] `go build ./console/...` green
- [x] `go vet ./console/...` clean
- [x] `go test ./...` all packages pass (console/deployments, console/templates, everything else)
- [x] `make test` 63 frontend test files (979 tests) and all Go tests pass
- [x] `make lint` no new findings against the changed files (pre-existing issues in unrelated files reproduce on main)
- [ ] E2E via CI

## Parent

Phase 1 of [HOL-562](https://linear.app/holos-run/issue/HOL-562/) "unify render surface onto one resolver-aware seam".

Generated with [Claude Code](https://claude.com/claude-code)