### PR TITLE
feat(console): wire real REQUIRE-rule resolver into CreateProject

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -92,6 +92,14 @@ const (
 	AnnotationDefaultShareRoles = "console.holos.run/default-share-roles"
 	AnnotationDeployment        = "console.holos.run/deployment"
 	AnnotationDeployerEmail     = "console.holos.run/deployer-email"
+	// AnnotationRequiredTemplate stamps ownership on resources that were
+	// applied by the project-creation-time REQUIRE-rule evaluator
+	// (HOL-571). It lives in a separate namespace from AnnotationDeployment
+	// so that a project's deployment whose name happens to match a
+	// required-template name cannot adopt, delete, or otherwise collide
+	// with required-template resources via the deployment reconcile/cleanup
+	// label selector (`project=X,deployment=Y`).
+	AnnotationRequiredTemplate = "console.holos.run/required-template"
 	AnnotationURL               = "console.holos.run/url"
 	AnnotationEnabled           = "console.holos.run/enabled"
 	AnnotationSettings          = "console.holos.run/project-settings"

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -104,9 +104,18 @@
 #AnnotationDefaultShareRoles: "console.holos.run/default-share-roles"
 #AnnotationDeployment:        "console.holos.run/deployment"
 #AnnotationDeployerEmail:     "console.holos.run/deployer-email"
-#AnnotationURL:               "console.holos.run/url"
-#AnnotationEnabled:           "console.holos.run/enabled"
-#AnnotationSettings:          "console.holos.run/project-settings"
+
+// AnnotationRequiredTemplate stamps ownership on resources that were
+// applied by the project-creation-time REQUIRE-rule evaluator
+// (HOL-571). It lives in a separate namespace from AnnotationDeployment
+// so that a project's deployment whose name happens to match a
+// required-template name cannot adopt, delete, or otherwise collide
+// with required-template resources via the deployment reconcile/cleanup
+// label selector (`project=X,deployment=Y`).
+#AnnotationRequiredTemplate: "console.holos.run/required-template"
+#AnnotationURL:              "console.holos.run/url"
+#AnnotationEnabled:          "console.holos.run/enabled"
+#AnnotationSettings:         "console.holos.run/project-settings"
 
 // AnnotationDefaultFolder stores the identifier (slug) of the default folder
 // for an organization. Written when the org is created and updatable via

--- a/console/console.go
+++ b/console/console.go
@@ -330,8 +330,19 @@ func (s *Server) Serve(ctx context.Context) error {
 		// Required template applier for project creation: evaluates
 		// TemplatePolicy REQUIRE rules and applies matched templates to the new
 		// project namespace via the unified Render + Apply path (ADR 021
-		// Decision 3). Phase 3 of HOL-562 wires the empty resolver; Phase 5
-		// (HOL-567) swaps in the real TemplatePolicy-backed resolver.
+		// Decision 3). Phase 9 of HOL-562 (HOL-571) swaps the Phase 3 empty
+		// resolver for the real TemplatePolicy-backed resolver wired below.
+		// The empty resolver remains available for tests and for local/dev
+		// wiring paths that do not have a live K8s client.
+		requireRuleResolver := templates.NewPolicyRequireRuleResolver(
+			policyresolver.NewAncestorPolicyLister(
+				templatePoliciesK8s,
+				nsWalker,
+				nsResolver,
+				policyresolver.RuleUnmarshalerFunc(templatepolicies.UnmarshalRules),
+			),
+			nsResolver.ProjectNamespace,
+		)
 		var requiredTmplApplier projects.RequiredTemplateApplier
 		if dynamicClient != nil {
 			requiredTmplApplier = templates.NewRequiredTemplateApplier(
@@ -339,7 +350,7 @@ func (s *Server) Serve(ctx context.Context) error {
 				nsWalker,
 				&deployments.CueRenderer{},
 				deployments.NewApplier(dynamicClient),
-				templates.NewEmptyRequireRuleResolver(),
+				requireRuleResolver,
 				policyResolverSeam,
 			)
 		}

--- a/console/deployments/apply.go
+++ b/console/deployments/apply.go
@@ -52,16 +52,48 @@ func NewApplier(client dynamic.Interface) *Applier {
 // Reconcile and Cleanup can scope queries to a single project, preventing
 // cross-project collisions in shared namespaces.
 func (a *Applier) Apply(ctx context.Context, project, deploymentName string, resources []unstructured.Unstructured) error {
+	return a.applyWithOwnerLabels(ctx, resources, map[string]string{
+		v1alpha2.LabelProject:        project,
+		v1alpha2.AnnotationDeployment: deploymentName,
+	}, map[string]string{
+		"project":    project,
+		"deployment": deploymentName,
+	})
+}
+
+// ApplyRequiredTemplate performs server-side apply of the rendered manifests
+// with a *required-template* ownership identity — never the deployment
+// identity. This is used by the project-creation-time REQUIRE-rule
+// evaluator (HOL-571) so that a future deployment whose name matches a
+// required-template name cannot adopt, delete, or otherwise collide with
+// required-template resources via the deployment Reconcile/Cleanup label
+// selector (`project=X,deployment=Y`). Required-template resources are
+// tagged with `project=X,required-template=T` — a disjoint selector.
+func (a *Applier) ApplyRequiredTemplate(ctx context.Context, project, templateName string, resources []unstructured.Unstructured) error {
+	return a.applyWithOwnerLabels(ctx, resources, map[string]string{
+		v1alpha2.LabelProject:              project,
+		v1alpha2.AnnotationRequiredTemplate: templateName,
+	}, map[string]string{
+		"project":          project,
+		"requiredTemplate": templateName,
+	})
+}
+
+// applyWithOwnerLabels SSAs resources after stamping the given ownership
+// labels. logAttrs carries the human-readable slog fields so debug output
+// reflects whichever ownership identity is in use.
+func (a *Applier) applyWithOwnerLabels(ctx context.Context, resources []unstructured.Unstructured, ownerLabels map[string]string, logAttrs map[string]string) error {
 	for i := range resources {
 		r := resources[i].DeepCopy()
 
-		// Inject ownership labels (project + deployment).
+		// Inject ownership labels (project + owner identity).
 		labels := r.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
 		}
-		labels[v1alpha2.LabelProject] = project
-		labels[v1alpha2.AnnotationDeployment] = deploymentName
+		for k, v := range ownerLabels {
+			labels[k] = v
+		}
 		r.SetLabels(labels)
 
 		kind := r.GetKind()
@@ -76,12 +108,15 @@ func (a *Applier) Apply(ctx context.Context, project, deploymentName string, res
 		}
 
 		namespace := r.GetNamespace()
-		slog.DebugContext(ctx, "applying resource",
+		attrs := []any{
 			slog.String("kind", kind),
 			slog.String("name", r.GetName()),
 			slog.String("namespace", namespace),
-			slog.String("deployment", deploymentName),
-		)
+		}
+		for k, v := range logAttrs {
+			attrs = append(attrs, slog.String(k, v))
+		}
+		slog.DebugContext(ctx, "applying resource", attrs...)
 
 		// Use the namespaced or cluster-scoped client depending on the resource.
 		var rc dynamic.ResourceInterface

--- a/console/deployments/apply.go
+++ b/console/deployments/apply.go
@@ -52,13 +52,17 @@ func NewApplier(client dynamic.Interface) *Applier {
 // Reconcile and Cleanup can scope queries to a single project, preventing
 // cross-project collisions in shared namespaces.
 func (a *Applier) Apply(ctx context.Context, project, deploymentName string, resources []unstructured.Unstructured) error {
-	return a.applyWithOwnerLabels(ctx, resources, map[string]string{
-		v1alpha2.LabelProject:        project,
-		v1alpha2.AnnotationDeployment: deploymentName,
-	}, map[string]string{
-		"project":    project,
-		"deployment": deploymentName,
-	})
+	return a.applyWithOwnerLabels(ctx, resources,
+		map[string]string{
+			v1alpha2.LabelProject:         project,
+			v1alpha2.AnnotationDeployment: deploymentName,
+		},
+		nil, // preserve any existing labels on the resource besides those we stamp
+		map[string]string{
+			"project":    project,
+			"deployment": deploymentName,
+		},
+	)
 }
 
 // ApplyRequiredTemplate performs server-side apply of the rendered manifests
@@ -69,28 +73,48 @@ func (a *Applier) Apply(ctx context.Context, project, deploymentName string, res
 // required-template resources via the deployment Reconcile/Cleanup label
 // selector (`project=X,deployment=Y`). Required-template resources are
 // tagged with `project=X,required-template=T` — a disjoint selector.
+//
+// Any preexisting `console.holos.run/deployment` label on the rendered
+// resource is stripped before SSA so a template author cannot accidentally
+// (or deliberately) emit a deployment label that would re-enable the
+// selector collision this path exists to prevent.
 func (a *Applier) ApplyRequiredTemplate(ctx context.Context, project, templateName string, resources []unstructured.Unstructured) error {
-	return a.applyWithOwnerLabels(ctx, resources, map[string]string{
-		v1alpha2.LabelProject:              project,
-		v1alpha2.AnnotationRequiredTemplate: templateName,
-	}, map[string]string{
-		"project":          project,
-		"requiredTemplate": templateName,
-	})
+	return a.applyWithOwnerLabels(ctx, resources,
+		map[string]string{
+			v1alpha2.LabelProject:               project,
+			v1alpha2.AnnotationRequiredTemplate: templateName,
+		},
+		[]string{v1alpha2.AnnotationDeployment},
+		map[string]string{
+			"project":          project,
+			"requiredTemplate": templateName,
+		},
+	)
 }
 
 // applyWithOwnerLabels SSAs resources after stamping the given ownership
-// labels. logAttrs carries the human-readable slog fields so debug output
-// reflects whichever ownership identity is in use.
-func (a *Applier) applyWithOwnerLabels(ctx context.Context, resources []unstructured.Unstructured, ownerLabels map[string]string, logAttrs map[string]string) error {
+// labels. stripLabels lists label keys that must be removed from the
+// rendered resource before the owner labels are applied — used by the
+// required-template path to strip any preexisting deployment label a
+// template author may have emitted so that path cannot re-introduce the
+// cross-identity selector collision it exists to prevent (HOL-571 review
+// round 2). logAttrs carries the human-readable slog fields so debug
+// output reflects whichever ownership identity is in use.
+func (a *Applier) applyWithOwnerLabels(ctx context.Context, resources []unstructured.Unstructured, ownerLabels map[string]string, stripLabels []string, logAttrs map[string]string) error {
 	for i := range resources {
 		r := resources[i].DeepCopy()
 
-		// Inject ownership labels (project + owner identity).
+		// Strip labels that would pollute the ownership selector before
+		// injecting our own. This runs before the stamp step so the
+		// stamped labels are never accidentally removed.
 		labels := r.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
 		}
+		for _, k := range stripLabels {
+			delete(labels, k)
+		}
+		// Inject ownership labels (project + owner identity).
 		for k, v := range ownerLabels {
 			labels[k] = v
 		}

--- a/console/deployments/apply_test.go
+++ b/console/deployments/apply_test.go
@@ -222,6 +222,43 @@ func TestApplier_ApplyRequiredTemplate(t *testing.T) {
 				v1alpha2.AnnotationDeployment)
 		}
 	})
+
+	// Regression guard for HOL-571 review round 2: a template author who
+	// emits `console.holos.run/deployment` on a rendered resource must not
+	// be able to smuggle that label back into the ownership selector that
+	// ApplyRequiredTemplate exists to keep disjoint from real deployments.
+	// The applier must strip the deployment label before stamping its own
+	// required-template identity.
+	t.Run("preexisting deployment label is stripped in patch payload", func(t *testing.T) {
+		applier, fakeClient := newFakeApplier()
+		res := makeDeploymentResource("sentinel", namespace)
+		// Emit the forbidden label from the rendered resource itself.
+		labels := res.GetLabels()
+		labels[v1alpha2.AnnotationDeployment] = "attacker-controlled"
+		res.SetLabels(labels)
+		resources := []unstructured.Unstructured{res}
+
+		if err := applier.ApplyRequiredTemplate(context.Background(), testProject, templateName, resources); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		sawDeploymentLabel := false
+		for _, a := range fakeClient.Actions() {
+			pa, ok := a.(testing2.PatchAction)
+			if !ok {
+				continue
+			}
+			patch := string(pa.GetPatch())
+			if containsStr(patch, v1alpha2.AnnotationDeployment) {
+				sawDeploymentLabel = true
+				break
+			}
+		}
+		if sawDeploymentLabel {
+			t.Errorf("required-template apply path must strip preexisting %q label, got it in patch",
+				v1alpha2.AnnotationDeployment)
+		}
+	})
 }
 
 func TestApplier_Cleanup(t *testing.T) {

--- a/console/deployments/apply_test.go
+++ b/console/deployments/apply_test.go
@@ -178,6 +178,52 @@ func TestApplier_Apply(t *testing.T) {
 	})
 }
 
+// TestApplier_ApplyRequiredTemplate asserts that the project-creation-time
+// REQUIRE-rule apply path (HOL-571) stamps a disjoint ownership identity —
+// project + required-template label — and NOT the deployment label. A
+// deployment whose name matches a required-template name must not be able
+// to adopt or delete those resources through its own
+// `project=X,deployment=Y` selector.
+func TestApplier_ApplyRequiredTemplate(t *testing.T) {
+	namespace := "prj-my-project"
+	templateName := "audit-policy"
+
+	t.Run("required-template label is injected into patch payload", func(t *testing.T) {
+		applier, fakeClient := newFakeApplier()
+		resources := []unstructured.Unstructured{
+			makeDeploymentResource("sentinel", namespace),
+		}
+
+		if err := applier.ApplyRequiredTemplate(context.Background(), testProject, templateName, resources); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		sawRequiredLabel := false
+		sawDeploymentLabel := false
+		for _, a := range fakeClient.Actions() {
+			pa, ok := a.(testing2.PatchAction)
+			if !ok {
+				continue
+			}
+			patch := string(pa.GetPatch())
+			if containsStr(patch, v1alpha2.AnnotationRequiredTemplate) {
+				sawRequiredLabel = true
+			}
+			if containsStr(patch, v1alpha2.AnnotationDeployment) {
+				sawDeploymentLabel = true
+			}
+		}
+		if !sawRequiredLabel {
+			t.Errorf("expected required-template ownership label %q in patch payload",
+				v1alpha2.AnnotationRequiredTemplate)
+		}
+		if sawDeploymentLabel {
+			t.Errorf("required-template apply path must not stamp deployment ownership label %q",
+				v1alpha2.AnnotationDeployment)
+		}
+	})
+}
+
 func TestApplier_Cleanup(t *testing.T) {
 	namespace := "prj-my-project"
 	deploymentName := "web-app"

--- a/console/deployments/record_applied_test.go
+++ b/console/deployments/record_applied_test.go
@@ -448,4 +448,3 @@ func TestHandler_UpdateDeployment_NilCheckerIsSafe(t *testing.T) {
 		t.Fatalf("unexpected error with nil checker: %v", err)
 	}
 }
-

--- a/console/policyresolver/ancestor_policies.go
+++ b/console/policyresolver/ancestor_policies.go
@@ -1,0 +1,140 @@
+package policyresolver
+
+import (
+	"context"
+	"log/slog"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// AncestorPolicyLister walks the ancestor chain of a starting namespace and
+// collects every TemplatePolicy rule stored in the folder and organization
+// namespaces on that chain. Project namespaces are skipped — storing a
+// TemplatePolicy in a project namespace is a HOL-554 storage-isolation
+// violation, and the loader must never consume such a record even if it
+// exists (an attacker could otherwise craft a policy in their own project
+// namespace that overrides the platform's constraints).
+//
+// This helper is shared by the render-time `folderResolver` (which classifies
+// rules as REQUIRE vs EXCLUDE and evaluates them against a render target)
+// and the project-creation-time `policyRequireRuleResolver` (which evaluates
+// REQUIRE rules against the new project's name before any deployment
+// exists). Keeping both callers on a single traversal means the
+// storage-isolation guardrail — and the slog-based error-logging contract
+// that goes with it — is implemented exactly once.
+type AncestorPolicyLister struct {
+	policyLister PolicyListerInNamespace
+	walker       WalkerInterface
+	resolver     *resolver.Resolver
+	unmarshaler  RuleUnmarshaler
+}
+
+// NewAncestorPolicyLister returns a lister wired with the given dependencies.
+// Any nil dependency yields a lister whose ListRules method returns an empty
+// slice without error (fail-open behavior — misconfigured bootstraps must not
+// block project creation or render).
+func NewAncestorPolicyLister(
+	policyLister PolicyListerInNamespace,
+	walker WalkerInterface,
+	r *resolver.Resolver,
+	unmarshaler RuleUnmarshaler,
+) *AncestorPolicyLister {
+	return &AncestorPolicyLister{
+		policyLister: policyLister,
+		walker:       walker,
+		resolver:     r,
+		unmarshaler:  unmarshaler,
+	}
+}
+
+// ListRules returns every TemplatePolicy rule declared in a folder or
+// organization namespace on the ancestor chain starting from startNs. The
+// returned rules preserve the walker's order (closest ancestor first) within
+// each policy and the policy-list order within each namespace; callers that
+// need a deterministic match order should dedup or sort after.
+//
+// startNs is typically the new project's namespace (project-creation time) or
+// the render target's project namespace (render time). Passing a
+// folder/organization namespace works too — any project namespace on the
+// chain (including the start itself) is skipped.
+//
+// A misconfigured lister (any nil dependency) returns (nil, nil) — the
+// fail-open contract matches `folderResolver.Resolve` so a bootstrap
+// misconfiguration degrades to "no policies" rather than "render errors on
+// every call".
+//
+// A walker failure returns (nil, err) so project-creation callers can choose
+// whether to fail closed (refuse to create the project) or fail open (create
+// without policy-injected templates). Today the project-creation caller
+// fails closed because a silent walker failure there would let a project
+// sneak in without required templates — a security-relevant outcome that
+// deserves explicit handling at the call site.
+//
+// Individual per-namespace lister or parse errors do not abort traversal;
+// they are logged and the namespace is skipped. This matches the resolver
+// contract that a single corrupted policy ConfigMap should not prevent
+// legitimate policies in peer namespaces from being honored.
+func (a *AncestorPolicyLister) ListRules(ctx context.Context, startNs string) ([]*consolev1.TemplatePolicyRule, error) {
+	if a == nil || a.policyLister == nil || a.walker == nil || a.resolver == nil || a.unmarshaler == nil {
+		slog.WarnContext(ctx, "ancestor policy lister is misconfigured; returning no rules",
+			slog.String("startNs", startNs),
+			slog.Bool("policyListerNil", a == nil || a.policyLister == nil),
+			slog.Bool("walkerNil", a == nil || a.walker == nil),
+			slog.Bool("resolverNil", a == nil || a.resolver == nil),
+			slog.Bool("unmarshalerNil", a == nil || a.unmarshaler == nil),
+		)
+		return nil, nil
+	}
+
+	ancestors, err := a.walker.WalkAncestors(ctx, startNs)
+	if err != nil {
+		return nil, err
+	}
+
+	var rules []*consolev1.TemplatePolicyRule
+	for _, ns := range ancestors {
+		if ns == nil {
+			continue
+		}
+		kind, _, kErr := a.resolver.ResourceTypeFromNamespace(ns.Name)
+		if kErr != nil {
+			continue
+		}
+		if kind == v1alpha2.ResourceTypeProject {
+			continue
+		}
+		cms, listErr := a.policyLister.ListPoliciesInNamespace(ctx, ns.Name)
+		if listErr != nil {
+			slog.WarnContext(ctx, "failed to list template policies in ancestor namespace",
+				slog.String("namespace", ns.Name),
+				slog.Any("error", listErr),
+			)
+			continue
+		}
+		for i := range cms {
+			cm := &cms[i]
+			raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyRules]
+			if raw == "" {
+				continue
+			}
+			parsed, parseErr := a.unmarshaler.UnmarshalRules(raw)
+			if parseErr != nil {
+				slog.WarnContext(ctx, "failed to parse template policy rules; skipping policy",
+					slog.String("namespace", ns.Name),
+					slog.String("policy", cm.Name),
+					slog.Any("error", parseErr),
+				)
+				continue
+			}
+			for _, rule := range parsed {
+				if rule == nil {
+					continue
+				}
+				rules = append(rules, rule)
+			}
+		}
+	}
+	return rules, nil
+}

--- a/console/policyresolver/applied_state_test.go
+++ b/console/policyresolver/applied_state_test.go
@@ -263,11 +263,11 @@ func TestDiffRenderSets(t *testing.T) {
 	c := &consolev1.LinkedTemplateRef{Scope: consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION, ScopeName: "acme", Name: "c"}
 
 	tests := []struct {
-		name     string
-		applied  []*consolev1.LinkedTemplateRef
-		current  []*consolev1.LinkedTemplateRef
-		wantAdd  []string
-		wantRem  []string
+		name      string
+		applied   []*consolev1.LinkedTemplateRef
+		current   []*consolev1.LinkedTemplateRef
+		wantAdd   []string
+		wantRem   []string
 		wantDrift bool
 	}{
 		{

--- a/console/policyresolver/drift_checker.go
+++ b/console/policyresolver/drift_checker.go
@@ -25,8 +25,8 @@ import (
 // cycles, DriftChecker's methods are named to match both interfaces where the
 // semantics coincide and dispatched on TargetKind where they diverge.
 type DriftChecker struct {
-	Resolver  PolicyResolver
-	State     *AppliedRenderStateClient
+	Resolver   PolicyResolver
+	State      *AppliedRenderStateClient
 	NsResolver *resolver.Resolver
 }
 
@@ -95,10 +95,10 @@ func (a *DeploymentDriftAdapter) PolicyState(ctx context.Context, project, deplo
 	added, removed, drift := DiffRenderSets(applied, current)
 	return &consolev1.PolicyState{
 		AppliedSet:      applied,
-		CurrentSet:     current,
-		AddedRefs:      added,
-		RemovedRefs:    removed,
-		Drift:          drift,
+		CurrentSet:      current,
+		AddedRefs:       added,
+		RemovedRefs:     removed,
+		Drift:           drift,
 		HasAppliedState: hasApplied,
 	}, nil
 }
@@ -140,10 +140,10 @@ func (a *ProjectTemplateDriftAdapter) PolicyState(ctx context.Context, project, 
 	added, removed, drift := DiffRenderSets(applied, current)
 	return &consolev1.PolicyState{
 		AppliedSet:      applied,
-		CurrentSet:     current,
-		AddedRefs:      added,
-		RemovedRefs:    removed,
-		Drift:          drift,
+		CurrentSet:      current,
+		AddedRefs:       added,
+		RemovedRefs:     removed,
+		Drift:           drift,
 		HasAppliedState: hasApplied,
 	}, nil
 }

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -7,7 +7,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -59,6 +58,13 @@ type folderResolver struct {
 	walker       WalkerInterface
 	resolver     *resolver.Resolver
 	unmarshaler  RuleUnmarshaler
+	// ancestorLister shares the ancestor-chain traversal and
+	// folder-namespace-only filter with the project-creation-time resolver
+	// in console/templates (HOL-571). When any of policyLister, walker,
+	// resolver, or unmarshaler is nil the fail-open branch in Resolve
+	// short-circuits before ancestorLister is consulted, so it is safe to
+	// construct from possibly-nil deps here.
+	ancestorLister *AncestorPolicyLister
 }
 
 // NewFolderResolver returns a folderResolver wired with the given dependencies.
@@ -73,10 +79,11 @@ func NewFolderResolver(
 	unmarshaler RuleUnmarshaler,
 ) PolicyResolver {
 	return &folderResolver{
-		policyLister: policyLister,
-		walker:       walker,
-		resolver:     r,
-		unmarshaler:  unmarshaler,
+		policyLister:   policyLister,
+		walker:         walker,
+		resolver:       r,
+		unmarshaler:    unmarshaler,
+		ancestorLister: NewAncestorPolicyLister(policyLister, walker, r, unmarshaler),
 	}
 }
 
@@ -137,7 +144,16 @@ func (r *folderResolver) Resolve(
 		project = ""
 	}
 
-	ancestors, walkErr := r.walker.WalkAncestors(ctx, projectNs)
+	// Collect every TemplatePolicy rule declared in a folder or
+	// organization namespace on the ancestor chain. The ancestor-policy
+	// lister handles the HOL-554 storage-isolation skip (project
+	// namespaces are never read) and per-namespace parse/list errors.
+	// Classify the returned rules by kind here because the resolver's
+	// REQUIRE/EXCLUDE evaluation cares about the distinction; the shared
+	// lister stays kind-agnostic so the project-creation-time caller
+	// (HOL-571) can reuse it without pulling EXCLUDE semantics it does
+	// not evaluate.
+	allRules, walkErr := r.ancestorLister.ListRules(ctx, projectNs)
 	if walkErr != nil {
 		// Degrade gracefully: a walker failure at resolve time should
 		// not block the render. Log and return the explicit refs so the
@@ -149,57 +165,14 @@ func (r *folderResolver) Resolve(
 		return explicitRefs, nil
 	}
 
-	// Collect REQUIRE/EXCLUDE rules from folder and organization
-	// namespaces only. ancestors[0] is the starting namespace; skip any
-	// namespace whose resource type is project (including the start when
-	// it is itself a project namespace).
 	var requireRules []*consolev1.TemplatePolicyRule
 	var excludeRules []*consolev1.TemplatePolicyRule
-	for _, ns := range ancestors {
-		if ns == nil {
-			continue
-		}
-		kind, _, kErr := r.resolver.ResourceTypeFromNamespace(ns.Name)
-		if kErr != nil {
-			continue
-		}
-		if kind == v1alpha2.ResourceTypeProject {
-			continue
-		}
-		cms, listErr := r.policyLister.ListPoliciesInNamespace(ctx, ns.Name)
-		if listErr != nil {
-			slog.WarnContext(ctx, "failed to list template policies in ancestor namespace",
-				slog.String("namespace", ns.Name),
-				slog.Any("error", listErr),
-			)
-			continue
-		}
-		for i := range cms {
-			cm := &cms[i]
-			raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyRules]
-			if raw == "" {
-				continue
-			}
-			rules, parseErr := r.unmarshaler.UnmarshalRules(raw)
-			if parseErr != nil {
-				slog.WarnContext(ctx, "failed to parse template policy rules; skipping policy",
-					slog.String("namespace", ns.Name),
-					slog.String("policy", cm.Name),
-					slog.Any("error", parseErr),
-				)
-				continue
-			}
-			for _, rule := range rules {
-				if rule == nil {
-					continue
-				}
-				switch rule.GetKind() {
-				case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE:
-					requireRules = append(requireRules, rule)
-				case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE:
-					excludeRules = append(excludeRules, rule)
-				}
-			}
+	for _, rule := range allRules {
+		switch rule.GetKind() {
+		case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE:
+			requireRules = append(requireRules, rule)
+		case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE:
+			excludeRules = append(excludeRules, rule)
 		}
 	}
 
@@ -385,4 +358,3 @@ func globMatch(pattern, subject string) bool {
 	}
 	return ok
 }
-

--- a/console/policyresolver/folder_resolver_test.go
+++ b/console/policyresolver/folder_resolver_test.go
@@ -140,12 +140,12 @@ func mkNs(name, kind, parent string) *corev1.Namespace {
 // (folder), projects under each, plus a project directly under the org.
 func buildFixture() (*fake.Clientset, *resolver.Resolver, map[string]string) {
 	r := baseResolver()
-	orgNs := r.OrgNamespace("acme")                     // holos-org-acme
-	folderEngNs := r.FolderNamespace("eng")             // holos-fld-eng
-	folderTeamANs := r.FolderNamespace("team-a")        // holos-fld-team-a
-	projectOrchids := r.ProjectNamespace("orchids")     // holos-prj-orchids (under org directly)
-	projectLilies := r.ProjectNamespace("lilies")       // holos-prj-lilies (under eng)
-	projectRoses := r.ProjectNamespace("roses")         // holos-prj-roses (under team-a)
+	orgNs := r.OrgNamespace("acme")                 // holos-org-acme
+	folderEngNs := r.FolderNamespace("eng")         // holos-fld-eng
+	folderTeamANs := r.FolderNamespace("team-a")    // holos-fld-team-a
+	projectOrchids := r.ProjectNamespace("orchids") // holos-prj-orchids (under org directly)
+	projectLilies := r.ProjectNamespace("lilies")   // holos-prj-lilies (under eng)
+	projectRoses := r.ProjectNamespace("roses")     // holos-prj-roses (under team-a)
 
 	objects := []runtime.Object{
 		mkNs(orgNs, v1alpha2.ResourceTypeOrganization, ""),
@@ -158,9 +158,9 @@ func buildFixture() (*fake.Clientset, *resolver.Resolver, map[string]string) {
 	client := fake.NewClientset(objects...)
 
 	namespaces := map[string]string{
-		"org":          orgNs,
-		"folderEng":    folderEngNs,
-		"folderTeamA":  folderTeamANs,
+		"org":            orgNs,
+		"folderEng":      folderEngNs,
+		"folderTeamA":    folderTeamANs,
 		"projectOrchids": projectOrchids,
 		"projectLilies":  projectLilies,
 		"projectRoses":   projectRoses,

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -13,15 +13,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
 	"github.com/holos-run/holos-console/console/secrets"
+	"github.com/holos-run/holos-console/console/templates"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
 
@@ -1368,6 +1372,379 @@ func TestCreateProject_NotCalledWhenNoOrgSpecified(t *testing.T) {
 	if applier.called {
 		t.Error("expected required template applier NOT to be called when org is empty")
 	}
+}
+
+// ---- CreateProject with REAL REQUIRE-rule resolver ----
+//
+// HOL-571 Phase 9 swapped the Phase 3 empty resolver for the real
+// TemplatePolicy-backed resolver that walks the new project's ancestor chain
+// looking for REQUIRE rules whose project_pattern matches the project name.
+// These tests wire the real resolver through a RequiredTemplateApplier
+// instance with a recording applier so the assertions can look at what a
+// real resolver actually picks up — the previous tests only exercised the
+// handler/applier wiring through a hand-crafted stub and never went through
+// the ancestor walk.
+
+// capturingApplier is a ResourceApplier that records every Apply call so a
+// test can assert which templates were rendered into which project.
+type capturingApplier struct {
+	calls []capturedApply
+	err   error
+}
+
+type capturedApply struct {
+	project        string
+	deploymentName string
+	resources      []unstructured.Unstructured
+}
+
+func (c *capturingApplier) Apply(_ context.Context, project, deploymentName string, resources []unstructured.Unstructured) error {
+	c.calls = append(c.calls, capturedApply{project: project, deploymentName: deploymentName, resources: resources})
+	return c.err
+}
+
+// makeOrgNamespace builds a fake organization namespace labeled so the
+// ancestor walker classifies it as an organization.
+func makeOrgNamespace(org string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-" + org,
+			Labels: map[string]string{
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+			},
+		},
+	}
+}
+
+// marshalFixtureRules serializes a minimal rule fixture in the shape
+// templatepolicies.UnmarshalRules expects on the annotation.
+func marshalFixtureRules(t *testing.T, rules []map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(rules)
+	if err != nil {
+		t.Fatalf("marshal fixture rules: %v", err)
+	}
+	return string(raw)
+}
+
+// seedOrgRequirePolicy returns a TemplatePolicy ConfigMap containing a single
+// REQUIRE rule that mandates the named organization-scope template for every
+// project matching projectPattern. Mirrors the minimal fixture used by the
+// templates package's require_policy_resolver tests.
+func seedOrgRequirePolicy(t *testing.T, org, templateName, projectPattern string) *corev1.ConfigMap {
+	t.Helper()
+	rules := []map[string]any{
+		{
+			"kind": "require",
+			"template": map[string]any{
+				"scope":      v1alpha2.TemplateScopeOrganization,
+				"scope_name": org,
+				"name":       templateName,
+			},
+			"target": map[string]any{
+				"project_pattern": projectPattern,
+			},
+		},
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "require-" + templateName,
+			Namespace: "holos-org-" + org,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplatePolicyRules: marshalFixtureRules(t, rules),
+			},
+		},
+	}
+}
+
+// seedOrgTemplate returns an organization-scope Template ConfigMap with a
+// minimal valid CUE source that emits exactly one ConfigMap resource into
+// the new project's namespace. The test harness does not fill the
+// PlatformInput struct into CUE, so the namespace is hardcoded in the CUE.
+func seedOrgTemplate(org, templateName, projectSlug string) *corev1.ConfigMap {
+	cueSrc := fmt.Sprintf(`projectResources: namespacedResources: "%s": ConfigMap: "sentinel-%s": {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	metadata: {
+		name:      "sentinel-%s"
+		namespace: "%s"
+		labels: "app.kubernetes.io/managed-by": "console.holos.run"
+	}
+}
+`, projectSlug, templateName, templateName, projectSlug)
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateName,
+			Namespace: "holos-org-" + org,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName: templateName,
+				v1alpha2.AnnotationEnabled:     "true",
+			},
+		},
+		Data: map[string]string{
+			templates.CueTemplateKey: cueSrc,
+		},
+	}
+}
+
+// TestCreateProject_RealRequireRuleResolver_AppliesOrgTemplate is the
+// HOL-571 end-to-end assertion: with the real policy-backed resolver wired
+// into the applier, creating a project under an organization whose
+// TemplatePolicy REQUIREs a template with project_pattern "*" causes that
+// template to be rendered and applied to the new project.
+func TestCreateProject_RealRequireRuleResolver_AppliesOrgTemplate(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	existing := managedNSWithOrg("existing", "acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgNs := makeOrgNamespace("acme")
+	orgTmpl := seedOrgTemplate("acme", "audit-policy", "holos-prj-new-prj")
+	policyCM := seedOrgRequirePolicy(t, "acme", "audit-policy", "*")
+
+	handler, fakeClient := buildCreateProjectRealResolverHandler(t, existing, orgNs, orgTmpl, policyCM)
+
+	recording := handler.requiredTemplateApplier.(*recordingAppliedTemplates)
+
+	ctx := contextWithClaims("alice@example.com")
+	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-prj",
+		Organization: "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "new-prj" {
+		t.Errorf("expected project name 'new-prj', got %q", resp.Msg.Name)
+	}
+
+	// Real resolver should have matched the wildcard REQUIRE rule and the
+	// recording applier should have been called exactly once with the
+	// org-scope template.
+	if len(recording.applied.calls) != 1 {
+		t.Fatalf("expected exactly 1 Apply call for REQUIRE-matched template, got %d", len(recording.applied.calls))
+	}
+	call := recording.applied.calls[0]
+	if call.project != "new-prj" {
+		t.Errorf("apply called with project=%q, want new-prj", call.project)
+	}
+	if call.deploymentName != "audit-policy" {
+		t.Errorf("apply called with templateName=%q, want audit-policy", call.deploymentName)
+	}
+	if len(call.resources) == 0 {
+		t.Error("expected at least one rendered resource, got 0")
+	}
+
+	// Sanity check the project namespace was actually created.
+	if _, err := fakeClient.CoreV1().Namespaces().Get(ctx, "holos-prj-new-prj", metav1.GetOptions{}); err != nil {
+		t.Errorf("project namespace not created: %v", err)
+	}
+}
+
+// TestCreateProject_RealRequireRuleResolver_SkipsProjectNamespacePolicy
+// exercises the HOL-554 storage-isolation guardrail end-to-end: a
+// TemplatePolicy ConfigMap seeded in a project namespace (where it is not
+// allowed to live) must not contribute REQUIRE matches even though the
+// ConfigMap itself would deserialize cleanly. A project owner who smuggled
+// a policy into their own project namespace must not be able to force
+// templates on newly created peer projects — the resolver only reads
+// folder/org namespaces.
+func TestCreateProject_RealRequireRuleResolver_SkipsProjectNamespacePolicy(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Create a project namespace and seed a (forbidden) TemplatePolicy
+	// ConfigMap inside it. The resolver must skip this namespace per
+	// HOL-554.
+	existing := managedNSWithOrg("existing", "acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgNs := makeOrgNamespace("acme")
+
+	pwnedNs := "holos-prj-pwned"
+	pwnedProjectNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pwnedNs,
+			Labels: map[string]string{
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelProject:      "pwned",
+			},
+		},
+	}
+
+	pwnedPolicy := seedOrgRequirePolicy(t, "acme", "should-be-ignored", "*")
+	pwnedPolicy.Namespace = pwnedNs // forbidden placement
+
+	handler, _ := buildCreateProjectRealResolverHandler(t, existing, orgNs, pwnedProjectNs, pwnedPolicy)
+
+	recording := handler.requiredTemplateApplier.(*recordingAppliedTemplates)
+
+	ctx := contextWithClaims("alice@example.com")
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-prj",
+		Organization: "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(recording.applied.calls) != 0 {
+		t.Errorf("project-namespace policy leaked into CreateProject apply: got %d calls, want 0",
+			len(recording.applied.calls))
+	}
+}
+
+// recordingAppliedTemplates wraps a RequiredTemplateApplier built out of the
+// real resolver + real applier so tests can assert both that the applier ran
+// and what it applied. The wrapper is needed because CreateProject's apply
+// call goes through RequiredTemplateApplier.ApplyRequiredTemplates (which
+// returns only an error), and the tests need to peek at the recording
+// applier inside.
+type recordingAppliedTemplates struct {
+	inner   RequiredTemplateApplier
+	applied *capturingApplier
+}
+
+func (r *recordingAppliedTemplates) ApplyRequiredTemplates(ctx context.Context, org, project, projectNamespace string, claims *rpc.Claims) error {
+	return r.inner.ApplyRequiredTemplates(ctx, org, project, projectNamespace, claims)
+}
+
+// buildCreateProjectRealResolverHandler wires a projects.Handler whose
+// RequiredTemplateApplier is constructed from the real
+// templates.PolicyRequireRuleResolver (backed by the given fake K8s client)
+// and a capturingApplier that records Apply calls. The recording wrapper is
+// returned as the handler's applier field so tests can reach into it.
+func buildCreateProjectRealResolverHandler(t *testing.T, namespaces ...runtime.Object) (*Handler, *fake.Clientset) {
+	t.Helper()
+
+	client := fake.NewClientset(namespaces...)
+	r := testResolver()
+	k8s := NewK8sClient(client, r)
+
+	nsWalker := &policyresolverWalker{client: client, resolver: r}
+	templatePoliciesLister := &configMapPolicyLister{client: client}
+	templatesK8s := templates.NewK8sClient(client, r)
+
+	ancestorLister := policyresolver.NewAncestorPolicyLister(
+		templatePoliciesLister,
+		nsWalker,
+		r,
+		policyresolver.RuleUnmarshalerFunc(templatepoliciesUnmarshalRules),
+	)
+	requireResolver := templates.NewPolicyRequireRuleResolver(
+		ancestorLister,
+		r.ProjectNamespace,
+	)
+	capturing := &capturingApplier{}
+	rta := templates.NewRequiredTemplateApplier(
+		templatesK8s,
+		nsWalker,
+		&deployments.CueRenderer{},
+		capturing,
+		requireResolver,
+		policyresolver.NewNoopResolver(),
+	)
+	wrapper := &recordingAppliedTemplates{inner: rta, applied: capturing}
+
+	handler := NewHandler(k8s, nil).WithRequiredTemplateApplier(wrapper)
+	return handler, client
+}
+
+// policyresolverWalker is a thin WalkAncestors adapter over a fake clientset
+// that avoids pulling in the full resolver.Walker (which would require
+// reimporting console/resolver into this package from
+// console/projects — already imported, but the fake here only needs the
+// ancestor-labels behavior, so keeping it inline avoids a circular setup).
+type policyresolverWalker struct {
+	client   *fake.Clientset
+	resolver *resolver.Resolver
+}
+
+func (w *policyresolverWalker) WalkAncestors(ctx context.Context, startNs string) ([]*corev1.Namespace, error) {
+	return (&resolver.Walker{Client: w.client, Resolver: w.resolver}).WalkAncestors(ctx, startNs)
+}
+
+// configMapPolicyLister is a PolicyListerInNamespace implementation over a
+// fake clientset that lists TemplatePolicy ConfigMaps by label. It mirrors
+// templatepolicies.K8sClient.ListPoliciesInNamespace without pulling the
+// whole package in.
+type configMapPolicyLister struct {
+	client *fake.Clientset
+}
+
+func (l *configMapPolicyLister) ListPoliciesInNamespace(ctx context.Context, ns string) ([]corev1.ConfigMap, error) {
+	labelSelector := v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeTemplatePolicy
+	list, err := l.client.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// templatepoliciesUnmarshalRules mirrors the JSON wire shape produced by the
+// templatepolicies package so tests in this package can drive the resolver
+// without importing that package (which would create a test-only dependency
+// cycle).
+func templatepoliciesUnmarshalRules(raw string) ([]*consolev1.TemplatePolicyRule, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	type storedRule struct {
+		Kind     string `json:"kind"`
+		Template struct {
+			Scope             string `json:"scope"`
+			ScopeName         string `json:"scope_name"`
+			Name              string `json:"name"`
+			VersionConstraint string `json:"version_constraint,omitempty"`
+		} `json:"template"`
+		Target struct {
+			ProjectPattern    string `json:"project_pattern"`
+			DeploymentPattern string `json:"deployment_pattern,omitempty"`
+		} `json:"target"`
+	}
+	var stored []storedRule
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		return nil, err
+	}
+	rules := make([]*consolev1.TemplatePolicyRule, 0, len(stored))
+	for _, s := range stored {
+		kind := consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_UNSPECIFIED
+		switch s.Kind {
+		case "require":
+			kind = consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE
+		case "exclude":
+			kind = consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE
+		}
+		scope := consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED
+		switch s.Template.Scope {
+		case v1alpha2.TemplateScopeOrganization:
+			scope = consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION
+		case v1alpha2.TemplateScopeFolder:
+			scope = consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER
+		case v1alpha2.TemplateScopeProject:
+			scope = consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT
+		}
+		rules = append(rules, &consolev1.TemplatePolicyRule{
+			Kind: kind,
+			Template: &consolev1.LinkedTemplateRef{
+				Scope:             scope,
+				ScopeName:         s.Template.ScopeName,
+				Name:              s.Template.Name,
+				VersionConstraint: s.Template.VersionConstraint,
+			},
+			Target: &consolev1.TemplatePolicyTarget{
+				ProjectPattern:    s.Target.ProjectPattern,
+				DeploymentPattern: s.Target.DeploymentPattern,
+			},
+		})
+	}
+	return rules, nil
 }
 
 // ---- CheckProjectIdentifier tests ----

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1398,8 +1398,8 @@ type capturedApply struct {
 	resources      []unstructured.Unstructured
 }
 
-func (c *capturingApplier) Apply(_ context.Context, project, deploymentName string, resources []unstructured.Unstructured) error {
-	c.calls = append(c.calls, capturedApply{project: project, deploymentName: deploymentName, resources: resources})
+func (c *capturingApplier) ApplyRequiredTemplate(_ context.Context, project, templateName string, resources []unstructured.Unstructured) error {
+	c.calls = append(c.calls, capturedApply{project: project, deploymentName: templateName, resources: resources})
 	return c.err
 }
 

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1549,6 +1549,105 @@ func TestCreateProject_RealRequireRuleResolver_AppliesOrgTemplate(t *testing.T) 
 	}
 }
 
+// TestCreateProject_RealRequireRuleResolver_PopulatesPlatformFolders
+// asserts that the HOL-571 review round-1 folder-ancestry fix is live: a
+// project under a folder whose required template references
+// `platform.folders` renders with the folder chain populated. The CUE
+// template emits a ConfigMap whose sentinel annotation is the first
+// folder name taken from `platform.folders`; if Folders were empty (the
+// regression this test guards against), CUE would fail the index
+// expression and the apply would error rather than succeed with the
+// expected folder name in the annotation.
+func TestCreateProject_RealRequireRuleResolver_PopulatesPlatformFolders(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Fixture: acme (org) → eng (folder) → new-prj (project under eng).
+	existing := managedNSWithOrg("existing", "acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	orgNs := makeOrgNamespace("acme")
+	folderEngNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-eng",
+			Labels: map[string]string{
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.AnnotationParent:  orgNs.Name,
+			},
+		},
+	}
+
+	// Template CUE reads the first element of platform.folders and emits
+	// it as an annotation. Without the round-1 Folders fix this fails to
+	// evaluate (empty slice indexed at [0]) and the apply errors out.
+	templateName := "folder-aware"
+	cueSrc := `platform: #PlatformInput
+projectResources: namespacedResources: "holos-prj-new-prj": ConfigMap: "sentinel": {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	metadata: {
+		name:      "sentinel"
+		namespace: "holos-prj-new-prj"
+		labels: "app.kubernetes.io/managed-by": "console.holos.run"
+		annotations: "folder": platform.folders[0].name
+	}
+}
+`
+	// Build the template with the folder-aware CUE source.
+	orgTmpl := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateName,
+			Namespace: "holos-org-acme",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName: templateName,
+				v1alpha2.AnnotationEnabled:     "true",
+			},
+		},
+		Data: map[string]string{
+			templates.CueTemplateKey: cueSrc,
+		},
+	}
+	policyCM := seedOrgRequirePolicy(t, "acme", templateName, "*")
+
+	handler, _ := buildCreateProjectRealResolverHandler(t, existing, orgNs, folderEngNs, orgTmpl, policyCM)
+
+	recording := handler.requiredTemplateApplier.(*recordingAppliedTemplates)
+
+	ctx := contextWithClaims("alice@example.com")
+	// Create the project under the eng folder so Folders is non-empty.
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "new-prj",
+		Organization: "acme",
+		ParentType:   consolev1.ParentType_PARENT_TYPE_FOLDER,
+		ParentName:   "eng",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error (CUE would fail with empty platform.folders), got %v", err)
+	}
+
+	if len(recording.applied.calls) != 1 {
+		t.Fatalf("expected exactly 1 Apply call for REQUIRE-matched template, got %d", len(recording.applied.calls))
+	}
+	// The resulting ConfigMap should carry the folder annotation
+	// `folder: eng`. A stale or missing Folders slice would have aborted
+	// the CUE render above; the extra assertion here keeps the folder
+	// ancestry explicitly in scope.
+	gotFolder := ""
+	for _, r := range recording.applied.calls[0].resources {
+		anns := r.GetAnnotations()
+		if v, ok := anns["folder"]; ok {
+			gotFolder = v
+			break
+		}
+	}
+	if gotFolder != "eng" {
+		t.Errorf("expected rendered annotation folder=eng (from platform.folders[0]), got %q", gotFolder)
+	}
+}
+
 // TestCreateProject_RealRequireRuleResolver_SkipsProjectNamespacePolicy
 // exercises the HOL-554 storage-isolation guardrail end-to-end: a
 // TemplatePolicy ConfigMap seeded in a project namespace (where it is not

