### PR TITLE
feat(console): reject EXCLUDE on explicitly-linked template

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -387,10 +387,17 @@ func (s *Server) Serve(ctx context.Context) error {
 		// templatePoliciesK8s was constructed earlier so the folderResolver
 		// could be wired; reuse the same client here so there is exactly
 		// one policy reader+writer in the process.
+		// Topology resolver enumerates project namespaces + their
+		// ProjectTemplate / Deployment ConfigMaps under a policy's scope so
+		// CreateTemplatePolicy and UpdateTemplatePolicy can reject an
+		// EXCLUDE rule that would contradict an explicit
+		// console.holos.run/linked-templates annotation (HOL-570).
+		templatePolicyTopology := templatepolicies.NewK8sResourceTopology(k8sClientset, nsResolver, nsWalker)
 		templatePoliciesHandler := templatepolicies.NewHandler(templatePoliciesK8s, nsResolver).
 			WithOrgGrantResolver(orgGrantResolver).
 			WithFolderGrantResolver(folderGrantResolver).
-			WithTemplateExistsResolver(templates.NewTemplateExistsAdapter(templatesK8s))
+			WithTemplateExistsResolver(templates.NewTemplateExistsAdapter(templatesK8s)).
+			WithResourceTopologyResolver(templatePolicyTopology)
 		templatePoliciesPath, templatePoliciesHTTPHandler := consolev1connect.NewTemplatePolicyServiceHandler(templatePoliciesHandler, protectedInterceptors)
 		mux.Handle(templatePoliciesPath, templatePoliciesHTTPHandler)
 

--- a/console/templatepolicies/exclude_explicit_link_test.go
+++ b/console/templatepolicies/exclude_explicit_link_test.go
@@ -297,13 +297,16 @@ func TestCreateRejectsExcludeOnExplicitlyLinkedProjectTemplate(t *testing.T) {
 	)
 
 	ctx := authedCtx("owner@example.com", nil)
+	// Empty deployment_pattern so the rule applies to project-template
+	// renders too — matches folder_resolver.ruleAppliesTo semantics where
+	// an empty pattern selects both Deployments and ProjectTemplates.
 	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
 		Scope: newOrgScope("acme"),
 		Policy: &consolev1.TemplatePolicy{
 			Name:     "block-httproute",
 			ScopeRef: newOrgScope("acme"),
 			Rules: []*consolev1.TemplatePolicyRule{
-				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", ""),
 			},
 		},
 	}))
@@ -609,5 +612,190 @@ func TestCreateRejectsExcludeAtFolderScope(t *testing.T) {
 	}))
 	if err != nil {
 		t.Fatalf("folder-team-a policy should not see lilies/web: %v", err)
+	}
+}
+
+// TestCreateReturnsPermissionDeniedBeforeExplicitLinkProbe is the regression
+// guard for the codex-review round 1 P1 finding: an unauthorized caller
+// must receive PermissionDenied (the generic auth-failure result) rather
+// than FailedPrecondition citing the linked resource. The guardrail runs
+// AFTER checkAccess, so a viewer who sends an EXCLUDE policy that *would*
+// conflict with an existing explicit link learns only that they lack write
+// permission — no information about which project links which template.
+func TestCreateReturnsPermissionDeniedBeforeExplicitLinkProbe(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	// Seed a conflict that the guardrail WOULD fire on, but set up share
+	// grants so the caller carries NO write permission at folder or org
+	// scope — checkAccess must reject first.
+	client, _ := buildHol570Fixture(
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+	r := newTestResolver()
+	k := NewK8sClient(client, r)
+	topology := NewK8sResourceTopology(client, r, &fakeWalker{client: client})
+	// Viewer grant only — no owner/editor role — so checkAccess denies.
+	h := NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}}).
+		WithResourceTopologyResolver(topology)
+
+	ctx := authedCtx("viewer@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "probe-attempt",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected authz rejection, got success")
+	}
+	if got := connect.CodeOf(err); got != connect.CodePermissionDenied {
+		t.Fatalf("expected CodePermissionDenied (not FailedPrecondition — the guardrail must not leak conflict details to an unauthorized caller), got %v: %v", got, err)
+	}
+	// Belt-and-suspenders: the error message MUST NOT name the offending
+	// resource (lilies/web). If it does, the ordering regressed and the
+	// guardrail ran before checkAccess.
+	if strings.Contains(err.Error(), "lilies/web") {
+		t.Errorf("authz rejection leaked conflict details: %v", err)
+	}
+}
+
+// TestUpdateReturnsPermissionDeniedBeforeExplicitLinkProbe mirrors the
+// create-path regression for UpdateTemplatePolicy. A viewer who tries to
+// Update a folder-scope policy with an EXCLUDE rule that would conflict
+// must receive PermissionDenied, not the conflict error.
+func TestUpdateReturnsPermissionDeniedBeforeExplicitLinkProbe(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	client, _ := buildHol570Fixture(
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+	// Seed an existing policy the viewer will try to Update.
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy",
+			Namespace: "holos-org-acme",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplatePolicyRules: `[]`,
+			},
+		},
+	}
+	if _, err := client.CoreV1().ConfigMaps("holos-org-acme").Create(context.Background(), existing, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seeding policy: %v", err)
+	}
+
+	r := newTestResolver()
+	k := NewK8sClient(client, r)
+	topology := NewK8sResourceTopology(client, r, &fakeWalker{client: client})
+	h := NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}}).
+		WithResourceTopologyResolver(topology)
+
+	ctx := authedCtx("viewer@example.com", nil)
+	_, err := h.UpdateTemplatePolicy(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "policy",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected authz rejection")
+	}
+	if got := connect.CodeOf(err); got != connect.CodePermissionDenied {
+		t.Fatalf("expected CodePermissionDenied, got %v: %v", got, err)
+	}
+	if strings.Contains(err.Error(), "lilies/web") {
+		t.Errorf("authz rejection leaked conflict details: %v", err)
+	}
+}
+
+// TestCreateAllowsDeploymentScopedExcludeWhenProjectTemplateNameOverlaps is
+// the regression guard for the codex-review round 1 P2 finding. A project
+// template named `api` with an explicit link should NOT block an EXCLUDE
+// rule whose `deployment_pattern: "api"` targets only deployments — the
+// resolver's ruleAppliesTo rejects project-template renders for any rule
+// with a non-empty deployment_pattern, so validating the rule against the
+// project-template is incorrect. Only deployments named `api` should be
+// candidate targets here, and no such deployment exists in the fixture.
+func TestCreateAllowsDeploymentScopedExcludeWhenProjectTemplateNameOverlaps(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	// A project-scope Template named `api` that explicitly links httproute.
+	// There is NO deployment named `api` in the fixture; if the pattern
+	// check incorrectly applied the deployment_pattern to the
+	// project-template, the EXCLUDE below would be (wrongly) rejected.
+	h := makeHol570Fixture(t,
+		mkProjectTemplate("holos-prj-lilies", "api", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute-on-api-deploy",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				// Non-empty deployment_pattern targets Deployments ONLY;
+				// the project template named `api` must be skipped.
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "api"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("deployment-scoped EXCLUDE must not match project-template by name: %v", err)
+	}
+}
+
+// TestCreateRejectsExcludeAgainstProjectTemplateOnlyWhenDeploymentPatternEmpty
+// is the positive companion to the "deployment_pattern skips project
+// templates" test. When the rule's deployment_pattern is empty (applies to
+// both kinds), an explicit project-template link still triggers the
+// rejection.
+func TestCreateRejectsExcludeAgainstProjectTemplateOnlyWhenDeploymentPatternEmpty(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkProjectTemplate("holos-prj-lilies", "api", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				// Empty deployment_pattern — applies to both kinds.
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", ""),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected FailedPrecondition on project-template conflict")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("expected CodeFailedPrecondition, got %v: %v", got, err)
+	}
+	if !strings.Contains(err.Error(), "project-template lilies/api") {
+		t.Errorf("expected error to name project-template lilies/api, got: %v", err)
 	}
 }

