### PR TITLE
feat(console): write-through RecordApplied on Create/Update happy paths

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -85,8 +85,17 @@ type AncestorWalker interface {
 // starting namespace for the ancestor walk; deploymentName identifies the
 // render target so the underlying PolicyResolver can key REQUIRE/EXCLUDE
 // evaluation off it (HOL-566 Phase 4).
+//
+// The second return value is the policy-effective ref set (explicit ∪
+// REQUIRE − EXCLUDE) that produced the sources. Exposing it here lets the
+// deployments Create/Update happy paths write-through the same set to the
+// applied-render-set store via PolicyDriftChecker.RecordApplied without
+// invoking the resolver a second time (HOL-569). A second invocation would
+// open a race with concurrent policy edits in which the stored set drifts
+// from the rendered set and GetDeploymentPolicyState reports false drift.
+// Callers that only need the sources can ignore the second return.
 type AncestorTemplateProvider interface {
-	ListAncestorTemplateSources(ctx context.Context, projectNs, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, error)
+	ListAncestorTemplateSources(ctx context.Context, projectNs, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error)
 }
 
 // ResourceApplier applies and cleans up K8s resources for a deployment.
@@ -201,23 +210,30 @@ func (h *Handler) WithPolicyDriftChecker(c PolicyDriftChecker) *Handler {
 // the full ancestor chain when an AncestorTemplateProvider is configured.
 // deploymentName identifies the render target so the underlying
 // PolicyResolver (HOL-566 Phase 4) can key REQUIRE/EXCLUDE evaluation off
-// it in Phase 5. Returns (sources, true) on success, or (nil, false) when no
-// provider is configured or the walk fails.
-func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, bool) {
+// it in Phase 5.
+//
+// Returns (sources, effectiveRefs, true) on success — the effectiveRefs
+// slice carries the policy-resolved ref set that produced the sources so
+// the deployments handler can write-through the same set to the applied-
+// render-set store after a successful apply/reconcile without a second
+// resolver invocation (HOL-569). Returns (nil, nil, false) when no
+// provider is configured or the walk fails; the caller should fall back to
+// a project-only render in that case.
+func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, bool) {
 	if h.ancestorTemplateProvider == nil {
-		return nil, false
+		return nil, nil, false
 	}
 	projectNs := h.k8s.Resolver.ProjectNamespace(project)
-	sources, err := h.ancestorTemplateProvider.ListAncestorTemplateSources(ctx, projectNs, deploymentName, linkedRefs)
+	sources, effectiveRefs, err := h.ancestorTemplateProvider.ListAncestorTemplateSources(ctx, projectNs, deploymentName, linkedRefs)
 	if err != nil {
 		slog.WarnContext(ctx, "ancestor template resolution failed, skipping platform template unification",
 			slog.String("project", project),
 			slog.String("deployment", deploymentName),
 			slog.Any("error", err),
 		)
-		return nil, false
+		return nil, nil, false
 	}
-	return sources, true
+	return sources, effectiveRefs, true
 }
 
 // renderResources renders deployment resources, unifying with platform
@@ -241,7 +257,7 @@ func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project, d
 // PolicyResolver (HOL-566 Phase 4). Phase 5 (HOL-567) keys REQUIRE/EXCLUDE
 // evaluation off it; until then it is observational.
 func (h *Handler) renderResources(ctx context.Context, project, deploymentName, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) ([]unstructured.Unstructured, error) {
-	grouped, err := h.renderResourcesGrouped(ctx, project, deploymentName, cueSource, platform, projectInput, linkedRefs)
+	grouped, _, err := h.renderResourcesGrouped(ctx, project, deploymentName, cueSource, platform, projectInput, linkedRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -264,18 +280,32 @@ func (h *Handler) renderResources(ctx context.Context, project, deploymentName, 
 // deploymentName is the render target name plumbed through to the
 // PolicyResolver (HOL-566 Phase 4). Phase 5 (HOL-567) keys REQUIRE/EXCLUDE
 // evaluation off it; until then it is observational.
-func (h *Handler) renderResourcesGrouped(ctx context.Context, project, deploymentName, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) (*GroupedResources, error) {
+//
+// The second return value is the policy-effective ref set the provider
+// reported — callers on the Create/Update write path pass it to
+// PolicyDriftChecker.RecordApplied so the applied-render-set store stays
+// aligned with what was actually rendered (HOL-569). Preview callers can
+// ignore it. It is nil when no AncestorTemplateProvider is configured or the
+// provider returned an error (the render falls back to project-only in both
+// cases, so there is no rendered set to record).
+func (h *Handler) renderResourcesGrouped(ctx context.Context, project, deploymentName, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput, linkedRefs []*consolev1.LinkedTemplateRef) (*GroupedResources, []*consolev1.LinkedTemplateRef, error) {
 	var ancestorSources []string
+	var effectiveRefs []*consolev1.LinkedTemplateRef
 	readPlatformResources := false
-	if sources, ok := h.resolveAncestorTemplateSources(ctx, project, deploymentName, linkedRefs); ok {
+	if sources, refs, ok := h.resolveAncestorTemplateSources(ctx, project, deploymentName, linkedRefs); ok {
 		ancestorSources = sources
+		effectiveRefs = refs
 		readPlatformResources = true
 	}
-	return h.renderer.Render(ctx, cueSource, ancestorSources, RenderInputs{
+	grouped, err := h.renderer.Render(ctx, cueSource, ancestorSources, RenderInputs{
 		Platform:              platform,
 		Project:               projectInput,
 		ReadPlatformResources: readPlatformResources,
 	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return grouped, effectiveRefs, nil
 }
 
 // ListDeployments returns all deployments in a project.
@@ -494,7 +524,7 @@ func (h *Handler) CreateDeployment(
 			Env:     envInputs,
 			Port:    defaultPort(int(req.Msg.Port)),
 		}
-		grouped, renderErr := h.renderResourcesGrouped(ctx, project, name, cueSource, platformIn, projectIn, linkedOrgTemplates)
+		grouped, effectiveRefs, renderErr := h.renderResourcesGrouped(ctx, project, name, cueSource, platformIn, projectIn, linkedOrgTemplates)
 		if renderErr != nil {
 			slog.WarnContext(ctx, "render failed after creating deployment — rolling back",
 				slog.String("project", project),
@@ -513,6 +543,24 @@ func (h *Handler) CreateDeployment(
 			)
 			h.rollbackCreate(ctx, ns, project, name)
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("applying deployment resources: %w", applyErr))
+		}
+		// Write-through the effective render set to the applied-render-set
+		// store so GetDeploymentPolicyState and the list-view policy_drift
+		// flag have a baseline to diff against (HOL-569). Skipped when no
+		// checker is wired (local/dev bootstrap without a cluster policy
+		// resolver). A record failure is logged at warn level and does NOT
+		// fail the RPC — the deployment was rendered and applied
+		// successfully, and the set can be reconstructed on the next render.
+		// This mirrors the SetOutputURLAnnotation precedent immediately
+		// below.
+		if h.policyDriftChecker != nil {
+			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, effectiveRefs); recordErr != nil {
+				slog.WarnContext(ctx, "failed to record applied render set after create",
+					slog.String("project", project),
+					slog.String("name", name),
+					slog.Any("error", recordErr),
+				)
+			}
 		}
 		// Cache the evaluated output.url on the ConfigMap annotation so
 		// later ListDeployments/GetDeployment calls can surface it without
@@ -654,7 +702,7 @@ func (h *Handler) UpdateDeployment(
 			Env:     envFromConfigMapAsV1alpha2(updated),
 			Port:    defaultPort(portFromConfigMap(updated)),
 		}
-		grouped, renderErr := h.renderResourcesGrouped(ctx, project, name, cueSource, platformIn, projectIn, linkedOrgTemplatesUpdate)
+		grouped, effectiveRefs, renderErr := h.renderResourcesGrouped(ctx, project, name, cueSource, platformIn, projectIn, linkedOrgTemplatesUpdate)
 		if renderErr != nil {
 			slog.WarnContext(ctx, "render failed during deployment update",
 				slog.String("project", project),
@@ -683,6 +731,20 @@ func (h *Handler) UpdateDeployment(
 				slog.Any("error", reconcileErr),
 			)
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("reconciling deployment resources: %w", reconcileErr))
+		}
+		// Write-through the effective render set so subsequent policy-state
+		// queries diff against what this update actually rendered (HOL-569).
+		// Same contract as the create path: nil checker is a no-op, record
+		// errors are logged but do not fail the RPC because reconcile
+		// already succeeded.
+		if h.policyDriftChecker != nil {
+			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, effectiveRefs); recordErr != nil {
+				slog.WarnContext(ctx, "failed to record applied render set after update",
+					slog.String("project", project),
+					slog.String("name", name),
+					slog.Any("error", recordErr),
+				)
+			}
 		}
 		// Refresh the cached output URL annotation. Unlike create, update
 		// always sets or clears so a template edit that drops the output
@@ -956,7 +1018,9 @@ func (h *Handler) GetDeploymentRenderPreview(
 	var grouped *GroupedResources
 	if h.renderer != nil {
 		var renderErr error
-		grouped, renderErr = h.renderResourcesGrouped(ctx, project, name, cueTemplate, platformIn, projectIn, linkedOrgTemplatesPreview)
+		// Preview path: discard the effective-ref set (second return) — only
+		// the write-through paths on Create/Update consume it (HOL-569).
+		grouped, _, renderErr = h.renderResourcesGrouped(ctx, project, name, cueTemplate, platformIn, projectIn, linkedOrgTemplatesPreview)
 		if renderErr != nil {
 			slog.WarnContext(ctx, "render failed during deployment preview",
 				slog.String("project", project),

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -548,12 +548,16 @@ func (h *Handler) CreateDeployment(
 		// store so GetDeploymentPolicyState and the list-view policy_drift
 		// flag have a baseline to diff against (HOL-569). Skipped when no
 		// checker is wired (local/dev bootstrap without a cluster policy
-		// resolver). A record failure is logged at warn level and does NOT
-		// fail the RPC — the deployment was rendered and applied
-		// successfully, and the set can be reconstructed on the next render.
-		// This mirrors the SetOutputURLAnnotation precedent immediately
-		// below.
-		if h.policyDriftChecker != nil {
+		// resolver) OR when the provider signaled a degraded render by
+		// returning nil effectiveRefs (walker failed / no walker) — in that
+		// case the render was project-only and persisting the policy-
+		// resolved set would falsely claim ancestor templates were applied
+		// (review round 1 P1 finding). A record failure is logged at warn
+		// level and does NOT fail the RPC — the deployment was rendered
+		// and applied successfully, and the set can be reconstructed on
+		// the next render. This mirrors the SetOutputURLAnnotation
+		// precedent immediately below.
+		if h.policyDriftChecker != nil && effectiveRefs != nil {
 			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, effectiveRefs); recordErr != nil {
 				slog.WarnContext(ctx, "failed to record applied render set after create",
 					slog.String("project", project),
@@ -736,8 +740,11 @@ func (h *Handler) UpdateDeployment(
 		// queries diff against what this update actually rendered (HOL-569).
 		// Same contract as the create path: nil checker is a no-op, record
 		// errors are logged but do not fail the RPC because reconcile
-		// already succeeded.
-		if h.policyDriftChecker != nil {
+		// already succeeded. Also skip when effectiveRefs is nil (degraded
+		// render path — walker failed / no walker) so the stored set
+		// cannot falsely claim ancestor templates participated (review
+		// round 1 P1 finding).
+		if h.policyDriftChecker != nil && effectiveRefs != nil {
 			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, effectiveRefs); recordErr != nil {
 				slog.WarnContext(ctx, "failed to record applied render set after update",
 					slog.String("project", project),

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -548,17 +548,23 @@ func (h *Handler) CreateDeployment(
 		// store so GetDeploymentPolicyState and the list-view policy_drift
 		// flag have a baseline to diff against (HOL-569). Skipped when no
 		// checker is wired (local/dev bootstrap without a cluster policy
-		// resolver) OR when the provider signaled a degraded render by
-		// returning nil effectiveRefs (walker failed / no walker) — in that
-		// case the render was project-only and persisting the policy-
-		// resolved set would falsely claim ancestor templates were applied
-		// (review round 1 P1 finding). A record failure is logged at warn
-		// level and does NOT fail the RPC — the deployment was rendered
-		// and applied successfully, and the set can be reconstructed on
-		// the next render. This mirrors the SetOutputURLAnnotation
-		// precedent immediately below.
-		if h.policyDriftChecker != nil && effectiveRefs != nil {
-			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, effectiveRefs); recordErr != nil {
+		// resolver). When the provider signaled a degraded render by
+		// returning nil effectiveRefs (walker failed / no walker), record
+		// a non-nil empty slice so the baseline reflects reality — zero
+		// ancestor templates actually participated in this apply. This
+		// keeps GetDeploymentPolicyState honest: a subsequent query whose
+		// resolver returns a non-empty current set will correctly report
+		// drift against the empty applied set (review round 2 P2 finding).
+		// A record failure is logged at warn level and does NOT fail the
+		// RPC — the deployment was rendered and applied successfully, and
+		// the set can be reconstructed on the next render. This mirrors
+		// the SetOutputURLAnnotation precedent immediately below.
+		if h.policyDriftChecker != nil {
+			refsToRecord := effectiveRefs
+			if refsToRecord == nil {
+				refsToRecord = []*consolev1.LinkedTemplateRef{}
+			}
+			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, refsToRecord); recordErr != nil {
 				slog.WarnContext(ctx, "failed to record applied render set after create",
 					slog.String("project", project),
 					slog.String("name", name),
@@ -740,12 +746,17 @@ func (h *Handler) UpdateDeployment(
 		// queries diff against what this update actually rendered (HOL-569).
 		// Same contract as the create path: nil checker is a no-op, record
 		// errors are logged but do not fail the RPC because reconcile
-		// already succeeded. Also skip when effectiveRefs is nil (degraded
-		// render path — walker failed / no walker) so the stored set
-		// cannot falsely claim ancestor templates participated (review
-		// round 1 P1 finding).
-		if h.policyDriftChecker != nil && effectiveRefs != nil {
-			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, effectiveRefs); recordErr != nil {
+		// already succeeded. A nil effectiveRefs signals a degraded render
+		// path (walker failed / no walker) — in that case overwrite the
+		// stored baseline with an empty set so any previously recorded
+		// policy-resolved set cannot mask the fact that this reconcile
+		// applied zero ancestor templates (review round 2 P2 finding).
+		if h.policyDriftChecker != nil {
+			refsToRecord := effectiveRefs
+			if refsToRecord == nil {
+				refsToRecord = []*consolev1.LinkedTemplateRef{}
+			}
+			if recordErr := h.policyDriftChecker.RecordApplied(ctx, project, name, refsToRecord); recordErr != nil {
 				slog.WarnContext(ctx, "failed to record applied render set after update",
 					slog.String("project", project),
 					slog.String("name", name),

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -1316,15 +1316,25 @@ func TestHandler_GetDeploymentRenderPreview(t *testing.T) {
 // stubAncestorTemplateProvider implements AncestorTemplateProvider for tests.
 type stubAncestorTemplateProvider struct {
 	sources            []string
+	effectiveRefs      []*consolev1.LinkedTemplateRef
 	err                error
 	called             bool
 	lastDeploymentName string
 }
 
-func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Context, _ string, deploymentName string, _ []*consolev1.LinkedTemplateRef) ([]string, error) {
+func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Context, _ string, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error) {
 	s.called = true
 	s.lastDeploymentName = deploymentName
-	return s.sources, s.err
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+	// When no explicit override, mirror the input refs back as the "resolved"
+	// effective set so tests that do not care about policy resolution still
+	// see a non-nil ref slice flow through the write-through path.
+	if s.effectiveRefs != nil {
+		return s.sources, s.effectiveRefs, nil
+	}
+	return s.sources, linkedRefs, nil
 }
 
 // trackingDeploymentRenderer extends stubRenderer to record whether Render
@@ -1452,7 +1462,7 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "policy"},
 		}
-		_, err := handler.renderResourcesGrouped(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
+		_, _, err := handler.renderResourcesGrouped(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1479,7 +1489,7 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "policy"},
 		}
-		_, err := handler.renderResourcesGrouped(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
+		_, _, err := handler.renderResourcesGrouped(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{}, refs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -1330,9 +1330,16 @@ func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Con
 	}
 	// When no explicit override, mirror the input refs back as the "resolved"
 	// effective set so tests that do not care about policy resolution still
-	// see a non-nil ref slice flow through the write-through path.
+	// see a non-nil ref slice flow through the write-through path. A nil
+	// input is coerced to a non-nil empty slice so callers distinguish
+	// "ancestor walk succeeded, no policy match" from "walk failed /
+	// degraded render" (the latter returns a nil effectiveRefs per the
+	// production contract in ListEffectiveTemplateSources).
 	if s.effectiveRefs != nil {
 		return s.sources, s.effectiveRefs, nil
+	}
+	if linkedRefs == nil {
+		return s.sources, []*consolev1.LinkedTemplateRef{}, nil
 	}
 	return s.sources, linkedRefs, nil
 }

--- a/console/deployments/policy_state_test.go
+++ b/console/deployments/policy_state_test.go
@@ -28,6 +28,12 @@ type stubPolicyDriftChecker struct {
 	stateErr    error
 
 	recordErr error
+
+	// Capture fields for the write-through acceptance tests (HOL-569).
+	recordCalls       int
+	lastRecordProject string
+	lastRecordName    string
+	lastRecordRefs    []*consolev1.LinkedTemplateRef
 }
 
 func (s *stubPolicyDriftChecker) Drift(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) (bool, bool, error) {
@@ -38,7 +44,11 @@ func (s *stubPolicyDriftChecker) PolicyState(_ context.Context, _, _ string, _ [
 	return s.stateResult, s.stateErr
 }
 
-func (s *stubPolicyDriftChecker) RecordApplied(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) error {
+func (s *stubPolicyDriftChecker) RecordApplied(_ context.Context, project, name string, refs []*consolev1.LinkedTemplateRef) error {
+	s.recordCalls++
+	s.lastRecordProject = project
+	s.lastRecordName = name
+	s.lastRecordRefs = refs
 	return s.recordErr
 }
 

--- a/console/deployments/record_applied_drift_e2e_test.go
+++ b/console/deployments/record_applied_drift_e2e_test.go
@@ -1,0 +1,209 @@
+package deployments
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"k8s.io/client-go/kubernetes/fake"
+
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// e2eDriftChecker is an in-memory combined PolicyDriftChecker that shares a
+// single applied-render-set map across RecordApplied and PolicyState. It
+// simulates the DriftChecker adapter in console/policyresolver without
+// standing up a full ancestor-walker fixture — all we need for this test
+// is to prove that:
+//
+//  1. CreateDeployment invokes RecordApplied with the effective ref set,
+//  2. GetDeploymentPolicyState then sees has_applied_state=true,
+//  3. and drift is false because the current set (from the resolver) equals
+//     the applied set.
+//
+// The fixture mirrors the behavior shape of
+// console/policyresolver/applied_state_test.go:
+// RecordAppliedRenderSet + ReadAppliedRenderSet + DiffRenderSets, so the
+// end-to-end proof here tracks the same wire contract as the real adapter
+// without the cross-package cycle.
+type e2eDriftChecker struct {
+	// applied[project+"/"+name] is the set previously recorded via
+	// RecordApplied. Absence means the target has never been applied.
+	applied map[string][]*consolev1.LinkedTemplateRef
+	// currentFn returns the resolver output for a given (project, name).
+	// Production wires a real resolver; tests supply a closure that mimics
+	// "policy forces a REQUIRE template" without standing up a policy CRD.
+	currentFn func(project, name string, explicitRefs []*consolev1.LinkedTemplateRef) []*consolev1.LinkedTemplateRef
+}
+
+func newE2EDriftChecker(currentFn func(string, string, []*consolev1.LinkedTemplateRef) []*consolev1.LinkedTemplateRef) *e2eDriftChecker {
+	return &e2eDriftChecker{
+		applied:   map[string][]*consolev1.LinkedTemplateRef{},
+		currentFn: currentFn,
+	}
+}
+
+func (e *e2eDriftChecker) key(project, name string) string { return project + "/" + name }
+
+func (e *e2eDriftChecker) Drift(_ context.Context, project, name string, explicitRefs []*consolev1.LinkedTemplateRef) (bool, bool, error) {
+	applied, ok := e.applied[e.key(project, name)]
+	if !ok {
+		return false, false, nil
+	}
+	current := e.currentFn(project, name, explicitRefs)
+	return diffRefs(applied, current), true, nil
+}
+
+func (e *e2eDriftChecker) PolicyState(_ context.Context, project, name string, explicitRefs []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error) {
+	applied, has := e.applied[e.key(project, name)]
+	current := e.currentFn(project, name, explicitRefs)
+	return &consolev1.PolicyState{
+		AppliedSet:      applied,
+		CurrentSet:      current,
+		Drift:           diffRefs(applied, current),
+		HasAppliedState: has,
+	}, nil
+}
+
+func (e *e2eDriftChecker) RecordApplied(_ context.Context, project, name string, refs []*consolev1.LinkedTemplateRef) error {
+	e.applied[e.key(project, name)] = refs
+	return nil
+}
+
+// diffRefs is a local, compact equivalent of
+// policyresolver.DiffRenderSets — true means the two slices differ by
+// (scope, scope_name, name, version_constraint). Kept in-package so the
+// end-to-end test does not pull in the full policyresolver fixture.
+func diffRefs(applied, current []*consolev1.LinkedTemplateRef) bool {
+	type k struct {
+		scope consolev1.TemplateScope
+		sn    string
+		n     string
+		vc    string
+	}
+	as := make(map[k]struct{}, len(applied))
+	for _, r := range applied {
+		if r == nil {
+			continue
+		}
+		as[k{r.GetScope(), r.GetScopeName(), r.GetName(), r.GetVersionConstraint()}] = struct{}{}
+	}
+	cs := make(map[k]struct{}, len(current))
+	for _, r := range current {
+		if r == nil {
+			continue
+		}
+		cs[k{r.GetScope(), r.GetScopeName(), r.GetName(), r.GetVersionConstraint()}] = struct{}{}
+	}
+	if len(as) != len(cs) {
+		return true
+	}
+	for key := range as {
+		if _, ok := cs[key]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHandler_CreateDeployment_DriftBecomesFalseAfterRecord is the ticket's
+// end-to-end acceptance test: seed a fake policy that forces a REQUIRE
+// template, call CreateDeployment, then call GetDeploymentPolicyState, and
+// assert has_applied_state=true and drift=false.
+//
+// The fake policy is modeled by the e2eDriftChecker's currentFn: it
+// deterministically prepends a folder-scoped REQUIRE template to the
+// resolver output. CreateDeployment receives the same REQUIRE-expanded set
+// via the AncestorTemplateProvider and writes it through to the checker
+// via RecordApplied. When GetDeploymentPolicyState then computes the
+// current set from the same fake policy, the diff is empty and drift is
+// false — proving the write-through wires the effective set (not the raw
+// explicit list) and that the two surfaces agree.
+func TestHandler_CreateDeployment_DriftBecomesFalseAfterRecord(t *testing.T) {
+	// Policy output: this is the "what the fake policy decides the render
+	// set should be" value. Both the AncestorTemplateProvider (applied
+	// path) and the drift checker's currentFn (query path) return this
+	// same value so applied == current and drift is false when recorded.
+	policyOutput := []*consolev1.LinkedTemplateRef{
+		{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION, ScopeName: "acme", Name: "httproute"},
+		{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "audit"},
+	}
+
+	// The AncestorTemplateProvider stub returns the policy-resolved set as
+	// the effective refs. This mirrors the production contract: the real
+	// AncestorTemplateResolver delegates to K8sClient.ListEffectiveTemplateSources
+	// which calls the PolicyResolver internally and surfaces the resolved
+	// set alongside sources. The folder "audit" ref here represents a
+	// REQUIRE-injected template — the caller did not explicitly link it,
+	// but policy resolution added it before the render.
+	atp := &stubAncestorTemplateProvider{
+		sources:       []string{"// folder audit template"},
+		effectiveRefs: policyOutput,
+	}
+
+	checker := newE2EDriftChecker(func(_, _ string, _ []*consolev1.LinkedTemplateRef) []*consolev1.LinkedTemplateRef {
+		// Return the same policy output regardless of the handler-supplied
+		// explicit refs. In production the PolicyResolver consults the
+		// TemplatePolicy CRD the same way on every call, so the apply-time
+		// and query-time resolutions agree by construction.
+		return policyOutput
+	})
+
+	// Seed an existing deployment config map so GetDeploymentPolicyState
+	// can read the target record. CreateDeployment will overwrite this
+	// with its own ConfigMap.
+	fakeClient := fake.NewClientset(projectNS("my-project"))
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	// Wire a TemplateResolver that surfaces the explicit linked list as
+	// the annotation on the deployment template ConfigMap. The handler
+	// uses this when resolving the deployment's linked-templates
+	// annotation on GetDeploymentPolicyState.
+	templateResolver := &stubTemplateResolver{cm: fakeTemplate("default")}
+
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, templateResolver, &stubRenderer{}, &stubApplier{}).
+		WithAncestorTemplateProvider(atp).
+		WithPolicyDriftChecker(checker)
+
+	// Step 1: CreateDeployment on the happy path records the applied set.
+	createReq := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	if _, err := h.CreateDeployment(authedCtx("alice@example.com", nil), createReq); err != nil {
+		t.Fatalf("CreateDeployment: %v", err)
+	}
+
+	// Step 2: GetDeploymentPolicyState observes the applied set and
+	// computes drift against the same policy. has_applied_state must
+	// flip to true and drift must stay false because the applied set
+	// equals the resolver output.
+	getReq := connect.NewRequest(&consolev1.GetDeploymentPolicyStateRequest{
+		Project: "my-project",
+		Name:    "web-app",
+	})
+	// The RBAC check uses viewer as the read role; add alice as viewer.
+	pr.users["alice@example.com"] = "viewer"
+	resp, err := h.GetDeploymentPolicyState(authedCtx("alice@example.com", nil), getReq)
+	if err != nil {
+		t.Fatalf("GetDeploymentPolicyState: %v", err)
+	}
+	state := resp.Msg.GetState()
+	if state == nil {
+		t.Fatal("GetDeploymentPolicyState returned nil state")
+	}
+	if !state.HasAppliedState {
+		t.Errorf("has_applied_state: got false after CreateDeployment wrote through; want true")
+	}
+	if state.Drift {
+		t.Errorf("drift: got true; want false (applied set should equal current set)")
+	}
+	// Sanity: both sides carry the same 2 refs.
+	if len(state.AppliedSet) != 2 || len(state.CurrentSet) != 2 {
+		t.Errorf("applied/current cardinality: applied=%d current=%d, want 2/2",
+			len(state.AppliedSet), len(state.CurrentSet))
+	}
+}

--- a/console/deployments/record_applied_test.go
+++ b/console/deployments/record_applied_test.go
@@ -187,14 +187,17 @@ func (degradedAncestorProvider) ListAncestorTemplateSources(_ context.Context, _
 	return nil, nil, nil
 }
 
-// TestHandler_CreateDeployment_SkipsRecordOnDegradedRender verifies that
+// TestHandler_CreateDeployment_RecordsEmptyOnDegradedRender verifies that
 // when the ancestor template provider returns nil effectiveRefs — the
 // contract for "ancestor walk failed / no walker, render is project-only"
-// after the review round 1 P1 finding — the handler does NOT call
-// RecordApplied. Persisting in that branch would falsely claim ancestor
-// templates participated in the render, producing spurious no-drift
-// reports on deployments that skipped their policy-injected templates.
-func TestHandler_CreateDeployment_SkipsRecordOnDegradedRender(t *testing.T) {
+// — the handler calls RecordApplied with a non-nil empty slice so the
+// stored applied baseline honestly reflects "zero ancestor templates were
+// unified into this apply" (review round 2 P2 finding). Skipping the
+// record would leave any previously recorded applied set in place, and a
+// subsequent GetDeploymentPolicyState read could compare the current
+// policy output against that stale baseline and report false no-drift
+// even though the last apply did not include those templates.
+func TestHandler_CreateDeployment_RecordsEmptyOnDegradedRender(t *testing.T) {
 	checker := &stubPolicyDriftChecker{}
 	fakeClient := fake.NewClientset(projectNS("my-project"))
 	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
@@ -213,8 +216,55 @@ func TestHandler_CreateDeployment_SkipsRecordOnDegradedRender(t *testing.T) {
 	if _, err := h.CreateDeployment(aliceEditorCtx(), req); err != nil {
 		t.Fatalf("unexpected error on degraded render: %v", err)
 	}
-	if checker.recordCalls != 0 {
-		t.Errorf("RecordApplied called %d times on degraded render; want 0", checker.recordCalls)
+	if checker.recordCalls != 1 {
+		t.Fatalf("RecordApplied called %d times on degraded render; want 1 (empty baseline)", checker.recordCalls)
+	}
+	if checker.lastRecordRefs == nil {
+		t.Errorf("RecordApplied refs: got nil on degraded render; want non-nil empty slice")
+	}
+	if len(checker.lastRecordRefs) != 0 {
+		t.Errorf("RecordApplied refs: got %d entries on degraded render; want 0", len(checker.lastRecordRefs))
+	}
+}
+
+// TestHandler_CreateDeployment_RecordsEmptyOnZeroExplicitRefs verifies the
+// HOL-569 baseline contract: a successful apply with no explicit linked
+// templates still persists an applied set (the empty slice) so
+// GetDeploymentPolicyState reports has_applied_state=true on the very
+// next read. Review round 2 P1a found a gap where the previous guard
+// (effectiveRefs != nil before RecordApplied) conflated "no refs to
+// record" with "degraded render"; the normalization in
+// ListEffectiveTemplateSources plus the empty-slice write-through here
+// keeps the two cases distinct and correct.
+func TestHandler_CreateDeployment_RecordsEmptyOnZeroExplicitRefs(t *testing.T) {
+	// Stub provider returns a non-nil empty effective-ref slice —
+	// mirroring what ListEffectiveTemplateSources now produces on a
+	// successful render whose resolver output is empty.
+	atp := &stubAncestorTemplateProvider{
+		sources:       []string{"// deployment template only"},
+		effectiveRefs: []*consolev1.LinkedTemplateRef{},
+	}
+	checker := &stubPolicyDriftChecker{}
+	h, _ := recordAppliedHandler(t, atp, checker, &stubRenderer{}, &stubApplier{})
+
+	req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	if _, err := h.CreateDeployment(aliceEditorCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checker.recordCalls != 1 {
+		t.Fatalf("RecordApplied called %d times, want 1 (even for zero-ref render)", checker.recordCalls)
+	}
+	if checker.lastRecordRefs == nil {
+		t.Error("RecordApplied refs: got nil on zero-ref render; want non-nil empty slice")
+	}
+	if len(checker.lastRecordRefs) != 0 {
+		t.Errorf("RecordApplied refs length: got %d, want 0", len(checker.lastRecordRefs))
 	}
 }
 

--- a/console/deployments/record_applied_test.go
+++ b/console/deployments/record_applied_test.go
@@ -174,6 +174,50 @@ func TestHandler_CreateDeployment_WarnButSucceedOnRecordFailure(t *testing.T) {
 	}
 }
 
+// degradedAncestorProvider models the contract
+// ListEffectiveTemplateSources now provides on the walker-failure and
+// nil-walker branches: nil sources and nil effectiveRefs so the HOL-569
+// write-through is skipped. Introduced by review round 1 P1 fix; kept as
+// a dedicated stub (vs. setting effectiveRefs=nil on the shared
+// stubAncestorTemplateProvider) because the shared stub mirrors input
+// refs back as a non-nil empty slice to exercise the happy path.
+type degradedAncestorProvider struct{}
+
+func (degradedAncestorProvider) ListAncestorTemplateSources(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error) {
+	return nil, nil, nil
+}
+
+// TestHandler_CreateDeployment_SkipsRecordOnDegradedRender verifies that
+// when the ancestor template provider returns nil effectiveRefs — the
+// contract for "ancestor walk failed / no walker, render is project-only"
+// after the review round 1 P1 finding — the handler does NOT call
+// RecordApplied. Persisting in that branch would falsely claim ancestor
+// templates participated in the render, producing spurious no-drift
+// reports on deployments that skipped their policy-injected templates.
+func TestHandler_CreateDeployment_SkipsRecordOnDegradedRender(t *testing.T) {
+	checker := &stubPolicyDriftChecker{}
+	fakeClient := fake.NewClientset(projectNS("my-project"))
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).
+		WithAncestorTemplateProvider(degradedAncestorProvider{}).
+		WithPolicyDriftChecker(checker)
+
+	req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	if _, err := h.CreateDeployment(aliceEditorCtx(), req); err != nil {
+		t.Fatalf("unexpected error on degraded render: %v", err)
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied called %d times on degraded render; want 0", checker.recordCalls)
+	}
+}
+
 // TestHandler_CreateDeployment_NilCheckerIsSafe verifies that a nil drift
 // checker is a silent no-op on the Create happy path — local/dev bootstraps
 // without a cluster policy resolver continue to work after HOL-569.

--- a/console/deployments/record_applied_test.go
+++ b/console/deployments/record_applied_test.go
@@ -1,0 +1,363 @@
+package deployments
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// recordAppliedHandler builds a deployments handler wired with a stub
+// ancestor template provider, a stub policy drift checker, and an editor-
+// grant on alice@example.com. The renderer and applier behavior is
+// controlled by the caller via the returned pointers so the caller can
+// toggle render/apply failures to exercise the rollback branches.
+//
+// The stubAncestorTemplateProvider mirrors whatever refs the caller passes
+// into ListAncestorTemplateSources back as the effective set (unless
+// effectiveRefs is explicitly set on the stub), so write-through tests
+// can pin the payload passed to RecordApplied.
+func recordAppliedHandler(
+	t *testing.T,
+	atp *stubAncestorTemplateProvider,
+	checker *stubPolicyDriftChecker,
+	renderer Renderer,
+	applier ResourceApplier,
+) (*Handler, *fake.Clientset) {
+	t.Helper()
+	fakeClient := fake.NewClientset(projectNS("my-project"))
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, applier).
+		WithAncestorTemplateProvider(atp)
+	if checker != nil {
+		h = h.WithPolicyDriftChecker(checker)
+	}
+	return h, fakeClient
+}
+
+// aliceEditorCtx returns an authenticated context for the editor test
+// principal used throughout this file.
+func aliceEditorCtx() context.Context {
+	return authedCtx("alice@example.com", nil)
+}
+
+// TestHandler_CreateDeployment_RecordsAppliedOnSuccess verifies that a
+// successful CreateDeployment happy path calls RecordApplied exactly once
+// with the effective ref set returned by AncestorTemplateProvider.
+func TestHandler_CreateDeployment_RecordsAppliedOnSuccess(t *testing.T) {
+	wantRefs := []*consolev1.LinkedTemplateRef{
+		{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION, ScopeName: "acme", Name: "httproute"},
+		{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "audit"},
+	}
+	atp := &stubAncestorTemplateProvider{
+		sources:       []string{"// folder template"},
+		effectiveRefs: wantRefs,
+	}
+	checker := &stubPolicyDriftChecker{}
+	h, _ := recordAppliedHandler(t, atp, checker, &stubRenderer{}, &stubApplier{})
+
+	req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	if _, err := h.CreateDeployment(aliceEditorCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checker.recordCalls != 1 {
+		t.Fatalf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+	if checker.lastRecordProject != "my-project" {
+		t.Errorf("RecordApplied project: got %q, want %q", checker.lastRecordProject, "my-project")
+	}
+	if checker.lastRecordName != "web-app" {
+		t.Errorf("RecordApplied name: got %q, want %q", checker.lastRecordName, "web-app")
+	}
+	if len(checker.lastRecordRefs) != len(wantRefs) {
+		t.Fatalf("RecordApplied refs length: got %d, want %d", len(checker.lastRecordRefs), len(wantRefs))
+	}
+	for i, r := range wantRefs {
+		got := checker.lastRecordRefs[i]
+		if got.GetScope() != r.GetScope() || got.GetScopeName() != r.GetScopeName() || got.GetName() != r.GetName() {
+			t.Errorf("RecordApplied refs[%d]: got %+v, want %+v", i, got, r)
+		}
+	}
+}
+
+// TestHandler_CreateDeployment_NoRecordOnRenderFailure verifies that when
+// rendering fails, the rollback branch runs and RecordApplied is NOT called —
+// nothing was actually rendered, so there is nothing to record.
+func TestHandler_CreateDeployment_NoRecordOnRenderFailure(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+	checker := &stubPolicyDriftChecker{}
+	renderer := &stubRenderer{err: errors.New("simulated render failure")}
+	applier := &stubApplier{}
+	h, _ := recordAppliedHandler(t, atp, checker, renderer, applier)
+
+	req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	if _, err := h.CreateDeployment(aliceEditorCtx(), req); err == nil {
+		t.Fatal("expected error from render failure")
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied was called %d times on render failure, want 0", checker.recordCalls)
+	}
+	if !applier.cleanupCalled {
+		t.Error("expected rollback Cleanup to be called")
+	}
+}
+
+// TestHandler_CreateDeployment_NoRecordOnApplyFailure verifies that when
+// Apply fails, the rollback branch runs and RecordApplied is NOT called.
+func TestHandler_CreateDeployment_NoRecordOnApplyFailure(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+	checker := &stubPolicyDriftChecker{}
+	renderer := &stubRenderer{}
+	applier := &stubApplier{applyErr: errors.New("simulated apply failure")}
+	h, _ := recordAppliedHandler(t, atp, checker, renderer, applier)
+
+	req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	if _, err := h.CreateDeployment(aliceEditorCtx(), req); err == nil {
+		t.Fatal("expected error from apply failure")
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied was called %d times on apply failure, want 0", checker.recordCalls)
+	}
+	if !applier.cleanupCalled {
+		t.Error("expected rollback Cleanup to be called")
+	}
+}
+
+// TestHandler_CreateDeployment_WarnButSucceedOnRecordFailure verifies that a
+// RecordApplied error is logged at warn level and swallowed — the RPC returns
+// success because the deployment was already rendered and applied.
+func TestHandler_CreateDeployment_WarnButSucceedOnRecordFailure(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+	checker := &stubPolicyDriftChecker{recordErr: errors.New("applied-state write failed")}
+	h, _ := recordAppliedHandler(t, atp, checker, &stubRenderer{}, &stubApplier{})
+
+	req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	resp, err := h.CreateDeployment(aliceEditorCtx(), req)
+	if err != nil {
+		t.Fatalf("expected success despite record failure, got %v", err)
+	}
+	if resp.Msg.Name != "web-app" {
+		t.Errorf("name: got %q, want web-app", resp.Msg.Name)
+	}
+	if checker.recordCalls != 1 {
+		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+}
+
+// TestHandler_CreateDeployment_NilCheckerIsSafe verifies that a nil drift
+// checker is a silent no-op on the Create happy path — local/dev bootstraps
+// without a cluster policy resolver continue to work after HOL-569.
+func TestHandler_CreateDeployment_NilCheckerIsSafe(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+	h, _ := recordAppliedHandler(t, atp, nil, &stubRenderer{}, &stubApplier{})
+
+	req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
+		Project:  "my-project",
+		Name:     "web-app",
+		Image:    "nginx",
+		Tag:      "1.25",
+		Template: "default",
+	})
+	if _, err := h.CreateDeployment(aliceEditorCtx(), req); err != nil {
+		t.Fatalf("unexpected error with nil checker: %v", err)
+	}
+}
+
+// TestHandler_UpdateDeployment_RecordsAppliedOnSuccess verifies the
+// UpdateDeployment happy path calls RecordApplied once with the effective
+// ref set returned by AncestorTemplateProvider after a successful reconcile.
+func TestHandler_UpdateDeployment_RecordsAppliedOnSuccess(t *testing.T) {
+	wantRefs := []*consolev1.LinkedTemplateRef{
+		{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, ScopeName: "payments", Name: "audit"},
+	}
+	atp := &stubAncestorTemplateProvider{
+		sources:       []string{"// folder template"},
+		effectiveRefs: wantRefs,
+	}
+	checker := &stubPolicyDriftChecker{}
+
+	// Update needs a seeded deployment ConfigMap to target.
+	fakeClient := fake.NewClientset(
+		projectNS("my-project"),
+		deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc"),
+	)
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).
+		WithAncestorTemplateProvider(atp).
+		WithPolicyDriftChecker(checker)
+
+	newTag := "1.26"
+	req := connect.NewRequest(&consolev1.UpdateDeploymentRequest{
+		Project: "my-project",
+		Name:    "web-app",
+		Tag:     &newTag,
+	})
+	if _, err := h.UpdateDeployment(aliceEditorCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checker.recordCalls != 1 {
+		t.Fatalf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+	if checker.lastRecordProject != "my-project" || checker.lastRecordName != "web-app" {
+		t.Errorf("RecordApplied (project,name): got (%q,%q), want (my-project,web-app)", checker.lastRecordProject, checker.lastRecordName)
+	}
+	if len(checker.lastRecordRefs) != 1 || checker.lastRecordRefs[0].GetName() != "audit" {
+		t.Errorf("RecordApplied refs: got %+v, want [audit]", checker.lastRecordRefs)
+	}
+}
+
+// TestHandler_UpdateDeployment_NoRecordOnRenderFailure verifies that a
+// render failure aborts the RPC before RecordApplied can run.
+func TestHandler_UpdateDeployment_NoRecordOnRenderFailure(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+	checker := &stubPolicyDriftChecker{}
+
+	fakeClient := fake.NewClientset(
+		projectNS("my-project"),
+		deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc"),
+	)
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	renderer := &stubRenderer{err: errors.New("simulated render failure")}
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, renderer, &stubApplier{}).
+		WithAncestorTemplateProvider(atp).
+		WithPolicyDriftChecker(checker)
+
+	newTag := "1.26"
+	req := connect.NewRequest(&consolev1.UpdateDeploymentRequest{
+		Project: "my-project",
+		Name:    "web-app",
+		Tag:     &newTag,
+	})
+	if _, err := h.UpdateDeployment(aliceEditorCtx(), req); err == nil {
+		t.Fatal("expected error from render failure")
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied was called %d times on render failure, want 0", checker.recordCalls)
+	}
+}
+
+// TestHandler_UpdateDeployment_NoRecordOnReconcileFailure verifies that a
+// reconcile failure aborts the RPC before RecordApplied can run.
+func TestHandler_UpdateDeployment_NoRecordOnReconcileFailure(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+	checker := &stubPolicyDriftChecker{}
+
+	fakeClient := fake.NewClientset(
+		projectNS("my-project"),
+		deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc"),
+	)
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	applier := &stubApplier{reconcileErr: errors.New("simulated reconcile failure")}
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, applier).
+		WithAncestorTemplateProvider(atp).
+		WithPolicyDriftChecker(checker)
+
+	newTag := "1.26"
+	req := connect.NewRequest(&consolev1.UpdateDeploymentRequest{
+		Project: "my-project",
+		Name:    "web-app",
+		Tag:     &newTag,
+	})
+	if _, err := h.UpdateDeployment(aliceEditorCtx(), req); err == nil {
+		t.Fatal("expected error from reconcile failure")
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied was called %d times on reconcile failure, want 0", checker.recordCalls)
+	}
+}
+
+// TestHandler_UpdateDeployment_WarnButSucceedOnRecordFailure verifies that a
+// RecordApplied error after a successful reconcile is logged and swallowed.
+func TestHandler_UpdateDeployment_WarnButSucceedOnRecordFailure(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+	checker := &stubPolicyDriftChecker{recordErr: errors.New("applied-state write failed")}
+
+	fakeClient := fake.NewClientset(
+		projectNS("my-project"),
+		deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc"),
+	)
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).
+		WithAncestorTemplateProvider(atp).
+		WithPolicyDriftChecker(checker)
+
+	newTag := "1.26"
+	req := connect.NewRequest(&consolev1.UpdateDeploymentRequest{
+		Project: "my-project",
+		Name:    "web-app",
+		Tag:     &newTag,
+	})
+	if _, err := h.UpdateDeployment(aliceEditorCtx(), req); err != nil {
+		t.Fatalf("expected success despite record failure, got %v", err)
+	}
+	if checker.recordCalls != 1 {
+		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+}
+
+// TestHandler_UpdateDeployment_NilCheckerIsSafe verifies that a nil drift
+// checker is a silent no-op on the Update happy path.
+func TestHandler_UpdateDeployment_NilCheckerIsSafe(t *testing.T) {
+	atp := &stubAncestorTemplateProvider{sources: []string{"// folder template"}}
+
+	fakeClient := fake.NewClientset(
+		projectNS("my-project"),
+		deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc"),
+	)
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+	k8s := NewK8sClient(fakeClient, testResolver())
+	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).
+		WithAncestorTemplateProvider(atp)
+
+	newTag := "1.26"
+	req := connect.NewRequest(&consolev1.UpdateDeploymentRequest{
+		Project: "my-project",
+		Name:    "web-app",
+		Tag:     &newTag,
+	})
+	if _, err := h.UpdateDeployment(aliceEditorCtx(), req); err != nil {
+		t.Fatalf("unexpected error with nil checker: %v", err)
+	}
+}
+
+// Ensure v1alpha2 is imported in this file even when the helpers collapse;
+// the package consumes annotation constants elsewhere in the test suite but
+// having an explicit dependency here keeps the import block meaningful for
+// future extensions.
+var _ = v1alpha2.AnnotationLinkedTemplates

--- a/console/deployments/record_applied_test.go
+++ b/console/deployments/record_applied_test.go
@@ -8,7 +8,6 @@ import (
 	"connectrpc.com/connect"
 	"k8s.io/client-go/kubernetes/fake"
 
-	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
 
@@ -356,8 +355,3 @@ func TestHandler_UpdateDeployment_NilCheckerIsSafe(t *testing.T) {
 	}
 }
 
-// Ensure v1alpha2 is imported in this file even when the helpers collapse;
-// the package consumes annotation constants elsewhere in the test suite but
-// having an explicit dependency here keeps the import block meaningful for
-// future extensions.
-var _ = v1alpha2.AnnotationLinkedTemplates

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -377,6 +377,16 @@ func (h *Handler) CreateTemplate(
 		return nil, mapK8sError(err)
 	}
 
+	// Write-through the policy-effective ref set for project-scope templates
+	// so GetProjectTemplatePolicyState has a baseline to diff against
+	// (HOL-569). Org/folder scopes are skipped because they are not
+	// render targets — only project-scope templates participate in policy
+	// resolution today. A nil drift checker (local/dev bootstrap without a
+	// cluster policy resolver) is a no-op. Record failures are logged at
+	// warn level and do not fail the RPC — the template was persisted
+	// successfully and the set is reconstructable on the next preview.
+	h.recordProjectTemplateApplied(ctx, scope, scopeName, name, tmpl.LinkedTemplates)
+
 	slog.InfoContext(ctx, "template created",
 		slog.String("action", "template_create"),
 		slog.String("resource_type", auditResourceType),
@@ -430,7 +440,12 @@ func (h *Handler) UpdateTemplate(
 	enabled := tmpl.Enabled
 
 	// Determine linked template handling based on the update_linked_templates flag.
+	// We also track the post-update effective explicit link set — new refs
+	// when the caller asked to update links, the existing refs otherwise —
+	// so the HOL-569 write-through on the success path records the right
+	// baseline against which future drift checks will compare.
 	var linkedTemplates []*consolev1.LinkedTemplateRef
+	var explicitRefsForRecord []*consolev1.LinkedTemplateRef
 	if req.Msg.GetUpdateLinkedTemplates() {
 		// Caller wants to modify links. Check permissions based on both old
 		// (being removed) and new (being added) linked template scopes.
@@ -462,14 +477,37 @@ func (h *Handler) UpdateTemplate(
 		if linkedTemplates == nil {
 			linkedTemplates = []*consolev1.LinkedTemplateRef{}
 		}
+		explicitRefsForRecord = linkedTemplates
+	} else {
+		// When update_linked_templates is false, linkedTemplates stays nil,
+		// which tells K8sClient.UpdateTemplate to preserve existing links.
+		// For the HOL-569 write-through we need to know what those existing
+		// links are so the resolver sees the same explicit ref set the
+		// next preview will see. Only read the existing template when we
+		// actually intend to record — project scope with a drift checker
+		// wired — so non-project scopes don't pay an unnecessary API call.
+		if scope == consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT && h.projectTemplateDriftChecker != nil {
+			existingCM, getErr := h.k8s.GetTemplate(ctx, scope, scopeName, name)
+			if getErr == nil {
+				if raw, ok := existingCM.Annotations[v1alpha2.AnnotationLinkedTemplates]; ok && raw != "" {
+					if existingRefs, parseErr := unmarshalLinkedTemplates(raw); parseErr == nil {
+						explicitRefsForRecord = existingRefs
+					}
+				}
+			}
+		}
 	}
-	// When update_linked_templates is false, linkedTemplates stays nil,
-	// which tells K8sClient.UpdateTemplate to preserve existing links.
 
 	_, err = h.k8s.UpdateTemplate(ctx, scope, scopeName, name, &displayName, &description, &cueTemplate, tmpl.Defaults, false, &enabled, linkedTemplates, false)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
+
+	// Write-through the policy-effective ref set for project-scope templates
+	// after a successful persist so GetProjectTemplatePolicyState reflects
+	// the new linking state (HOL-569). Non-project scopes are skipped as on
+	// the create path. Record failures are logged but do not fail the RPC.
+	h.recordProjectTemplateApplied(ctx, scope, scopeName, name, explicitRefsForRecord)
 
 	slog.InfoContext(ctx, "template updated",
 		slog.String("action", "template_update"),
@@ -482,6 +520,60 @@ func (h *Handler) UpdateTemplate(
 	)
 
 	return connect.NewResponse(&consolev1.UpdateTemplateResponse{}), nil
+}
+
+// recordProjectTemplateApplied writes the policy-effective ref set for a
+// project-scope template to the applied-render-set store. This is the
+// write-through path invoked from the CreateTemplate/UpdateTemplate happy
+// paths so GetProjectTemplatePolicyState and the project-template drift
+// badge have a baseline to diff against (HOL-569).
+//
+// This is a no-op for non-project scopes because only project-scope
+// templates participate in TemplatePolicy resolution today (org/folder
+// templates are not render targets on their own — they are only unified
+// into a project render via ancestor walks). It is also a no-op when
+// no ProjectTemplateDriftChecker is wired (local/dev bootstrap without a
+// cluster policy resolver).
+//
+// The resolver is invoked directly (not via ListEffectiveTemplateSources)
+// because the template handler does not render during Create/Update — the
+// sources are irrelevant here, only the resolved ref set is. A failure
+// is logged at warn level and swallowed so the RPC's success contract is
+// not broken: the template was persisted, and the set can be reconstructed
+// on the next preview.
+func (h *Handler) recordProjectTemplateApplied(
+	ctx context.Context,
+	scope consolev1.TemplateScope,
+	scopeName, name string,
+	explicitRefs []*consolev1.LinkedTemplateRef,
+) {
+	if scope != consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT {
+		return
+	}
+	if h.projectTemplateDriftChecker == nil {
+		return
+	}
+	effectiveRefs := explicitRefs
+	if h.policyResolver != nil {
+		projectNs := h.resolver.ProjectNamespace(scopeName)
+		resolved, resolveErr := h.policyResolver.Resolve(ctx, projectNs, policyresolver.TargetKindProjectTemplate, name, explicitRefs)
+		if resolveErr != nil {
+			slog.WarnContext(ctx, "failed to resolve policy for project template applied-set write-through",
+				slog.String("project", scopeName),
+				slog.String("template", name),
+				slog.Any("error", resolveErr),
+			)
+			return
+		}
+		effectiveRefs = resolved
+	}
+	if recordErr := h.projectTemplateDriftChecker.RecordApplied(ctx, scopeName, name, effectiveRefs); recordErr != nil {
+		slog.WarnContext(ctx, "failed to record applied render set for project template",
+			slog.String("project", scopeName),
+			slog.String("template", name),
+			slog.Any("error", recordErr),
+		)
+	}
 }
 
 // DeleteTemplate deletes a template.
@@ -661,7 +753,7 @@ func (h *Handler) renderTemplateGrouped(ctx context.Context, msg *consolev1.Rend
 			// unreachable today but kept as belt-and-suspenders so a future
 			// edit that starts propagating walker errors out of the helper
 			// still degrades to the plain-render fallback here.
-			sources, walkErr := h.k8s.ListEffectiveTemplateSources(
+			sources, _, walkErr := h.k8s.ListEffectiveTemplateSources(
 				ctx,
 				startNs,
 				previewTargetKindForScope(msg.GetScope().GetScope()),

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -444,8 +444,14 @@ func (h *Handler) UpdateTemplate(
 	// when the caller asked to update links, the existing refs otherwise —
 	// so the HOL-569 write-through on the success path records the right
 	// baseline against which future drift checks will compare.
+	//
+	// skipRecordPreservedLinks flips to true when the preserve-links branch
+	// could not determine the existing explicit set (read or parse failure)
+	// so the write-through can be skipped rather than recording a phantom
+	// empty set that would produce false drift on the next policy-state read.
 	var linkedTemplates []*consolev1.LinkedTemplateRef
 	var explicitRefsForRecord []*consolev1.LinkedTemplateRef
+	skipRecordPreservedLinks := false
 	if req.Msg.GetUpdateLinkedTemplates() {
 		// Caller wants to modify links. Check permissions based on both old
 		// (being removed) and new (being added) linked template scopes.
@@ -486,15 +492,40 @@ func (h *Handler) UpdateTemplate(
 		// next preview will see. Only read the existing template when we
 		// actually intend to record — project scope with a drift checker
 		// wired — so non-project scopes don't pay an unnecessary API call.
+		//
+		// If the pre-update read or annotation parse fails, we set
+		// skipRecordPreservedLinks so the write-through is skipped
+		// entirely; recording nil in that branch would silently persist
+		// an empty applied set even though the ConfigMap kept its
+		// original links, producing false drift on the next policy-state
+		// read (review findings P2 from codex round 1).
 		if scope == consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT && h.projectTemplateDriftChecker != nil {
 			existingCM, getErr := h.k8s.GetTemplate(ctx, scope, scopeName, name)
-			if getErr == nil {
-				if raw, ok := existingCM.Annotations[v1alpha2.AnnotationLinkedTemplates]; ok && raw != "" {
-					if existingRefs, parseErr := unmarshalLinkedTemplates(raw); parseErr == nil {
-						explicitRefsForRecord = existingRefs
-					}
+			if getErr != nil {
+				slog.WarnContext(ctx, "failed to read existing template for applied-set write-through, skipping record",
+					slog.String("scope", scope.String()),
+					slog.String("scopeName", scopeName),
+					slog.String("name", name),
+					slog.Any("error", getErr),
+				)
+				skipRecordPreservedLinks = true
+			} else if raw, ok := existingCM.Annotations[v1alpha2.AnnotationLinkedTemplates]; ok && raw != "" {
+				existingRefs, parseErr := unmarshalLinkedTemplates(raw)
+				if parseErr != nil {
+					slog.WarnContext(ctx, "failed to parse existing linked-templates annotation for applied-set write-through, skipping record",
+						slog.String("scope", scope.String()),
+						slog.String("scopeName", scopeName),
+						slog.String("name", name),
+						slog.Any("error", parseErr),
+					)
+					skipRecordPreservedLinks = true
+				} else {
+					explicitRefsForRecord = existingRefs
 				}
 			}
+			// If the template exists with no AnnotationLinkedTemplates,
+			// the template has zero explicit links; explicitRefsForRecord
+			// stays nil which is the correct baseline and we do NOT skip.
 		}
 	}
 
@@ -507,7 +538,12 @@ func (h *Handler) UpdateTemplate(
 	// after a successful persist so GetProjectTemplatePolicyState reflects
 	// the new linking state (HOL-569). Non-project scopes are skipped as on
 	// the create path. Record failures are logged but do not fail the RPC.
-	h.recordProjectTemplateApplied(ctx, scope, scopeName, name, explicitRefsForRecord)
+	// Skip entirely when the preserve-links branch could not read the
+	// existing explicit set — recording nil in that case would silently
+	// persist a mismatched applied set (review round 1 P2 finding).
+	if !skipRecordPreservedLinks {
+		h.recordProjectTemplateApplied(ctx, scope, scopeName, name, explicitRefsForRecord)
+	}
 
 	slog.InfoContext(ctx, "template updated",
 		slog.String("action", "template_update"),

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -930,7 +930,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 
 		// Apply path: runs via AncestorTemplateResolver + ListEffectiveTemplateSources.
 		applyResolver := NewAncestorTemplateResolver(k8s, walker, policyresolver.NewNoopResolver())
-		applySources, err := applyResolver.ListAncestorTemplateSources(
+		applySources, _, err := applyResolver.ListAncestorTemplateSources(
 			context.Background(),
 			"prj-"+project,
 			"test-deployment",

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -402,6 +402,16 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 		}
 		effectiveRefs = resolved
 	}
+	// Normalize a nil effectiveRefs to a non-nil empty slice so the happy
+	// path (successful render with zero policy-effective refs) is
+	// distinguishable from the degraded-render path below (nil effectiveRefs
+	// signals "do not record"). A deployment template with no linked-
+	// templates annotation is a perfectly valid apply and must still
+	// persist an applied baseline so GetDeploymentPolicyState returns
+	// has_applied_state=true (review round 2 P1a finding).
+	if effectiveRefs == nil {
+		effectiveRefs = []*consolev1.LinkedTemplateRef{}
+	}
 
 	if walker == nil {
 		// No walker means no ancestor sources are unified in. Returning
@@ -492,6 +502,21 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 		}
 	}
 
+	// Design choice for HOL-569: the returned effectiveRefs are the
+	// resolver's verbatim output, NOT the subset of refs whose ancestor
+	// ConfigMaps were actually found and unified into allSources. A
+	// template can be policy-effective yet produce zero sources (disabled
+	// in its ancestor namespace, missing ConfigMap, or unresolvable
+	// version constraint). Storing the resolver output keeps the applied-
+	// and current-side reads symmetric — GetDeploymentPolicyState invokes
+	// the same resolver to compute the current set, so comparing the two
+	// produces no spurious drift even when some refs never materialize.
+	// Filtering to "refs that produced sources" would introduce asymmetry
+	// and reopen the race that option 1 of the ticket was chosen to
+	// avoid: a concurrent policy edit between apply-time resolution and
+	// query-time resolution could make the two disagree. Review round 2
+	// P1b raised this concern; the decision to stick with the resolver
+	// output is intentional.
 	return allSources, effectiveRefs, nil
 }
 

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -321,8 +321,9 @@ type RenderHierarchyWalker interface {
 }
 
 // ListEffectiveTemplateSources returns the ordered, deduplicated CUE sources
-// that participate in rendering the given target. The effective set at each
-// ancestor namespace is:
+// that participate in rendering the given target, alongside the policy-
+// effective ref set that produced them. The effective set at each ancestor
+// namespace is:
 //
 //	enabled AND ref IN explicitRefs
 //
@@ -346,8 +347,11 @@ type RenderHierarchyWalker interface {
 // "foo" correctly survive as two distinct sources.
 //
 // The walker drives ancestor traversal. If walker is nil, the method returns
-// nil (no ancestor sources). If the walker returns an error, the method
-// degrades gracefully to an empty slice — callers render project-only.
+// nil sources and the policy-resolved effective refs (still computed). If the
+// walker returns an error, the method degrades gracefully to an empty sources
+// slice — callers render project-only — but still returns the resolver-
+// computed effective refs so write-through to the applied-render-set store
+// can record what would have been rendered.
 //
 // resolver evaluates TemplatePolicy REQUIRE/EXCLUDE rules against the
 // caller's explicitRefs before the ancestor walk. Phase 4 (HOL-566) threads
@@ -356,6 +360,15 @@ type RenderHierarchyWalker interface {
 // swaps in a real policy-backed implementation. When resolver is nil the
 // call site predates the seam — the function falls back to using
 // explicitRefs directly so tests that have not been updated keep working.
+//
+// The effectiveRefs return value is the single authoritative representation
+// of "what the policy chain decided would participate in this render." Every
+// write-through to the applied-render-set store (HOL-569) consumes this
+// value directly so the stored set always matches the rendered set without
+// a second resolver invocation that could race a policy edit. Callers that
+// need just the sources can ignore this value; callers that need the ref
+// set (Create/Update write-through) MUST read it from here rather than
+// re-invoking the resolver.
 //
 // Storage-isolation note (HOL-554): the walk deliberately skips the starting
 // namespace (ancestors[0]) and only reads templates, releases, and — once
@@ -370,11 +383,7 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 	explicitRefs []*consolev1.LinkedTemplateRef,
 	walker RenderHierarchyWalker,
 	resolver policyresolver.PolicyResolver,
-) ([]string, error) {
-	if walker == nil {
-		return nil, nil
-	}
-
+) ([]string, []*consolev1.LinkedTemplateRef, error) {
 	// Resolve the caller's explicit refs through the PolicyResolver seam
 	// before walking ancestors. Phase 4 (HOL-566) wires a no-op resolver at
 	// every call site; Phase 5 swaps in real REQUIRE/EXCLUDE evaluation.
@@ -385,9 +394,13 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 	if resolver != nil {
 		resolved, resolveErr := resolver.Resolve(ctx, projectNs, targetKind, targetName, explicitRefs)
 		if resolveErr != nil {
-			return nil, fmt.Errorf("resolving template policy for %q: %w", targetName, resolveErr)
+			return nil, nil, fmt.Errorf("resolving template policy for %q: %w", targetName, resolveErr)
 		}
 		effectiveRefs = resolved
+	}
+
+	if walker == nil {
+		return nil, effectiveRefs, nil
 	}
 
 	ancestors, err := walker.WalkAncestors(ctx, projectNs)
@@ -396,7 +409,7 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 			slog.String("projectNs", projectNs),
 			slog.Any("error", err),
 		)
-		return nil, nil
+		return nil, effectiveRefs, nil
 	}
 
 	// Build a lookup from (scope, scopeName, name) -> linked ref so linked
@@ -466,7 +479,7 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 		}
 	}
 
-	return allSources, nil
+	return allSources, effectiveRefs, nil
 }
 
 // ListLinkableTemplateInfos returns all enabled templates at the given scope
@@ -964,7 +977,10 @@ func NewAncestorTemplateResolver(k8s *K8sClient, walker RenderHierarchyWalker, r
 
 // ListAncestorTemplateSources satisfies deployments.AncestorTemplateProvider.
 // The targetName identifies the deployment driving the render so Phase 5
-// REQUIRE/EXCLUDE evaluation can key off it.
-func (a *AncestorTemplateResolver) ListAncestorTemplateSources(ctx context.Context, projectNs, targetName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, error) {
+// REQUIRE/EXCLUDE evaluation can key off it. Returns the effective policy-
+// resolved ref set alongside the sources so the deployments handler can
+// write-through to the applied-render-set store without invoking the
+// resolver a second time (HOL-569).
+func (a *AncestorTemplateResolver) ListAncestorTemplateSources(ctx context.Context, projectNs, targetName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error) {
 	return a.k8s.ListEffectiveTemplateSources(ctx, projectNs, TargetKindDeployment, targetName, linkedRefs, a.walker, a.resolver)
 }

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -347,11 +347,12 @@ type RenderHierarchyWalker interface {
 // "foo" correctly survive as two distinct sources.
 //
 // The walker drives ancestor traversal. If walker is nil, the method returns
-// nil sources and the policy-resolved effective refs (still computed). If the
-// walker returns an error, the method degrades gracefully to an empty sources
-// slice — callers render project-only — but still returns the resolver-
-// computed effective refs so write-through to the applied-render-set store
-// can record what would have been rendered.
+// (nil, nil, nil): no sources AND no effective refs, because the caller
+// will render project-only and must not persist an applied-render-set that
+// claims ancestor templates were unified in. If the walker returns an
+// error, the method degrades gracefully the same way — nil refs plus a
+// warn log — so HOL-569 write-through never persists refs that did not
+// actually participate in the render.
 //
 // resolver evaluates TemplatePolicy REQUIRE/EXCLUDE rules against the
 // caller's explicitRefs before the ancestor walk. Phase 4 (HOL-566) threads
@@ -362,13 +363,16 @@ type RenderHierarchyWalker interface {
 // explicitRefs directly so tests that have not been updated keep working.
 //
 // The effectiveRefs return value is the single authoritative representation
-// of "what the policy chain decided would participate in this render." Every
-// write-through to the applied-render-set store (HOL-569) consumes this
-// value directly so the stored set always matches the rendered set without
-// a second resolver invocation that could race a policy edit. Callers that
-// need just the sources can ignore this value; callers that need the ref
-// set (Create/Update write-through) MUST read it from here rather than
-// re-invoking the resolver.
+// of "what the policy chain decided would participate in this render AND
+// the ancestor walk succeeded." Every write-through to the applied-render-
+// set store (HOL-569) consumes this value directly so the stored set
+// always matches the rendered set without a second resolver invocation
+// that could race a policy edit. Callers that need just the sources can
+// ignore this value; callers that need the ref set (Create/Update write-
+// through) MUST read it from here rather than re-invoking the resolver,
+// and MUST treat a nil effectiveRefs as "do not record" because a nil
+// signals a degraded render path where the stored set would not match
+// what actually rendered.
 //
 // Storage-isolation note (HOL-554): the walk deliberately skips the starting
 // namespace (ancestors[0]) and only reads templates, releases, and — once
@@ -400,7 +404,10 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 	}
 
 	if walker == nil {
-		return nil, effectiveRefs, nil
+		// No walker means no ancestor sources are unified in. Returning
+		// nil effectiveRefs prevents the HOL-569 write-through from
+		// recording a set that does not match the degraded render.
+		return nil, nil, nil
 	}
 
 	ancestors, err := walker.WalkAncestors(ctx, projectNs)
@@ -409,7 +416,13 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 			slog.String("projectNs", projectNs),
 			slog.Any("error", err),
 		)
-		return nil, effectiveRefs, nil
+		// Walker failure degrades to project-only render. Discard
+		// effectiveRefs for the same reason as the nil-walker branch:
+		// callers MUST NOT persist an applied set that claims ancestor
+		// templates were unified when they were not. Callers that want a
+		// policy-resolved set independent of ancestor sourcing can invoke
+		// the resolver directly.
+		return nil, nil, nil
 	}
 
 	// Build a lookup from (scope, scopeName, name) -> linked ref so linked

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -517,7 +517,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		fakeClient := fake.NewClientset(orgNsObj)
 		k8s := NewK8sClient(fakeClient, testResolver())
 
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, nil, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, nil, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -536,7 +536,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -561,7 +561,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			{Scope: orgScope, ScopeName: "my-org", Name: "httproute"},
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -586,7 +586,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 		walker := &stubHierarchyWalker{ancestors: fullAncestors}
 
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -604,7 +604,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -642,7 +642,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			folderLinkedRefWithConstraint("payments", "payments-policy", ">=1.0.0"),
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -662,7 +662,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			{Scope: folderScope, ScopeName: "payments", Name: "payments-policy"},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("expected graceful degradation, got error: %v", err)
 		}
@@ -678,7 +678,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		k8s := NewK8sClient(fakeClient, testResolver())
 		walker := &stubHierarchyWalker{ancestors: fullAncestors}
 
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -706,7 +706,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			{Scope: orgScope, ScopeName: "my-org", Name: sharedName},
 			{Scope: folderScope, ScopeName: "payments", Name: sharedName},
 		}
-		sources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -737,11 +737,11 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			{Scope: orgScope, ScopeName: "my-org", Name: "httproute"},
 		}
 
-		deploymentSources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		deploymentSources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error (deployment): %v", err)
 		}
-		projectSources, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindProjectTemplate, "tmpl", refs, walker, policyresolver.NewNoopResolver())
+		projectSources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindProjectTemplate, "tmpl", refs, walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error (project template): %v", err)
 		}

--- a/console/templates/policy_state_test.go
+++ b/console/templates/policy_state_test.go
@@ -18,13 +18,23 @@ type stubProjectTemplateDriftChecker struct {
 	stateResult *consolev1.PolicyState
 	stateErr    error
 	recordErr   error
+
+	// Capture fields for the HOL-569 write-through acceptance tests.
+	recordCalls       int
+	lastRecordProject string
+	lastRecordName    string
+	lastRecordRefs    []*consolev1.LinkedTemplateRef
 }
 
 func (s *stubProjectTemplateDriftChecker) PolicyState(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error) {
 	return s.stateResult, s.stateErr
 }
 
-func (s *stubProjectTemplateDriftChecker) RecordApplied(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) error {
+func (s *stubProjectTemplateDriftChecker) RecordApplied(_ context.Context, project, name string, refs []*consolev1.LinkedTemplateRef) error {
+	s.recordCalls++
+	s.lastRecordProject = project
+	s.lastRecordName = name
+	s.lastRecordRefs = refs
 	return s.recordErr
 }
 

--- a/console/templates/record_applied_test.go
+++ b/console/templates/record_applied_test.go
@@ -1,0 +1,523 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// recordingResolver is a PolicyResolver test double that captures its last
+// invocation and returns a caller-controlled resolved set. Tests use it to
+// assert the handler invokes the seam once with the right inputs and
+// forwards the policy-expanded set into RecordApplied (not the raw explicit
+// refs).
+type recordingResolver struct {
+	resolved         []*consolev1.LinkedTemplateRef
+	err              error
+	calls            int
+	lastProjectNs    string
+	lastTargetKind   policyresolver.TargetKind
+	lastTargetName   string
+	lastExplicitRefs []*consolev1.LinkedTemplateRef
+}
+
+func (r *recordingResolver) Resolve(
+	_ context.Context,
+	projectNs string,
+	targetKind policyresolver.TargetKind,
+	targetName string,
+	explicitRefs []*consolev1.LinkedTemplateRef,
+) ([]*consolev1.LinkedTemplateRef, error) {
+	r.calls++
+	r.lastProjectNs = projectNs
+	r.lastTargetKind = targetKind
+	r.lastTargetName = targetName
+	r.lastExplicitRefs = explicitRefs
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.resolved != nil {
+		return r.resolved, nil
+	}
+	return explicitRefs, nil
+}
+
+// recordAppliedTemplateHandler wires a templates handler with project-scope
+// write access for owner@localhost, a configurable PolicyResolver, and an
+// optional ProjectTemplateDriftChecker. seedObjs are additional runtime.Object
+// fixtures written into the fake clientset (e.g. an existing template
+// ConfigMap for update-path tests).
+func recordAppliedTemplateHandler(
+	t *testing.T,
+	policyResolver policyresolver.PolicyResolver,
+	checker ProjectTemplateDriftChecker,
+	seedObjs ...runtime.Object,
+) *Handler {
+	t.Helper()
+	objs := []runtime.Object{projectNS("my-project")}
+	objs = append(objs, seedObjs...)
+	fakeClient := fake.NewClientset(objs...)
+
+	h := newTestHandler(fakeClient, map[string]string{"owner@localhost": "owner"})
+	// Replace the no-op resolver wired by newTestHandler with the test's
+	// controlled instance so assertions can pin the effective ref set.
+	h.policyResolver = policyResolver
+	if checker != nil {
+		h = h.WithProjectTemplateDriftChecker(checker)
+	}
+	return h
+}
+
+// ownerCtx returns an authenticated context for owner@localhost, the
+// principal mapped to "owner" by recordAppliedTemplateHandler.
+func ownerCtx() context.Context {
+	return authedCtx("owner@localhost", nil)
+}
+
+// existingProjectTemplateWithLinks returns a seeded project-scope template
+// ConfigMap carrying the supplied explicit link list on the
+// AnnotationLinkedTemplates annotation. Used by UpdateTemplate tests that
+// exercise the "preserve existing links" branch.
+func existingProjectTemplateWithLinks(project, name string, refs []*consolev1.LinkedTemplateRef) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "prj-" + project,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationEnabled: "true",
+			},
+		},
+		Data: map[string]string{
+			CueTemplateKey: "#Input: { name: string }\n",
+		},
+	}
+	if len(refs) > 0 {
+		raw, err := marshalLinkedTemplatesForTest(refs)
+		if err == nil {
+			cm.Annotations[v1alpha2.AnnotationLinkedTemplates] = raw
+		}
+	}
+	return cm
+}
+
+// marshalLinkedTemplatesForTest serializes linked refs using the same JSON
+// shape the production helper emits. Re-implementing the shape here avoids
+// taking a dependency on an unexported helper.
+func marshalLinkedTemplatesForTest(refs []*consolev1.LinkedTemplateRef) (string, error) {
+	type storedRef struct {
+		Scope             string `json:"scope"`
+		ScopeName         string `json:"scope_name"`
+		Name              string `json:"name"`
+		VersionConstraint string `json:"version_constraint,omitempty"`
+	}
+	stored := make([]storedRef, 0, len(refs))
+	for _, r := range refs {
+		stored = append(stored, storedRef{
+			Scope:             scopeLabelValue(r.GetScope()),
+			ScopeName:         r.GetScopeName(),
+			Name:              r.GetName(),
+			VersionConstraint: r.GetVersionConstraint(),
+		})
+	}
+	b, err := json.Marshal(stored)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// TestHandler_CreateTemplate_RecordsAppliedOnSuccess verifies that a
+// successful project-scope CreateTemplate calls RecordApplied with the
+// policy-resolved effective ref set (explicit ∪ REQUIRE − EXCLUDE), not
+// the raw explicit list.
+func TestHandler_CreateTemplate_RecordsAppliedOnSuccess(t *testing.T) {
+	explicit := []*consolev1.LinkedTemplateRef{
+		orgLinkedRef("acme", "httproute"),
+	}
+	required := []*consolev1.LinkedTemplateRef{
+		orgLinkedRef("acme", "httproute"),
+		folderLinkedRef("payments", "audit"),
+	}
+	resolver := &recordingResolver{resolved: required}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	h := recordAppliedTemplateHandler(t, resolver, checker)
+
+	req := connect.NewRequest(&consolev1.CreateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:            "web-app",
+			CueTemplate:     validCue,
+			LinkedTemplates: explicit,
+		},
+	})
+	if _, err := h.CreateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resolver.calls != 1 {
+		t.Fatalf("resolver.Resolve called %d times, want 1", resolver.calls)
+	}
+	if resolver.lastTargetKind != policyresolver.TargetKindProjectTemplate {
+		t.Errorf("resolver targetKind: got %v, want TargetKindProjectTemplate", resolver.lastTargetKind)
+	}
+	if resolver.lastProjectNs != "prj-my-project" {
+		t.Errorf("resolver projectNs: got %q, want prj-my-project", resolver.lastProjectNs)
+	}
+	if resolver.lastTargetName != "web-app" {
+		t.Errorf("resolver targetName: got %q, want web-app", resolver.lastTargetName)
+	}
+
+	if checker.recordCalls != 1 {
+		t.Fatalf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+	if checker.lastRecordProject != "my-project" || checker.lastRecordName != "web-app" {
+		t.Errorf("RecordApplied (project,name): got (%q,%q)", checker.lastRecordProject, checker.lastRecordName)
+	}
+	if len(checker.lastRecordRefs) != 2 {
+		t.Fatalf("RecordApplied refs length: got %d, want 2 (explicit + REQUIRE)", len(checker.lastRecordRefs))
+	}
+	foundAudit := false
+	for _, r := range checker.lastRecordRefs {
+		if r.GetName() == "audit" {
+			foundAudit = true
+		}
+	}
+	if !foundAudit {
+		t.Errorf("RecordApplied refs: missing REQUIRE-injected 'audit', got %+v", checker.lastRecordRefs)
+	}
+}
+
+// TestHandler_CreateTemplate_NoRecordAtOrgOrFolderScope verifies that
+// non-project-scope templates do not record applied state. The stub
+// checker and resolver would record the call if it was invoked, so a
+// recordCalls value of 0 is the assertion. Covers the acceptance criterion
+// that org/folder CreateTemplate is a no-op for the write-through.
+func TestHandler_CreateTemplate_NoRecordAtOrgOrFolderScope(t *testing.T) {
+	resolver := &recordingResolver{}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	// Seed org and folder namespaces so CreateTemplate can write into them.
+	orgNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-acme"},
+	}
+	folderNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "fld-payments"},
+	}
+	// newTestHandler only wires a project grant; the in-memory handler's
+	// owner gets access to org/folder templates via the same
+	// shareUsers map because newTestHandler only adds ProjectGrantResolver.
+	// For org/folder we need the corresponding grant resolvers; since this
+	// test only exercises the write-through side, we bypass the checkAccess
+	// gate by calling the internal helper.
+	//
+	// Instead, assert the write-through is scope-gated by invoking
+	// recordProjectTemplateApplied directly with each non-project scope.
+	// This keeps the assertion narrow: if the helper is scope-gated,
+	// RecordApplied is never called.
+	h := recordAppliedTemplateHandler(t, resolver, checker, orgNs, folderNs)
+
+	h.recordProjectTemplateApplied(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+		"acme",
+		"httproute",
+		nil,
+	)
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied called at org scope (%d times), want 0", checker.recordCalls)
+	}
+
+	h.recordProjectTemplateApplied(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+		"payments",
+		"audit",
+		nil,
+	)
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied called at folder scope (%d times), want 0", checker.recordCalls)
+	}
+	if resolver.calls != 0 {
+		t.Errorf("resolver.Resolve called at non-project scope (%d times), want 0", resolver.calls)
+	}
+}
+
+// TestHandler_CreateTemplate_WarnButSucceedOnRecordFailure verifies that
+// a RecordApplied error on the create path is logged at warn level and
+// swallowed — the RPC returns success because the template ConfigMap
+// was persisted.
+func TestHandler_CreateTemplate_WarnButSucceedOnRecordFailure(t *testing.T) {
+	resolver := &recordingResolver{}
+	checker := &stubProjectTemplateDriftChecker{recordErr: errors.New("applied-state write failed")}
+
+	h := recordAppliedTemplateHandler(t, resolver, checker)
+
+	req := connect.NewRequest(&consolev1.CreateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+	})
+	if _, err := h.CreateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("expected success despite record failure, got %v", err)
+	}
+	if checker.recordCalls != 1 {
+		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+}
+
+// TestHandler_CreateTemplate_NilCheckerIsSafe verifies that a nil drift
+// checker is a silent no-op on the project-scope create path. Also
+// verifies the resolver is not invoked when there is nothing to record —
+// a nil checker short-circuits the write-through.
+func TestHandler_CreateTemplate_NilCheckerIsSafe(t *testing.T) {
+	resolver := &recordingResolver{}
+	h := recordAppliedTemplateHandler(t, resolver, nil)
+
+	req := connect.NewRequest(&consolev1.CreateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+	})
+	if _, err := h.CreateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("unexpected error with nil checker: %v", err)
+	}
+	if resolver.calls != 0 {
+		t.Errorf("resolver.Resolve called %d times with nil checker, want 0", resolver.calls)
+	}
+}
+
+// TestHandler_CreateTemplate_NoRecordOnPersistFailure verifies that a
+// failure to persist the ConfigMap aborts the RPC before RecordApplied
+// can run. Seeding an AlreadyExists collision drives the K8s error path.
+func TestHandler_CreateTemplate_NoRecordOnPersistFailure(t *testing.T) {
+	resolver := &recordingResolver{}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-app",
+			Namespace: "prj-my-project",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+			},
+		},
+	}
+	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
+
+	req := connect.NewRequest(&consolev1.CreateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+	})
+	if _, err := h.CreateTemplate(ownerCtx(), req); err == nil {
+		t.Fatal("expected AlreadyExists error from persist failure")
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied called %d times on persist failure, want 0", checker.recordCalls)
+	}
+}
+
+// TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_NewLinks verifies the
+// update_linked_templates=true path: the new linked list is resolved and
+// recorded.
+func TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_NewLinks(t *testing.T) {
+	newLinks := []*consolev1.LinkedTemplateRef{
+		folderLinkedRef("payments", "audit"),
+	}
+	resolver := &recordingResolver{resolved: newLinks}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	existing := existingProjectTemplateWithLinks("my-project", "web-app", []*consolev1.LinkedTemplateRef{
+		orgLinkedRef("acme", "httproute"),
+	})
+	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
+
+	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:            "web-app",
+			CueTemplate:     validCue,
+			LinkedTemplates: newLinks,
+		},
+		UpdateLinkedTemplates: true,
+	})
+	if _, err := h.UpdateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resolver.calls != 1 {
+		t.Errorf("resolver.Resolve called %d times, want 1", resolver.calls)
+	}
+	if len(resolver.lastExplicitRefs) != 1 || resolver.lastExplicitRefs[0].GetName() != "audit" {
+		t.Errorf("resolver explicitRefs: got %+v, want [audit]", resolver.lastExplicitRefs)
+	}
+	if checker.recordCalls != 1 {
+		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+}
+
+// TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_PreserveLinks verifies
+// the update_linked_templates=false path: the pre-existing linked list is
+// resolved and recorded so drift is computed against the unchanged link
+// state.
+func TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_PreserveLinks(t *testing.T) {
+	existingLinks := []*consolev1.LinkedTemplateRef{
+		orgLinkedRef("acme", "httproute"),
+	}
+	resolver := &recordingResolver{}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	existing := existingProjectTemplateWithLinks("my-project", "web-app", existingLinks)
+	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
+
+	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+		UpdateLinkedTemplates: false,
+	})
+	if _, err := h.UpdateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resolver.calls != 1 {
+		t.Fatalf("resolver.Resolve called %d times, want 1", resolver.calls)
+	}
+	if len(resolver.lastExplicitRefs) != 1 || resolver.lastExplicitRefs[0].GetName() != "httproute" {
+		t.Errorf("resolver explicitRefs (preserve-links path): got %+v, want [httproute]", resolver.lastExplicitRefs)
+	}
+	if checker.recordCalls != 1 {
+		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+	if len(checker.lastRecordRefs) != 1 || checker.lastRecordRefs[0].GetName() != "httproute" {
+		t.Errorf("RecordApplied refs (preserve-links path): got %+v, want [httproute]", checker.lastRecordRefs)
+	}
+}
+
+// TestHandler_UpdateTemplate_NoRecordOnPersistFailure verifies that when
+// the template ConfigMap does not exist (NotFound on the Update path),
+// RecordApplied is not called.
+func TestHandler_UpdateTemplate_NoRecordOnPersistFailure(t *testing.T) {
+	resolver := &recordingResolver{}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	// No existing template seeded — UpdateTemplate should fail NotFound.
+	h := recordAppliedTemplateHandler(t, resolver, checker)
+
+	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+		UpdateLinkedTemplates: false,
+	})
+	if _, err := h.UpdateTemplate(ownerCtx(), req); err == nil {
+		t.Fatal("expected error from missing template")
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied called %d times on persist failure, want 0", checker.recordCalls)
+	}
+}
+
+// TestHandler_UpdateTemplate_WarnButSucceedOnRecordFailure verifies that a
+// RecordApplied error after a successful Update is logged and swallowed.
+func TestHandler_UpdateTemplate_WarnButSucceedOnRecordFailure(t *testing.T) {
+	resolver := &recordingResolver{}
+	checker := &stubProjectTemplateDriftChecker{recordErr: errors.New("applied-state write failed")}
+
+	existing := existingProjectTemplateWithLinks("my-project", "web-app", nil)
+	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
+
+	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+		UpdateLinkedTemplates: false,
+	})
+	if _, err := h.UpdateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("expected success despite record failure, got %v", err)
+	}
+	if checker.recordCalls != 1 {
+		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
+	}
+}
+
+// TestHandler_UpdateTemplate_NilCheckerIsSafe verifies that a nil drift
+// checker is a silent no-op on the project-scope update path and the
+// resolver is not invoked.
+func TestHandler_UpdateTemplate_NilCheckerIsSafe(t *testing.T) {
+	resolver := &recordingResolver{}
+	existing := existingProjectTemplateWithLinks("my-project", "web-app", nil)
+	h := recordAppliedTemplateHandler(t, resolver, nil, existing)
+
+	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+		UpdateLinkedTemplates: false,
+	})
+	if _, err := h.UpdateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("unexpected error with nil checker: %v", err)
+	}
+	if resolver.calls != 0 {
+		t.Errorf("resolver.Resolve called %d times with nil checker, want 0", resolver.calls)
+	}
+}
+
+// TestHandler_UpdateTemplate_ResolverFailureIsSwallowed verifies that a
+// resolver failure on the write-through path does not fail the RPC — the
+// template was persisted and the warn log captures the diagnostic.
+func TestHandler_UpdateTemplate_ResolverFailureIsSwallowed(t *testing.T) {
+	resolver := &recordingResolver{err: errors.New("policy fetch failed")}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	existing := existingProjectTemplateWithLinks("my-project", "web-app", nil)
+	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
+
+	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+		UpdateLinkedTemplates: false,
+	})
+	if _, err := h.UpdateTemplate(ownerCtx(), req); err != nil {
+		t.Fatalf("expected success despite resolver failure, got %v", err)
+	}
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied called %d times on resolver failure, want 0 (write-through aborted)", checker.recordCalls)
+	}
+}

--- a/console/templates/record_applied_test.go
+++ b/console/templates/record_applied_test.go
@@ -496,6 +496,56 @@ func TestHandler_UpdateTemplate_NilCheckerIsSafe(t *testing.T) {
 	}
 }
 
+// TestHandler_UpdateTemplate_SkipsRecordOnMalformedExistingLinks verifies
+// that when update_linked_templates=false and the stored
+// AnnotationLinkedTemplates cannot be parsed, the write-through is
+// skipped rather than recording an empty set (review round 1 P2 finding).
+// Persisting nil in that case would silently overwrite the applied set
+// with a value that no longer matches the preserved K8s annotation,
+// producing false drift on the next policy-state read.
+func TestHandler_UpdateTemplate_SkipsRecordOnMalformedExistingLinks(t *testing.T) {
+	resolver := &recordingResolver{}
+	checker := &stubProjectTemplateDriftChecker{}
+
+	// Seed a template with a malformed linked-templates annotation so the
+	// parser fails on the pre-update read. The handler should log the
+	// failure and skip the write-through rather than record nil.
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-app",
+			Namespace: "prj-my-project",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationEnabled:         "true",
+				v1alpha2.AnnotationLinkedTemplates: "{not-json",
+			},
+		},
+		Data: map[string]string{CueTemplateKey: "#Input: { name: string }\n"},
+	}
+	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
+
+	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
+		Scope: projectScopeRef("my-project"),
+		Template: &consolev1.Template{
+			Name:        "web-app",
+			CueTemplate: validCue,
+		},
+		UpdateLinkedTemplates: false,
+	})
+	// The handler's UpdateTemplate itself may return an error for
+	// malformed-annotation inputs today (see
+	// TestUpdateTemplateMalformedLinkedAnnotation). This test focuses on
+	// the write-through skip regardless of the outer RPC outcome.
+	_, _ = h.UpdateTemplate(ownerCtx(), req)
+	if checker.recordCalls != 0 {
+		t.Errorf("RecordApplied called %d times on malformed-annotation preserve-links path; want 0", checker.recordCalls)
+	}
+}
+
 // TestHandler_UpdateTemplate_ResolverFailureIsSwallowed verifies that a
 // resolver failure on the write-through path does not fail the RPC — the
 // template was persisted and the warn log captures the diagnostic.

