### PR TITLE
feat(frontend): surface policy drift on deployment + project-template list/detail with Reconcile

### DIFF
--- a/frontend/src/components/policy-drift/-PolicySection.test.tsx
+++ b/frontend/src/components/policy-drift/-PolicySection.test.tsx
@@ -155,4 +155,38 @@ describe('PolicySection', () => {
     render(<PolicySection state={state} heading="TemplatePolicy" />)
     expect(screen.getByRole('heading', { name: /templatepolicy/i })).toBeInTheDocument()
   })
+
+  // HOL-559 AC: the Policy section must be collapsible on both detail
+  // surfaces. The shared component uses a native <details>/<summary>
+  // disclosure to satisfy this.
+  describe('collapsible', () => {
+    it('renders a <details>/<summary> disclosure wrapper', () => {
+      const state = makeState({ hasAppliedState: true })
+      render(<PolicySection state={state} />)
+      const section = screen.getByTestId('policy-section')
+      expect(section.tagName.toLowerCase()).toBe('details')
+      expect(screen.getByTestId('policy-section-summary').tagName.toLowerCase()).toBe('summary')
+    })
+
+    it('is collapsed by default when drift is false (in sync)', () => {
+      const state = makeState({ hasAppliedState: true, drift: false })
+      render(<PolicySection state={state} />)
+      const section = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(section.open).toBe(false)
+    })
+
+    it('is expanded by default when drift is true', () => {
+      const state = makeState({ hasAppliedState: true, drift: true, currentSet: [makeRef({})] })
+      render(<PolicySection state={state} />)
+      const section = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(section.open).toBe(true)
+    })
+
+    it('respects defaultOpen prop override', () => {
+      const state = makeState({ hasAppliedState: true, drift: false })
+      render(<PolicySection state={state} defaultOpen={true} />)
+      const section = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(section.open).toBe(true)
+    })
+  })
 })

--- a/frontend/src/components/policy-drift/-PolicySection.test.tsx
+++ b/frontend/src/components/policy-drift/-PolicySection.test.tsx
@@ -188,5 +188,27 @@ describe('PolicySection', () => {
       const section = screen.getByTestId('policy-section') as HTMLDetailsElement
       expect(section.open).toBe(true)
     })
+
+    // Regression for codex review round-2 finding: the details element
+    // must be UNCONTROLLED after mount so that a parent re-render (for
+    // example the deployment detail page's 5s status poll) does not
+    // stomp the user's toggle. If the component passed `open` as a
+    // controlled prop, simulating the user collapsing the disclosure and
+    // then re-rendering with the same props would reset `open` to the
+    // original defaultOpen value.
+    it('preserves the user toggle across parent re-renders', () => {
+      const state = makeState({ hasAppliedState: true, drift: true, addedRefs: [makeRef({})], currentSet: [makeRef({})] })
+      const { rerender } = render(<PolicySection state={state} />)
+      const section = screen.getByTestId('policy-section') as HTMLDetailsElement
+      // Drift-by-default opens the disclosure.
+      expect(section.open).toBe(true)
+      // Simulate the user collapsing it.
+      section.open = false
+      expect(section.open).toBe(false)
+      // A parent re-render with the same props must NOT reopen it.
+      rerender(<PolicySection state={state} />)
+      const after = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(after.open).toBe(false)
+    })
   })
 })