--- a/console/templatepolicies/exclude_explicit_link_test.go
+++ b/console/templatepolicies/exclude_explicit_link_test.go
@@ -3,6 +3,7 @@ package templatepolicies
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -761,6 +762,93 @@ func TestCreateAllowsDeploymentScopedExcludeWhenProjectTemplateNameOverlaps(t *t
 	}))
 	if err != nil {
 		t.Fatalf("deployment-scoped EXCLUDE must not match project-template by name: %v", err)
+	}
+}
+
+// failingTopology wraps K8sResourceTopology and forces ListProjectsUnderScope
+// to return an error. Used by TestCreateSurfacesTopologyErrors to assert the
+// handler propagates the failure as CodeInternal rather than treating a
+// bypassed descendant as "no conflict".
+type failingTopology struct{ err error }
+
+func (f *failingTopology) ListProjectsUnderScope(_ context.Context, _ consolev1.TemplateScope, _ string) ([]*corev1.Namespace, error) {
+	return nil, f.err
+}
+func (f *failingTopology) ListProjectTemplates(_ context.Context, _ string) ([]corev1.ConfigMap, error) {
+	return nil, nil
+}
+func (f *failingTopology) ListProjectDeployments(_ context.Context, _ string) ([]corev1.ConfigMap, error) {
+	return nil, nil
+}
+
+// TestCreateSurfacesTopologyErrorsAsInternal is the regression guard for the
+// codex-review round 2 P1 finding: if the topology resolver cannot
+// enumerate projects under the policy scope (for example because an
+// ancestor walk errors on a descendant namespace), the handler MUST return
+// CodeInternal rather than silently accepting the EXCLUDE rule as if the
+// skipped projects held no conflicts. The failingTopology below simulates
+// the downstream walker-failure path surfaced by the handler.
+func TestCreateSurfacesTopologyErrorsAsInternal(t *testing.T) {
+	client, _ := buildHol570Fixture()
+	r := newTestResolver()
+	k := NewK8sClient(client, r)
+	h := NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+		WithResourceTopologyResolver(&failingTopology{err: errors.New("walker: namespace Get failed")})
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "topology-error-block",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected topology failure to surface as an error")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Fatalf("expected CodeInternal, got %v: %v", got, err)
+	}
+}
+
+// TestUpdateReturnsNotFoundEvenWhenSubmittedRulesConflict is the
+// regression guard for the codex-review round 2 P2 finding. If the caller
+// tries to Update a non-existent policy with an EXCLUDE rule that WOULD
+// conflict with an existing explicit link, the handler must return
+// NotFound (the precedence clients rely on for idempotent update flows),
+// not FailedPrecondition. The guardrail MUST run after GetPolicy so a
+// missing target never short-circuits to the new HOL-570 error.
+func TestUpdateReturnsNotFoundEvenWhenSubmittedRulesConflict(t *testing.T) {
+	// Seed an offending Deployment so the EXCLUDE below would normally
+	// fail validation — but do NOT seed the target policy itself.
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.UpdateTemplatePolicy(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "does-not-exist",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected NotFound on missing policy Update")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Fatalf("expected CodeNotFound (missing-policy precedence must beat FailedPrecondition), got %v: %v", got, err)
 	}
 }
 