--- a/console/templates/require_apply.go
+++ b/console/templates/require_apply.go
@@ -176,7 +176,7 @@ func (a *RequiredTemplateApplier) applyMatch(
 		Name:      match.TemplateName,
 	}
 
-	ancestorSources, err := a.k8s.ListEffectiveTemplateSources(
+	ancestorSources, _, err := a.k8s.ListEffectiveTemplateSources(
 		ctx,
 		projectNs,
 		TargetKindProjectTemplate,


### PR DESCRIPTION
## Summary

- Extend `AncestorTemplateProvider.ListAncestorTemplateSources` and `K8sClient.ListEffectiveTemplateSources` to return the policy-resolved effective ref set alongside sources, so Create/Update can write-through without invoking the resolver a second time (ticket preferred option 1).
- Wire `PolicyDriftChecker.RecordApplied` into the `CreateDeployment` and `UpdateDeployment` happy paths after a successful Apply/Reconcile. Record failures are logged at warn level and do not fail the RPC (mirrors the `SetOutputURLAnnotation` precedent).
- Wire `ProjectTemplateDriftChecker.RecordApplied` into the `CreateTemplate`/`UpdateTemplate` happy paths at `TEMPLATE_SCOPE_PROJECT` only. The templates handler does not render during Create/Update, so it invokes `h.policyResolver.Resolve` directly through a new `recordProjectTemplateApplied` helper. Non-project scopes and nil checkers are silent no-ops.
- Add the 12-test acceptance matrix from the ticket plus an end-to-end drift-becomes-false test that seeds a fake policy, calls `CreateDeployment`, then calls `GetDeploymentPolicyState` and asserts `has_applied_state=true` and `drift=false`.

Fixes HOL-569

## Test plan

- [x] `make test` passes (Go + frontend unit tests, 979 frontend tests green)
- [x] `go test ./console/...` passes
- [x] `go vet ./console/...` clean
- [x] No new `make lint` findings in modified files (pre-existing lint issues in unrelated files remain)
- [x] `TestHandler_CreateDeployment_RecordsAppliedOnSuccess` and the three failure-mode siblings
- [x] `TestHandler_UpdateDeployment_RecordsAppliedOnSuccess` and the three failure-mode siblings
- [x] `TestHandler_CreateTemplate_RecordsAppliedOnSuccess`, `_WarnButSucceedOnRecordFailure`, `_NilCheckerIsSafe`, `_NoRecordOnPersistFailure`, `_NoRecordAtOrgOrFolderScope`
- [x] `TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_NewLinks` and `_PreserveLinks` branches plus the failure-mode siblings
- [x] `TestHandler_CreateDeployment_DriftBecomesFalseAfterRecord` (end-to-end write-through proof)

Generated with [Claude Code](https://claude.com/claude-code)