--- a/console/templatepolicies/exclude_explicit_link_test.go
+++ b/console/templatepolicies/exclude_explicit_link_test.go
@@ -917,9 +917,9 @@ func TestCreateIgnoresBrokenProjectsInOtherOrgs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "holos-prj-broken",
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeProject,
-				v1alpha2.LabelOrganization:  "other",
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelOrganization: "other",
 				// NOTE: intentionally missing AnnotationParent.
 			},
 		},

--- a/console/templates/require_apply.go
+++ b/console/templates/require_apply.go
@@ -40,6 +40,12 @@ type RequireRuleMatch struct {
 	ScopeName string
 	// TemplateName is the name of the template ConfigMap to render.
 	TemplateName string
+	// VersionConstraint carries the policy-author-declared semver
+	// constraint (if any) so applyMatch can pin the required template
+	// to the rule's version band at render time. Empty string means "use
+	// the live template source" — identical to the behavior of a
+	// LinkedTemplateRef with no version_constraint.
+	VersionConstraint string
 }
 
 // RequireRuleResolver evaluates TemplatePolicy REQUIRE rules for a project at
@@ -216,12 +222,13 @@ func (a *RequiredTemplateApplier) applyMatch(
 	platformInput v1alpha2.PlatformInput,
 ) error {
 	templateRef := &consolev1.LinkedTemplateRef{
-		Scope:     match.Scope,
-		ScopeName: match.ScopeName,
-		Name:      match.TemplateName,
+		Scope:             match.Scope,
+		ScopeName:         match.ScopeName,
+		Name:              match.TemplateName,
+		VersionConstraint: match.VersionConstraint,
 	}
 
-	ancestorSources, _, err := a.k8s.ListEffectiveTemplateSources(
+	ancestorSources, effectiveRefs, err := a.k8s.ListEffectiveTemplateSources(
 		ctx,
 		projectNs,
 		TargetKindProjectTemplate,
@@ -233,6 +240,18 @@ func (a *RequiredTemplateApplier) applyMatch(
 	if err != nil {
 		return fmt.Errorf("listing ancestor sources for required template %q (%s/%s): %w",
 			match.TemplateName, match.Scope, match.ScopeName, err)
+	}
+	// HOL-571 review round 3 P1: fail closed when ancestor lookup
+	// degrades to the nil-source signal. ListEffectiveTemplateSources
+	// returns (nil, nil, nil) on walker failure or when the walker is
+	// not configured — both cases mean "we could not confirm the
+	// required-template source unified into the render". Project
+	// creation must refuse rather than apply an empty manifest, because
+	// a policy-REQUIRE'd template that silently renders empty defeats
+	// the enforcement boundary this path exists for.
+	if ancestorSources == nil && effectiveRefs == nil {
+		return fmt.Errorf("required template %q (%s/%s) source lookup returned empty; refusing to create project %q without policy-required manifests",
+			match.TemplateName, match.Scope, match.ScopeName, project)
 	}
 
 	grouped, err := a.renderer.Render(ctx, "", ancestorSources, deployments.RenderInputs{

--- a/console/templates/require_apply.go
+++ b/console/templates/require_apply.go
@@ -15,12 +15,17 @@ import (
 )
 
 // ResourceApplier applies rendered Kubernetes resources to the cluster using
-// each resource's own namespace. This is the same contract the legacy
-// MandatoryTemplateApplier used; it survives into Phase 3 because the
-// unified Render + Apply path at project creation time still needs a way to
-// write resources.
+// each resource's own namespace.
+//
+// ApplyRequiredTemplate stamps a *required-template* ownership identity
+// (project + required-template label, NOT project + deployment) so that a
+// future deployment whose name matches a required-template name cannot
+// adopt or delete required-template resources via the deployment
+// reconcile/cleanup label selector (HOL-571 review round 1). Production
+// wires deployments.Applier here, which keeps deployment-owned resources
+// and required-template-owned resources in disjoint label namespaces.
 type ResourceApplier interface {
-	Apply(ctx context.Context, project, deploymentName string, resources []unstructured.Unstructured) error
+	ApplyRequiredTemplate(ctx context.Context, project, templateName string, resources []unstructured.Unstructured) error
 }
 
 // RequireRuleMatch describes a single template that a TemplatePolicy REQUIRE
@@ -138,7 +143,47 @@ func (a *RequiredTemplateApplier) ApplyRequiredTemplates(ctx context.Context, or
 	platformInput := v1alpha2.PlatformInput{
 		Project:          project,
 		Namespace:        projectNamespace,
+		Organization:     org,
 		GatewayNamespace: deployments.DefaultGatewayNamespace,
+	}
+	// Populate PlatformInput.Folders from the project's ancestor chain so
+	// folder/org-scope templates that reference `platform.folders` render
+	// correctly. The deployment render path does the same thing via
+	// AncestorWalker.GetProjectFolders; at project-creation time we have
+	// the RenderHierarchyWalker already wired for ancestor-template
+	// resolution, so walk with it and extract folder-kind ancestors.
+	// Failures here log a warning but do not abort the create — a missing
+	// Folders value may render the wrong manifests for a template that
+	// relies on folder ancestry, but refusing to create the project is
+	// worse when the ancestor chain is otherwise intact. Templates that
+	// require folder ancestry can enforce presence via CUE constraints.
+	if a.walker != nil {
+		ancestors, walkErr := a.walker.WalkAncestors(ctx, projectNs)
+		if walkErr != nil {
+			slog.WarnContext(ctx, "could not resolve folder ancestry for required-template platform input",
+				slog.String("project", project),
+				slog.Any("error", walkErr),
+			)
+		} else {
+			// ancestors is child→parent order (project first, org last).
+			// Reverse so PlatformInput.Folders is org→project (matches the
+			// contract documented on v1alpha2.PlatformInput.Folders).
+			var folders []v1alpha2.FolderInfo
+			for i := len(ancestors) - 1; i >= 0; i-- {
+				ns := ancestors[i]
+				if ns == nil {
+					continue
+				}
+				kind, name, err := a.k8s.Resolver.ResourceTypeFromNamespace(ns.Name)
+				if err != nil {
+					continue
+				}
+				if kind == v1alpha2.ResourceTypeFolder {
+					folders = append(folders, v1alpha2.FolderInfo{Name: name})
+				}
+			}
+			platformInput.Folders = folders
+		}
 	}
 	if claims != nil {
 		platformInput.Claims = v1alpha2.Claims{
@@ -204,7 +249,7 @@ func (a *RequiredTemplateApplier) applyMatch(
 	resources = append(resources, grouped.Platform...)
 	resources = append(resources, grouped.Project...)
 
-	if err := a.applier.Apply(ctx, project, match.TemplateName, resources); err != nil {
+	if err := a.applier.ApplyRequiredTemplate(ctx, project, match.TemplateName, resources); err != nil {
 		return fmt.Errorf("applying required template %q (%s/%s) to project %q: %w",
 			match.TemplateName, match.Scope, match.ScopeName, project, err)
 	}

--- a/console/templates/require_apply_test.go
+++ b/console/templates/require_apply_test.go
@@ -35,11 +35,17 @@ func (s *stubRequireRuleResolver) ResolveRequiredTemplates(_ context.Context, _,
 
 // stubHierarchyWalkerFromNamespaces adapts a flat list of namespaces to the
 // RenderHierarchyWalker interface so tests can drive ancestor resolution.
+// Records every WalkAncestors call so tests can guard against regressions
+// that skip the walk entirely (HOL-571 review round 2).
 type stubHierarchyWalkerFromNamespaces struct {
-	ancestors []*corev1.Namespace
+	ancestors   []*corev1.Namespace
+	callCount   int
+	lastStartNs string
 }
 
-func (s *stubHierarchyWalkerFromNamespaces) WalkAncestors(_ context.Context, _ string) ([]*corev1.Namespace, error) {
+func (s *stubHierarchyWalkerFromNamespaces) WalkAncestors(_ context.Context, startNs string) ([]*corev1.Namespace, error) {
+	s.callCount++
+	s.lastStartNs = startNs
 	return s.ancestors, nil
 }
 
@@ -223,14 +229,16 @@ func TestEmptyRequireRuleResolver(t *testing.T) {
 	}
 }
 
-// TestRequiredTemplateApplier_WalksFolderAncestryForPlatformInput exercises
-// the guard introduced in HOL-571 review round 1 finding 2: the applier
-// must consult the RenderHierarchyWalker when building PlatformInput so
+// TestRequiredTemplateApplier_WalksFolderAncestryForPlatformInput guards
+// the fix from HOL-571 review round 1 finding 2: the applier must consult
+// the RenderHierarchyWalker when building PlatformInput so
 // `platform.folders` is populated for folder/org-scope required templates.
-// Asserting the Folders content end-to-end needs a renderer that can
-// capture the inputs it receives; that's covered by the integration test
-// in console/projects/handler_test.go. This unit-level check guards
-// against a regression where the walk is skipped entirely.
+// The stub walker records every invocation, so if the walk call is ever
+// removed from ApplyRequiredTemplates the assertion will fire — covering
+// the round-2 gap where checking fixture data alone was not enough.
+// End-to-end Folders-content assertions live in the handler-level
+// integration tests; at the unit level we guard against the call being
+// skipped entirely.
 func TestRequiredTemplateApplier_WalksFolderAncestryForPlatformInput(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
@@ -273,13 +281,13 @@ func TestRequiredTemplateApplier_WalksFolderAncestryForPlatformInput(t *testing.
 	// consulted.
 	_ = rta.ApplyRequiredTemplates(context.Background(), "acme", "new-prj", "prj-new-prj", nil)
 
-	// The stub walker records its ancestors return; a non-nil set means
-	// ApplyRequiredTemplates reached the walk. If the code short-circuits
-	// before touching the walker, this passes trivially — so further
-	// assertions on Folders content live in the handler-level integration
-	// test. At the unit-level we just guard against the regression where
-	// the walk is skipped entirely.
-	if len(walker.ancestors) != 3 {
-		t.Errorf("fixture walker seed was lost: got %d ancestors, want 3", len(walker.ancestors))
+	if walker.callCount < 1 {
+		t.Errorf("expected WalkAncestors to be called at least once, got %d", walker.callCount)
+	}
+	// The walk starts from the new project's namespace so folder
+	// ancestry is resolved relative to the right node.
+	if walker.lastStartNs != "prj-new-prj" {
+		t.Errorf("expected WalkAncestors start namespace %q, got %q",
+			"prj-new-prj", walker.lastStartNs)
 	}
 }

--- a/console/templates/require_apply_test.go
+++ b/console/templates/require_apply_test.go
@@ -43,8 +43,10 @@ func (s *stubHierarchyWalkerFromNamespaces) WalkAncestors(_ context.Context, _ s
 	return s.ancestors, nil
 }
 
-// recordingApplier captures Apply calls so the test can assert deployment name
-// and resource list without running against a real cluster.
+// recordingApplier captures ApplyRequiredTemplate calls so the test can
+// assert template name and resource list without running against a real
+// cluster. Named fields preserve the old shape for brevity; the
+// deploymentName field now carries the templateName argument.
 type recordingApplier struct {
 	calls []recordedApply
 	err   error
@@ -56,8 +58,8 @@ type recordedApply struct {
 	resources      []unstructured.Unstructured
 }
 
-func (r *recordingApplier) Apply(_ context.Context, project, deploymentName string, resources []unstructured.Unstructured) error {
-	r.calls = append(r.calls, recordedApply{project: project, deploymentName: deploymentName, resources: resources})
+func (r *recordingApplier) ApplyRequiredTemplate(_ context.Context, project, templateName string, resources []unstructured.Unstructured) error {
+	r.calls = append(r.calls, recordedApply{project: project, deploymentName: templateName, resources: resources})
 	return r.err
 }
 
@@ -218,5 +220,66 @@ func TestEmptyRequireRuleResolver(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Errorf("expected 0 matches, got %d", len(matches))
+	}
+}
+
+// TestRequiredTemplateApplier_WalksFolderAncestryForPlatformInput exercises
+// the guard introduced in HOL-571 review round 1 finding 2: the applier
+// must consult the RenderHierarchyWalker when building PlatformInput so
+// `platform.folders` is populated for folder/org-scope required templates.
+// Asserting the Folders content end-to-end needs a renderer that can
+// capture the inputs it receives; that's covered by the integration test
+// in console/projects/handler_test.go. This unit-level check guards
+// against a regression where the walk is skipped entirely.
+func TestRequiredTemplateApplier_WalksFolderAncestryForPlatformInput(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Minimal fixture: org acme → folder eng → project new-prj.
+	orgNsObj := orgNS("acme")
+	folderEngNsObj := folderNS("eng")
+	projectNsObj := projectNS("new-prj")
+	fakeClient := fake.NewClientset(orgNsObj, folderEngNsObj, projectNsObj)
+
+	r := &resolver.Resolver{
+		NamespacePrefix:    "",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
+	k8s := NewK8sClient(fakeClient, r)
+
+	// child→parent order so applyRequired walks project, folder, org.
+	walker := &stubHierarchyWalkerFromNamespaces{
+		ancestors: []*corev1.Namespace{projectNsObj, folderEngNsObj, orgNsObj},
+	}
+	applier := &recordingApplier{}
+	// Resolver matches one template so the walker path is actually
+	// exercised; the apply failure on the empty template body is tolerated
+	// because the test asserts on the walk, not the apply.
+	res := &stubRequireRuleResolver{
+		matches: []RequireRuleMatch{
+			{
+				Scope:        consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:    "acme",
+				TemplateName: "missing-template",
+			},
+		},
+	}
+	rta := NewRequiredTemplateApplier(k8s, walker, &deployments.CueRenderer{}, applier, res, policyresolver.NewNoopResolver())
+
+	// ApplyRequiredTemplates will walk ancestors to build Folders, then
+	// try to render the (nonexistent) template and fail. The error is
+	// expected — the assertion below only cares that the walker was
+	// consulted.
+	_ = rta.ApplyRequiredTemplates(context.Background(), "acme", "new-prj", "prj-new-prj", nil)
+
+	// The stub walker records its ancestors return; a non-nil set means
+	// ApplyRequiredTemplates reached the walk. If the code short-circuits
+	// before touching the walker, this passes trivially — so further
+	// assertions on Folders content live in the handler-level integration
+	// test. At the unit-level we just guard against the regression where
+	// the walk is skipped entirely.
+	if len(walker.ancestors) != 3 {
+		t.Errorf("fixture walker seed was lost: got %d ancestors, want 3", len(walker.ancestors))
 	}
 }

--- a/console/templates/require_apply_test.go
+++ b/console/templates/require_apply_test.go
@@ -229,6 +229,48 @@ func TestEmptyRequireRuleResolver(t *testing.T) {
 	}
 }
 
+// TestRequiredTemplateApplier_FailsClosedWhenAncestorLookupEmpty guards the
+// HOL-571 round 3 P1 fix: when ListEffectiveTemplateSources returns the
+// (nil, nil, nil) "degraded" signal (a nil walker or walker failure),
+// applyMatch must refuse to proceed. Silently rendering an empty manifest
+// would let a project be created without the policy-REQUIRE'd templates,
+// defeating the enforcement boundary.
+func TestRequiredTemplateApplier_FailsClosedWhenAncestorLookupEmpty(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	r := &resolver.Resolver{
+		NamespacePrefix:    "",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
+	k8s := NewK8sClient(fake.NewClientset(), r)
+	applier := &recordingApplier{}
+	res := &stubRequireRuleResolver{
+		matches: []RequireRuleMatch{
+			{
+				Scope:        consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+				ScopeName:    "acme",
+				TemplateName: "audit-policy",
+			},
+		},
+	}
+	// Passing a nil walker makes ListEffectiveTemplateSources return
+	// (nil, nil, nil), the "degraded" signal this guard is written for.
+	rta := NewRequiredTemplateApplier(k8s, nil, &deployments.CueRenderer{}, applier, res, policyresolver.NewNoopResolver())
+
+	err := rta.ApplyRequiredTemplates(context.Background(), "acme", "new-prj", "prj-new-prj", nil)
+	if err == nil {
+		t.Fatal("expected a fail-closed error when ancestor lookup degrades, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to create project") {
+		t.Errorf("expected fail-closed error message, got %q", err.Error())
+	}
+	if len(applier.calls) != 0 {
+		t.Errorf("expected no Apply calls on fail-closed path, got %d", len(applier.calls))
+	}
+}
+
 // TestRequiredTemplateApplier_WalksFolderAncestryForPlatformInput guards
 // the fix from HOL-571 review round 1 finding 2: the applier must consult
 // the RenderHierarchyWalker when building PlatformInput so

--- a/console/templates/require_policy_resolver.go
+++ b/console/templates/require_policy_resolver.go
@@ -1,0 +1,153 @@
+package templates
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path"
+
+	"github.com/holos-run/holos-console/console/policyresolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// policyRequireRuleResolver is the real, TemplatePolicy-backed
+// RequireRuleResolver wired into CreateProject. It walks the ancestor chain
+// of the newly created project's namespace (project → folder(s) → org),
+// reads TemplatePolicy ConfigMaps from every folder and organization
+// namespace on the chain (never from the project namespace itself — HOL-554
+// storage-isolation), and emits a RequireRuleMatch for each REQUIRE rule
+// whose project_pattern matches the new project's name via path.Match.
+//
+// deployment_pattern is deliberately ignored at project-creation time: a new
+// project has zero Deployments and zero ProjectTemplates, so a rule gated by
+// a deployment_pattern has no candidate name to match. The same rule will
+// still fire at deployment render time via folderResolver (which does
+// evaluate deployment_pattern), so org-wide "REQUIRE this template on every
+// deployment" rules continue to work — they just do not pre-populate the
+// project namespace at creation time unless they also declare an empty
+// deployment_pattern (the "this applies to every target kind" form used by
+// project-level required templates).
+//
+// Wildcard semantics mirror folderResolver.globMatch so policy authors have
+// one mental model across both evaluators.
+type policyRequireRuleResolver struct {
+	lister *policyresolver.AncestorPolicyLister
+	// projectNamespaceFor maps a project slug to the Kubernetes
+	// namespace name from which the ancestor walk should start. The
+	// walker classifies a project namespace as a project and skips it
+	// for policy reads; the walker still needs the project namespace as
+	// the starting node so it can find the folder/org parents labeled
+	// above it.
+	projectNamespaceFor func(project string) string
+}
+
+// NewPolicyRequireRuleResolver returns a RequireRuleResolver that evaluates
+// TemplatePolicy REQUIRE rules against a new project's name, pulling rules
+// from ancestor folder and organization namespaces only.
+//
+// Any nil dependency yields a resolver that returns (nil, nil) — the
+// fail-open contract for misconfigured bootstraps, matching
+// folderResolver's behavior. At project-creation time, failing open means
+// "no REQUIRE rules injected"; the project is still created with whatever
+// templates the owner explicitly links. A follow-up render when the first
+// deployment is created will re-evaluate policies via folderResolver, so a
+// transient bootstrap gap here does not permanently lose the policy.
+func NewPolicyRequireRuleResolver(
+	lister *policyresolver.AncestorPolicyLister,
+	projectNamespaceFor func(project string) string,
+) RequireRuleResolver {
+	return &policyRequireRuleResolver{
+		lister:              lister,
+		projectNamespaceFor: projectNamespaceFor,
+	}
+}
+
+// ResolveRequiredTemplates returns one RequireRuleMatch per REQUIRE rule
+// whose project_pattern matches the given project name. Matches are deduped
+// by `(scope, scopeName, templateName)` so a template required from both
+// the folder and the org above it appears once, not twice.
+func (r *policyRequireRuleResolver) ResolveRequiredTemplates(ctx context.Context, org, project string) ([]RequireRuleMatch, error) {
+	if r == nil || r.lister == nil || r.projectNamespaceFor == nil {
+		slog.WarnContext(ctx, "policy require-rule resolver is misconfigured; returning no matches",
+			slog.String("organization", org),
+			slog.String("project", project),
+			slog.Bool("resolverNil", r == nil),
+			slog.Bool("listerNil", r == nil || r.lister == nil),
+			slog.Bool("projectNamespaceForNil", r == nil || r.projectNamespaceFor == nil),
+		)
+		return nil, nil
+	}
+	if project == "" {
+		return nil, nil
+	}
+
+	startNs := r.projectNamespaceFor(project)
+	rules, err := r.lister.ListRules(ctx, startNs)
+	if err != nil {
+		return nil, fmt.Errorf("listing ancestor template policies for project %q: %w", project, err)
+	}
+
+	type dedupKey struct {
+		scope     consolev1.TemplateScope
+		scopeName string
+		name      string
+	}
+	seen := make(map[dedupKey]struct{}, len(rules))
+	matches := make([]RequireRuleMatch, 0, len(rules))
+
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+		if rule.GetKind() != consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE {
+			continue
+		}
+		target := rule.GetTarget()
+		if target == nil {
+			continue
+		}
+		projectPattern := target.GetProjectPattern()
+		if projectPattern == "" {
+			// An empty project_pattern behaves as "*" everywhere else
+			// in the policy surface (validatePolicyRules normalizes
+			// it, folderResolver.ruleAppliesTo treats it as "*").
+			// Stay consistent so a hand-authored ConfigMap with an
+			// omitted field still fires.
+			projectPattern = "*"
+		}
+		if !globMatchesProject(projectPattern, project) {
+			continue
+		}
+		tmpl := rule.GetTemplate()
+		if tmpl == nil || tmpl.GetName() == "" {
+			continue
+		}
+		key := dedupKey{scope: tmpl.GetScope(), scopeName: tmpl.GetScopeName(), name: tmpl.GetName()}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		matches = append(matches, RequireRuleMatch{
+			Scope:        tmpl.GetScope(),
+			ScopeName:    tmpl.GetScopeName(),
+			TemplateName: tmpl.GetName(),
+		})
+	}
+	return matches, nil
+}
+
+// globMatchesProject mirrors folderResolver.globMatch: pattern failures are
+// treated as non-matching rather than propagated, because the policy
+// validator rejects invalid patterns at write time and a resolve-time error
+// would surface as a cryptic CreateProject failure for what is really a
+// stale-data problem.
+func globMatchesProject(pattern, subject string) bool {
+	if pattern == "" {
+		return false
+	}
+	ok, err := path.Match(pattern, subject)
+	if err != nil {
+		return false
+	}
+	return ok
+}

--- a/console/templates/require_policy_resolver.go
+++ b/console/templates/require_policy_resolver.go
@@ -127,10 +127,16 @@ func (r *policyRequireRuleResolver) ResolveRequiredTemplates(ctx context.Context
 			continue
 		}
 		seen[key] = struct{}{}
+		// Preserve the policy-author-declared version constraint so
+		// applyMatch pins the required template to the rule's version
+		// band at render time (HOL-571 review round 3 P2). Dropping it
+		// would silently render whichever template version happens to
+		// be live, bypassing the explicit pin.
 		matches = append(matches, RequireRuleMatch{
-			Scope:        tmpl.GetScope(),
-			ScopeName:    tmpl.GetScopeName(),
-			TemplateName: tmpl.GetName(),
+			Scope:             tmpl.GetScope(),
+			ScopeName:         tmpl.GetScopeName(),
+			TemplateName:      tmpl.GetName(),
+			VersionConstraint: tmpl.GetVersionConstraint(),
 		})
 	}
 	return matches, nil

--- a/console/templates/require_policy_resolver_test.go
+++ b/console/templates/require_policy_resolver_test.go
@@ -1,0 +1,592 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// storedRuleFixture mirrors the JSON shape that templatepolicies serializes
+// into the AnnotationTemplatePolicyRules annotation. Vendored into the tests
+// to avoid a cross-package import from templates → templatepolicies just for
+// the decoder (the decoder is also exercised in its owning package).
+type storedRuleFixture struct {
+	Kind     string `json:"kind"`
+	Template struct {
+		Scope             string `json:"scope"`
+		ScopeName         string `json:"scope_name"`
+		Name              string `json:"name"`
+		VersionConstraint string `json:"version_constraint,omitempty"`
+	} `json:"template"`
+	Target struct {
+		ProjectPattern    string `json:"project_pattern"`
+		DeploymentPattern string `json:"deployment_pattern,omitempty"`
+	} `json:"target"`
+}
+
+func fixtureUnmarshalRules(raw string) ([]*consolev1.TemplatePolicyRule, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var stored []storedRuleFixture
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		return nil, err
+	}
+	rules := make([]*consolev1.TemplatePolicyRule, 0, len(stored))
+	for _, s := range stored {
+		kind := consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_UNSPECIFIED
+		switch s.Kind {
+		case "require":
+			kind = consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE
+		case "exclude":
+			kind = consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE
+		}
+		scope := consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED
+		switch s.Template.Scope {
+		case v1alpha2.TemplateScopeOrganization:
+			scope = consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION
+		case v1alpha2.TemplateScopeFolder:
+			scope = consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER
+		case v1alpha2.TemplateScopeProject:
+			scope = consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT
+		}
+		rules = append(rules, &consolev1.TemplatePolicyRule{
+			Kind: kind,
+			Template: &consolev1.LinkedTemplateRef{
+				Scope:             scope,
+				ScopeName:         s.Template.ScopeName,
+				Name:              s.Template.Name,
+				VersionConstraint: s.Template.VersionConstraint,
+			},
+			Target: &consolev1.TemplatePolicyTarget{
+				ProjectPattern:    s.Target.ProjectPattern,
+				DeploymentPattern: s.Target.DeploymentPattern,
+			},
+		})
+	}
+	return rules, nil
+}
+
+// policyListerMap implements policyresolver.PolicyListerInNamespace. Tests
+// drive it by pre-seeding the ConfigMap list for each folder/org namespace.
+type policyListerMap struct {
+	items map[string][]corev1.ConfigMap
+}
+
+func (p *policyListerMap) ListPoliciesInNamespace(_ context.Context, ns string) ([]corev1.ConfigMap, error) {
+	return p.items[ns], nil
+}
+
+func mkNamespace(name, kind, parent string) *corev1.Namespace {
+	labels := map[string]string{
+		v1alpha2.LabelResourceType: kind,
+	}
+	if parent != "" {
+		labels[v1alpha2.AnnotationParent] = parent
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+// policyCM returns a fake TemplatePolicy ConfigMap with the given rules
+// encoded into the annotation.
+func policyCM(namespace, name string, rules []storedRuleFixture, t *testing.T) corev1.ConfigMap {
+	t.Helper()
+	raw, err := json.Marshal(rules)
+	if err != nil {
+		t.Fatalf("marshal rules: %v", err)
+	}
+	return corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplatePolicyRules: string(raw),
+			},
+		},
+	}
+}
+
+type policyFixture struct {
+	resolver   *resolver.Resolver
+	walker     *resolver.Walker
+	namespaces map[string]string
+}
+
+// buildPolicyFixture mirrors folder_resolver_test's canonical hierarchy:
+// acme/ (org), acme/eng/ (folder), acme/eng/team-a/ (folder), plus projects
+// under each level. Project slugs cover the "under org directly",
+// "under folder eng", and "under folder team-a (nested under eng)" cases.
+func buildPolicyFixture(t *testing.T) *policyFixture {
+	t.Helper()
+	r := &resolver.Resolver{
+		NamespacePrefix:    "holos-",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
+	orgNs := r.OrgNamespace("acme")              // holos-org-acme
+	folderEngNs := r.FolderNamespace("eng")      // holos-fld-eng
+	folderTeamANs := r.FolderNamespace("team-a") // holos-fld-team-a
+	projectOrchids := r.ProjectNamespace("orchids")
+	projectLilies := r.ProjectNamespace("lilies")
+	projectRoses := r.ProjectNamespace("roses")
+	projectFooAlpha := r.ProjectNamespace("foo-alpha")
+	projectBarAlpha := r.ProjectNamespace("bar-alpha")
+
+	objects := []runtime.Object{
+		mkNamespace(orgNs, v1alpha2.ResourceTypeOrganization, ""),
+		mkNamespace(folderEngNs, v1alpha2.ResourceTypeFolder, orgNs),
+		mkNamespace(folderTeamANs, v1alpha2.ResourceTypeFolder, folderEngNs),
+		mkNamespace(projectOrchids, v1alpha2.ResourceTypeProject, orgNs),
+		mkNamespace(projectLilies, v1alpha2.ResourceTypeProject, folderEngNs),
+		mkNamespace(projectRoses, v1alpha2.ResourceTypeProject, folderTeamANs),
+		mkNamespace(projectFooAlpha, v1alpha2.ResourceTypeProject, folderEngNs),
+		mkNamespace(projectBarAlpha, v1alpha2.ResourceTypeProject, folderEngNs),
+	}
+
+	client := fake.NewClientset(objects...)
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	return &policyFixture{
+		resolver: r,
+		walker:   walker,
+		namespaces: map[string]string{
+			"org":             orgNs,
+			"folderEng":       folderEngNs,
+			"folderTeamA":     folderTeamANs,
+			"projectOrchids":  projectOrchids,
+			"projectLilies":   projectLilies,
+			"projectRoses":    projectRoses,
+			"projectFooAlpha": projectFooAlpha,
+			"projectBarAlpha": projectBarAlpha,
+		},
+	}
+}
+
+func requireRule(scope, scopeName, templateName, projectPattern, deploymentPattern string) storedRuleFixture {
+	sr := storedRuleFixture{Kind: "require"}
+	sr.Template.Scope = scope
+	sr.Template.ScopeName = scopeName
+	sr.Template.Name = templateName
+	sr.Target.ProjectPattern = projectPattern
+	sr.Target.DeploymentPattern = deploymentPattern
+	return sr
+}
+
+func excludeRule(scope, scopeName, templateName, projectPattern, deploymentPattern string) storedRuleFixture {
+	sr := storedRuleFixture{Kind: "exclude"}
+	sr.Template.Scope = scope
+	sr.Template.ScopeName = scopeName
+	sr.Template.Name = templateName
+	sr.Target.ProjectPattern = projectPattern
+	sr.Target.DeploymentPattern = deploymentPattern
+	return sr
+}
+
+func matchNames(matches []RequireRuleMatch) []string {
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m.TemplateName)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestPolicyRequireRuleResolver_ResolveRequiredTemplates(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	tests := []struct {
+		name      string
+		project   string
+		policies  map[string][]corev1.ConfigMap
+		wantNames []string
+	}{
+		{
+			name:      "no policies yields zero matches",
+			project:   "lilies",
+			policies:  nil,
+			wantNames: nil,
+		},
+		{
+			name:    "org-scope REQUIRE with project_pattern=* matches every project",
+			project: "orchids",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["org"]: {
+						policyCM(fx.namespaces["org"], "audit", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: []string{"audit-policy"},
+		},
+		{
+			name:    "folder-scope REQUIRE matches project under that folder",
+			project: "lilies",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["folderEng"]: {
+						policyCM(fx.namespaces["folderEng"], "eng-required", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeFolder, "eng", "eng-baseline", "*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: []string{"eng-baseline"},
+		},
+		{
+			name:    "folder-scope REQUIRE does not match project under a sibling branch",
+			project: "orchids",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["folderEng"]: {
+						policyCM(fx.namespaces["folderEng"], "eng-required", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeFolder, "eng", "eng-baseline", "*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: nil, // orchids is under org, not folder eng, so no eng-baseline
+		},
+		{
+			name:    "narrow project_pattern matches prefix only",
+			project: "foo-alpha",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["folderEng"]: {
+						policyCM(fx.namespaces["folderEng"], "foo-only", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeFolder, "eng", "foo-baseline", "foo-*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: []string{"foo-baseline"},
+		},
+		{
+			name:    "narrow project_pattern does not match other prefix",
+			project: "bar-alpha",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["folderEng"]: {
+						policyCM(fx.namespaces["folderEng"], "foo-only", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeFolder, "eng", "foo-baseline", "foo-*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: nil,
+		},
+		{
+			name:    "overlapping require rules dedupe by (scope, scopeName, name)",
+			project: "roses",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				// Org and both folders all require the same template; the
+				// project sits under team-a (under eng under org) so every
+				// level matches. Expect one match, not three.
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["org"]: {
+						policyCM(fx.namespaces["org"], "org-p", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "*", ""),
+						}, t),
+					},
+					fx.namespaces["folderEng"]: {
+						policyCM(fx.namespaces["folderEng"], "eng-p", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "*", ""),
+						}, t),
+					},
+					fx.namespaces["folderTeamA"]: {
+						policyCM(fx.namespaces["folderTeamA"], "team-a-p", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: []string{"audit-policy"},
+		},
+		{
+			name:    "multiple distinct templates across ancestors all match",
+			project: "roses",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["org"]: {
+						policyCM(fx.namespaces["org"], "org-p", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "org-template", "*", ""),
+						}, t),
+					},
+					fx.namespaces["folderEng"]: {
+						policyCM(fx.namespaces["folderEng"], "eng-p", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeFolder, "eng", "eng-template", "*", ""),
+						}, t),
+					},
+					fx.namespaces["folderTeamA"]: {
+						policyCM(fx.namespaces["folderTeamA"], "team-a-p", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeFolder, "team-a", "team-a-template", "*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: []string{"eng-template", "org-template", "team-a-template"},
+		},
+		{
+			name:    "EXCLUDE rules never contribute to require matches",
+			project: "lilies",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["org"]: {
+						policyCM(fx.namespaces["org"], "exclusion", []storedRuleFixture{
+							excludeRule(v1alpha2.TemplateScopeOrganization, "acme", "banned-template", "*", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: nil,
+		},
+		{
+			name:    "REQUIRE with deployment_pattern still matches on project_pattern at project-creation time",
+			project: "lilies",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				// deployment_pattern is observed but must not filter at
+				// project-creation time (no candidate deployment name
+				// exists yet). project_pattern controls the match.
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["org"]: {
+						policyCM(fx.namespaces["org"], "api-only", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "api-template", "*", "api"),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: []string{"api-template"},
+		},
+		{
+			name:    "REQUIRE with project_pattern that does not match is skipped",
+			project: "orchids",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["org"]: {
+						policyCM(fx.namespaces["org"], "lilies-only", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "lilies", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: nil,
+		},
+		{
+			name:    "rule with empty project_pattern behaves like '*'",
+			project: "orchids",
+			policies: func() map[string][]corev1.ConfigMap {
+				fx := buildPolicyFixture(t)
+				return map[string][]corev1.ConfigMap{
+					fx.namespaces["org"]: {
+						policyCM(fx.namespaces["org"], "no-pattern", []storedRuleFixture{
+							requireRule(v1alpha2.TemplateScopeOrganization, "acme", "always-apply", "", ""),
+						}, t),
+					},
+				}
+			}(),
+			wantNames: []string{"always-apply"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fx := buildPolicyFixture(t)
+			lister := policyresolver.NewAncestorPolicyLister(
+				&policyListerMap{items: tc.policies},
+				fx.walker,
+				fx.resolver,
+				policyresolver.RuleUnmarshalerFunc(fixtureUnmarshalRules),
+			)
+			rr := NewPolicyRequireRuleResolver(lister, fx.resolver.ProjectNamespace)
+
+			matches, err := rr.ResolveRequiredTemplates(context.Background(), "acme", tc.project)
+			if err != nil {
+				t.Fatalf("ResolveRequiredTemplates returned error: %v", err)
+			}
+			got := matchNames(matches)
+			want := append([]string(nil), tc.wantNames...)
+			sort.Strings(want)
+			if !equalStrings(got, want) {
+				t.Errorf("match names: got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestPolicyRequireRuleResolver_IgnoresProjectNamespacePolicies is the
+// HOL-554 storage-isolation guardrail for project-creation time: a synthetic
+// (forbidden) policy ConfigMap seeded in a project namespace must NOT be
+// picked up even if it declares a REQUIRE rule with a wildcard pattern.
+func TestPolicyRequireRuleResolver_IgnoresProjectNamespacePolicies(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	fx := buildPolicyFixture(t)
+	rules := []storedRuleFixture{
+		requireRule(v1alpha2.TemplateScopeOrganization, "acme", "should-be-ignored", "*", ""),
+	}
+	policies := map[string][]corev1.ConfigMap{
+		// Forbidden placement: a policy living in a project namespace.
+		fx.namespaces["projectLilies"]: {
+			policyCM(fx.namespaces["projectLilies"], "pwned", rules, t),
+		},
+	}
+
+	lister := policyresolver.NewAncestorPolicyLister(
+		&policyListerMap{items: policies},
+		fx.walker,
+		fx.resolver,
+		policyresolver.RuleUnmarshalerFunc(fixtureUnmarshalRules),
+	)
+	rr := NewPolicyRequireRuleResolver(lister, fx.resolver.ProjectNamespace)
+
+	got, err := rr.ResolveRequiredTemplates(context.Background(), "acme", "lilies")
+	if err != nil {
+		t.Fatalf("ResolveRequiredTemplates returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("project-namespace policy leaked into require matches: got %v", matchNames(got))
+	}
+}
+
+// TestPolicyRequireRuleResolver_NilResolverIsNoOp exercises the fail-open
+// contract: any nil dependency should degrade to (nil, nil) rather than
+// panicking or returning an error.
+func TestPolicyRequireRuleResolver_NilResolverIsNoOp(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	fx := buildPolicyFixture(t)
+	rrNilLister := NewPolicyRequireRuleResolver(nil, fx.resolver.ProjectNamespace)
+	got, err := rrNilLister.ResolveRequiredTemplates(context.Background(), "acme", "lilies")
+	if err != nil {
+		t.Fatalf("expected no error with nil lister, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 matches with nil lister, got %d", len(got))
+	}
+
+	lister := policyresolver.NewAncestorPolicyLister(
+		&policyListerMap{},
+		fx.walker,
+		fx.resolver,
+		policyresolver.RuleUnmarshalerFunc(fixtureUnmarshalRules),
+	)
+	rrNilNamespaceFunc := NewPolicyRequireRuleResolver(lister, nil)
+	got, err = rrNilNamespaceFunc.ResolveRequiredTemplates(context.Background(), "acme", "lilies")
+	if err != nil {
+		t.Fatalf("expected no error with nil projectNamespaceFor, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 matches with nil projectNamespaceFor, got %d", len(got))
+	}
+}
+
+// TestPolicyRequireRuleResolver_EmptyProjectIsNoOp: if the caller passes an
+// empty project name, there is nothing to match against and the resolver
+// returns no matches without a walker round-trip.
+func TestPolicyRequireRuleResolver_EmptyProjectIsNoOp(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	fx := buildPolicyFixture(t)
+	lister := policyresolver.NewAncestorPolicyLister(
+		&policyListerMap{items: map[string][]corev1.ConfigMap{
+			fx.namespaces["org"]: {
+				policyCM(fx.namespaces["org"], "p", []storedRuleFixture{
+					requireRule(v1alpha2.TemplateScopeOrganization, "acme", "should-never-apply", "*", ""),
+				}, t),
+			},
+		}},
+		fx.walker,
+		fx.resolver,
+		policyresolver.RuleUnmarshalerFunc(fixtureUnmarshalRules),
+	)
+	rr := NewPolicyRequireRuleResolver(lister, fx.resolver.ProjectNamespace)
+	got, err := rr.ResolveRequiredTemplates(context.Background(), "acme", "")
+	if err != nil {
+		t.Fatalf("expected no error with empty project, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 matches with empty project, got %d", len(got))
+	}
+}
+
+// TestPolicyRequireRuleResolver_WalkerErrorPropagates: a walker failure is
+// a hard error at project-creation time so the caller can decide to roll
+// back the project rather than silently skip policy-injected templates.
+func TestPolicyRequireRuleResolver_WalkerErrorPropagates(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	r := &resolver.Resolver{
+		NamespacePrefix:    "holos-",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
+	lister := policyresolver.NewAncestorPolicyLister(
+		&policyListerMap{},
+		&failingWalkerFixture{err: errors.New("walker exploded")},
+		r,
+		policyresolver.RuleUnmarshalerFunc(fixtureUnmarshalRules),
+	)
+	rr := NewPolicyRequireRuleResolver(lister, r.ProjectNamespace)
+
+	_, err := rr.ResolveRequiredTemplates(context.Background(), "acme", "lilies")
+	if err == nil {
+		t.Fatal("expected walker error to propagate, got nil")
+	}
+}
+
+type failingWalkerFixture struct {
+	err error
+}
+
+func (f *failingWalkerFixture) WalkAncestors(_ context.Context, _ string) ([]*corev1.Namespace, error) {
+	return nil, f.err
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/console/templates/require_policy_resolver_test.go
+++ b/console/templates/require_policy_resolver_test.go
@@ -449,6 +449,48 @@ func TestPolicyRequireRuleResolver_ResolveRequiredTemplates(t *testing.T) {
 	}
 }
 
+// TestPolicyRequireRuleResolver_PreservesVersionConstraint verifies that a
+// REQUIRE rule's template.version_constraint is threaded through to the
+// resulting RequireRuleMatch. Dropping it would silently render whichever
+// version of the template is live instead of the one the policy author
+// pinned via semver band — bypassing the explicit constraint (HOL-571
+// review round 3 P2).
+func TestPolicyRequireRuleResolver_PreservesVersionConstraint(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	fx := buildPolicyFixture(t)
+	rule := storedRuleFixture{Kind: "require"}
+	rule.Template.Scope = v1alpha2.TemplateScopeOrganization
+	rule.Template.ScopeName = "acme"
+	rule.Template.Name = "audit-policy"
+	rule.Template.VersionConstraint = ">=1.0.0 <2.0.0"
+	rule.Target.ProjectPattern = "*"
+
+	policies := map[string][]corev1.ConfigMap{
+		fx.namespaces["org"]: {
+			policyCM(fx.namespaces["org"], "pinned", []storedRuleFixture{rule}, t),
+		},
+	}
+	lister := policyresolver.NewAncestorPolicyLister(
+		&policyListerMap{items: policies},
+		fx.walker,
+		fx.resolver,
+		policyresolver.RuleUnmarshalerFunc(fixtureUnmarshalRules),
+	)
+	rr := NewPolicyRequireRuleResolver(lister, fx.resolver.ProjectNamespace)
+
+	matches, err := rr.ResolveRequiredTemplates(context.Background(), "acme", "orchids")
+	if err != nil {
+		t.Fatalf("ResolveRequiredTemplates returned error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if got := matches[0].VersionConstraint; got != ">=1.0.0 <2.0.0" {
+		t.Errorf("expected version_constraint=%q, got %q", ">=1.0.0 <2.0.0", got)
+	}
+}
+
 // TestPolicyRequireRuleResolver_IgnoresProjectNamespacePolicies is the
 // HOL-554 storage-isolation guardrail for project-creation time: a synthetic
 // (forbidden) policy ConfigMap seeded in a project namespace must NOT be


### PR DESCRIPTION
## Summary

- Phase 9 of HOL-562: swaps the Phase 3 empty `RequireRuleResolver` stub wired at project creation for a real TemplatePolicy-backed resolver that walks the new project's ancestor chain, reads policies from folder and organization namespaces only (HOL-554 storage-isolation), and emits a `RequireRuleMatch` per REQUIRE rule whose `project_pattern` matches the new project's name.
- Extracts the ancestor-chain walk + folder-namespace-only filter into a new `policyresolver.AncestorPolicyLister.ListRules` helper shared by `folderResolver` (render-time) and the new project-creation-time resolver, so the storage-isolation guardrail lives in one place.
- Closes the deferred AC from HOL-567 / PR #974. After this change, creating a project under an org/folder whose TemplatePolicy declares a `REQUIRE` rule with a matching `project_pattern` renders + applies the required templates into the new project namespace via the existing unified `CueRenderer.Render` + `ResourceApplier.Apply` path.

`deployment_pattern` is deliberately observed but non-filtering at project-creation time (a new project has no deployments yet to match against); the same rule still fires at deployment render time through `folderResolver`. Dedup key for matches is `(scope, scopeName, name)` so an overlapping REQUIRE from both a folder and the org above it yields one match.

Fixes HOL-571

## Test plan

- [x] `make test` — all Go and UI unit tests pass.
- [x] New resolver unit tests (table-driven + storage-isolation + misconfig + walker-error): no policies, org `*`, folder `*`, narrow prefix `foo-*`, overlapping REQUIREs across ancestors, EXCLUDE ignored, `deployment_pattern` observed but not filtering, empty `project_pattern` treated as `*`, project-namespace-seeded policy ignored.
- [x] New integration tests in `console/projects/handler_test.go` exercise the real resolver end-to-end through `RequiredTemplateApplier` with a capturing `ResourceApplier`: one asserts the REQUIRE-matched template is rendered + applied; one asserts a forbidden project-namespace-seeded policy is ignored.
- [x] Existing `TestCreateProject_CallsRequiredTemplateApplierOnSuccess` and `TestCreateProject_NotCalledWhenNoOrgSpecified` continue to pass unchanged.
- [x] Existing `policyresolver` tests pass unchanged after the `folderResolver` refactor to use `AncestorPolicyLister.ListRules`.
- [ ] Local `make test-e2e` was not run (no k3d cluster available in this worktree); relying on CI `test-e2e` check.

Generated with [Claude Code](https://claude.com/claude-code)