--- a/console/templatepolicies/exclude_explicit_link_test.go
+++ b/console/templatepolicies/exclude_explicit_link_test.go
@@ -1,0 +1,613 @@
+package templatepolicies
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// ============================================================================
+// HOL-570 test fixtures
+//
+// These tests exercise the "EXCLUDE cannot contradict an explicit link"
+// guardrail in CreateTemplatePolicy / UpdateTemplatePolicy. The fixture
+// mirrors the HOL-567 namespace hierarchy used elsewhere in the codebase
+// (org `acme`, folder `eng` under the org, folder `team-a` under `eng`,
+// projects under each level) so the test shape tracks the policy resolver's
+// own table-driven tests.
+// ============================================================================
+
+// hol570Fixture holds the named fake namespaces for tests below. The namespace
+// names match the production resolver prefixes (`holos-`, `org-`, `fld-`,
+// `prj-`) so namespace classification errors would surface exactly as they
+// would in a real cluster.
+type hol570Fixture struct {
+	orgNs         string
+	folderEngNs   string
+	folderTeamANs string
+	projLilies    string // project under folder eng
+	projRoses     string // project under folder team-a
+	projOrchids   string // project directly under org
+}
+
+// hol570Namespaces returns the canonical fixture namespace names. The
+// values match the newTestResolver() prefixes so a test that passes these
+// strings back through the resolver round-trips cleanly.
+func hol570Namespaces() hol570Fixture {
+	return hol570Fixture{
+		orgNs:         "holos-org-acme",
+		folderEngNs:   "holos-fld-eng",
+		folderTeamANs: "holos-fld-team-a",
+		projLilies:    "holos-prj-lilies",
+		projRoses:     "holos-prj-roses",
+		projOrchids:   "holos-prj-orchids",
+	}
+}
+
+// mkNsForFixture constructs a managed namespace with the expected label set
+// (resource-type + parent). Keeping the helper in this file mirrors the
+// fake-client fixture used by console/policyresolver/folder_resolver_test.go
+// without sharing a cross-package testing util.
+func mkNsForFixture(name, kind, parent string) *corev1.Namespace {
+	labels := map[string]string{
+		v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+		v1alpha2.LabelResourceType: kind,
+	}
+	if parent != "" {
+		labels[v1alpha2.AnnotationParent] = parent
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+// mkLinkedTemplatesAnnotation marshals a list of (scope, scope_name, name)
+// triples into the linked-templates JSON wire shape.
+func mkLinkedTemplatesAnnotation(t *testing.T, refs ...linkedTripleForTest) string {
+	t.Helper()
+	type storedRef struct {
+		Scope     string `json:"scope"`
+		ScopeName string `json:"scope_name"`
+		Name      string `json:"name"`
+	}
+	stored := make([]storedRef, 0, len(refs))
+	for _, r := range refs {
+		stored = append(stored, storedRef{Scope: r.scope, ScopeName: r.scopeName, Name: r.name})
+	}
+	raw, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatalf("marshaling linked-templates: %v", err)
+	}
+	return string(raw)
+}
+
+type linkedTripleForTest struct {
+	scope     string // e.g. v1alpha2.TemplateScopeOrganization
+	scopeName string
+	name      string
+}
+
+// mkDeployment constructs a Deployment ConfigMap with the given
+// linked-templates annotation.
+func mkDeployment(namespace, name, linkedTemplatesJSON string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeDeployment,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationLinkedTemplates: linkedTemplatesJSON,
+			},
+		},
+	}
+}
+
+// mkProjectTemplate constructs a project-scope Template ConfigMap with the
+// given linked-templates annotation.
+func mkProjectTemplate(namespace, name, linkedTemplatesJSON string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationLinkedTemplates: linkedTemplatesJSON,
+			},
+		},
+	}
+}
+
+// fakeWalker is a lightweight ancestor walker backed by any
+// kubernetes.Interface. It follows the same parent-label contract as
+// *resolver.Walker without dragging in its max-depth / cycle-detection
+// machinery — the test fixtures in this file are acyclic and shallow.
+type fakeWalker struct {
+	client kubernetes.Interface
+}
+
+func (w *fakeWalker) WalkAncestors(ctx context.Context, startNs string) ([]*corev1.Namespace, error) {
+	var chain []*corev1.Namespace
+	current := startNs
+	for {
+		ns, err := w.client.CoreV1().Namespaces().Get(ctx, current, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, ns)
+		if ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeOrganization {
+			return chain, nil
+		}
+		parent := ns.Labels[v1alpha2.AnnotationParent]
+		if parent == "" {
+			return chain, nil
+		}
+		current = parent
+	}
+}
+
+// buildHol570Fixture returns a fake client seeded with the canonical
+// namespace hierarchy plus the supplied ProjectTemplate / Deployment
+// ConfigMaps. Callers pass the Templates + Deployments they want on each
+// project so a test case can isolate the annotation state it needs.
+func buildHol570Fixture(resources ...runtime.Object) (*fake.Clientset, hol570Fixture) {
+	fx := hol570Namespaces()
+	objects := []runtime.Object{
+		mkNsForFixture(fx.orgNs, v1alpha2.ResourceTypeOrganization, ""),
+		mkNsForFixture(fx.folderEngNs, v1alpha2.ResourceTypeFolder, fx.orgNs),
+		mkNsForFixture(fx.folderTeamANs, v1alpha2.ResourceTypeFolder, fx.folderEngNs),
+		mkNsForFixture(fx.projLilies, v1alpha2.ResourceTypeProject, fx.folderEngNs),
+		mkNsForFixture(fx.projRoses, v1alpha2.ResourceTypeProject, fx.folderTeamANs),
+		mkNsForFixture(fx.projOrchids, v1alpha2.ResourceTypeProject, fx.orgNs),
+	}
+	objects = append(objects, resources...)
+	return fake.NewClientset(objects...), fx
+}
+
+// orgTemplateRef is a short constructor for an org-scope LinkedTemplateRef
+// used as an EXCLUDE target in the test table.
+func orgTemplateRef(scopeName, name string) *consolev1.LinkedTemplateRef {
+	return &consolev1.LinkedTemplateRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+		ScopeName: scopeName,
+		Name:      name,
+	}
+}
+
+// excludeRuleFor builds a TemplatePolicyRule with kind EXCLUDE pointing at
+// the given template ref and target patterns.
+func excludeRuleFor(tmpl *consolev1.LinkedTemplateRef, projectPattern, deploymentPattern string) *consolev1.TemplatePolicyRule {
+	return &consolev1.TemplatePolicyRule{
+		Kind:     consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE,
+		Template: tmpl,
+		Target: &consolev1.TemplatePolicyTarget{
+			ProjectPattern:    projectPattern,
+			DeploymentPattern: deploymentPattern,
+		},
+	}
+}
+
+// requireRuleFor mirrors excludeRuleFor for REQUIRE rules used in the
+// "REQUIRE is unaffected" test case.
+func requireRuleFor(tmpl *consolev1.LinkedTemplateRef, projectPattern, deploymentPattern string) *consolev1.TemplatePolicyRule {
+	return &consolev1.TemplatePolicyRule{
+		Kind:     consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE,
+		Template: tmpl,
+		Target: &consolev1.TemplatePolicyTarget{
+			ProjectPattern:    projectPattern,
+			DeploymentPattern: deploymentPattern,
+		},
+	}
+}
+
+// makeHol570Fixture is a convenience wrapper that builds the client + walker
+// adapter and returns a wired Handler. The fake client stays accessible via
+// the returned *Handler (through its K8sClient) but tests that only need the
+// Handler itself can ignore the other return values.
+func makeHol570Fixture(t *testing.T, resources ...runtime.Object) *Handler {
+	t.Helper()
+	client, _ := buildHol570Fixture(resources...)
+	return newHol570HandlerFromClient(t, client)
+}
+
+func newHol570HandlerFromClient(t *testing.T, client *fake.Clientset) *Handler {
+	t.Helper()
+	r := newTestResolver()
+	k := NewK8sClient(client, r)
+	topology := NewK8sResourceTopology(client, r, &fakeWalker{client: client})
+	return NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+		WithResourceTopologyResolver(topology)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+// TestCreateRejectsExcludeOnExplicitlyLinkedDeployment is the primary HOL-570
+// positive test: a wildcard-wildcard EXCLUDE rule against a template that is
+// explicitly linked by one existing Deployment must be rejected with
+// FailedPrecondition, and the error message must name the offending
+// deployment.
+func TestCreateRejectsExcludeOnExplicitlyLinkedDeployment(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected FailedPrecondition")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("expected CodeFailedPrecondition, got %v: %v", got, err)
+	}
+	if !strings.Contains(err.Error(), "deployment lilies/web") {
+		t.Errorf("expected error to name deployment lilies/web, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "rule 0") {
+		t.Errorf("expected error to cite rule index 0, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "httproute") {
+		t.Errorf("expected error to cite template name, got: %v", err)
+	}
+}
+
+// TestCreateRejectsExcludeOnExplicitlyLinkedProjectTemplate asserts the same
+// rejection path fires for a ProjectTemplate owner-link, not just
+// Deployments. The fixture places the explicit link on a project-scope
+// Template ConfigMap so the error message must name that resource instead.
+func TestCreateRejectsExcludeOnExplicitlyLinkedProjectTemplate(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkProjectTemplate("holos-prj-lilies", "web-tmpl", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected FailedPrecondition")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("expected CodeFailedPrecondition, got %v: %v", got, err)
+	}
+	if !strings.Contains(err.Error(), "project-template lilies/web-tmpl") {
+		t.Errorf("expected error to name project-template lilies/web-tmpl, got: %v", err)
+	}
+}
+
+// TestCreateAllowsExcludeWhenNoExplicitLinkExists verifies the allow-path:
+// an EXCLUDE rule against a template that no existing resource explicitly
+// links is accepted. The deployment in the fixture links a *different*
+// template than the one the EXCLUDE targets, so there is no conflict.
+func TestCreateAllowsExcludeWhenNoExplicitLinkExists(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "different-template",
+	})
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("expected EXCLUDE against unlinked template to be accepted: %v", err)
+	}
+}
+
+// TestCreateAllowsExcludeWhenDeploymentPatternMissesConflict verifies the
+// narrow-pattern allow-path. A deployment_pattern that does not match the
+// only project/deployment holding the explicit link must accept the rule.
+func TestCreateAllowsExcludeWhenDeploymentPatternMissesConflict(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute-for-other-pattern",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				// Pattern "api" does not match "web", so there is no conflict
+				// even though the template IS linked on lilies/web.
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "api"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("expected narrow deployment_pattern to avoid conflict: %v", err)
+	}
+}
+
+// TestCreateAllowsRequireAgainstExplicitlyLinkedTemplate confirms the
+// guardrail is scoped to EXCLUDE rules only. A REQUIRE rule carrying the
+// identical template + target pattern must be accepted even though the
+// deployment explicitly links the template.
+func TestCreateAllowsRequireAgainstExplicitlyLinkedTemplate(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "require-httproute",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				requireRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("REQUIRE against explicitly-linked template must be accepted: %v", err)
+	}
+}
+
+// TestCreateRejectsOffendingExcludeAmongMultipleRules asserts the per-rule
+// error shape. A policy with one innocuous REQUIRE and one offending
+// EXCLUDE rejects with the EXCLUDE rule's index (1, not 0).
+func TestCreateRejectsOffendingExcludeAmongMultipleRules(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "mixed",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				requireRuleFor(orgTemplateRef("acme", "audit-log"), "*", "*"),
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected FailedPrecondition")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("expected CodeFailedPrecondition, got %v: %v", got, err)
+	}
+	if !strings.Contains(err.Error(), "rule 1") {
+		t.Errorf("expected error to cite rule index 1 (the EXCLUDE), got: %v", err)
+	}
+}
+
+// TestCreateAllowsExcludeOnEmptyScope asserts the empty-scope permissive
+// rule: when there are no candidate resources under the policy scope, any
+// EXCLUDE rule is accepted because there is nothing to conflict with.
+func TestCreateAllowsExcludeOnEmptyScope(t *testing.T) {
+	// Fixture carries the namespace hierarchy but zero Deployments or
+	// ProjectTemplates — so no resource can hold the linked-templates
+	// annotation.
+	h := makeHol570Fixture(t)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "preemptive-block",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("empty scope must accept EXCLUDE: %v", err)
+	}
+}
+
+// TestUpdateRejectsOffendingExcludeAndLeavesStoredRulesUnchanged asserts the
+// Update path: an existing policy is on disk, the caller submits new rules
+// that include an offending EXCLUDE, the Update rejects with
+// FailedPrecondition, and the stored ConfigMap's rules annotation is NOT
+// rewritten. This proves the guardrail runs BEFORE k8s.UpdatePolicy, so a
+// rejected call cannot partially mutate state.
+func TestUpdateRejectsOffendingExcludeAndLeavesStoredRulesUnchanged(t *testing.T) {
+	// Seed an offending Deployment first.
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	client, _ := buildHol570Fixture(
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+	// Seed an initial policy via the K8s client directly — we want the
+	// Update code path under test, not the Create path.
+	initialRules := []byte(`[{"kind":"require","template":{"scope":"organization","scope_name":"acme","name":"audit"},"target":{"project_pattern":"*"}}]`)
+	initial := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy",
+			Namespace: "holos-org-acme",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplatePolicyRules: string(initialRules),
+				v1alpha2.AnnotationDisplayName:         "original",
+				v1alpha2.AnnotationDescription:         "original description",
+				v1alpha2.AnnotationCreatorEmail:        "seed@example.com",
+			},
+		},
+	}
+	if _, err := client.CoreV1().ConfigMaps("holos-org-acme").Create(context.Background(), initial, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seeding policy: %v", err)
+	}
+
+	h := newHol570HandlerFromClient(t, client)
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.UpdateTemplatePolicy(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "policy",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected Update to be rejected with FailedPrecondition")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("expected CodeFailedPrecondition, got %v: %v", got, err)
+	}
+
+	// The rejection MUST short-circuit before k8s.UpdatePolicy runs, so the
+	// stored rules annotation stays byte-for-byte equal to the seed.
+	after, err := client.CoreV1().ConfigMaps("holos-org-acme").Get(context.Background(), "policy", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("fetching stored policy: %v", err)
+	}
+	if got, want := after.Annotations[v1alpha2.AnnotationTemplatePolicyRules], string(initialRules); got != want {
+		t.Errorf("rules annotation mutated by rejected Update:\n got: %s\nwant: %s", got, want)
+	}
+	if got, want := after.Annotations[v1alpha2.AnnotationDisplayName], "original"; got != want {
+		t.Errorf("display name mutated by rejected Update: got %q want %q", got, want)
+	}
+}
+
+// TestCreateAllowsExcludeWhenNoTopologyResolverWired guards the unit-test
+// ergonomic carve-out: a Handler constructed without
+// WithResourceTopologyResolver must accept EXCLUDE rules without error so
+// tests that never exercise the guardrail do not need to stub the
+// topology resolver. The default newTestHandler() helper used by the rest
+// of the suite intentionally leaves topologyResolver unset, so this case
+// documents that contract.
+func TestCreateAllowsExcludeWhenNoTopologyResolverWired(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	// Explicitly do NOT call WithResourceTopologyResolver.
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "optimistic-block",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("handler with no topology resolver must accept EXCLUDE: %v", err)
+	}
+}
+
+// TestCreateRejectsExcludeAtFolderScope asserts the guardrail honors the
+// policy's owning scope: a folder-scope policy must consider only projects
+// under that folder (including nested folders). Here the offending
+// Deployment lives under folder eng; a policy at folder eng MUST reject it,
+// but a policy at folder team-a (a sibling leaf) would accept it because
+// lilies is not under team-a. Demonstrates the ancestor-chain traversal
+// correctly narrows to descendants.
+func TestCreateRejectsExcludeAtFolderScope(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+
+	// Folder eng — lilies is under eng, so the rule conflicts.
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newFolderScope("eng"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newFolderScope("eng"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected folder-eng policy to reject EXCLUDE conflicting with lilies/web")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("expected CodeFailedPrecondition, got %v", got)
+	}
+
+	// Folder team-a — lilies is NOT under team-a, so the rule must be
+	// accepted.
+	_, err = h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newFolderScope("team-a"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newFolderScope("team-a"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("folder-team-a policy should not see lilies/web: %v", err)
+	}
+}

--- a/console/templatepolicies/exclude_explicit_link_test.go
+++ b/console/templatepolicies/exclude_explicit_link_test.go
@@ -57,7 +57,10 @@ func hol570Namespaces() hol570Fixture {
 }
 
 // mkNsForFixture constructs a managed namespace with the expected label set
-// (resource-type + parent). Keeping the helper in this file mirrors the
+// (managed-by + resource-type + parent + organization). The organization
+// label is set on folders and projects so the HOL-570 topology-scan
+// prefilter can narrow to the policy's owning org without calling
+// resolver.Walker. Keeping the helper in this file mirrors the
 // fake-client fixture used by console/policyresolver/folder_resolver_test.go
 // without sharing a cross-package testing util.
 func mkNsForFixture(name, kind, parent string) *corev1.Namespace {
@@ -67,6 +70,12 @@ func mkNsForFixture(name, kind, parent string) *corev1.Namespace {
 	}
 	if parent != "" {
 		labels[v1alpha2.AnnotationParent] = parent
+	}
+	// The canonical HOL-570 fixture always lives under the `acme`
+	// organization, so non-org namespaces carry the matching label. An
+	// explicit org-label makes the topology prefilter deterministic.
+	if kind != v1alpha2.ResourceTypeOrganization {
+		labels[v1alpha2.LabelOrganization] = "acme"
 	}
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -102,14 +111,17 @@ type linkedTripleForTest struct {
 	name      string
 }
 
-// mkDeployment constructs a Deployment ConfigMap with the given
-// linked-templates annotation.
+// mkDeployment constructs a managed Deployment ConfigMap with the given
+// linked-templates annotation. Carries the `managed-by=console.holos.run`
+// label so it is visible to the HOL-570 topology scan (which intentionally
+// ignores user-planted ConfigMaps).
 func mkDeployment(namespace, name, linkedTemplatesJSON string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
 				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeDeployment,
 			},
 			Annotations: map[string]string{
@@ -119,14 +131,15 @@ func mkDeployment(namespace, name, linkedTemplatesJSON string) *corev1.ConfigMap
 	}
 }
 
-// mkProjectTemplate constructs a project-scope Template ConfigMap with the
-// given linked-templates annotation.
+// mkProjectTemplate constructs a managed project-scope Template ConfigMap
+// with the given linked-templates annotation.
 func mkProjectTemplate(namespace, name, linkedTemplatesJSON string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
 				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
 			},
@@ -885,5 +898,103 @@ func TestCreateRejectsExcludeAgainstProjectTemplateOnlyWhenDeploymentPatternEmpt
 	}
 	if !strings.Contains(err.Error(), "project-template lilies/api") {
 		t.Errorf("expected error to name project-template lilies/api, got: %v", err)
+	}
+}
+
+// TestCreateIgnoresBrokenProjectsInOtherOrgs is the regression guard for
+// the codex-review round 3 P1 finding. A broken project namespace (missing
+// parent label, stale hierarchy) in some OTHER organization must not fail
+// policy writes scoped to a well-formed organization. The topology
+// prefilter keys on LabelOrganization so ancestor walks only fire against
+// candidates that plausibly belong under the policy's owning org.
+func TestCreateIgnoresBrokenProjectsInOtherOrgs(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	// Canonical acme fixture + one broken project in org `other` that has
+	// a missing parent label (so a walker would fail on it).
+	brokenProject := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-broken",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelOrganization:  "other",
+				// NOTE: intentionally missing AnnotationParent.
+			},
+		},
+	}
+	h := makeHol570Fixture(t,
+		mkDeployment("holos-prj-lilies", "web", linkedJSON),
+		brokenProject,
+	)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	// We EXPECT the acme/lilies/web conflict to trigger FailedPrecondition;
+	// what we do NOT want is a CodeInternal from the broken-other-org
+	// project short-circuiting the walk.
+	if err == nil {
+		t.Fatal("expected acme conflict to surface")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("expected CodeFailedPrecondition from acme conflict, not CodeInternal from broken other-org project; got %v: %v", got, err)
+	}
+	if !strings.Contains(err.Error(), "lilies/web") {
+		t.Errorf("expected error to cite lilies/web, got: %v", err)
+	}
+}
+
+// TestCreateAllowsExcludeWhenOnlyUnmanagedConfigMapHoldsLink is the
+// regression guard for the codex-review round 3 P2 finding. A hand-rolled
+// ConfigMap in a project namespace (created by a project owner who has
+// namespace-scoped write access) with a linked-templates annotation must
+// NOT cause the HOL-570 guardrail to fire — the topology selectors must
+// pin managed-by=console.holos.run so project-owner-planted ConfigMaps
+// cannot forge a conflict that blocks legitimate policy writes.
+func TestCreateAllowsExcludeWhenOnlyUnmanagedConfigMapHoldsLink(t *testing.T) {
+	linkedJSON := mkLinkedTemplatesAnnotation(t, linkedTripleForTest{
+		scope: v1alpha2.TemplateScopeOrganization, scopeName: "acme", name: "httproute",
+	})
+	// A ConfigMap with the right resource-type label and annotation, but
+	// WITHOUT managed-by=console.holos.run. The topology scan must ignore
+	// it.
+	poisoning := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-deployment",
+			Namespace: "holos-prj-lilies",
+			Labels: map[string]string{
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeDeployment,
+				// NOTE: managed-by intentionally omitted — user-planted.
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationLinkedTemplates: linkedJSON,
+			},
+		},
+	}
+	h := makeHol570Fixture(t, poisoning)
+
+	ctx := authedCtx("owner@example.com", nil)
+	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
+		Scope: newOrgScope("acme"),
+		Policy: &consolev1.TemplatePolicy{
+			Name:     "block-httproute",
+			ScopeRef: newOrgScope("acme"),
+			Rules: []*consolev1.TemplatePolicyRule{
+				excludeRuleFor(orgTemplateRef("acme", "httproute"), "*", "*"),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("unmanaged ConfigMap must not trigger HOL-570 rejection: %v", err)
 	}
 }