--- a/frontend/src/components/policy-drift/-PolicySection.test.tsx
+++ b/frontend/src/components/policy-drift/-PolicySection.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { PolicySection, PolicyDriftBadge } from './PolicySection'
+import type { PolicyState, LinkedTemplateRef } from '@/gen/holos/console/v1/policy_state_pb'
+import { TemplateScope } from '@/gen/holos/console/v1/policy_state_pb'
+
+function makeRef(partial: Partial<LinkedTemplateRef>): LinkedTemplateRef {
+  return {
+    $typeName: 'holos.console.v1.LinkedTemplateRef',
+    scope: TemplateScope.ORGANIZATION,
+    scopeName: 'acme',
+    name: 'base',
+    versionConstraint: '',
+    ...partial,
+  } as LinkedTemplateRef
+}
+
+function makeState(partial: Partial<PolicyState>): PolicyState {
+  return {
+    $typeName: 'holos.console.v1.PolicyState',
+    appliedSet: [],
+    currentSet: [],
+    addedRefs: [],
+    removedRefs: [],
+    drift: false,
+    hasAppliedState: true,
+    ...partial,
+  } as PolicyState
+}
+
+describe('PolicyDriftBadge', () => {
+  it('renders the badge with aria-label and Policy Drift text', () => {
+    render(<PolicyDriftBadge />)
+    const badge = screen.getByTestId('policy-drift-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveAttribute('aria-label', 'Policy drift')
+    expect(screen.getByText(/policy drift/i)).toBeInTheDocument()
+  })
+})
+
+describe('PolicySection', () => {
+  it('renders a loading skeleton when isPending is true', () => {
+    render(<PolicySection isPending={true} />)
+    expect(screen.getByTestId('policy-section')).toBeInTheDocument()
+    // No drift badge while loading.
+    expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+  })
+
+  it('renders a loading skeleton when state is undefined', () => {
+    render(<PolicySection state={undefined} />)
+    expect(screen.getByTestId('policy-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+  })
+
+  it('renders the error message when error is present', () => {
+    render(<PolicySection error={new Error('rpc failed: internal')} />)
+    expect(screen.getByText(/rpc failed: internal/)).toBeInTheDocument()
+  })
+
+  it('renders the never-applied note when hasAppliedState is false', () => {
+    const state = makeState({
+      hasAppliedState: false,
+      currentSet: [makeRef({ name: 'base' })],
+    })
+    render(<PolicySection state={state} />)
+    expect(screen.getByTestId('policy-never-applied')).toBeInTheDocument()
+    // Drift badge is not rendered when hasAppliedState is false, regardless
+    // of the drift flag, because un-initialized is not drifted.
+    expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+    // Current effective set is still shown.
+    expect(screen.getByTestId('policy-current-set')).toBeInTheDocument()
+  })
+
+  it('renders the "In sync" indicator when drift is false and state is applied', () => {
+    const state = makeState({
+      hasAppliedState: true,
+      drift: false,
+      appliedSet: [makeRef({ name: 'base' })],
+      currentSet: [makeRef({ name: 'base' })],
+    })
+    render(<PolicySection state={state} />)
+    expect(screen.getByTestId('policy-in-sync')).toBeInTheDocument()
+    expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+  })
+
+  it('renders the drift badge and diff sections when drift is true', () => {
+    const state = makeState({
+      hasAppliedState: true,
+      drift: true,
+      appliedSet: [makeRef({ name: 'base' })],
+      currentSet: [makeRef({ name: 'base' }), makeRef({ name: 'sidecar' })],
+      addedRefs: [makeRef({ name: 'sidecar' })],
+      removedRefs: [],
+    })
+    render(<PolicySection state={state} />)
+    expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+    expect(screen.getByTestId('policy-added-refs')).toBeInTheDocument()
+    // removed list is empty but renders the "None" placeholder.
+    expect(screen.getByTestId('policy-removed-refs-empty')).toBeInTheDocument()
+  })
+
+  it('renders the reconcile slot only when drift is true and an action is provided', () => {
+    const state = makeState({
+      hasAppliedState: true,
+      drift: true,
+      currentSet: [makeRef({ name: 'base' })],
+      addedRefs: [makeRef({ name: 'base' })],
+    })
+    const { rerender } = render(
+      <PolicySection
+        state={state}
+        reconcileAction={<button type="button">Reconcile</button>}
+      />,
+    )
+    expect(screen.getByTestId('policy-reconcile-slot')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reconcile/i })).toBeInTheDocument()
+
+    // Viewer case: no reconcileAction, no slot.
+    rerender(<PolicySection state={state} />)
+    expect(screen.queryByTestId('policy-reconcile-slot')).not.toBeInTheDocument()
+  })
+
+  it('does not render the reconcile slot when drift is false even if an action is provided', () => {
+    const state = makeState({ hasAppliedState: true, drift: false })
+    render(
+      <PolicySection
+        state={state}
+        reconcileAction={<button type="button">Reconcile</button>}
+      />,
+    )
+    expect(screen.queryByTestId('policy-reconcile-slot')).not.toBeInTheDocument()
+  })
+
+  it('formats refs with scope prefix and optional version constraint', () => {
+    const state = makeState({
+      hasAppliedState: true,
+      drift: true,
+      currentSet: [
+        makeRef({ scope: TemplateScope.ORGANIZATION, scopeName: 'acme', name: 'base' }),
+        makeRef({ scope: TemplateScope.FOLDER, scopeName: 'infra', name: 'istio', versionConstraint: '>=1.0.0' }),
+        makeRef({ scope: TemplateScope.PROJECT, scopeName: 'web', name: 'api' }),
+      ],
+      addedRefs: [makeRef({ scope: TemplateScope.FOLDER, scopeName: 'infra', name: 'istio', versionConstraint: '>=1.0.0' })],
+    })
+    render(<PolicySection state={state} />)
+    // Added ref appears in both the added-refs list and the current
+    // effective set — assert that both occurrences render.
+    expect(screen.getByText('org:acme/base')).toBeInTheDocument()
+    expect(screen.getAllByText('folder:infra/istio@>=1.0.0').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('project:web/api')).toBeInTheDocument()
+  })
+
+  it('renders the custom heading when provided', () => {
+    const state = makeState({ hasAppliedState: true })
+    render(<PolicySection state={state} heading="TemplatePolicy" />)
+    expect(screen.getByRole('heading', { name: /templatepolicy/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/policy-drift/-PolicySection.test.tsx
+++ b/frontend/src/components/policy-drift/-PolicySection.test.tsx
@@ -190,8 +190,8 @@ describe('PolicySection', () => {
     })
 
     // Regression for codex review round-2 finding: the details element
-    // must be UNCONTROLLED after mount so that a parent re-render (for
-    // example the deployment detail page's 5s status poll) does not
+    // must not be a naively controlled element, so a parent re-render
+    // (for example the deployment detail page's 5s status poll) cannot
     // stomp the user's toggle. If the component passed `open` as a
     // controlled prop, simulating the user collapsing the disclosure and
     // then re-rendering with the same props would reset `open` to the
@@ -202,11 +202,51 @@ describe('PolicySection', () => {
       const section = screen.getByTestId('policy-section') as HTMLDetailsElement
       // Drift-by-default opens the disclosure.
       expect(section.open).toBe(true)
-      // Simulate the user collapsing it.
+      // Simulate the user collapsing it; the <details> element fires a
+      // native toggle event when `open` changes.
       section.open = false
+      section.dispatchEvent(new Event('toggle'))
       expect(section.open).toBe(false)
       // A parent re-render with the same props must NOT reopen it.
       rerender(<PolicySection state={state} />)
+      const after = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(after.open).toBe(false)
+    })
+
+    // Regression for codex review round-3 finding: when the section
+    // mounts in its loading state (defaultOpen=false) and the policy-
+    // state RPC later resolves with drift=true, the disclosure MUST
+    // auto-open so the attention signal is visible without the user
+    // having to click. A shell that captures `open` exactly once on
+    // mount (the round-2 approach) fails this test because the user
+    // would see the section collapsed on first paint after loading
+    // resolves.
+    it('auto-opens when defaultOpen flips after mount and user has not toggled', () => {
+      // First mount: loading state (state undefined → defaultOpen=false).
+      const { rerender } = render(<PolicySection isPending={true} />)
+      const loading = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(loading.open).toBe(false)
+      // Policy-state RPC resolves with drift=true → defaultOpen becomes true.
+      const drifted = makeState({ hasAppliedState: true, drift: true, addedRefs: [makeRef({})], currentSet: [makeRef({})] })
+      rerender(<PolicySection state={drifted} />)
+      const after = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(after.open).toBe(true)
+    })
+
+    // The auto-open sync must stop once the user interacts. If a user
+    // has already collapsed the drifted section, a later prop change
+    // (for example a refetch that still reports drift=true) must not
+    // reopen the section against the user's intent.
+    it('does not auto-reopen after the user collapses a drifted section', () => {
+      const drifted = makeState({ hasAppliedState: true, drift: true, addedRefs: [makeRef({})], currentSet: [makeRef({})] })
+      const { rerender } = render(<PolicySection state={drifted} />)
+      const section = screen.getByTestId('policy-section') as HTMLDetailsElement
+      expect(section.open).toBe(true)
+      // User collapses.
+      section.open = false
+      section.dispatchEvent(new Event('toggle'))
+      // A later re-render with the same drift=true props must not reopen.
+      rerender(<PolicySection state={drifted} />)
       const after = screen.getByTestId('policy-section') as HTMLDetailsElement
       expect(after.open).toBe(false)
     })

--- a/frontend/src/components/policy-drift/PolicySection.tsx
+++ b/frontend/src/components/policy-drift/PolicySection.tsx
@@ -1,4 +1,4 @@
-import { TriangleAlert } from 'lucide-react'
+import { ChevronRight, TriangleAlert } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -9,9 +9,12 @@ import type {
 } from '@/gen/holos/console/v1/policy_state_pb'
 
 // PolicySection renders the TemplatePolicy drift snapshot for a render
-// target — either a Deployment or a project-scope Template — and exposes a
-// Reconcile action slot so callers can wire in the appropriate Update
-// mutation (useUpdateDeployment / useUpdateTemplate).
+// target — either a Deployment or a project-scope Template — inside a
+// native <details>/<summary> disclosure, and exposes a caller-supplied
+// Reconcile action slot so both surfaces share identical visual treatment
+// and tests. HOL-559 requires the section be collapsible on both detail
+// views; this component provides that via the native element so no Radix
+// dependency is needed and screen readers get built-in a11y semantics.
 //
 // IMPORTANT: PolicyState is sourced exclusively from the
 // GetDeploymentPolicyState / GetProjectTemplatePolicyState RPCs. Both RPCs
@@ -39,6 +42,12 @@ export interface PolicySectionProps {
    * for instance to "TemplatePolicy" or similar.
    */
   heading?: string
+  /**
+   * When true the disclosure is expanded by default. Defaults to "open
+   * only when drifted" so the attention signal is visible without the
+   * user having to click.
+   */
+  defaultOpen?: boolean
 }
 
 /**
@@ -80,43 +89,91 @@ function RefList({ refs, testid }: { refs: LinkedTemplateRef[]; testid: string }
   )
 }
 
+/**
+ * CollapsibleShell wraps the section in a native <details> disclosure.
+ * Using the native element keeps keyboard and screen-reader behavior
+ * correct without pulling in a third-party collapsible primitive.
+ *
+ * The Reconcile button is rendered outside the <summary> (absolutely
+ * positioned on the right of the header row) so that nested interactive
+ * elements inside <summary> do not interfere with the native
+ * click-to-toggle behavior.
+ */
+function CollapsibleShell({
+  heading,
+  summaryExtra,
+  headerAction,
+  defaultOpen,
+  children,
+}: {
+  heading: string
+  summaryExtra?: React.ReactNode
+  headerAction?: React.ReactNode
+  defaultOpen: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <details
+      className="space-y-4 group relative"
+      data-testid="policy-section"
+      open={defaultOpen}
+    >
+      <summary
+        className="flex items-center gap-2 cursor-pointer list-none select-none pr-36"
+        data-testid="policy-section-summary"
+      >
+        <h3 className="text-sm font-medium flex items-center gap-2">
+          <ChevronRight
+            aria-hidden="true"
+            className="h-4 w-4 transition-transform group-open:rotate-90"
+          />
+          {heading}
+          {summaryExtra}
+        </h3>
+      </summary>
+      {headerAction && (
+        <div className="absolute top-0 right-0">{headerAction}</div>
+      )}
+      <Separator />
+      {children}
+    </details>
+  )
+}
+
 export function PolicySection({
   state,
   isPending = false,
   error,
   reconcileAction,
   heading = 'Policy',
+  defaultOpen,
 }: PolicySectionProps) {
-  // Error state — surface the message inline.
+  // Error state — surface the message inline. Open by default so the
+  // error is visible without requiring the user to click.
   if (error) {
     return (
-      <div className="space-y-4" data-testid="policy-section">
-        <h3 className="text-sm font-medium">{heading}</h3>
-        <Separator />
+      <CollapsibleShell heading={heading} defaultOpen={defaultOpen ?? true}>
         <p className="text-sm text-destructive">{error.message}</p>
-      </div>
+      </CollapsibleShell>
     )
   }
 
   if (isPending || !state) {
     return (
-      <div className="space-y-4" data-testid="policy-section">
-        <h3 className="text-sm font-medium">{heading}</h3>
-        <Separator />
+      <CollapsibleShell heading={heading} defaultOpen={defaultOpen ?? false}>
         <Skeleton className="h-5 w-48" />
         <Skeleton className="h-24 w-full" />
-      </div>
+      </CollapsibleShell>
     )
   }
 
   // "Never applied" state — the target has not been rendered through the
-  // HOL-567 applied-state path yet, so drift is not meaningful. Show a note
-  // so the user understands why no diff is rendered.
+  // HOL-567 applied-state path yet, so drift is not meaningful. Collapsed
+  // by default so it stays visually quiet for the common "new target"
+  // case.
   if (!state.hasAppliedState) {
     return (
-      <div className="space-y-4" data-testid="policy-section">
-        <h3 className="text-sm font-medium">{heading}</h3>
-        <Separator />
+      <CollapsibleShell heading={heading} defaultOpen={defaultOpen ?? false}>
         <p className="text-sm text-muted-foreground" data-testid="policy-never-applied">
           No applied state recorded yet. Drift will be reported after the next render.
         </p>
@@ -126,32 +183,30 @@ export function PolicySection({
           </p>
           <RefList refs={state.currentSet} testid="policy-current-set" />
         </div>
-      </div>
+      </CollapsibleShell>
     )
   }
 
+  // Drifted — expand by default so the attention signal is visible
+  // without the user having to click. In-sync → collapsed by default.
+  const summaryExtra = state.drift ? (
+    <PolicyDriftBadge />
+  ) : (
+    <span className="text-xs text-muted-foreground" data-testid="policy-in-sync">
+      In sync
+    </span>
+  )
+  const headerAction =
+    state.drift && reconcileAction ? (
+      <div data-testid="policy-reconcile-slot">{reconcileAction}</div>
+    ) : null
   return (
-    <div className="space-y-4" data-testid="policy-section">
-      <div className="flex items-center justify-between gap-2">
-        <h3 className="text-sm font-medium flex items-center gap-2">
-          {heading}
-          {state.drift ? (
-            <PolicyDriftBadge />
-          ) : (
-            <span
-              className="text-xs text-muted-foreground"
-              data-testid="policy-in-sync"
-            >
-              In sync
-            </span>
-          )}
-        </h3>
-        {state.drift && reconcileAction ? (
-          <div data-testid="policy-reconcile-slot">{reconcileAction}</div>
-        ) : null}
-      </div>
-      <Separator />
-
+    <CollapsibleShell
+      heading={heading}
+      summaryExtra={summaryExtra}
+      headerAction={headerAction}
+      defaultOpen={defaultOpen ?? state.drift}
+    >
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
           <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
@@ -173,7 +228,7 @@ export function PolicySection({
         </p>
         <RefList refs={state.currentSet} testid="policy-current-set" />
       </div>
-    </div>
+    </CollapsibleShell>
   )
 }
 

--- a/frontend/src/components/policy-drift/PolicySection.tsx
+++ b/frontend/src/components/policy-drift/PolicySection.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { ChevronRight, TriangleAlert } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
@@ -94,6 +95,15 @@ function RefList({ refs, testid }: { refs: LinkedTemplateRef[]; testid: string }
  * Using the native element keeps keyboard and screen-reader behavior
  * correct without pulling in a third-party collapsible primitive.
  *
+ * Open state is UNCONTROLLED: we set the initial `open` attribute once on
+ * mount via a ref callback and never touch it again from React. This is
+ * important because the deployment detail page polls
+ * `useGetDeploymentStatus` on a 5-second refetchInterval, which re-renders
+ * this component; a controlled `open={defaultOpen}` prop would force the
+ * disclosure back to the initial state on every poll, stomping the user's
+ * toggle. The ref-callback approach lets the browser own the `open`
+ * attribute after mount while still seeding the initial value from props.
+ *
  * The Reconcile button is rendered outside the <summary> (absolutely
  * positioned on the right of the header row) so that nested interactive
  * elements inside <summary> do not interfere with the native
@@ -112,11 +122,22 @@ function CollapsibleShell({
   defaultOpen: boolean
   children: React.ReactNode
 }) {
+  const initialisedRef = useRef(false)
+  const setInitialOpen = (el: HTMLDetailsElement | null) => {
+    // Set the initial open attribute exactly once, on the first mount of
+    // this component instance. Subsequent re-renders must not touch
+    // `el.open` so that the user's toggle is preserved across parent
+    // re-renders (e.g. the deployment status poll).
+    if (el && !initialisedRef.current) {
+      el.open = defaultOpen
+      initialisedRef.current = true
+    }
+  }
   return (
     <details
+      ref={setInitialOpen}
       className="space-y-4 group relative"
       data-testid="policy-section"
-      open={defaultOpen}
     >
       <summary
         className="flex items-center gap-2 cursor-pointer list-none select-none pr-36"

--- a/frontend/src/components/policy-drift/PolicySection.tsx
+++ b/frontend/src/components/policy-drift/PolicySection.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { ChevronRight, TriangleAlert } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
@@ -95,17 +95,30 @@ function RefList({ refs, testid }: { refs: LinkedTemplateRef[]; testid: string }
  * Using the native element keeps keyboard and screen-reader behavior
  * correct without pulling in a third-party collapsible primitive.
  *
- * Open state is UNCONTROLLED: we set the initial `open` attribute once on
- * mount via a ref callback and never touch it again from React. This is
- * important because the deployment detail page polls
- * `useGetDeploymentStatus` on a 5-second refetchInterval, which re-renders
- * this component; a controlled `open={defaultOpen}` prop would force the
- * disclosure back to the initial state on every poll, stomping the user's
- * toggle. The ref-callback approach lets the browser own the `open`
- * attribute after mount while still seeding the initial value from props.
+ * Open-state management has to satisfy two requirements simultaneously:
+ *   1. The user's toggle must be preserved across parent re-renders.
+ *      The deployment detail page polls `useGetDeploymentStatus` every
+ *      five seconds; naïvely passing `open={defaultOpen}` would make
+ *      React reconcile the attribute back to the initial value on every
+ *      poll, stomping a user-initiated collapse/expand.
+ *   2. The open default must track `defaultOpen` until the user
+ *      interacts. On first mount the section is typically rendered in
+ *      its loading state (defaultOpen=false), and only after the
+ *      policy-state RPC resolves does `defaultOpen` flip to true for a
+ *      drifted target. If the shell captured `open` exactly once on
+ *      mount the section would stay collapsed on first paint even when
+ *      drift is present, hiding the attention signal until the user
+ *      manually expands it.
+ *
+ * The implementation tracks whether the user has toggled the disclosure
+ * via the <details> `onToggle` event + a sentinel ref. While the user
+ * has NOT toggled, a useEffect syncs `el.open` to `defaultOpen` whenever
+ * `defaultOpen` changes. Once the user toggles, the sentinel flips and
+ * subsequent `defaultOpen` changes are ignored — the user's choice wins
+ * for the lifetime of the component instance.
  *
  * The Reconcile button is rendered outside the <summary> (absolutely
- * positioned on the right of the header row) so that nested interactive
+ * positioned on the right of the header row) so nested interactive
  * elements inside <summary> do not interfere with the native
  * click-to-toggle behavior.
  */
@@ -122,20 +135,45 @@ function CollapsibleShell({
   defaultOpen: boolean
   children: React.ReactNode
 }) {
-  const initialisedRef = useRef(false)
-  const setInitialOpen = (el: HTMLDetailsElement | null) => {
-    // Set the initial open attribute exactly once, on the first mount of
-    // this component instance. Subsequent re-renders must not touch
-    // `el.open` so that the user's toggle is preserved across parent
-    // re-renders (e.g. the deployment status poll).
-    if (el && !initialisedRef.current) {
-      el.open = defaultOpen
-      initialisedRef.current = true
+  const detailsRef = useRef<HTMLDetailsElement | null>(null)
+  // Tracks whether the user has manually toggled the disclosure. Once
+  // true, defaultOpen changes are ignored so the user's preference wins
+  // over the prop-driven default.
+  const userToggledRef = useRef(false)
+  // Suppresses the `onToggle` handler when we set `el.open` ourselves,
+  // so our programmatic sync does not count as a user toggle. <details>
+  // fires `toggle` on every state change, including attribute writes.
+  const suppressToggleRef = useRef(false)
+
+  // Sync `open` to `defaultOpen` until the user interacts. The effect
+  // runs every time `defaultOpen` changes, and no-ops after the user
+  // toggles. This means: on first mount the disclosure follows the
+  // prop; when the policy-state RPC resolves and flips `defaultOpen`
+  // from false to true (drift), the disclosure opens automatically;
+  // after the user clicks to collapse/expand, the prop stops driving.
+  useEffect(() => {
+    if (!userToggledRef.current && detailsRef.current && detailsRef.current.open !== defaultOpen) {
+      suppressToggleRef.current = true
+      detailsRef.current.open = defaultOpen
     }
+  }, [defaultOpen])
+
+  const handleToggle = () => {
+    // Swallow the synthetic toggle event that fires when we set
+    // `el.open` programmatically above; otherwise the first prop-driven
+    // sync would mark the disclosure as user-toggled and lock out any
+    // subsequent prop-driven auto-open on drift.
+    if (suppressToggleRef.current) {
+      suppressToggleRef.current = false
+      return
+    }
+    userToggledRef.current = true
   }
+
   return (
     <details
-      ref={setInitialOpen}
+      ref={detailsRef}
+      onToggle={handleToggle}
       className="space-y-4 group relative"
       data-testid="policy-section"
     >

--- a/frontend/src/components/policy-drift/PolicySection.tsx
+++ b/frontend/src/components/policy-drift/PolicySection.tsx
@@ -1,0 +1,199 @@
+import { TriangleAlert } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/skeleton'
+import { TemplateScope } from '@/gen/holos/console/v1/policy_state_pb'
+import type {
+  LinkedTemplateRef,
+  PolicyState,
+} from '@/gen/holos/console/v1/policy_state_pb'
+
+// PolicySection renders the TemplatePolicy drift snapshot for a render
+// target — either a Deployment or a project-scope Template — and exposes a
+// Reconcile action slot so callers can wire in the appropriate Update
+// mutation (useUpdateDeployment / useUpdateTemplate).
+//
+// IMPORTANT: PolicyState is sourced exclusively from the
+// GetDeploymentPolicyState / GetProjectTemplatePolicyState RPCs. Both RPCs
+// read drift state from the folder namespace (per the HOL-554 "storage
+// isolation: folder-namespace only" design). Never read drift state from a
+// project-namespace resource directly — the folder-namespace rendering path
+// is the single source of truth, and project-namespace annotations are
+// treated as derivable output, not authoritative state.
+
+export interface PolicySectionProps {
+  /** Policy state returned by Get*PolicyState. Undefined while loading. */
+  state?: PolicyState
+  /** True while the policy-state RPC is in flight. */
+  isPending?: boolean
+  /** Error from the policy-state RPC, if any. */
+  error?: Error | null
+  /**
+   * Optional reconcile action (button). When undefined the section renders
+   * drift information but no action — this is how viewer-role users see the
+   * section: they can see drift but cannot reconcile.
+   */
+  reconcileAction?: React.ReactNode
+  /**
+   * Optional heading override. Defaults to "Policy". Callers can override
+   * for instance to "TemplatePolicy" or similar.
+   */
+  heading?: string
+}
+
+/**
+ * Formats a LinkedTemplateRef as a human-readable scope-qualified name.
+ * Example: "org:acme/base-app", "folder:infra/istio", "project:web/api@>=1.0.0".
+ */
+function formatRef(ref: LinkedTemplateRef): string {
+  const scopeLabel =
+    ref.scope === TemplateScope.ORGANIZATION
+      ? 'org'
+      : ref.scope === TemplateScope.FOLDER
+        ? 'folder'
+        : ref.scope === TemplateScope.PROJECT
+          ? 'project'
+          : 'unknown'
+  const base = `${scopeLabel}:${ref.scopeName}/${ref.name}`
+  return ref.versionConstraint ? `${base}@${ref.versionConstraint}` : base
+}
+
+function RefList({ refs, testid }: { refs: LinkedTemplateRef[]; testid: string }) {
+  if (refs.length === 0) {
+    return (
+      <span className="text-sm text-muted-foreground" data-testid={`${testid}-empty`}>
+        None
+      </span>
+    )
+  }
+  return (
+    <ul className="flex flex-col gap-1" data-testid={testid}>
+      {refs.map((ref) => (
+        <li
+          key={`${ref.scope}/${ref.scopeName}/${ref.name}/${ref.versionConstraint ?? ''}`}
+          className="font-mono text-xs text-muted-foreground"
+        >
+          {formatRef(ref)}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export function PolicySection({
+  state,
+  isPending = false,
+  error,
+  reconcileAction,
+  heading = 'Policy',
+}: PolicySectionProps) {
+  // Error state — surface the message inline.
+  if (error) {
+    return (
+      <div className="space-y-4" data-testid="policy-section">
+        <h3 className="text-sm font-medium">{heading}</h3>
+        <Separator />
+        <p className="text-sm text-destructive">{error.message}</p>
+      </div>
+    )
+  }
+
+  if (isPending || !state) {
+    return (
+      <div className="space-y-4" data-testid="policy-section">
+        <h3 className="text-sm font-medium">{heading}</h3>
+        <Separator />
+        <Skeleton className="h-5 w-48" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    )
+  }
+
+  // "Never applied" state — the target has not been rendered through the
+  // HOL-567 applied-state path yet, so drift is not meaningful. Show a note
+  // so the user understands why no diff is rendered.
+  if (!state.hasAppliedState) {
+    return (
+      <div className="space-y-4" data-testid="policy-section">
+        <h3 className="text-sm font-medium">{heading}</h3>
+        <Separator />
+        <p className="text-sm text-muted-foreground" data-testid="policy-never-applied">
+          No applied state recorded yet. Drift will be reported after the next render.
+        </p>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
+            Current effective set
+          </p>
+          <RefList refs={state.currentSet} testid="policy-current-set" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4" data-testid="policy-section">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-medium flex items-center gap-2">
+          {heading}
+          {state.drift ? (
+            <PolicyDriftBadge />
+          ) : (
+            <span
+              className="text-xs text-muted-foreground"
+              data-testid="policy-in-sync"
+            >
+              In sync
+            </span>
+          )}
+        </h3>
+        {state.drift && reconcileAction ? (
+          <div data-testid="policy-reconcile-slot">{reconcileAction}</div>
+        ) : null}
+      </div>
+      <Separator />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
+            Added (policy now requires)
+          </p>
+          <RefList refs={state.addedRefs} testid="policy-added-refs" />
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
+            Removed (no longer required)
+          </p>
+          <RefList refs={state.removedRefs} testid="policy-removed-refs" />
+        </div>
+      </div>
+
+      <div>
+        <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
+          Current effective set
+        </p>
+        <RefList refs={state.currentSet} testid="policy-current-set" />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * PolicyDriftBadge is the shared warning badge rendered on list rows and
+ * inside PolicySection. Yellow/amber is used for "attention required" in
+ * this codebase (see PhaseBadge PENDING and template update ArrowUpCircle).
+ */
+export function PolicyDriftBadge({ className }: { className?: string }) {
+  return (
+    <Badge
+      data-testid="policy-drift-badge"
+      aria-label="Policy drift"
+      className={
+        'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 border-transparent inline-flex items-center gap-1 ' +
+        (className ?? '')
+      }
+    >
+      <TriangleAlert className="h-3 w-3" aria-hidden="true" />
+      Policy Drift
+    </Badge>
+  )
+}

--- a/frontend/src/components/policy-drift/ProjectTemplateDriftBadge.tsx
+++ b/frontend/src/components/policy-drift/ProjectTemplateDriftBadge.tsx
@@ -1,0 +1,43 @@
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { PolicyDriftBadge } from './PolicySection'
+import { useGetProjectTemplatePolicyState } from '@/queries/templates'
+import type { TemplateScopeRef } from '@/queries/templates'
+
+// ProjectTemplateDriftBadge renders the PolicyDriftBadge on a project
+// template list row when the backend reports drift for the template.
+//
+// Unlike deployments, project-scope templates do not carry a
+// ProjectTemplateStatusSummary surface (see the HOL-567 scope decision
+// recorded in templates.proto): the per-row drift signal is fetched via
+// GetProjectTemplatePolicyState instead. The response's PolicyState is
+// sourced from the folder-namespace render-state store — never read drift
+// state from project-namespace resources directly.
+//
+// Rendering is strictly conditional on `state.drift === true` so the list
+// view stays visually clean for templates that are in sync or have never
+// been applied through the HOL-567 path. The component renders nothing
+// while the RPC is pending or errors.
+export function ProjectTemplateDriftBadge({
+  scope,
+  templateName,
+}: {
+  scope: TemplateScopeRef
+  templateName: string
+}) {
+  const { data: state } = useGetProjectTemplatePolicyState(scope, templateName)
+  if (!state?.drift) return null
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span>
+            <PolicyDriftBadge />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          The template was rendered before a template policy changed; click Reconcile to re-render.
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/frontend/src/queries/deployments.ts
+++ b/frontend/src/queries/deployments.ts
@@ -65,6 +65,12 @@ export function useUpdateDeployment(project: string, name: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: deploymentListKey(project) })
       queryClient.invalidateQueries({ queryKey: deploymentGetKey(project, name) })
+      // HOL-559: a successful UpdateDeployment re-renders against the
+      // current TemplatePolicy chain and records a fresh applied render
+      // set on the backend. Invalidate the policy-state query so the
+      // UI's drift badge + diff refresh from the authoritative state
+      // rather than continuing to show the stale "drifted" snapshot.
+      queryClient.invalidateQueries({ queryKey: deploymentPolicyStateKey(project, name) })
     },
   })
 }

--- a/frontend/src/queries/deployments.ts
+++ b/frontend/src/queries/deployments.ts
@@ -170,6 +170,30 @@ export function useGetDeploymentRenderPreview(project: string, name: string) {
   })
 }
 
+// useGetDeploymentPolicyState fetches the TemplatePolicy drift snapshot for
+// a deployment (HOL-567). The response's PolicyState is sourced from the
+// folder-namespace render-state store — see PolicySection's component-level
+// comment for the storage-isolation guarantee. This hook is the sole read
+// path used by the drift UI; never infer drift from other deployment
+// fields.
+function deploymentPolicyStateKey(project: string, name: string) {
+  return ['deployments', 'policy-state', project, name] as const
+}
+
+export function useGetDeploymentPolicyState(project: string, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(DeploymentService, transport), [transport])
+  return useQuery({
+    queryKey: deploymentPolicyStateKey(project, name),
+    queryFn: async () => {
+      const response = await client.getDeploymentPolicyState({ project, name })
+      return response.state
+    },
+    enabled: isAuthenticated && !!project && !!name,
+  })
+}
+
 function namespaceSecretsKey(project: string) {
   return ['deployments', 'namespace-secrets', project] as const
 }

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -333,6 +333,37 @@ export function useCheckUpdates(scope: TemplateScopeRef, templateName = '', opti
   })
 }
 
+// useGetProjectTemplatePolicyState fetches the TemplatePolicy drift snapshot
+// for a project-scope template (HOL-567). PolicyState is sourced from the
+// folder-namespace render-state store — see PolicySection's component-level
+// comment for the storage-isolation guarantee. This RPC is the sole read
+// path used by the drift UI for project-scope templates; never infer drift
+// from other template fields.
+//
+// The request uses TEMPLATE_SCOPE_PROJECT; the backend validates the scope
+// and rejects non-project scopes with InvalidArgument.
+function projectTemplatePolicyStateKey(scope: TemplateScopeRef, name: string) {
+  return ['templates', 'policy-state', scope.scope, scope.scopeName, name] as const
+}
+
+export function useGetProjectTemplatePolicyState(scope: TemplateScopeRef, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  return useQuery({
+    queryKey: projectTemplatePolicyStateKey(scope, name),
+    queryFn: async () => {
+      const response = await client.getProjectTemplatePolicyState({ scope, name })
+      return response.state
+    },
+    enabled:
+      isAuthenticated &&
+      !!scope.scopeName &&
+      !!name &&
+      scope.scope === TemplateScope.PROJECT,
+  })
+}
+
 // useRenderTemplate renders a CUE template with the given inputs. The scope
 // parameter determines which ancestor platform templates are resolved.
 // linkedTemplates optionally passes explicit linked template refs to unify

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -183,6 +183,13 @@ export function useUpdateTemplate(scope: TemplateScopeRef, name: string) {
       // Invalidate all check-updates queries for this scope so upgrade badges
       // and dialogs reflect the new state immediately after a template update.
       queryClient.invalidateQueries({ queryKey: ['templates', 'checkUpdates'] })
+      // HOL-559: a successful UpdateTemplate re-renders against the
+      // current TemplatePolicy chain and records a fresh applied render
+      // set on the backend. Invalidate all policy-state queries for this
+      // scope so the list-row drift badge and the detail PolicySection
+      // both refresh from the authoritative state rather than showing
+      // the stale "drifted" snapshot after reconcile.
+      queryClient.invalidateQueries({ queryKey: ['templates', 'policy-state', scope.scope, scope.scopeName] })
     },
   })
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -39,10 +39,11 @@ import {
 import { ArrowLeft, CheckCircle2, Copy, ExternalLink, Info, TriangleAlert, XCircle } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import type { EnvVar, Event, ContainerStatus } from '@/gen/holos/console/v1/deployments_pb'
-import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useGetDeploymentRenderPreview, useUpdateDeployment, useDeleteDeployment } from '@/queries/deployments'
+import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useGetDeploymentRenderPreview, useGetDeploymentPolicyState, useUpdateDeployment, useDeleteDeployment } from '@/queries/deployments'
 import { makeProjectScope } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { isSafeHttpUrl } from '@/lib/url'
+import { PolicySection } from '@/components/policy-drift/PolicySection'
 
 type DeploymentTab = 'status' | 'logs' | 'template'
 
@@ -138,6 +139,7 @@ export function DeploymentDetailPage({
   const { data: status } = useGetDeploymentStatus(projectName, deploymentName, { refetchInterval: 5000 })
   const { data: project } = useGetProject(projectName)
   const { data: preview, isPending: isPreviewPending } = useGetDeploymentRenderPreview(projectName, deploymentName)
+  const { data: policyState, isPending: isPolicyPending, error: policyError } = useGetDeploymentPolicyState(projectName, deploymentName)
 
   const [tailLines, setTailLines] = useState<number>(100)
   const [previous, setPrevious] = useState(false)
@@ -194,6 +196,29 @@ export function DeploymentDetailPage({
     setRedeployError(null)
     updateMutation.reset()
     setRedeployOpen(true)
+  }
+
+  // handleReconcile fires an UpdateDeployment with the deployment's current
+  // image/tag/port/command/args/env. The backend treats this as a re-render:
+  // the template is re-evaluated against the current TemplatePolicy chain
+  // and the applied render set is re-recorded, which clears drift on
+  // success. No functional changes are made to the running workload when
+  // the rendered manifest is unchanged.
+  const handleReconcile = async () => {
+    if (!deployment) return
+    try {
+      await updateMutation.mutateAsync({
+        image: deployment.image,
+        tag: deployment.tag,
+        port: deployment.port || 8080,
+        command: deployment.command ?? [],
+        args: deployment.args ?? [],
+        env: filterEnvVars(deployment.env ?? []),
+      })
+      toast.success('Reconcile requested')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
   }
 
   const handleRedeploy = async () => {
@@ -465,6 +490,33 @@ export function DeploymentDetailPage({
                   <p className="text-sm text-muted-foreground">No events.</p>
                 )}
               </div>
+
+              {/*
+                Policy section — renders the TemplatePolicy drift snapshot
+                for this deployment (HOL-567 / HOL-559). The data is fetched
+                via GetDeploymentPolicyState, which reads PolicyState from
+                the folder-namespace render-state store. The UI never reads
+                drift state directly from project-namespace resources.
+                Reconcile is gated on PERMISSION_DEPLOYMENTS_WRITE (role
+                OWNER or EDITOR); viewers see the badge but no button.
+              */}
+              <PolicySection
+                state={policyState}
+                isPending={isPolicyPending}
+                error={policyError}
+                reconcileAction={
+                  canWrite ? (
+                    <Button
+                      size="sm"
+                      onClick={handleReconcile}
+                      disabled={updateMutation.isPending}
+                      aria-label="Reconcile policy drift"
+                    >
+                      {updateMutation.isPending ? 'Reconciling...' : 'Reconcile'}
+                    </Button>
+                  ) : undefined
+                }
+              />
 
               {deployment && deployment.env && deployment.env.length > 0 && (
                 <div className="space-y-4">

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@/queries/deployments', () => ({
   useListNamespaceSecrets: vi.fn(),
   useListNamespaceConfigMaps: vi.fn(),
   useGetDeploymentRenderPreview: vi.fn(),
+  useGetDeploymentPolicyState: vi.fn(),
 }))
 
 vi.mock('@/queries/projects', () => ({
@@ -45,7 +46,7 @@ vi.mock('@/queries/templates', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useUpdateDeployment, useDeleteDeployment, useListNamespaceSecrets, useListNamespaceConfigMaps, useGetDeploymentRenderPreview } from '@/queries/deployments'
+import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useUpdateDeployment, useDeleteDeployment, useListNamespaceSecrets, useListNamespaceConfigMaps, useGetDeploymentRenderPreview, useGetDeploymentPolicyState } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 import { useRenderTemplate } from '@/queries/templates'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -181,6 +182,7 @@ function setupMocks(userRole = Role.OWNER) {
   ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
   ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
   ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: mockPreview, isPending: false, error: null })
+  ;(useGetDeploymentPolicyState as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
   ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: mockPreview.renderedYaml, renderedJson: '' }, error: null, isFetching: false })
 }
 
@@ -1121,6 +1123,125 @@ describe('DeploymentDetailPage', () => {
       render(<DeploymentDetailPage />)
       const link = screen.getByRole('link', { name: /http:\/\/example\.com\/app/ })
       expect(link.getAttribute('href')).toBe('http://example.com/app')
+    })
+  })
+
+  // HOL-559: drift badge + Reconcile action for the deployment detail page.
+  // The detail page fetches PolicyState via useGetDeploymentPolicyState and
+  // renders the shared PolicySection. Reconcile is gated on write
+  // permission (OWNER / EDITOR); viewers see the drift signal but no
+  // action. All RPCs are mocked.
+  describe('policy drift section', () => {
+    function setupDriftState(drift: boolean) {
+      ;(useGetDeploymentPolicyState as Mock).mockReturnValue({
+        data: {
+          $typeName: 'holos.console.v1.PolicyState',
+          appliedSet: [{ $typeName: 'holos.console.v1.LinkedTemplateRef', scope: 1, scopeName: 'acme', name: 'base', versionConstraint: '' }],
+          currentSet: [{ $typeName: 'holos.console.v1.LinkedTemplateRef', scope: 1, scopeName: 'acme', name: 'base', versionConstraint: '' }],
+          addedRefs: drift ? [{ $typeName: 'holos.console.v1.LinkedTemplateRef', scope: 1, scopeName: 'acme', name: 'sidecar', versionConstraint: '' }] : [],
+          removedRefs: [],
+          drift,
+          hasAppliedState: true,
+        },
+        isPending: false,
+        error: null,
+      })
+    }
+
+    it('renders the Policy Drift badge when drift is true', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      render(<DeploymentDetailPage />)
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+    })
+
+    it('does not render the Policy Drift badge when drift is false', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(false)
+      render(<DeploymentDetailPage />)
+      expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+      expect(screen.getByTestId('policy-in-sync')).toBeInTheDocument()
+    })
+
+    it('renders the Reconcile button for owners when drift is true', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      render(<DeploymentDetailPage />)
+      expect(screen.getByRole('button', { name: /reconcile policy drift/i })).toBeInTheDocument()
+    })
+
+    it('renders the Reconcile button for editors when drift is true', () => {
+      setupMocks(Role.EDITOR)
+      setupDriftState(true)
+      render(<DeploymentDetailPage />)
+      expect(screen.getByRole('button', { name: /reconcile policy drift/i })).toBeInTheDocument()
+    })
+
+    it('does not render the Reconcile button for viewers', () => {
+      setupMocks(Role.VIEWER)
+      setupDriftState(true)
+      render(<DeploymentDetailPage />)
+      // Viewers still see the drift badge — the read-only signal — but
+      // never see the Reconcile action.
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /reconcile policy drift/i })).not.toBeInTheDocument()
+    })
+
+    it('clicking Reconcile calls useUpdateDeployment with preserved fields', async () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      render(<DeploymentDetailPage />)
+      fireEvent.click(screen.getByRole('button', { name: /reconcile policy drift/i }))
+      const mutateAsync = (useUpdateDeployment as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            image: mockDeployment.image,
+            tag: mockDeployment.tag,
+            port: mockDeployment.port,
+          }),
+        )
+      })
+    })
+
+    it('Reconcile success shows a success toast', async () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      const { toast } = await import('sonner')
+      render(<DeploymentDetailPage />)
+      fireEvent.click(screen.getByRole('button', { name: /reconcile policy drift/i }))
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Reconcile requested')
+      })
+    })
+
+    it('Reconcile failure shows an error toast', async () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      ;(useUpdateDeployment as Mock).mockReturnValue({
+        mutateAsync: vi.fn().mockRejectedValue(new Error('boom')),
+        isPending: false,
+        reset: vi.fn(),
+      })
+      const { toast } = await import('sonner')
+      render(<DeploymentDetailPage />)
+      fireEvent.click(screen.getByRole('button', { name: /reconcile policy drift/i }))
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('boom')
+      })
+    })
+
+    it('Reconcile button is disabled while update mutation is pending', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      ;(useUpdateDeployment as Mock).mockReturnValue({
+        mutateAsync: vi.fn(),
+        isPending: true,
+        reset: vi.fn(),
+      })
+      render(<DeploymentDetailPage />)
+      const btn = screen.getByRole('button', { name: /reconcile policy drift/i })
+      expect(btn).toBeDisabled()
     })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
@@ -37,6 +37,7 @@ function makeSummary(
   readyReplicas = 0,
   desiredReplicas = 0,
   output?: DeploymentOutput,
+  policyDrift?: boolean,
 ): DeploymentStatusSummary {
   return {
     $typeName: 'holos.console.v1.DeploymentStatusSummary',
@@ -48,6 +49,7 @@ function makeSummary(
     observedGeneration: 0n,
     message: '',
     output,
+    policyDrift,
   }
 }
 
@@ -263,5 +265,65 @@ describe('DeploymentsPage', () => {
     ])
     render(<DeploymentsPage />)
     expect(screen.queryByRole('link', { name: /open api/i })).not.toBeInTheDocument()
+  })
+
+  describe('policy drift badge', () => {
+    // HOL-559: the deployment list surfaces policy drift when the backend
+    // populates status_summary.policy_drift. The flag is sourced from the
+    // folder-namespace render-state store via HOL-567.
+    it('renders the Policy Drift badge when policy_drift is true', () => {
+      setupMocks([
+        makeDeployment(
+          'api',
+          'ghcr.io/org/app',
+          'v1.0.0',
+          makeSummary(DeploymentPhase.RUNNING, 1, 1, undefined, true),
+        ),
+      ])
+      render(<DeploymentsPage />)
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+    })
+
+    it('does not render the Policy Drift badge when policy_drift is false', () => {
+      setupMocks([
+        makeDeployment(
+          'api',
+          'ghcr.io/org/app',
+          'v1.0.0',
+          makeSummary(DeploymentPhase.RUNNING, 1, 1, undefined, false),
+        ),
+      ])
+      render(<DeploymentsPage />)
+      expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+    })
+
+    it('does not render the Policy Drift badge when policy_drift is undefined', () => {
+      setupMocks([
+        makeDeployment(
+          'api',
+          'ghcr.io/org/app',
+          'v1.0.0',
+          makeSummary(DeploymentPhase.RUNNING, 1, 1),
+        ),
+      ])
+      render(<DeploymentsPage />)
+      expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+    })
+
+    it('renders the Policy Drift badge for viewers as well (read-only signal)', () => {
+      setupMocks(
+        [
+          makeDeployment(
+            'api',
+            'ghcr.io/org/app',
+            'v1.0.0',
+            makeSummary(DeploymentPhase.RUNNING, 1, 1, undefined, true),
+          ),
+        ],
+        Role.VIEWER,
+      )
+      render(<DeploymentsPage />)
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -24,6 +24,8 @@ import {
 import { ExternalLink, Trash2 } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { PhaseBadge } from '@/components/phase-badge'
+import { PolicyDriftBadge } from '@/components/policy-drift/PolicySection'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 import { isSafeHttpUrl } from '@/lib/url'
@@ -145,7 +147,31 @@ export function DeploymentsPage({ projectName: propProjectName }: { projectName?
                     <TableCell className="font-mono text-sm">{deployment.image}</TableCell>
                     <TableCell className="font-mono text-sm">{deployment.tag}</TableCell>
                     <TableCell>
-                      <PhaseBadge summary={deployment.statusSummary} />
+                      <div className="inline-flex items-center gap-2 flex-wrap">
+                        <PhaseBadge summary={deployment.statusSummary} />
+                        {/*
+                          Policy drift badge — surfaces the status_summary.policy_drift
+                          flag populated by the backend (HOL-567 / HOL-557).
+                          The flag is sourced from the folder-namespace
+                          render-state store; callers needing the full diff
+                          invoke GetDeploymentPolicyState (see the Policy
+                          section on the deployment detail page).
+                        */}
+                        {deployment.statusSummary?.policyDrift ? (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span>
+                                  <PolicyDriftBadge />
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                The deployment was rendered before a template policy changed; click Reconcile to re-render.
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : null}
+                      </div>
                     </TableCell>
                     <TableCell className="text-right">
                       {/*

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -22,12 +22,13 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, useCheckUpdates, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
+import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, useCheckUpdates, useGetProjectTemplatePolicyState, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { LinkifiedText } from '@/components/linkified-text'
 import { UpgradeDialog } from '@/components/template-updates'
+import { PolicySection } from '@/components/policy-drift/PolicySection'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/$templateName')({
   component: DeploymentTemplateDetailRoute,
@@ -79,6 +80,11 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   // status indicator on each pill badge.
   const { data: templateUpdates = [] } = useCheckUpdates(scope, templateName, { includeCurrent: true })
 
+  // Fetch the TemplatePolicy drift snapshot for this project-scope template
+  // (HOL-567). PolicyState is sourced from the folder-namespace render-state
+  // store — never read drift state directly from project-namespace resources.
+  const { data: policyState, isPending: isPolicyPending, error: policyError } = useGetProjectTemplatePolicyState(scope, templateName)
+
   useEffect(() => {
     if (template?.cueTemplate !== undefined) {
       setCueTemplate(template.cueTemplate)
@@ -92,6 +98,27 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
 
   const defaultPlatformInput = `platform: {\n  project:          "${projectName}"\n  namespace:        "holos-prj-${projectName}"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
+
+  // handleReconcile triggers an UpdateTemplate with the template's current
+  // fields (display name, description, CUE body, enabled flag, linked
+  // templates). The backend treats this as a re-render against the current
+  // TemplatePolicy chain, which clears drift on success. No functional
+  // changes are made to the template.
+  const handleReconcile = async () => {
+    try {
+      await updateMutation.mutateAsync({
+        displayName: template?.displayName,
+        description: template?.description,
+        cueTemplate,
+        enabled: template?.enabled,
+        linkedTemplates: template?.linkedTemplates ?? [],
+        updateLinkedTemplates: true,
+      })
+      toast.success('Reconcile requested')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
+  }
 
   const handleSave = async () => {
     try {
@@ -381,6 +408,34 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
               </div>
             </div>
           </div>
+
+          {/*
+            Policy section — renders the TemplatePolicy drift snapshot for
+            this project-scope template (HOL-567 / HOL-559). The data is
+            fetched via GetProjectTemplatePolicyState, which reads
+            PolicyState from the folder-namespace render-state store. The UI
+            never reads drift state directly from project-namespace
+            resources. Reconcile is gated on PERMISSION_TEMPLATES_WRITE at
+            project scope (role OWNER or EDITOR); viewers see the badge but
+            no button.
+          */}
+          <PolicySection
+            state={policyState}
+            isPending={isPolicyPending}
+            error={policyError}
+            reconcileAction={
+              canWrite ? (
+                <Button
+                  size="sm"
+                  onClick={handleReconcile}
+                  disabled={updateMutation.isPending}
+                  aria-label="Reconcile policy drift"
+                >
+                  {updateMutation.isPending ? 'Reconciling...' : 'Reconcile'}
+                </Button>
+              ) : undefined
+            }
+          />
 
           <div className="space-y-4">
             <div className="flex items-center justify-between">

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/queries/templates', () => ({
   useRenderTemplate: vi.fn(),
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
   useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  useGetProjectTemplatePolicyState: vi.fn().mockReturnValue({ data: undefined, isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
   linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>
@@ -49,7 +50,7 @@ vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: vi.fn((value: unknown) => value),
 }))
 
-import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useRenderTemplate, useListLinkableTemplates, useCheckUpdates } from '@/queries/templates'
+import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useRenderTemplate, useListLinkableTemplates, useCheckUpdates, useGetProjectTemplatePolicyState } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -871,6 +872,121 @@ describe('DeploymentTemplateDetailPage', () => {
         expect.any(String), // templateName
         expect.objectContaining({ includeCurrent: true }),
       )
+    })
+  })
+
+  // HOL-559: the project-template detail page renders the shared
+  // PolicySection with a Reconcile action gated on write permission. The
+  // Reconcile mutation preserves every existing field (displayName,
+  // description, cueTemplate, enabled, linkedTemplates) so the backend
+  // re-renders against the current TemplatePolicy chain without changing
+  // functional behavior.
+  describe('policy drift section', () => {
+    function setupDriftState(drift: boolean) {
+      ;(useGetProjectTemplatePolicyState as Mock).mockReturnValue({
+        data: {
+          $typeName: 'holos.console.v1.PolicyState',
+          appliedSet: [{ $typeName: 'holos.console.v1.LinkedTemplateRef', scope: 1, scopeName: 'acme', name: 'base', versionConstraint: '' }],
+          currentSet: [{ $typeName: 'holos.console.v1.LinkedTemplateRef', scope: 1, scopeName: 'acme', name: 'base', versionConstraint: '' }],
+          addedRefs: drift ? [{ $typeName: 'holos.console.v1.LinkedTemplateRef', scope: 1, scopeName: 'acme', name: 'sidecar', versionConstraint: '' }] : [],
+          removedRefs: [],
+          drift,
+          hasAppliedState: true,
+        },
+        isPending: false,
+        error: null,
+      })
+    }
+
+    it('renders the Policy Drift badge when drift is true', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+    })
+
+    it('does not render the Policy Drift badge when drift is false', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(false)
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+      expect(screen.getByTestId('policy-in-sync')).toBeInTheDocument()
+    })
+
+    it('renders the Reconcile button for owners when drift is true', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByRole('button', { name: /reconcile policy drift/i })).toBeInTheDocument()
+    })
+
+    it('renders the Reconcile button for editors when drift is true', () => {
+      setupMocks(Role.EDITOR)
+      setupDriftState(true)
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByRole('button', { name: /reconcile policy drift/i })).toBeInTheDocument()
+    })
+
+    it('does not render the Reconcile button for viewers', () => {
+      setupMocks(Role.VIEWER)
+      setupDriftState(true)
+      render(<DeploymentTemplateDetailPage />)
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /reconcile policy drift/i })).not.toBeInTheDocument()
+    })
+
+    it('clicking Reconcile calls useUpdateTemplate with preserved fields', async () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      render(<DeploymentTemplateDetailPage />)
+      fireEvent.click(screen.getByRole('button', { name: /reconcile policy drift/i }))
+      const mutateAsync = (useUpdateTemplate as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cueTemplate: expect.any(String),
+            updateLinkedTemplates: true,
+          }),
+        )
+      })
+    })
+
+    it('Reconcile success shows a success toast', async () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      const { toast } = await import('sonner')
+      render(<DeploymentTemplateDetailPage />)
+      fireEvent.click(screen.getByRole('button', { name: /reconcile policy drift/i }))
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Reconcile requested')
+      })
+    })
+
+    it('Reconcile failure shows an error toast', async () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      ;(useUpdateTemplate as Mock).mockReturnValue({
+        mutateAsync: vi.fn().mockRejectedValue(new Error('conflict')),
+        isPending: false,
+      })
+      const { toast } = await import('sonner')
+      render(<DeploymentTemplateDetailPage />)
+      fireEvent.click(screen.getByRole('button', { name: /reconcile policy drift/i }))
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('conflict')
+      })
+    })
+
+    it('Reconcile button is disabled while update mutation is pending', () => {
+      setupMocks(Role.OWNER)
+      setupDriftState(true)
+      ;(useUpdateTemplate as Mock).mockReturnValue({
+        mutateAsync: vi.fn(),
+        isPending: true,
+      })
+      render(<DeploymentTemplateDetailPage />)
+      const btn = screen.getByRole('button', { name: /reconcile policy drift/i })
+      expect(btn).toBeDisabled()
     })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/queries/templates', () => ({
   useCloneTemplate: vi.fn(),
   useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
   useGetTemplate: vi.fn().mockReturnValue({ data: undefined, isPending: false, error: null }),
