### PR TITLE
refactor(console): introduce PolicyResolver interface as no-op seam

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -37,6 +37,7 @@ import (
 	"github.com/holos-run/holos-console/console/folders"
 	"github.com/holos-run/holos-console/console/oidc"
 	"github.com/holos-run/holos-console/console/organizations"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/projects"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
@@ -292,6 +293,13 @@ func (s *Server) Serve(ctx context.Context) error {
 		// org_templates.K8sClient from v1alpha1 — ADR 021 Decision 1).
 		templatesK8s := templates.NewK8sClient(k8sClientset, nsResolver)
 
+		// TemplatePolicy resolution seam (HOL-566 Phase 4). A single no-op
+		// resolver is threaded through every render path — deployments,
+		// project-scope templates, and required-template application — so
+		// Phase 5 (HOL-567) can swap the implementation for a real
+		// REQUIRE/EXCLUDE resolver without revisiting call sites.
+		policyResolverSeam := policyresolver.NewNoopResolver()
+
 		// Wire defaults seeder for populate_defaults org creation flow.
 		projectPrefix := nsResolver.NamespacePrefix + nsResolver.ProjectPrefix
 		orgsHandler.WithDefaultsSeeder(templatesK8s, &projects.ProjectCreatorAdapter{K8s: projectsK8s}, projectPrefix)
@@ -309,6 +317,7 @@ func (s *Server) Serve(ctx context.Context) error {
 				&deployments.CueRenderer{},
 				deployments.NewApplier(dynamicClient),
 				templates.NewEmptyRequireRuleResolver(),
+				policyResolverSeam,
 			)
 		}
 
@@ -336,7 +345,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		// Unified TemplateService handler — manages templates at org, folder, and
 		// project scopes in a single service (ADR 021).
 		folderGrantResolver := folders.NewFolderGrantResolver(foldersK8s)
-		templatesHandler := templates.NewHandler(templatesK8s, nsResolver, templates.NewCueRendererAdapter()).
+		templatesHandler := templates.NewHandler(templatesK8s, nsResolver, templates.NewCueRendererAdapter(), policyResolverSeam).
 			WithOrgGrantResolver(orgGrantResolver).
 			WithFolderGrantResolver(folderGrantResolver).
 			WithProjectGrantResolver(projectResolver).
@@ -368,7 +377,7 @@ func (s *Server) Serve(ctx context.Context) error {
 			deploymentsApplier = deployments.NewApplier(dynamicClient)
 		}
 		projectFolderResolver := projects.NewProjectFolderResolver(projectsK8s, nsWalker)
-		ancestorTemplateResolver := templates.NewAncestorTemplateResolver(templatesK8s, nsWalker)
+		ancestorTemplateResolver := templates.NewAncestorTemplateResolver(templatesK8s, nsWalker, policyResolverSeam)
 		// Deployment status informer cache: one shared watch scoped to
 		// console-managed apps/v1.Deployment resources via the managed-by
 		// label. The informer lifecycle is tied to the server context so it

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -79,9 +79,11 @@ type AncestorWalker interface {
 
 // AncestorTemplateProvider resolves platform template CUE sources from the
 // full ancestor chain (org + folders) for render. The projectNs is the
-// starting namespace for the ancestor walk.
+// starting namespace for the ancestor walk; deploymentName identifies the
+// render target so the underlying PolicyResolver can key REQUIRE/EXCLUDE
+// evaluation off it (HOL-566 Phase 4).
 type AncestorTemplateProvider interface {
-	ListAncestorTemplateSources(ctx context.Context, projectNs string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, error)
+	ListAncestorTemplateSources(ctx context.Context, projectNs, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, error)
 }
 
 // ResourceApplier applies and cleans up K8s resources for a deployment.
@@ -159,17 +161,20 @@ func (h *Handler) WithStatusCache(c statuscache.Cache) *Handler {
 
 // resolveAncestorTemplateSources resolves platform template CUE sources from
 // the full ancestor chain when an AncestorTemplateProvider is configured.
-// Returns (sources, true) on success, or (nil, false) when no provider is
-// configured or the walk fails.
-func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, bool) {
+// deploymentName identifies the render target so the underlying
+// PolicyResolver (HOL-566 Phase 4) can key REQUIRE/EXCLUDE evaluation off
+// it in Phase 5. Returns (sources, true) on success, or (nil, false) when no
+// provider is configured or the walk fails.
+func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, bool) {
 	if h.ancestorTemplateProvider == nil {
 		return nil, false
 	}
 	projectNs := h.k8s.Resolver.ProjectNamespace(project)
-	sources, err := h.ancestorTemplateProvider.ListAncestorTemplateSources(ctx, projectNs, linkedRefs)
+	sources, err := h.ancestorTemplateProvider.ListAncestorTemplateSources(ctx, projectNs, deploymentName, linkedRefs)
 	if err != nil {
 		slog.WarnContext(ctx, "ancestor template resolution failed, skipping platform template unification",
 			slog.String("project", project),
+			slog.String("deployment", deploymentName),
 			slog.Any("error", err),
 		)
 		return nil, false
@@ -193,8 +198,12 @@ func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project st
 //
 // This helper flattens the grouped render result into a single list. Callers
 // that need the per-origin split should use renderResourcesGrouped.
-func (h *Handler) renderResources(ctx context.Context, project, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) ([]unstructured.Unstructured, error) {
-	grouped, err := h.renderResourcesGrouped(ctx, project, cueSource, platform, projectInput, linkedRefs)
+//
+// deploymentName is the render target name plumbed through to the
+// PolicyResolver (HOL-566 Phase 4). Phase 5 (HOL-567) keys REQUIRE/EXCLUDE
+// evaluation off it; until then it is observational.
+func (h *Handler) renderResources(ctx context.Context, project, deploymentName, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) ([]unstructured.Unstructured, error) {
+	grouped, err := h.renderResourcesGrouped(ctx, project, deploymentName, cueSource, platform, projectInput, linkedRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -213,10 +222,14 @@ func (h *Handler) renderResources(ctx context.Context, project, cueSource string
 // ancestor chain returns zero sources, so a deployment template authored with
 // its own platformResources still emits them. When no provider is configured
 // we fall back to a project-level render (ADR 016 Decision 8).
-func (h *Handler) renderResourcesGrouped(ctx context.Context, project, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) (*GroupedResources, error) {
+//
+// deploymentName is the render target name plumbed through to the
+// PolicyResolver (HOL-566 Phase 4). Phase 5 (HOL-567) keys REQUIRE/EXCLUDE
+// evaluation off it; until then it is observational.
+func (h *Handler) renderResourcesGrouped(ctx context.Context, project, deploymentName, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) (*GroupedResources, error) {
 	var ancestorSources []string
 	readPlatformResources := false
-	if sources, ok := h.resolveAncestorTemplateSources(ctx, project, linkedRefs); ok {
+	if sources, ok := h.resolveAncestorTemplateSources(ctx, project, deploymentName, linkedRefs); ok {
 		ancestorSources = sources
 		readPlatformResources = true
 	}
@@ -443,7 +456,7 @@ func (h *Handler) CreateDeployment(
 			Env:     envInputs,
 			Port:    defaultPort(int(req.Msg.Port)),
 		}
-		grouped, renderErr := h.renderResourcesGrouped(ctx, project, cueSource, platformIn, projectIn, linkedOrgTemplates)
+		grouped, renderErr := h.renderResourcesGrouped(ctx, project, name, cueSource, platformIn, projectIn, linkedOrgTemplates)
 		if renderErr != nil {
 			slog.WarnContext(ctx, "render failed after creating deployment — rolling back",
 				slog.String("project", project),
@@ -603,7 +616,7 @@ func (h *Handler) UpdateDeployment(
 			Env:     envFromConfigMapAsV1alpha2(updated),
 			Port:    defaultPort(portFromConfigMap(updated)),
 		}
-		grouped, renderErr := h.renderResourcesGrouped(ctx, project, cueSource, platformIn, projectIn, linkedOrgTemplatesUpdate)
+		grouped, renderErr := h.renderResourcesGrouped(ctx, project, name, cueSource, platformIn, projectIn, linkedOrgTemplatesUpdate)
 		if renderErr != nil {
 			slog.WarnContext(ctx, "render failed during deployment update",
 				slog.String("project", project),
@@ -905,7 +918,7 @@ func (h *Handler) GetDeploymentRenderPreview(
 	var grouped *GroupedResources
 	if h.renderer != nil {
 		var renderErr error
-		grouped, renderErr = h.renderResourcesGrouped(ctx, project, cueTemplate, platformIn, projectIn, linkedOrgTemplatesPreview)
+		grouped, renderErr = h.renderResourcesGrouped(ctx, project, name, cueTemplate, platformIn, projectIn, linkedOrgTemplatesPreview)
 		if renderErr != nil {
 			slog.WarnContext(ctx, "render failed during deployment preview",
 				slog.String("project", project),

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -1315,13 +1315,15 @@ func TestHandler_GetDeploymentRenderPreview(t *testing.T) {
 
 // stubAncestorTemplateProvider implements AncestorTemplateProvider for tests.
 type stubAncestorTemplateProvider struct {
-	sources []string
-	err     error
-	called  bool
+	sources            []string
+	err                error
+	called             bool
+	lastDeploymentName string
 }
 
-func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Context, _ string, _ []*consolev1.LinkedTemplateRef) ([]string, error) {
+func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Context, _ string, deploymentName string, _ []*consolev1.LinkedTemplateRef) ([]string, error) {
 	s.called = true
+	s.lastDeploymentName = deploymentName
 	return s.sources, s.err
 }
 
@@ -1368,7 +1370,7 @@ func TestRenderResourcesWithAncestorProvider(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "policy"},
 		}
-		_, err := handler.renderResources(context.Background(), "my-project", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
+		_, err := handler.renderResources(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1396,7 +1398,7 @@ func TestRenderResourcesWithAncestorProvider(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION, ScopeName: "acme", Name: "httproute"},
 		}
-		_, err := handler.renderResources(context.Background(), "my-project", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
+		_, err := handler.renderResources(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1420,7 +1422,7 @@ func TestRenderResourcesWithAncestorProvider(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION, ScopeName: "acme", Name: "httproute"},
 		}
-		_, err := handler.renderResources(context.Background(), "my-project", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
+		_, err := handler.renderResources(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1450,7 +1452,7 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "policy"},
 		}
-		_, err := handler.renderResourcesGrouped(context.Background(), "my-project", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
+		_, err := handler.renderResourcesGrouped(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1477,7 +1479,7 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "policy"},
 		}
-		_, err := handler.renderResourcesGrouped(context.Background(), "my-project", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
+		_, err := handler.renderResourcesGrouped(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/console/policyresolver/resolver.go
+++ b/console/policyresolver/resolver.go
@@ -1,0 +1,84 @@
+// Package policyresolver defines the TemplatePolicy resolution seam used by
+// every render path in the console — deployments (create/update/preview),
+// project-scope templates (create/update/preview), and project creation
+// (REQUIRE-matched templates).
+//
+// The package exists so Phase 5 of HOL-562 (HOL-567) can swap the no-op
+// implementation for a real TemplatePolicy-backed resolver without touching
+// call sites. In Phase 4 (HOL-566) the interface is introduced and wired
+// everywhere, but every call path still receives the no-op implementation
+// that returns explicit refs unchanged.
+//
+// Keeping the resolver in its own package (rather than in
+// console/templates/) prevents the PolicyResolver abstraction from leaking
+// into the CUE renderer and related apply/preview machinery. The renderer
+// operates on CUE sources; resolution decisions belong to the caller.
+package policyresolver
+
+import (
+	"context"
+
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// TargetKind identifies the kind of render target driving a call to the
+// resolver. Phase 4 wires the value through every call site; Phase 5 uses it
+// to key REQUIRE/EXCLUDE evaluation so the resolver can apply different
+// policies to deployment renders vs project-scope template previews.
+type TargetKind int
+
+const (
+	// TargetKindProjectTemplate is the preview render path for project-scope
+	// templates (the RenderTemplate RPC and the project-scope Create/Update
+	// template handlers).
+	TargetKindProjectTemplate TargetKind = iota
+	// TargetKindDeployment is the apply render path for deployments
+	// (AncestorTemplateProvider on the deployments handler).
+	TargetKindDeployment
+)
+
+// PolicyResolver filters and augments the caller's explicit linked-template
+// refs according to TemplatePolicy REQUIRE/EXCLUDE rules before the
+// ancestor-source helper walks the namespace chain.
+//
+// Phase 4 (HOL-566) introduces this contract; every production wire-up
+// receives a no-op implementation that returns explicitRefs unchanged. Phase
+// 5 (HOL-567) swaps in a real implementation backed by the TemplatePolicy
+// service.
+//
+// Implementations must not mutate the input slice. The returned slice is owned
+// by the caller and may be appended to freely.
+type PolicyResolver interface {
+	Resolve(
+		ctx context.Context,
+		projectNs string,
+		targetKind TargetKind,
+		targetName string,
+		explicitRefs []*consolev1.LinkedTemplateRef,
+	) ([]*consolev1.LinkedTemplateRef, error)
+}
+
+// noopResolver returns explicitRefs unchanged. It is the Phase 4 placeholder
+// that every render call site receives until Phase 5 lands a real
+// TemplatePolicy-backed implementation.
+type noopResolver struct{}
+
+// NewNoopResolver returns a PolicyResolver that returns its inputs unchanged.
+// Wire one instance at server startup and pass it into every handler that
+// owns a render path.
+func NewNoopResolver() PolicyResolver {
+	return noopResolver{}
+}
+
+// Resolve returns explicitRefs verbatim. The context, projectNs, targetKind,
+// and targetName arguments are accepted for signature stability — Phase 5
+// consults them, but the no-op implementation never does.
+func (noopResolver) Resolve(
+	_ context.Context,
+	_ string,
+	_ TargetKind,
+	_ string,
+	explicitRefs []*consolev1.LinkedTemplateRef,
+) ([]*consolev1.LinkedTemplateRef, error) {
+	return explicitRefs, nil
+}

--- a/console/policyresolver/resolver_test.go
+++ b/console/policyresolver/resolver_test.go
@@ -1,0 +1,109 @@
+package policyresolver
+
+import (
+	"context"
+	"testing"
+
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// TestNoopResolver_ReturnsInputsUnchanged asserts the Phase 4 invariant that
+// every render path is behaviorally unchanged after the PolicyResolver seam
+// is introduced: the noopResolver must return the caller's explicit refs
+// verbatim regardless of target kind, project namespace, or target name.
+func TestNoopResolver_ReturnsInputsUnchanged(t *testing.T) {
+	orgRef := &consolev1.LinkedTemplateRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+		ScopeName: "acme",
+		Name:      "httproute",
+	}
+	folderRef := &consolev1.LinkedTemplateRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+		ScopeName: "payments",
+		Name:      "audit-policy",
+	}
+
+	tests := []struct {
+		name         string
+		projectNs    string
+		targetKind   TargetKind
+		targetName   string
+		explicitRefs []*consolev1.LinkedTemplateRef
+	}{
+		{
+			name:         "deployment with multiple refs",
+			projectNs:    "prj-orders",
+			targetKind:   TargetKindDeployment,
+			targetName:   "api",
+			explicitRefs: []*consolev1.LinkedTemplateRef{orgRef, folderRef},
+		},
+		{
+			name:         "project template with single ref",
+			projectNs:    "prj-orders",
+			targetKind:   TargetKindProjectTemplate,
+			targetName:   "audit-policy",
+			explicitRefs: []*consolev1.LinkedTemplateRef{folderRef},
+		},
+		{
+			name:         "deployment with nil refs",
+			projectNs:    "prj-orders",
+			targetKind:   TargetKindDeployment,
+			targetName:   "api",
+			explicitRefs: nil,
+		},
+		{
+			name:         "project template with empty refs",
+			projectNs:    "prj-orders",
+			targetKind:   TargetKindProjectTemplate,
+			targetName:   "audit-policy",
+			explicitRefs: []*consolev1.LinkedTemplateRef{},
+		},
+	}
+
+	resolver := NewNoopResolver()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolver.Resolve(context.Background(), tc.projectNs, tc.targetKind, tc.targetName, tc.explicitRefs)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.explicitRefs) {
+				t.Fatalf("length mismatch: got %d, want %d", len(got), len(tc.explicitRefs))
+			}
+			for i, ref := range tc.explicitRefs {
+				if got[i] != ref {
+					t.Errorf("ref %d: got %+v, want %+v (pointer equality)", i, got[i], ref)
+				}
+			}
+		})
+	}
+}
+
+// TestNoopResolver_DoesNotMutateInput guards against a future edit that
+// starts mutating the input slice. The contract is clear: return a new or
+// aliasing slice, but never modify the caller's.
+func TestNoopResolver_DoesNotMutateInput(t *testing.T) {
+	orgRef := &consolev1.LinkedTemplateRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+		ScopeName: "acme",
+		Name:      "httproute",
+	}
+	input := []*consolev1.LinkedTemplateRef{orgRef}
+	original := make([]*consolev1.LinkedTemplateRef, len(input))
+	copy(original, input)
+
+	resolver := NewNoopResolver()
+	if _, err := resolver.Resolve(context.Background(), "prj-orders", TargetKindDeployment, "api", input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(input) != len(original) {
+		t.Fatalf("input slice length changed: got %d, want %d", len(input), len(original))
+	}
+	for i := range input {
+		if input[i] != original[i] {
+			t.Errorf("input[%d] changed: got %p, want %p", i, input[i], original[i])
+		}
+	}
+}

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
@@ -96,11 +97,18 @@ type Handler struct {
 	walker               AncestorWalker
 	resolver             *resolver.Resolver
 	renderer             Renderer
+	// policyResolver is the TemplatePolicy resolution seam threaded through
+	// every render path in this handler (HOL-566 Phase 4). Phase 5 (HOL-567)
+	// swaps the no-op implementation wired at server startup for a real
+	// REQUIRE/EXCLUDE resolver without touching this handler.
+	policyResolver policyresolver.PolicyResolver
 }
 
-// NewHandler creates a TemplateService handler.
-func NewHandler(k8s *K8sClient, r *resolver.Resolver, renderer Renderer) *Handler {
-	return &Handler{k8s: k8s, resolver: r, renderer: renderer}
+// NewHandler creates a TemplateService handler. policyResolver is the
+// TemplatePolicy resolution seam — Phase 4 callers should pass
+// policyresolver.NewNoopResolver(); Phase 5 swaps in a real implementation.
+func NewHandler(k8s *K8sClient, r *resolver.Resolver, renderer Renderer, policyResolver policyresolver.PolicyResolver) *Handler {
+	return &Handler{k8s: k8s, resolver: r, renderer: renderer, policyResolver: policyResolver}
 }
 
 // WithOrgGrantResolver configures the handler with an OrgGrantResolver.
@@ -629,7 +637,7 @@ func (h *Handler) renderTemplateGrouped(ctx context.Context, msg *consolev1.Rend
 				msg.GetScope().GetScopeName(),
 				msg.LinkedTemplates,
 				h.walker,
-				nil, // Phase 4 (HOL-566) wires a real PolicyResolver here.
+				h.policyResolver,
 			)
 			if walkErr != nil {
 				slog.WarnContext(ctx, "ancestor template resolution failed, falling back to plain render",
@@ -659,16 +667,17 @@ func (h *Handler) renderTemplateGrouped(ctx context.Context, msg *consolev1.Rend
 // TargetKind the unified helper expects. Project scope means a project-scope
 // template is being previewed (TargetKindProjectTemplate). Org/folder/unknown
 // scopes also use TargetKindProjectTemplate today — no call site actually
-// differentiates yet (the discriminator is plumbed for Phase 4 policy
-// evaluation).
+// differentiates yet. The discriminator is plumbed end-to-end by HOL-566
+// Phase 4 so Phase 5 (HOL-567) can key real REQUIRE/EXCLUDE evaluation off
+// it without touching call sites.
 //
 // IMPORTANT: This helper is for the PREVIEW render path only. The deployments
 // apply path does NOT go through this function: it calls
 // K8sClient.ListEffectiveTemplateSources directly with TargetKindDeployment
-// from AncestorTemplateResolver. When Phase 4 wires real policy evaluation,
+// from AncestorTemplateResolver. When Phase 5 wires real policy evaluation,
 // do not add a branch here that returns TargetKindDeployment — that would be
 // wrong because this function never runs on the apply path. The scope input
-// is intentionally ignored today; the parameter exists so Phase 4 can add
+// is intentionally ignored today; the parameter exists so Phase 5 can add
 // preview-path-specific TargetKind discrimination (e.g., different kinds for
 // project-vs-folder preview) without changing the call site signature.
 func previewTargetKindForScope(scope consolev1.TemplateScope) TargetKind {

--- a/console/templates/handler_linkable_test.go
+++ b/console/templates/handler_linkable_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -135,7 +136,7 @@ func makeReleaseCMWithData(ns, templateName, version, cue, defaults string) *cor
 func newLinkableTestHandler(fakeClient *fake.Clientset, shareUsers map[string]string, walker AncestorWalker) *Handler {
 	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 	k8s := NewK8sClient(fakeClient, r)
-	handler := NewHandler(k8s, r, &stubRenderer{})
+	handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
 	handler.WithProjectGrantResolver(&stubProjectGrantResolver{users: shareUsers})
 	handler.WithAncestorWalker(walker)
 	return handler
@@ -384,7 +385,7 @@ func TestListLinkableTemplatesIncludeSelfScope(t *testing.T) {
 		fakeClient := fake.NewClientset(orgNsObj, folderNsObj, orgTemplate, folderTemplate)
 		r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 		k8s := NewK8sClient(fakeClient, r)
-		handler := NewHandler(k8s, r, &stubRenderer{})
+		handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
 		handler.WithAncestorWalker(&stubAncestorWalker{ancestors: ancestors})
 		// Wire whichever grant resolver matches the request scope so
 		// checkAccess passes.

--- a/console/templates/handler_release_test.go
+++ b/console/templates/handler_release_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -19,7 +20,7 @@ import (
 func newOrgTestHandler(fakeClient *fake.Clientset, shareUsers map[string]string) *Handler {
 	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 	k8s := NewK8sClient(fakeClient, r)
-	handler := NewHandler(k8s, r, &stubRenderer{})
+	handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
 	handler.WithOrgGrantResolver(&stubOrgGrantResolver{users: shareUsers})
 	return handler
 }

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
@@ -258,7 +259,7 @@ func TestValidateCueSyntax(t *testing.T) {
 func newTestHandler(fakeClient *fake.Clientset, shareUsers map[string]string) *Handler {
 	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 	k8s := NewK8sClient(fakeClient, r)
-	handler := NewHandler(k8s, r, &stubRenderer{})
+	handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
 	handler.WithProjectGrantResolver(&stubProjectGrantResolver{users: shareUsers})
 	return handler
 }
@@ -703,7 +704,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 			ancestors: []*corev1.Namespace{prjNsObj, fldNsObj, orgNsObj},
 		}
 
-		handler := NewHandler(k8s, r, renderer)
+		handler := NewHandler(k8s, r, renderer, policyresolver.NewNoopResolver())
 		handler.WithAncestorWalker(walker)
 
 		msg := &consolev1.RenderTemplateRequest{
@@ -794,7 +795,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 			ancestors: []*corev1.Namespace{prjNsObj, fldNsObj, orgNsObj},
 		}
 
-		handler := NewHandler(k8s, r, renderer)
+		handler := NewHandler(k8s, r, renderer, policyresolver.NewNoopResolver())
 		handler.WithAncestorWalker(walker)
 
 		msg := &consolev1.RenderTemplateRequest{
@@ -838,7 +839,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, r)
 		renderer := &trackingRenderer{}
 		// No walker configured.
-		handler := NewHandler(k8s, r, renderer)
+		handler := NewHandler(k8s, r, renderer, policyresolver.NewNoopResolver())
 
 		msg := &consolev1.RenderTemplateRequest{
 			CueTemplate: validCue,
@@ -914,7 +915,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 		walker := &stubAncestorWalker{
 			ancestors: []*corev1.Namespace{prjNsObj, fldNsObj, orgNsObj},
 		}
-		handler := NewHandler(k8s, r, renderer)
+		handler := NewHandler(k8s, r, renderer, policyresolver.NewNoopResolver())
 		handler.WithAncestorWalker(walker)
 		_, err := handler.renderTemplateGrouped(context.Background(), &consolev1.RenderTemplateRequest{
 			Scope:       projectScopeRef(project),
@@ -928,10 +929,11 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 		}
 
 		// Apply path: runs via AncestorTemplateResolver + ListEffectiveTemplateSources.
-		applyResolver := NewAncestorTemplateResolver(k8s, walker)
+		applyResolver := NewAncestorTemplateResolver(k8s, walker, policyresolver.NewNoopResolver())
 		applySources, err := applyResolver.ListAncestorTemplateSources(
 			context.Background(),
 			"prj-"+project,
+			"test-deployment",
 			[]*consolev1.LinkedTemplateRef{folderLinkedRef(folder, "shared")},
 		)
 		if err != nil {
@@ -1240,7 +1242,7 @@ input: #ProjectInput & {
 
 			r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 			k8s := NewK8sClient(fakeClient, r)
-			handler := NewHandler(k8s, r, &stubRenderer{})
+			handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
 			handler.WithProjectGrantResolver(&stubProjectGrantResolver{users: shareUsers})
 			handler.WithOrgGrantResolver(&stubOrgGrantResolver{users: shareUsers})
 
@@ -1294,7 +1296,7 @@ input: #ProjectInput & {
 func TestGetTemplateDefaultsValidation(t *testing.T) {
 	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 	k8s := NewK8sClient(fake.NewClientset(), r)
-	handler := NewHandler(k8s, r, &stubRenderer{})
+	handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
 	handler.WithProjectGrantResolver(&stubProjectGrantResolver{})
 	handler.WithOrgGrantResolver(&stubOrgGrantResolver{})
 

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -294,28 +295,23 @@ func (k *K8sClient) ListTemplatesInNamespace(ctx context.Context, ns string) ([]
 	return list.Items, nil
 }
 
-// TargetKind identifies the kind of render target driving a call to
-// ListEffectiveTemplateSources. In this phase it is purely descriptive — both
-// values exercise the same resolution logic — but Phase 4 will key
-// PolicyResolver evaluation off this discriminator so the signature is stable
-// across call sites today.
-type TargetKind int
+// TargetKind is re-exported from console/policyresolver so existing call
+// sites in this package and its tests keep compiling after the PolicyResolver
+// seam moved out (HOL-566). The underlying type and constants live in the
+// policyresolver package because TargetKind is part of the PolicyResolver
+// contract — handlers and helpers that own resolution decisions consume
+// both together.
+type TargetKind = policyresolver.TargetKind
 
 const (
 	// TargetKindProjectTemplate is the preview render path for project-scope
 	// templates (the RenderTemplate RPC and the project-scope Create/Update
 	// template handlers once they grow a render step).
-	TargetKindProjectTemplate TargetKind = iota
+	TargetKindProjectTemplate = policyresolver.TargetKindProjectTemplate
 	// TargetKindDeployment is the apply render path for deployments
 	// (AncestorTemplateProvider on the deployments handler).
-	TargetKindDeployment
+	TargetKindDeployment = policyresolver.TargetKindDeployment
 )
-
-// PolicyResolver is a forward-declared placeholder for the TemplatePolicy
-// resolver interface introduced in Phase 4 (HOL-566). Every call site passes
-// nil today; Phase 4 replaces the alias with a concrete interface without
-// touching call sites.
-type PolicyResolver = any
 
 // RenderHierarchyWalker walks the namespace hierarchy for render-time ancestor
 // template resolution. This mirrors HierarchyWalker from apply.go but is
@@ -353,14 +349,13 @@ type RenderHierarchyWalker interface {
 // nil (no ancestor sources). If the walker returns an error, the method
 // degrades gracefully to an empty slice — callers render project-only.
 //
-// policyResolver is currently an untyped nil placeholder (Phase 2 of
-// HOL-562). Phase 4 (HOL-566) replaces the PolicyResolver alias with a real
-// interface and wires evaluation through this function; every call site
-// passes nil today so that phase swap is internal.
-//
-// targetKind is accepted but not yet consulted — Phase 4 keys
-// PolicyResolver.Evaluate off it. Every call site already passes the
-// appropriate discriminator so no call site touching is needed later.
+// resolver evaluates TemplatePolicy REQUIRE/EXCLUDE rules against the
+// caller's explicitRefs before the ancestor walk. Phase 4 (HOL-566) threads
+// the PolicyResolver seam through every call site with a no-op
+// implementation that returns explicitRefs unchanged; Phase 5 (HOL-567)
+// swaps in a real policy-backed implementation. When resolver is nil the
+// call site predates the seam — the function falls back to using
+// explicitRefs directly so tests that have not been updated keep working.
 //
 // Storage-isolation note (HOL-554): the walk deliberately skips the starting
 // namespace (ancestors[0]) and only reads templates, releases, and — once
@@ -374,15 +369,25 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 	targetName string,
 	explicitRefs []*consolev1.LinkedTemplateRef,
 	walker RenderHierarchyWalker,
-	_ PolicyResolver,
+	resolver policyresolver.PolicyResolver,
 ) ([]string, error) {
-	// targetKind and targetName are accepted for a stable signature; both
-	// become load-bearing in Phase 4 when PolicyResolver evaluates per target.
-	_ = targetKind
-	_ = targetName
-
 	if walker == nil {
 		return nil, nil
+	}
+
+	// Resolve the caller's explicit refs through the PolicyResolver seam
+	// before walking ancestors. Phase 4 (HOL-566) wires a no-op resolver at
+	// every call site; Phase 5 swaps in real REQUIRE/EXCLUDE evaluation.
+	// A nil resolver means the call site predates the seam — fall back to
+	// explicitRefs unchanged so tests that were written before HOL-566 keep
+	// exercising the ancestor walk without modification.
+	effectiveRefs := explicitRefs
+	if resolver != nil {
+		resolved, resolveErr := resolver.Resolve(ctx, projectNs, targetKind, targetName, explicitRefs)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("resolving template policy for %q: %w", targetName, resolveErr)
+		}
+		effectiveRefs = resolved
 	}
 
 	ancestors, err := walker.WalkAncestors(ctx, projectNs)
@@ -396,8 +401,8 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 
 	// Build a lookup from (scope, scopeName, name) -> linked ref so linked
 	// templates with version constraints resolve their release source.
-	linkedByKey := make(map[linkedRef]*consolev1.LinkedTemplateRef, len(explicitRefs))
-	for _, ref := range explicitRefs {
+	linkedByKey := make(map[linkedRef]*consolev1.LinkedTemplateRef, len(effectiveRefs))
+	for _, ref := range effectiveRefs {
 		if ref == nil {
 			continue
 		}
@@ -936,24 +941,30 @@ func scopeAndNameFromNs(r *resolver.Resolver, ns string) (consolev1.TemplateScop
 	return consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED, ""
 }
 
-// AncestorTemplateResolver adapts K8sClient + a walker into a single-method
-// interface suitable for the deployments package (which cannot import templates
-// directly due to the avoid-import-cycle convention). The walker is closed over
-// at construction time so the caller only needs to pass project namespace and
+// AncestorTemplateResolver adapts K8sClient + a walker + a PolicyResolver
+// into a single-method interface suitable for the deployments package (which
+// cannot import templates directly due to the avoid-import-cycle
+// convention). The walker and resolver are closed over at construction time
+// so the caller only needs to pass project namespace, deployment name, and
 // linked refs.
 type AncestorTemplateResolver struct {
-	k8s    *K8sClient
-	walker RenderHierarchyWalker
+	k8s      *K8sClient
+	walker   RenderHierarchyWalker
+	resolver policyresolver.PolicyResolver
 }
 
-// NewAncestorTemplateResolver creates an AncestorTemplateResolver.
-func NewAncestorTemplateResolver(k8s *K8sClient, walker RenderHierarchyWalker) *AncestorTemplateResolver {
-	return &AncestorTemplateResolver{k8s: k8s, walker: walker}
+// NewAncestorTemplateResolver creates an AncestorTemplateResolver. resolver
+// is the TemplatePolicy resolution seam (HOL-566 Phase 4). Callers should
+// pass policyresolver.NewNoopResolver() until Phase 5 wires a real
+// implementation; nil is accepted for backwards compatibility in tests
+// written before HOL-566.
+func NewAncestorTemplateResolver(k8s *K8sClient, walker RenderHierarchyWalker, resolver policyresolver.PolicyResolver) *AncestorTemplateResolver {
+	return &AncestorTemplateResolver{k8s: k8s, walker: walker, resolver: resolver}
 }
 
 // ListAncestorTemplateSources satisfies deployments.AncestorTemplateProvider.
-// The targetName is unused in this phase; Phase 4 (HOL-566) will key policy
-// evaluation off it.
-func (a *AncestorTemplateResolver) ListAncestorTemplateSources(ctx context.Context, projectNs string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, error) {
-	return a.k8s.ListEffectiveTemplateSources(ctx, projectNs, TargetKindDeployment, "", linkedRefs, a.walker, nil)
+// The targetName identifies the deployment driving the render so Phase 5
+// REQUIRE/EXCLUDE evaluation can key off it.
+func (a *AncestorTemplateResolver) ListAncestorTemplateSources(ctx context.Context, projectNs, targetName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, error) {
+	return a.k8s.ListEffectiveTemplateSources(ctx, projectNs, TargetKindDeployment, targetName, linkedRefs, a.walker, a.resolver)
 }

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -516,7 +517,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		fakeClient := fake.NewClientset(orgNsObj)
 		k8s := NewK8sClient(fakeClient, testResolver())
 
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, nil, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, nil, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -535,7 +536,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -560,7 +561,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			{Scope: orgScope, ScopeName: "my-org", Name: "httproute"},
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -585,7 +586,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 		walker := &stubHierarchyWalker{ancestors: fullAncestors}
 
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -603,7 +604,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -641,7 +642,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			folderLinkedRefWithConstraint("payments", "payments-policy", ">=1.0.0"),
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -661,7 +662,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("expected graceful degradation, got error: %v", err)
 		}
@@ -677,7 +678,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 		walker := &stubHierarchyWalker{ancestors: fullAncestors}
 
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -705,7 +706,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			{Scope: orgScope, ScopeName: "my-org", Name: sharedName},
 			{Scope: folderScope, ScopeName: "payments", Name: sharedName},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, nil)
+		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -736,11 +737,11 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			{Scope: orgScope, ScopeName: "my-org", Name: "httproute"},
 		}
 
-		deploymentSources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, nil)
+		deploymentSources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error (deployment): %v", err)
 		}
-		projectSources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindProjectTemplate, "tmpl", refs, walker, nil)
+		projectSources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindProjectTemplate, "tmpl", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error (project template): %v", err)
 		}

--- a/console/templates/require_apply.go
+++ b/console/templates/require_apply.go
@@ -9,6 +9,7 @@ import (
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -74,28 +75,34 @@ func NewEmptyRequireRuleResolver() RequireRuleResolver {
 // source. This matches ADR 021 Decision 3 and replaces the v1alpha1-era
 // parallel render path deleted in HOL-565.
 type RequiredTemplateApplier struct {
-	k8s      *K8sClient
-	walker   RenderHierarchyWalker
-	renderer *deployments.CueRenderer
-	applier  ResourceApplier
-	resolver RequireRuleResolver
+	k8s            *K8sClient
+	walker         RenderHierarchyWalker
+	renderer       *deployments.CueRenderer
+	applier        ResourceApplier
+	resolver       RequireRuleResolver
+	policyResolver policyresolver.PolicyResolver
 }
 
 // NewRequiredTemplateApplier creates a RequiredTemplateApplier. resolver must
 // not be nil — use NewEmptyRequireRuleResolver for the Phase 3 placeholder.
+// policyResolver is the HOL-566 Phase 4 TemplatePolicy resolution seam;
+// callers should pass policyresolver.NewNoopResolver() until Phase 5 wires
+// a real implementation.
 func NewRequiredTemplateApplier(
 	k8s *K8sClient,
 	walker RenderHierarchyWalker,
 	renderer *deployments.CueRenderer,
 	applier ResourceApplier,
 	resolver RequireRuleResolver,
+	policyResolver policyresolver.PolicyResolver,
 ) *RequiredTemplateApplier {
 	return &RequiredTemplateApplier{
-		k8s:      k8s,
-		walker:   walker,
-		renderer: renderer,
-		applier:  applier,
-		resolver: resolver,
+		k8s:            k8s,
+		walker:         walker,
+		renderer:       renderer,
+		applier:        applier,
+		resolver:       resolver,
+		policyResolver: policyResolver,
 	}
 }
 
@@ -176,7 +183,7 @@ func (a *RequiredTemplateApplier) applyMatch(
 		match.TemplateName,
 		[]*consolev1.LinkedTemplateRef{templateRef},
 		a.walker,
-		nil,
+		a.policyResolver,
 	)
 	if err != nil {
 		return fmt.Errorf("listing ancestor sources for required template %q (%s/%s): %w",

--- a/console/templates/require_apply_test.go
+++ b/console/templates/require_apply_test.go
@@ -15,6 +15,7 @@ import (
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
@@ -157,7 +158,7 @@ func TestRequiredTemplateApplier(t *testing.T) {
 			applier := &recordingApplier{err: tc.applyErr}
 			resolver := &stubRequireRuleResolver{matches: tc.matches, err: tc.resolveErr}
 
-			rta := NewRequiredTemplateApplier(k8s, walker, &deployments.CueRenderer{}, applier, resolver)
+			rta := NewRequiredTemplateApplier(k8s, walker, &deployments.CueRenderer{}, applier, resolver, policyresolver.NewNoopResolver())
 
 			claims := &rpc.Claims{Sub: "alice", Email: "alice@example.com"}
 			err := rta.ApplyRequiredTemplates(context.Background(), "acme", "new-prj", "prj-new-prj", claims)
@@ -199,7 +200,7 @@ func TestRequiredTemplateApplier_NilResolverIsNoOp(t *testing.T) {
 	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 	k8s := NewK8sClient(fake.NewClientset(), r)
 	applier := &recordingApplier{}
-	rta := NewRequiredTemplateApplier(k8s, nil, &deployments.CueRenderer{}, applier, nil)
+	rta := NewRequiredTemplateApplier(k8s, nil, &deployments.CueRenderer{}, applier, nil, policyresolver.NewNoopResolver())
 
 	if err := rta.ApplyRequiredTemplates(context.Background(), "acme", "new-prj", "prj-new-prj", nil); err != nil {
 		t.Fatalf("expected no error with nil resolver, got %v", err)


### PR DESCRIPTION
## Summary

- Introduce `console/policyresolver` package with `PolicyResolver` interface and `noopResolver` that returns inputs unchanged.
- Move `TargetKind` into the new package as part of the resolver contract; re-export it from `console/templates` to keep call sites compiling.
- Wire a single `noopResolver` instance through the console bootstrap into the deployments handler, templates handler, and `RequiredTemplateApplier`; update every `ListEffectiveTemplateSources` call site to pass the wired resolver.
- Thread `deploymentName` through `AncestorTemplateProvider.ListAncestorTemplateSources`, `renderResources`, and `renderResourcesGrouped` so Phase 5 can key REQUIRE/EXCLUDE evaluation off the render target.
- Add table-driven unit tests for `noopResolver` covering both `TargetKindProjectTemplate` and `TargetKindDeployment`, plus a no-mutation contract test.

After this phase, every render path in `console/` — deployments (create/update/preview), project-scope templates (create/update/preview), and project creation (REQUIRE-matched templates) — shares one named resolver seam. Behavior does not change; Phase 5 (HOL-567) swaps the no-op for a real implementation.

Phase 4 of HOL-562.

Fixes HOL-566

## Test plan

- [x] `make test` — all Go and frontend tests pass locally
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./console/policyresolver/ ./console/templates/ ./console/deployments/` reports only pre-existing findings (one errcheck in `logs.go`, one staticcheck in `semver_test.go` — neither in files touched by this PR)
- [ ] CI unit + lint green
- [ ] CI E2E green (local E2E was not run — change is internal wiring of a no-op resolver with no behavior change; relying on CI E2E)

Generated with [Claude Code](https://claude.com/claude-code)