--- a/console/templatepolicies/handler.go
+++ b/console/templatepolicies/handler.go
@@ -39,6 +39,7 @@ package templatepolicies
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -76,6 +77,41 @@ type TemplateExistsResolver interface {
 	TemplateExists(ctx context.Context, scope consolev1.TemplateScope, scopeName, name string) (bool, error)
 }
 
+// ResourceTopologyResolver enumerates the render-target resources (project
+// namespaces plus their ProjectTemplate and Deployment ConfigMaps) that live
+// under a TemplatePolicy's owning scope. The handler uses it to enforce the
+// HOL-570 "EXCLUDE cannot contradict an explicit link" guardrail at policy
+// authoring time: every EXCLUDE rule is checked against the
+// `console.holos.run/linked-templates` annotation of every candidate target,
+// so the operator learns immediately that the rule they just wrote cannot
+// do what they expect.
+//
+// Methods are intentionally narrow so the handler never reaches into the
+// cluster directly — that keeps both the import graph and the test seam
+// simple. A nil ResourceTopologyResolver disables the guardrail (so unit
+// tests that never exercise EXCLUDE rules do not need to stub it).
+//
+// ListProjectsUnderScope returns project namespaces whose ancestor chain
+// passes through the namespace that owns the policy. Implementations MUST
+// filter by DeletionTimestamp and MUST NOT surface a folder or organization
+// namespace. When the scope is an organization, every project in that
+// organization is reachable regardless of which folder contains it.
+//
+// ListProjectTemplates returns Template ConfigMaps stored in the given
+// project namespace; only project-scope Template resources are considered
+// candidate EXCLUDE targets (org and folder-scope templates are injected by
+// REQUIRE rules, never owned by a project).
+//
+// ListProjectDeployments returns Deployment ConfigMaps stored in the given
+// project namespace. Both lists are filtered by the standard
+// `console.holos.run/resource-type` label selectors so unmanaged ConfigMaps
+// do not appear as candidate targets.
+type ResourceTopologyResolver interface {
+	ListProjectsUnderScope(ctx context.Context, scope consolev1.TemplateScope, scopeName string) ([]*corev1.Namespace, error)
+	ListProjectTemplates(ctx context.Context, projectNs string) ([]corev1.ConfigMap, error)
+	ListProjectDeployments(ctx context.Context, projectNs string) ([]corev1.ConfigMap, error)
+}
+
 // Handler implements the TemplatePolicyService.
 type Handler struct {
 	consolev1connect.UnimplementedTemplatePolicyServiceHandler
@@ -84,6 +120,7 @@ type Handler struct {
 	orgGrantResolver    OrgGrantResolver
 	folderGrantResolver FolderGrantResolver
 	templateResolver    TemplateExistsResolver
+	topologyResolver    ResourceTopologyResolver
 }
 
 // NewHandler creates a TemplatePolicyService handler.
@@ -107,6 +144,16 @@ func (h *Handler) WithFolderGrantResolver(fgr FolderGrantResolver) *Handler {
 // used when validating a policy's rules.
 func (h *Handler) WithTemplateExistsResolver(ter TemplateExistsResolver) *Handler {
 	h.templateResolver = ter
+	return h
+}
+
+// WithResourceTopologyResolver configures the enumerator used by the HOL-570
+// EXCLUDE-vs-explicit-link guardrail. Leaving it unset keeps the guardrail
+// off (every EXCLUDE is accepted), which is the safe default for unit tests
+// that never author EXCLUDE rules but would otherwise need to stub the
+// resolver just to exercise the Create/Update paths.
+func (h *Handler) WithResourceTopologyResolver(r ResourceTopologyResolver) *Handler {
+	h.topologyResolver = r
 	return h
 }
 
@@ -220,6 +267,16 @@ func (h *Handler) CreateTemplatePolicy(
 	if err := validatePolicyRules(policy.GetRules()); err != nil {
 		return nil, err
 	}
+	// HOL-570: EXCLUDE rules are rejected when they would contradict an
+	// explicit `console.holos.run/linked-templates` annotation already set on
+	// a matching ProjectTemplate or Deployment. Runs after
+	// validatePolicyRules so the error message can cite the rule index the
+	// caller just failed on; runs before checkAccess + CreatePolicy so the
+	// rejection is visible to every caller, not just ones that would have
+	// passed RBAC.
+	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
+		return nil, err
+	}
 
 	claims := rpc.ClaimsFromContext(ctx)
 	if claims == nil {
@@ -283,6 +340,12 @@ func (h *Handler) UpdateTemplatePolicy(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
 	}
 	if err := validatePolicyRules(policy.GetRules()); err != nil {
+		return nil, err
+	}
+	// HOL-570: reject EXCLUDE rules that would contradict explicit links.
+	// Runs before the stored policy is mutated so the current on-disk rules
+	// are preserved when the caller tries to write a conflicting rule set.
+	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
 		return nil, err
 	}
 
@@ -556,6 +619,196 @@ func (h *Handler) probeReferencedTemplates(ctx context.Context, rules []*console
 			)
 		}
 	}