+  useGetProjectTemplatePolicyState: vi.fn().mockReturnValue({ data: undefined, isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-project' }),
 }))
 
@@ -36,7 +37,7 @@ vi.mock('@/queries/projects', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useListTemplates, useDeleteTemplate, useCloneTemplate } from '@/queries/templates'
+import { useListTemplates, useDeleteTemplate, useCloneTemplate, useGetProjectTemplatePolicyState } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { DeploymentTemplatesPage } from './index'
@@ -191,6 +192,56 @@ describe('DeploymentTemplatesPage', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
       const mutateAsync = (useCloneTemplate as Mock).mock.results[0].value.mutateAsync
       expect(mutateAsync).not.toHaveBeenCalled()
+    })
+  })
+
+  // HOL-559: the project templates list surfaces policy drift for project-
+  // scope templates via the per-row ProjectTemplateDriftBadge, which fetches
+  // GetProjectTemplatePolicyState. Project-scope templates do not carry a
+  // ProjectTemplateStatusSummary surface (HOL-567 scope decision).
+  describe('policy drift badge', () => {
+    it('renders the Policy Drift badge on rows whose state.drift is true', () => {
+      setupMocks([makeTemplate('web-app', 'Standard web app')])
+      ;(useGetProjectTemplatePolicyState as Mock).mockReturnValue({
+        data: { drift: true, hasAppliedState: true, appliedSet: [], currentSet: [], addedRefs: [], removedRefs: [] },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentTemplatesPage />)
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
+    })
+
+    it('does not render the Policy Drift badge when state.drift is false', () => {
+      setupMocks([makeTemplate('web-app', 'Standard web app')])
+      ;(useGetProjectTemplatePolicyState as Mock).mockReturnValue({
+        data: { drift: false, hasAppliedState: true, appliedSet: [], currentSet: [], addedRefs: [], removedRefs: [] },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentTemplatesPage />)
+      expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+    })
+
+    it('does not render the Policy Drift badge when state is undefined (pending/error)', () => {
+      setupMocks([makeTemplate('web-app', 'Standard web app')])
+      ;(useGetProjectTemplatePolicyState as Mock).mockReturnValue({
+        data: undefined,
+        isPending: true,
+        error: null,
+      })
+      render(<DeploymentTemplatesPage />)
+      expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
+    })
+
+    it('renders the Policy Drift badge for viewers as well (read-only signal)', () => {
+      setupMocks([makeTemplate('web-app', 'Standard web app')], Role.VIEWER)
+      ;(useGetProjectTemplatePolicyState as Mock).mockReturnValue({
+        data: { drift: true, hasAppliedState: true, appliedSet: [], currentSet: [], addedRefs: [], removedRefs: [] },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentTemplatesPage />)
+      expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/queries/templates', () => ({
   useRenderTemplate: vi.fn(),
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
   useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  useGetProjectTemplatePolicyState: vi.fn().mockReturnValue({ data: undefined, isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
   linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-version-selector.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-version-selector.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/queries/templates', () => ({
   useRenderTemplate: vi.fn(),
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
   useCheckUpdates: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  useGetProjectTemplatePolicyState: vi.fn().mockReturnValue({ data: undefined, isPending: false, error: null }),
   makeProjectScope: vi.fn().mockReturnValue({ scope: 3, scopeName: 'test-project' }),
   TemplateScope: { UNSPECIFIED: 0, ORGANIZATION: 1, FOLDER: 2, PROJECT: 3 },
   linkableKey: (scope: number | undefined, scopeName: string | undefined, name: string) =>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -28,6 +28,7 @@ import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useListTemplates, useDeleteTemplate, useCloneTemplate, useCheckUpdates, useGetTemplate, makeProjectScope } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { UpdatesAvailableBadge, UpgradeDialog } from '@/components/template-updates'
+import { ProjectTemplateDriftBadge } from '@/components/policy-drift/ProjectTemplateDriftBadge'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/')({
   component: DeploymentTemplatesRoute,
@@ -189,6 +190,18 @@ export function DeploymentTemplatesPage({ projectName: propProjectName }: { proj
                           templateName={template.name}
                           onClick={() => handleOpenUpgrade(template.name)}
                         />
+                        {/*
+                          Policy drift badge — HOL-567 surfaces project-
+                          template drift via GetProjectTemplatePolicyState
+                          rather than a status_summary field (project-scope
+                          templates have no live-status concept). The
+                          per-row component issues its own small query and
+                          renders nothing when drift is false or the RPC is
+                          pending/errored, so list rendering stays fast for
+                          in-sync templates. PolicyState is sourced from
+                          the folder-namespace render-state store.
+                        */}
+                        <ProjectTemplateDriftBadge scope={scope} templateName={template.name} />
                       </div>
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION
## Summary
- New shared `PolicySection` component + `PolicyDriftBadge` under `frontend/src/components/policy-drift/` render the TemplatePolicy drift snapshot (applied set, current set, added/removed refs, in-sync indicator) and expose a caller-supplied Reconcile action slot. Component comment documents the HOL-554 storage-isolation guarantee: `PolicyState` is sourced exclusively from `GetDeploymentPolicyState` / `GetProjectTemplatePolicyState`, both of which read state from the folder namespace.
- Deployment list row shows the Policy Drift badge with a tooltip when `status_summary.policy_drift=true`; Deployment detail (Status tab) gains a Policy section + Reconcile button that calls `UpdateDeployment` with every existing field preserved (image/tag/port/command/args/env). Gated on `PERMISSION_DEPLOYMENTS_WRITE`; viewers see the badge but no button.
- Project-template list row shows the badge via a small per-row `ProjectTemplateDriftBadge` that issues `GetProjectTemplatePolicyState` (project-scope templates have no `StatusSummary`, per the HOL-567 scope decision). Template detail gains the same Policy section + Reconcile button that calls `UpdateTemplate` with `updateLinkedTemplates: true` so the linked set is preserved. Gated on `PERMISSION_TEMPLATES_WRITE` at project scope.
- New query hooks: `useGetDeploymentPolicyState` (deployments) and `useGetProjectTemplatePolicyState` (templates; disabled when scope is not `TEMPLATE_SCOPE_PROJECT`, so the backend's `InvalidArgument` check is never triggered from the UI).
- Vitest + React Testing Library coverage (37 new tests) for the shared component, both list views (drift true/false/undefined + viewer read-only), and both detail views (role gating, mutation payload, success/error toasts, pending-disabled). All RPCs mocked via `vi.mock`.

Fixes HOL-559

## Test plan
- [x] `make test` passes (Go 17 packages cached-green; Vitest 1016 tests, 37 new).
- [x] Frontend lint: no new warnings introduced (pre-existing `react-hooks/exhaustive-deps` on `$deploymentName.tsx:183` untouched).
- [x] Read path: drift state is fetched exclusively via the two policy-state RPCs; no project-namespace reads.
- [x] Viewer-gating: badge visible in all four surfaces; Reconcile button hidden for `Role.VIEWER` on both detail pages.
- [x] Reconcile mutation preserves every existing field on both Deployment (image/tag/port/command/args/env) and Template (displayName/description/cueTemplate/enabled/linkedTemplates with `updateLinkedTemplates: true`).
- [ ] CI test + lint + e2e checks.

Local E2E was not run (no k3d cluster available in this worktree). Relying on the CI `test-e2e` check. The UI logic is mocked-hook-driven at the unit-test layer, and the round-trip (drift=true on a stale render, drift=false after Reconcile) is covered by the Phase 3 backend tests already landed via HOL-569/570/571.

Generated with [Claude Code](https://claude.com/claude-code)