### PR TITLE
docs(deployments): clarify Renderer.Render level selector (HOL-568)

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -62,9 +62,12 @@ const DefaultGatewayNamespace = "istio-ingress"
 type Renderer interface {
 	// Render evaluates the deployment template unified with zero or more
 	// ancestor template CUE sources and the provided inputs, returning
-	// resources grouped by origin (platform vs project). When
-	// ancestorSources is empty this is a project-level render and
-	// platformResources is not read (ADR 016 Decision 8).
+	// resources grouped by origin (platform vs project). The render level is
+	// controlled by inputs.ReadPlatformResources (project-level: false;
+	// organization/folder-level: true); ancestorSources may be empty at
+	// either level and carries additional template CUE sources unified with
+	// the deployment template but does not select the render level (ADR 016
+	// Decision 8).
 	Render(ctx context.Context, cueSource string, ancestorSources []string, inputs RenderInputs) (*GroupedResources, error)
 }
 


### PR DESCRIPTION
## Summary

- Update the `Renderer` interface doc comment in `console/deployments/handler.go` to describe the actual post-HOL-563 contract: the render level is controlled by `inputs.ReadPlatformResources` (project-level: false; organization/folder-level: true), not by whether `ancestorSources` is empty.
- The old wording ("When ancestorSources is empty this is a project-level render and platformResources is not read") was correct before PR #970 but was made incorrect by that PR's round-1 fix, which moved the level selector onto `RenderInputs.ReadPlatformResources`. The handler explicitly sets `ReadPlatformResources=true` for org/folder-level renders even when the ancestor walk returns zero sources, so the stale interface doc could mislead future callers.
- Interface doc now matches the wording already present on the `CueRenderer.Render` implementation doc at `console/deployments/render.go:81-95`.
- ADR 016 Decision 8 citation retained; no behavior change (doc-only).

Fixes HOL-568

## Test plan

- [x] `go build ./console/deployments/...` is green
- [x] `go vet ./console/deployments/...` is clean
- [x] `go test ./console/deployments/...` all pass
- [ ] CI Unit Tests and Lint pass

Generated with [Claude Code](https://claude.com/claude-code)