+}
+
+// validateExcludeRulesAgainstExplicitLinks enforces the HOL-570 guardrail:
+// an EXCLUDE rule cannot reference a template that any existing ProjectTemplate
+// or Deployment *explicitly* linked via the
+// `console.holos.run/linked-templates` annotation. At render time, the
+// policy resolver already ignores EXCLUDE against owner-linked refs
+// (console/policyresolver/folder_resolver.go), so the subtraction would
+// silently be a no-op. Failing fast at policy-authoring time tells the
+// platform engineer that the rule they just wrote cannot do what they
+// expect; they can either narrow the rule's patterns or ask the resource
+// owner to unlink the template.
+//
+// Scope of the check: the rule's (project_pattern, deployment_pattern) is
+// evaluated against every project namespace that lives under the policy's
+// owning scope (ancestor chain passes through the folder or organization
+// namespace). Within each matching project, ProjectTemplates and Deployments
+// that match the rule's deployment_pattern are inspected for the EXCLUDE
+// template in their LinkedTemplates annotation. The first offense per rule
+// short-circuits validation with the rule index, so a policy with multiple
+// EXCLUDEs surfaces one conflict at a time.
+//
+// An empty scope (no existing candidate resources) accepts any EXCLUDE rule.
+// A resource owner who later links the excluded template is an operator
+// problem, not a policy-author problem — the guardrail fires only against
+// the state visible to the author at the moment they submit the rule. When
+// the handler is constructed without a topologyResolver, the guardrail is
+// disabled (unit tests that never exercise EXCLUDE rules can skip the
+// wiring). REQUIRE rules are unaffected.
+func (h *Handler) validateExcludeRulesAgainstExplicitLinks(
+	ctx context.Context,
+	scope consolev1.TemplateScope,
+	scopeName string,
+	rules []*consolev1.TemplatePolicyRule,
+) error {
+	if h.topologyResolver == nil {
+		return nil
+	}
+	// Fast path: no EXCLUDE rules means nothing to validate. Avoids a
+	// potentially expensive namespace enumeration for the common REQUIRE-only
+	// policy.
+	hasExclude := false
+	for _, rule := range rules {
+		if rule != nil && rule.GetKind() == consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE {
+			hasExclude = true
+			break
+		}
+	}
+	if !hasExclude {
+		return nil
+	}
+
+	projects, err := h.topologyResolver.ListProjectsUnderScope(ctx, scope, scopeName)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal,
+			fmt.Errorf("enumerating projects under scope %s/%s: %w", scope, scopeName, err))
+	}
+	if len(projects) == 0 {
+		return nil
+	}
+
+	for i, rule := range rules {
+		if rule == nil || rule.GetKind() != consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE {
+			continue
+		}
+		tmpl := rule.GetTemplate()
+		target := rule.GetTarget()
+		if tmpl == nil || target == nil {
+			continue // validatePolicyRules already rejected this shape
+		}
+		projectPattern := target.GetProjectPattern()
+		deploymentPattern := target.GetDeploymentPattern()
+
+		for _, projectNs := range projects {
+			projectSlug, err := h.resolver.ProjectFromNamespace(projectNs.Name)
+			if err != nil {
+				// Fall back to the raw namespace name if the resolver can't
+				// strip the prefix — matching still works on the
+				// fully-qualified name in that degenerate case.
+				projectSlug = projectNs.Name
+			}
+			matched, err := filepath.Match(projectPattern, projectSlug)
+			if err != nil || !matched {
+				continue
+			}
+
+			offender, err := h.findExplicitLinkOffender(ctx, projectNs.Name, projectSlug, deploymentPattern, tmpl)
+			if err != nil {
+				return connect.NewError(connect.CodeInternal,
+					fmt.Errorf("rule %d: listing candidate targets in %q: %w", i, projectNs.Name, err))
+			}
+			if offender != "" {
+				return connect.NewError(connect.CodeFailedPrecondition,
+					fmt.Errorf("rule %d: EXCLUDE of template %s/%s/%s conflicts with explicit link on %s; unlink the template or narrow the rule's patterns",
+						i,
+						templateScopeLabel(tmpl.GetScope()),
+						tmpl.GetScopeName(),
+						tmpl.GetName(),
+						offender))
+			}
+		}
+	}
+	return nil
+}
+
+// findExplicitLinkOffender returns a human-readable resource identifier of
+// the first candidate (ProjectTemplate or Deployment) in projectNs whose
+// linked-templates annotation contains `tmpl` AND whose name matches the
+// rule's deployment_pattern. Empty string means "no conflict in this
+// project". ProjectTemplates are checked before Deployments so the reported
+// identifier prefers the template-bearing resource when both exist.
+func (h *Handler) findExplicitLinkOffender(
+	ctx context.Context,
+	projectNs, projectSlug, deploymentPattern string,
+	tmpl *consolev1.LinkedTemplateRef,
+) (string, error) {
+	templates, err := h.topologyResolver.ListProjectTemplates(ctx, projectNs)
+	if err != nil {
+		return "", fmt.Errorf("listing project templates: %w", err)
+	}
+	for i := range templates {
+		if matchesPattern(deploymentPattern, templates[i].Name) && annotationLinksTemplate(&templates[i], tmpl) {
+			return fmt.Sprintf("project-template %s/%s", projectSlug, templates[i].Name), nil
+		}
+	}
+	deployments, err := h.topologyResolver.ListProjectDeployments(ctx, projectNs)
+	if err != nil {
+		return "", fmt.Errorf("listing deployments: %w", err)
+	}
+	for i := range deployments {
+		if matchesPattern(deploymentPattern, deployments[i].Name) && annotationLinksTemplate(&deployments[i], tmpl) {
+			return fmt.Sprintf("deployment %s/%s", projectSlug, deployments[i].Name), nil
+		}
+	}
+	return "", nil
+}
+
+// matchesPattern applies the rule's deployment_pattern glob against a
+// resource name. An empty pattern matches everything — mirroring the
+// folder_resolver Resolve path, which treats empty deployment_pattern as
+// "apply to every deployment in the project".
+func matchesPattern(pattern, name string) bool {
+	if pattern == "" {
+		return true
+	}
+	ok, err := filepath.Match(pattern, name)
+	if err != nil {
+		// validatePolicyRules already rejected bad patterns, so an error
+		// here means the rule was mutated in-flight — treat as non-match so
+		// the caller cannot use a malformed pattern to bypass the check in
+		// one direction while it correctly fires in another.
+		return false
+	}
+	return ok
+}
+
+// annotationLinksTemplate returns true when the `linked-templates` annotation
+// on cm contains the exact (scope, scope_name, name) triple of ref. The JSON
+// wire shape matches the one on Template + Deployment ConfigMaps (see
+// console/templates/k8s.go:marshalLinkedTemplates). A malformed annotation
+// is treated as "no explicit link" — the guardrail refuses to give the
+// operator a false positive when the annotation itself is broken; any
+// real-world malformed data would have already surfaced a warning from the
+// owning handler when the resource was created.
+func annotationLinksTemplate(cm *corev1.ConfigMap, ref *consolev1.LinkedTemplateRef) bool {
+	if cm == nil || cm.Annotations == nil || ref == nil {
+		return false
+	}
+	raw, ok := cm.Annotations[v1alpha2.AnnotationLinkedTemplates]
+	if !ok || raw == "" {
+		return false
+	}
+	type storedRef struct {
+		Scope     string `json:"scope"`
+		ScopeName string `json:"scope_name"`
+		Name      string `json:"name"`
+	}
+	var stored []storedRef
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		return false
+	}
+	wantScope := templateScopeLabel(ref.GetScope())
+	wantScopeName := ref.GetScopeName()
+	wantName := ref.GetName()
+	for _, s := range stored {
+		if s.Scope == wantScope && s.ScopeName == wantScopeName && s.Name == wantName {
+			return true
+		}
+	}
+	return false
 }
 
 // configMapToPolicy converts a stored ConfigMap into a TemplatePolicy proto.

--- a/console/templatepolicies/handler.go
+++ b/console/templatepolicies/handler.go
@@ -354,22 +354,26 @@ func (h *Handler) UpdateTemplatePolicy(
 		return nil, err
 	}
 
-	// HOL-570: reject EXCLUDE rules that would contradict explicit links.
-	// Runs AFTER checkAccess to avoid leaking "template X is linked on
-	// project Y" to an unauthorized caller (see the matching comment in
-	// CreateTemplatePolicy) and BEFORE GetPolicy + UpdatePolicy so a
-	// rejected call never touches the stored ConfigMap.
-	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
-		return nil, err
-	}
-
 	// Fetch the existing policy so we can distinguish "unset" from "set to
 	// empty" for the top-level metadata fields. The previous read is also
 	// required to surface NotFound before we attempt the Update (the K8s API
-	// would otherwise return a less-informative error).
+	// would otherwise return a less-informative error). The explicit-link
+	// guardrail below runs AFTER this read so an Update to a non-existent
+	// policy still returns connect.CodeNotFound regardless of the submitted
+	// rules — clients rely on that distinction for idempotent upsert flows.
 	existing, err := h.k8s.GetPolicy(ctx, scope, scopeName, name)
 	if err != nil {
 		return nil, mapK8sError(err)
+	}
+
+	// HOL-570: reject EXCLUDE rules that would contradict explicit links.
+	// Runs AFTER checkAccess (to avoid leaking "template X is linked on
+	// project Y" to an unauthorized caller — see the matching comment in
+	// CreateTemplatePolicy) AND AFTER GetPolicy (to preserve the NotFound
+	// error precedence). Runs BEFORE k8s.UpdatePolicy so a rejected call
+	// never rewrites the stored ConfigMap's rules annotation.
+	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
+		return nil, err
 	}
 
 	// Preserve unspecified fields. Proto3 scalars default to "" which we

--- a/console/templatepolicies/handler.go
+++ b/console/templatepolicies/handler.go
@@ -267,16 +267,6 @@ func (h *Handler) CreateTemplatePolicy(
 	if err := validatePolicyRules(policy.GetRules()); err != nil {
 		return nil, err
 	}
-	// HOL-570: EXCLUDE rules are rejected when they would contradict an
-	// explicit `console.holos.run/linked-templates` annotation already set on
-	// a matching ProjectTemplate or Deployment. Runs after
-	// validatePolicyRules so the error message can cite the rule index the
-	// caller just failed on; runs before checkAccess + CreatePolicy so the
-	// rejection is visible to every caller, not just ones that would have
-	// passed RBAC.
-	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
-		return nil, err
-	}
 
 	claims := rpc.ClaimsFromContext(ctx)
 	if claims == nil {
@@ -284,6 +274,18 @@ func (h *Handler) CreateTemplatePolicy(
 	}
 
 	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatePoliciesWrite); err != nil {
+		return nil, err
+	}
+
+	// HOL-570: EXCLUDE rules are rejected when they would contradict an
+	// explicit `console.holos.run/linked-templates` annotation already set on
+	// a matching ProjectTemplate or Deployment. Runs AFTER checkAccess so an
+	// unauthorized caller cannot use the guardrail's "conflict with
+	// lilies/web" error as a probe oracle that reveals which project
+	// explicitly links which template (information disclosure to someone
+	// without policy-write access). Runs BEFORE CreatePolicy so the
+	// rejection short-circuits the Kubernetes write.
+	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
 		return nil, err
 	}
 
@@ -342,12 +344,6 @@ func (h *Handler) UpdateTemplatePolicy(
 	if err := validatePolicyRules(policy.GetRules()); err != nil {
 		return nil, err
 	}
-	// HOL-570: reject EXCLUDE rules that would contradict explicit links.
-	// Runs before the stored policy is mutated so the current on-disk rules
-	// are preserved when the caller tries to write a conflicting rule set.
-	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
-		return nil, err
-	}
 
 	claims := rpc.ClaimsFromContext(ctx)
 	if claims == nil {
@@ -355,6 +351,15 @@ func (h *Handler) UpdateTemplatePolicy(
 	}
 
 	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatePoliciesWrite); err != nil {
+		return nil, err
+	}
+
+	// HOL-570: reject EXCLUDE rules that would contradict explicit links.
+	// Runs AFTER checkAccess to avoid leaking "template X is linked on
+	// project Y" to an unauthorized caller (see the matching comment in
+	// CreateTemplatePolicy) and BEFORE GetPolicy + UpdatePolicy so a
+	// rejected call never touches the stored ConfigMap.
+	if err := h.validateExcludeRulesAgainstExplicitLinks(ctx, scope, scopeName, policy.GetRules()); err != nil {
 		return nil, err
 	}
 
@@ -726,22 +731,34 @@ func (h *Handler) validateExcludeRulesAgainstExplicitLinks(
 
 // findExplicitLinkOffender returns a human-readable resource identifier of
 // the first candidate (ProjectTemplate or Deployment) in projectNs whose
-// linked-templates annotation contains `tmpl` AND whose name matches the
-// rule's deployment_pattern. Empty string means "no conflict in this
-// project". ProjectTemplates are checked before Deployments so the reported
-// identifier prefers the template-bearing resource when both exist.
+// linked-templates annotation contains `tmpl` AND whose target kind +
+// deployment_pattern pair would select it at render time. Empty string
+// means "no conflict in this project". ProjectTemplates are checked before
+// Deployments so the reported identifier prefers the template-bearing
+// resource when both would conflict.
+//
+// The render-selection contract (see console/policyresolver/
+// folder_resolver.go:ruleAppliesTo): an EXCLUDE rule with a non-empty
+// `deployment_pattern` applies ONLY to Deployments, never to project-scope
+// Templates. Matching the same pattern against project-template names here
+// would incorrectly reject deployment-only EXCLUDE rules that happen to
+// carry a name overlapping an existing project-template. An empty
+// `deployment_pattern` applies to both resource kinds, matching the
+// resolver's behavior for project-template previews.
 func (h *Handler) findExplicitLinkOffender(
 	ctx context.Context,
 	projectNs, projectSlug, deploymentPattern string,
 	tmpl *consolev1.LinkedTemplateRef,
 ) (string, error) {
-	templates, err := h.topologyResolver.ListProjectTemplates(ctx, projectNs)
-	if err != nil {
-		return "", fmt.Errorf("listing project templates: %w", err)
-	}
-	for i := range templates {
-		if matchesPattern(deploymentPattern, templates[i].Name) && annotationLinksTemplate(&templates[i], tmpl) {
-			return fmt.Sprintf("project-template %s/%s", projectSlug, templates[i].Name), nil
+	if deploymentPattern == "" {
+		templates, err := h.topologyResolver.ListProjectTemplates(ctx, projectNs)
+		if err != nil {
+			return "", fmt.Errorf("listing project templates: %w", err)
+		}
+		for i := range templates {
+			if annotationLinksTemplate(&templates[i], tmpl) {
+				return fmt.Sprintf("project-template %s/%s", projectSlug, templates[i].Name), nil
+			}
 		}
 	}
 	deployments, err := h.topologyResolver.ListProjectDeployments(ctx, projectNs)
@@ -749,18 +766,18 @@ func (h *Handler) findExplicitLinkOffender(
 		return "", fmt.Errorf("listing deployments: %w", err)
 	}
 	for i := range deployments {
-		if matchesPattern(deploymentPattern, deployments[i].Name) && annotationLinksTemplate(&deployments[i], tmpl) {
+		if matchesDeploymentPattern(deploymentPattern, deployments[i].Name) && annotationLinksTemplate(&deployments[i], tmpl) {
 			return fmt.Sprintf("deployment %s/%s", projectSlug, deployments[i].Name), nil
 		}
 	}
 	return "", nil
 }
 
-// matchesPattern applies the rule's deployment_pattern glob against a
-// resource name. An empty pattern matches everything — mirroring the
-// folder_resolver Resolve path, which treats empty deployment_pattern as
-// "apply to every deployment in the project".
-func matchesPattern(pattern, name string) bool {
+// matchesDeploymentPattern applies the rule's deployment_pattern glob
+// against a Deployment name. An empty pattern matches everything —
+// mirroring the resolver's behavior that treats an empty deployment_pattern
+// as "apply to every deployment in the project".
+func matchesDeploymentPattern(pattern, name string) bool {
 	if pattern == "" {
 		return true
 	}

--- a/console/templatepolicies/topology.go
+++ b/console/templatepolicies/topology.go
@@ -71,17 +71,21 @@ func (t *K8sResourceTopology) scopeNamespace(scope consolev1.TemplateScope, scop
 // ancestor chain passes through the policy's owning scope namespace. The
 // cluster-wide namespace list is filtered by the
 // `console.holos.run/managed-by` and `resource-type=project` labels so
-// unmanaged namespaces never appear.
+// unmanaged namespaces never appear, and by the policy's owning
+// organization label so projects in other orgs never become walker
+// candidates — one stale project in an unrelated org cannot fail a policy
+// write scoped to a well-formed org / folder.
 //
-// An ancestor-walk error for any candidate project namespace propagates to
+// An ancestor-walk error for a candidate project namespace propagates to
 // the caller (which turns it into connect.CodeInternal in
 // validateExcludeRulesAgainstExplicitLinks). Silently dropping a project
 // would bypass the HOL-570 guardrail whenever a transient namespace Get
 // fails, the hierarchy is temporarily inconsistent, or the walker hits its
 // depth / cycle guard — any of those conditions could hide an existing
-// explicit link from the validator. Better to fail loudly and let the
-// caller retry than to accept an EXCLUDE that will silently do nothing at
-// render time.
+// explicit link from the validator. The organization-label prefilter keeps
+// this fail-loud behavior narrowly scoped to descendants of the policy's
+// own organization, which is the blast radius operators already accept for
+// TemplatePolicy authoring.
 func (t *K8sResourceTopology) ListProjectsUnderScope(
 	ctx context.Context,
 	scope consolev1.TemplateScope,
@@ -91,8 +95,15 @@ func (t *K8sResourceTopology) ListProjectsUnderScope(
 	if err != nil {
 		return nil, err
 	}
+	orgLabel, err := t.organizationForScope(ctx, scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
 	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
 		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeProject
+	if orgLabel != "" {
+		labelSelector += "," + v1alpha2.LabelOrganization + "=" + orgLabel
+	}
 	list, err := t.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, fmt.Errorf("listing project namespaces: %w", err)
@@ -114,6 +125,33 @@ func (t *K8sResourceTopology) ListProjectsUnderScope(
 	return result, nil
 }
 
+// organizationForScope resolves the organization slug that owns the given
+// policy scope. For organization scope the slug is the scopeName directly;
+// for folder scope we read the folder namespace's
+// `console.holos.run/organization` label. The label is set by the folder
+// creation path and is what ListProjectsUnderScope uses to narrow the
+// project-namespace candidate list. Returns an empty string when the label
+// is missing — in that case the caller falls back to the unfiltered search
+// so the guardrail still fires for correctly-managed projects.
+func (t *K8sResourceTopology) organizationForScope(
+	ctx context.Context,
+	scope consolev1.TemplateScope,
+	scopeName string,
+) (string, error) {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return scopeName, nil
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		ns, err := t.Client.CoreV1().Namespaces().Get(ctx, t.Resolver.FolderNamespace(scopeName), metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("getting folder namespace for org label: %w", err)
+		}
+		return ns.Labels[v1alpha2.LabelOrganization], nil
+	default:
+		return "", nil
+	}
+}
+
 // ancestorChainContains reports whether `wantNs` appears in the ancestor
 // chain of `startNs`. A walker error is surfaced to the caller rather than
 // swallowed — skipping the project on walker failure would silently weaken
@@ -132,12 +170,19 @@ func (t *K8sResourceTopology) ancestorChainContains(ctx context.Context, startNs
 	return false, nil
 }
 
-// ListProjectTemplates returns all Template ConfigMaps in the project
-// namespace. Listing by label keeps unmanaged ConfigMaps (for example,
-// anything dropped into the namespace by a customer script) from being
-// treated as a candidate EXCLUDE target.
+// ListProjectTemplates returns project-scope Template ConfigMaps managed
+// by the console in the project namespace. The selector pins
+// `managed-by=console.holos.run`, `resource-type=template`, and
+// `template-scope=project` so a hand-authored ConfigMap created by a
+// project owner (who has namespace-scoped write access) cannot poison the
+// topology scan by fabricating a linked-templates annotation the guardrail
+// would then cite as a conflict. Only ConfigMaps the console itself wrote
+// — i.e. the actual render targets at HOL-570 policy-authoring time — are
+// considered.
 func (t *K8sResourceTopology) ListProjectTemplates(ctx context.Context, projectNs string) ([]corev1.ConfigMap, error) {
-	labelSelector := v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeTemplate
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeTemplate + "," +
+		v1alpha2.LabelTemplateScope + "=" + v1alpha2.TemplateScopeProject
 	list, err := t.Client.CoreV1().ConfigMaps(projectNs).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, fmt.Errorf("listing project templates in %q: %w", projectNs, err)
@@ -145,10 +190,14 @@ func (t *K8sResourceTopology) ListProjectTemplates(ctx context.Context, projectN
 	return list.Items, nil
 }
 
-// ListProjectDeployments returns all Deployment ConfigMaps in the project
-// namespace. Same rationale as ListProjectTemplates for the label filter.
+// ListProjectDeployments returns Deployment ConfigMaps managed by the
+// console in the project namespace. Same rationale as ListProjectTemplates
+// for the managed-by filter — the guardrail must ignore user-planted
+// ConfigMaps so a project owner cannot forge a "conflict" that blocks an
+// administrator's legitimate EXCLUDE rule.
 func (t *K8sResourceTopology) ListProjectDeployments(ctx context.Context, projectNs string) ([]corev1.ConfigMap, error) {
-	labelSelector := v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeDeployment
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeDeployment
 	list, err := t.Client.CoreV1().ConfigMaps(projectNs).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, fmt.Errorf("listing deployments in %q: %w", projectNs, err)

--- a/console/templatepolicies/topology.go
+++ b/console/templatepolicies/topology.go
@@ -1,0 +1,143 @@
+package templatepolicies
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// WalkerInterface is the subset of the ancestor walker used by the topology
+// resolver. It is satisfied by *resolver.Walker and by the cached variant
+// returned from Walker.CachedWalker(). Declaring the local interface keeps
+// the topology resolver independent of concrete walker construction and
+// also eases testing — tests can inject a stub that enumerates ancestors
+// without touching the K8s API.
+type WalkerInterface interface {
+	WalkAncestors(ctx context.Context, startNs string) ([]*corev1.Namespace, error)
+}
+
+// K8sResourceTopology implements ResourceTopologyResolver against a live
+// kubernetes.Interface. It is intentionally a thin shim: the handler layer
+// owns all business logic (pattern matching, annotation parsing, error
+// shaping), so this type only answers three narrow listing questions.
+//
+// ListProjectsUnderScope walks the managed project-namespace list and keeps
+// every namespace whose ancestor chain contains the policy's owning scope
+// namespace. That is stricter than a one-hop child match (which would miss
+// projects inside a nested folder under a folder-scope policy) and strictly
+// cheaper than calling ListChildProjects per-folder-node, because the
+// ancestor walk is needed anyway to distinguish "descendant of this folder"
+// from "descendant of a sibling folder with the same display name" when
+// non-default resolver prefixes are in use.
+type K8sResourceTopology struct {
+	Client   kubernetes.Interface
+	Resolver *resolver.Resolver
+	Walker   WalkerInterface
+}
+
+// NewK8sResourceTopology constructs a topology resolver wired to the given
+// kubernetes client, namespace-prefix resolver, and ancestor walker. The
+// walker must be non-nil at call time so ancestor checks can run; all three
+// arguments are required.
+func NewK8sResourceTopology(client kubernetes.Interface, r *resolver.Resolver, w WalkerInterface) *K8sResourceTopology {
+	return &K8sResourceTopology{Client: client, Resolver: r, Walker: w}
+}
+
+// scopeNamespace returns the Kubernetes namespace name the policy owns. We
+// intentionally do not call through to K8sClient.namespaceForScope here
+// because this helper must accept the organization and folder scopes only
+// (project scope is rejected at handler entry) without failing on the
+// ResourceTypeFromNamespace classification check — the walker enumerates
+// project namespaces in a separate step.
+func (t *K8sResourceTopology) scopeNamespace(scope consolev1.TemplateScope, scopeName string) (string, error) {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return t.Resolver.OrgNamespace(scopeName), nil
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return t.Resolver.FolderNamespace(scopeName), nil
+	default:
+		return "", fmt.Errorf("unsupported scope %v for topology traversal", scope)
+	}
+}
+
+// ListProjectsUnderScope enumerates every managed project namespace whose
+// ancestor chain passes through the policy's owning scope namespace. The
+// cluster-wide namespace list is filtered by the
+// `console.holos.run/managed-by` and `resource-type=project` labels so
+// unmanaged namespaces never appear.
+func (t *K8sResourceTopology) ListProjectsUnderScope(
+	ctx context.Context,
+	scope consolev1.TemplateScope,
+	scopeName string,
+) ([]*corev1.Namespace, error) {
+	scopeNs, err := t.scopeNamespace(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeProject
+	list, err := t.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing project namespaces: %w", err)
+	}
+	result := make([]*corev1.Namespace, 0, len(list.Items))
+	for i := range list.Items {
+		ns := &list.Items[i]
+		if ns.DeletionTimestamp != nil {
+			continue
+		}
+		if t.ancestorChainContains(ctx, ns.Name, scopeNs) {
+			result = append(result, ns)
+		}
+	}
+	return result, nil
+}
+
+// ancestorChainContains reports whether `wantNs` appears in the ancestor
+// chain of `startNs`. Walker errors fall back to "not a descendant" — a
+// project namespace that cannot be walked (missing parent label, cycle) is
+// already dysfunctional and cannot reliably host an EXCLUDE conflict; we
+// refuse to erroneously cite it as a conflict source.
+func (t *K8sResourceTopology) ancestorChainContains(ctx context.Context, startNs, wantNs string) bool {
+	chain, err := t.Walker.WalkAncestors(ctx, startNs)
+	if err != nil {
+		return false
+	}
+	for _, ancestor := range chain {
+		if ancestor.Name == wantNs {
+			return true
+		}
+	}
+	return false
+}
+
+// ListProjectTemplates returns all Template ConfigMaps in the project
+// namespace. Listing by label keeps unmanaged ConfigMaps (for example,
+// anything dropped into the namespace by a customer script) from being
+// treated as a candidate EXCLUDE target.
+func (t *K8sResourceTopology) ListProjectTemplates(ctx context.Context, projectNs string) ([]corev1.ConfigMap, error) {
+	labelSelector := v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeTemplate
+	list, err := t.Client.CoreV1().ConfigMaps(projectNs).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing project templates in %q: %w", projectNs, err)
+	}
+	return list.Items, nil
+}
+
+// ListProjectDeployments returns all Deployment ConfigMaps in the project
+// namespace. Same rationale as ListProjectTemplates for the label filter.
+func (t *K8sResourceTopology) ListProjectDeployments(ctx context.Context, projectNs string) ([]corev1.ConfigMap, error) {
+	labelSelector := v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeDeployment
+	list, err := t.Client.CoreV1().ConfigMaps(projectNs).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing deployments in %q: %w", projectNs, err)
+	}
+	return list.Items, nil
+}

--- a/console/templatepolicies/topology.go
+++ b/console/templatepolicies/topology.go
@@ -72,6 +72,16 @@ func (t *K8sResourceTopology) scopeNamespace(scope consolev1.TemplateScope, scop
 // cluster-wide namespace list is filtered by the
 // `console.holos.run/managed-by` and `resource-type=project` labels so
 // unmanaged namespaces never appear.
+//
+// An ancestor-walk error for any candidate project namespace propagates to
+// the caller (which turns it into connect.CodeInternal in
+// validateExcludeRulesAgainstExplicitLinks). Silently dropping a project
+// would bypass the HOL-570 guardrail whenever a transient namespace Get
+// fails, the hierarchy is temporarily inconsistent, or the walker hits its
+// depth / cycle guard — any of those conditions could hide an existing
+// explicit link from the validator. Better to fail loudly and let the
+// caller retry than to accept an EXCLUDE that will silently do nothing at
+// render time.
 func (t *K8sResourceTopology) ListProjectsUnderScope(
 	ctx context.Context,
 	scope consolev1.TemplateScope,
@@ -93,7 +103,11 @@ func (t *K8sResourceTopology) ListProjectsUnderScope(
 		if ns.DeletionTimestamp != nil {
 			continue
 		}
-		if t.ancestorChainContains(ctx, ns.Name, scopeNs) {
+		contained, err := t.ancestorChainContains(ctx, ns.Name, scopeNs)
+		if err != nil {
+			return nil, fmt.Errorf("walking ancestors of %q: %w", ns.Name, err)
+		}
+		if contained {
 			result = append(result, ns)
 		}
 	}
@@ -101,21 +115,21 @@ func (t *K8sResourceTopology) ListProjectsUnderScope(
 }
 
 // ancestorChainContains reports whether `wantNs` appears in the ancestor
-// chain of `startNs`. Walker errors fall back to "not a descendant" — a
-// project namespace that cannot be walked (missing parent label, cycle) is
-// already dysfunctional and cannot reliably host an EXCLUDE conflict; we
-// refuse to erroneously cite it as a conflict source.
-func (t *K8sResourceTopology) ancestorChainContains(ctx context.Context, startNs, wantNs string) bool {
+// chain of `startNs`. A walker error is surfaced to the caller rather than
+// swallowed — skipping the project on walker failure would silently weaken
+// the HOL-570 guardrail. Callers convert the error to connect.CodeInternal
+// so the RPC layer can distinguish it from validation-failure categories.
+func (t *K8sResourceTopology) ancestorChainContains(ctx context.Context, startNs, wantNs string) (bool, error) {
 	chain, err := t.Walker.WalkAncestors(ctx, startNs)
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, ancestor := range chain {
 		if ancestor.Name == wantNs {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // ListProjectTemplates returns all Template ConfigMaps in the project


### PR DESCRIPTION
## Summary

- Adds the HOL-570 write-time guardrail: `CreateTemplatePolicy` and `UpdateTemplatePolicy` now reject an EXCLUDE rule that targets a template already present in an existing ProjectTemplate or Deployment's `console.holos.run/linked-templates` annotation, returning `connect.CodeFailedPrecondition` with a message naming the offending resource.
- New `ResourceTopologyResolver` interface on `templatepolicies.Handler` enumerates project namespaces under the policy's owning scope (ancestor-chain traversal) plus their Template and Deployment ConfigMaps. Default implementation `K8sResourceTopology` lives in `console/templatepolicies/topology.go` and is wired from `console.go`.
- REQUIRE rules are unaffected. Empty scopes accept any EXCLUDE. Pattern matching uses the same `path.Match` semantics as `validatePolicyRules`.
- 10 new table-driven tests in `console/templatepolicies/exclude_explicit_link_test.go` covering wildcard hits on Deployments + ProjectTemplates, the narrow-pattern allow path, REQUIRE pass-through, multi-rule error indexing, folder-scope descendant narrowing, empty-scope allow, the "no topology resolver wired" ergonomic carve-out, and the Update-path assertion that the stored rules annotation is unchanged after a rejected write.
- Part of HOL-554 (render-set constraints); follow-up to HOL-557 / HOL-567 that deferred this AC.

Fixes HOL-570

## Test plan

- [x] `make test` (Go + frontend) — 979 frontend tests and all Go packages green locally.
- [x] Unit tests cover each AC bullet listed in the Linear ticket.
- [ ] CI: Go tests, lint, frontend tests, and E2E pass.

Generated with [Claude Code](https://claude.com/claude-code)