### PR TITLE
feat(console): add link annotation parser (HOL-573)

### DIFF
--- a/console/links/parser.go
+++ b/console/links/parser.go
@@ -1,0 +1,196 @@
+// Package links parses external-link annotations off a Kubernetes resource
+// (or, more generally, any annotation map) into normalised
+// *consolev1.Link proto messages.
+//
+// The package is deliberately pure-Go and framework-agnostic: it accepts a
+// `map[string]string` and returns proto structs. That shape lets the
+// aggregator (HOL-574) call the parser uniformly whether the annotations
+// come from a `*unstructured.Unstructured`, a `*corev1.ConfigMap`, or the
+// cached JSON blob maintained on the deployment ConfigMap itself.
+//
+// Two annotation families are recognised, mirroring the parent plan
+// HOL-550:
+//
+//   - `console.holos.run/external-link.<name>` — JSON body
+//     {url, title, description}. Source = "holos". Name = <name>.
+//   - `console.holos.run/primary-url` — JSON body {url, title, description}.
+//     Returned as the `primary` result, not inside `links`. Source =
+//     "holos". Name = "primary".
+//   - `link.argocd.argoproj.io/<suffix>` — bare URL value. Source =
+//     "argocd". Name = <suffix>. Title defaults to <suffix>.
+//
+// Malformed JSON, empty URLs, and URLs whose scheme is not http or https
+// are skipped with a warning — the request that gathered these annotations
+// must not fail just because one resource authored a bad link.
+package links
+
+import (
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"strings"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+const (
+	// sourceHolos tags links discovered through
+	// `console.holos.run/external-link.*` (and the companion primary-url
+	// annotation).
+	sourceHolos = "holos"
+	// sourceArgoCD tags links discovered through
+	// `link.argocd.argoproj.io/*`.
+	sourceArgoCD = "argocd"
+	// primaryName is the synthetic `Link.name` assigned to the primary-url
+	// annotation. The primary annotation has no suffix, but surfacing a
+	// stable non-empty name keeps downstream de-duplication (by name plus
+	// source) straightforward.
+	primaryName = "primary"
+)
+
+// linkValue is the JSON shape of a `console.holos.run/external-link.<name>`
+// annotation value (and of the primary-url annotation). Kept unexported
+// because callers interact with *consolev1.Link, not this intermediate
+// representation.
+type linkValue struct {
+	URL         string `json:"url"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// ParseAnnotations walks an annotation map and returns the external links
+// surfaced for the corresponding Kubernetes resource plus, when the
+// `console.holos.run/primary-url` annotation is present and valid, the
+// primary link. `links` is sorted deterministically by (name, source) so
+// callers can rely on a stable ordering without re-sorting.
+//
+// Malformed entries (non-JSON where JSON is required, empty URLs, or URLs
+// using a scheme other than http/https) are dropped with a warning; they
+// never abort the overall parse. This matches the parent plan's
+// "best-effort aggregation" contract: a single badly authored annotation
+// cannot break the deployment detail RPC.
+func ParseAnnotations(ann map[string]string) (links []*consolev1.Link, primary *consolev1.Link) {
+	if len(ann) == 0 {
+		return nil, nil
+	}
+
+	for key, value := range ann {
+		switch {
+		case key == v1alpha2.AnnotationPrimaryURL:
+			if parsed := parseHolosJSON(key, primaryName, value); parsed != nil {
+				primary = parsed
+			}
+		case strings.HasPrefix(key, v1alpha2.AnnotationExternalLinkPrefix):
+			name := strings.TrimPrefix(key, v1alpha2.AnnotationExternalLinkPrefix)
+			if name == "" {
+				// `console.holos.run/external-link.` with no suffix
+				// is ambiguous — drop it rather than guess an
+				// identity for the link.
+				slog.Warn("skipping holos external-link annotation with empty suffix",
+					slog.String("annotation", key))
+				continue
+			}
+			if parsed := parseHolosJSON(key, name, value); parsed != nil {
+				links = append(links, parsed)
+			}
+		case strings.HasPrefix(key, v1alpha2.AnnotationArgoCDLinkPrefix):
+			name := strings.TrimPrefix(key, v1alpha2.AnnotationArgoCDLinkPrefix)
+			if name == "" {
+				// `link.argocd.argoproj.io/` with no suffix is
+				// likewise ambiguous.
+				slog.Warn("skipping argocd link annotation with empty suffix",
+					slog.String("annotation", key))
+				continue
+			}
+			if parsed := parseArgoCDBareURL(key, name, value); parsed != nil {
+				links = append(links, parsed)
+			}
+		}
+	}
+
+	sort.Slice(links, func(i, j int) bool {
+		if links[i].GetName() != links[j].GetName() {
+			return links[i].GetName() < links[j].GetName()
+		}
+		return links[i].GetSource() < links[j].GetSource()
+	})
+
+	return links, primary
+}
+
+// parseHolosJSON decodes a holos-authored annotation value (JSON-encoded
+// linkValue) into a *consolev1.Link. Returns nil when the value is
+// malformed, the url is empty, or the url scheme is not http/https — each
+// failure mode is logged so operators can trace misauthored annotations.
+func parseHolosJSON(annotationKey, name, value string) *consolev1.Link {
+	var v linkValue
+	if err := json.Unmarshal([]byte(value), &v); err != nil {
+		slog.Warn("skipping holos link annotation with malformed JSON",
+			slog.String("annotation", annotationKey),
+			slog.String("error", err.Error()))
+		return nil
+	}
+	if v.URL == "" {
+		slog.Warn("skipping holos link annotation with empty url",
+			slog.String("annotation", annotationKey))
+		return nil
+	}
+	if !isHTTPScheme(v.URL) {
+		slog.Warn("skipping holos link annotation with non-http scheme",
+			slog.String("annotation", annotationKey),
+			slog.String("url", v.URL))
+		return nil
+	}
+	title := v.Title
+	if title == "" {
+		// Fall back to the annotation suffix so the UI always has
+		// something to render. Documented contract on Link.title in
+		// proto/holos/console/v1/deployments.proto (HOL-572).
+		title = name
+	}
+	return &consolev1.Link{
+		Url:         v.URL,
+		Title:       title,
+		Description: v.Description,
+		Source:      sourceHolos,
+		Name:        name,
+	}
+}
+
+// parseArgoCDBareURL turns an `link.argocd.argoproj.io/<suffix>: <url>`
+// annotation into a *consolev1.Link. ArgoCD's convention stores the URL
+// directly in the annotation value (no JSON envelope), so the suffix is
+// the only source of human-readable naming available; it doubles as the
+// link's `name` and fallback `title`.
+func parseArgoCDBareURL(annotationKey, name, value string) *consolev1.Link {
+	url := strings.TrimSpace(value)
+	if url == "" {
+		slog.Warn("skipping argocd link annotation with empty url",
+			slog.String("annotation", annotationKey))
+		return nil
+	}
+	if !isHTTPScheme(url) {
+		slog.Warn("skipping argocd link annotation with non-http scheme",
+			slog.String("annotation", annotationKey),
+			slog.String("url", url))
+		return nil
+	}
+	return &consolev1.Link{
+		Url:         url,
+		Title:       name,
+		Description: "",
+		Source:      sourceArgoCD,
+		Name:        name,
+	}
+}
+
+// isHTTPScheme reports whether rawURL looks like an http:// or https:// URL.
+// A plain prefix check is sufficient for our validation budget here:
+// ParseAnnotations is a gatekeeper against obviously hostile schemes
+// (javascript:, file:, data:) from leaking into the UI, not a URL parser.
+// Callers further downstream (the frontend anchor renderer) are expected
+// to treat the value as untrusted and may apply their own sanitisation.
+func isHTTPScheme(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "https://") || strings.HasPrefix(rawURL, "http://")
+}

--- a/console/links/parser_test.go
+++ b/console/links/parser_test.go
@@ -1,0 +1,345 @@
+package links
+
+import (
+	"strings"
+	"testing"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// TestParseAnnotations exercises the full acceptance criteria for HOL-573:
+// the parser must accept a raw annotation map, drop values that cannot be
+// interpreted as Link proto messages, normalise source labels, sort the
+// surviving entries deterministically, and separate the primary link from
+// the rest of the collection. Table-driven coverage mirrors the ticket's
+// AC bullets so regressions surface as a named subtest rather than a
+// generic expectation failure.
+func TestParseAnnotations(t *testing.T) {
+	t.Parallel()
+
+	type wantLink struct {
+		url         string
+		title       string
+		description string
+		source      string
+		name        string
+	}
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantLinks   []wantLink
+		wantPrimary *wantLink
+	}{
+		{
+			name:        "nil map returns empty slice and nil primary",
+			annotations: nil,
+			wantLinks:   nil,
+		},
+		{
+			name:        "empty map returns empty slice and nil primary",
+			annotations: map[string]string{},
+			wantLinks:   nil,
+		},
+		{
+			name: "unrelated annotations are ignored",
+			annotations: map[string]string{
+				"example.com/something": "value",
+				"app":                   "my-app",
+			},
+			wantLinks: nil,
+		},
+		{
+			name: "single holos link",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com","title":"Logs","description":"App logs"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "https://logs.example.com", title: "Logs", description: "App logs", source: "holos", name: "logs"},
+			},
+		},
+		{
+			name: "multiple holos links sorted deterministically by name",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix + "zeta":  `{"url":"https://zeta.example.com","title":"Zeta"}`,
+				v1alpha2.AnnotationExternalLinkPrefix + "alpha": `{"url":"https://alpha.example.com","title":"Alpha"}`,
+				v1alpha2.AnnotationExternalLinkPrefix + "mid":   `{"url":"https://mid.example.com","title":"Mid"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "https://alpha.example.com", title: "Alpha", source: "holos", name: "alpha"},
+				{url: "https://mid.example.com", title: "Mid", source: "holos", name: "mid"},
+				{url: "https://zeta.example.com", title: "Zeta", source: "holos", name: "zeta"},
+			},
+		},
+		{
+			name: "argocd bare url picks up suffix as title",
+			annotations: map[string]string{
+				v1alpha2.AnnotationArgoCDLinkPrefix + "grafana": "https://grafana.example.com",
+			},
+			wantLinks: []wantLink{
+				{url: "https://grafana.example.com", title: "grafana", source: "argocd", name: "grafana"},
+			},
+		},
+		{
+			name: "mixed holos and argocd links both surface, sorted by name then source",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix + "logs":  `{"url":"https://logs.example.com","title":"Logs"}`,
+				v1alpha2.AnnotationArgoCDLinkPrefix + "grafana": "https://grafana.example.com",
+				v1alpha2.AnnotationArgoCDLinkPrefix + "logs":    "https://argo-logs.example.com",
+			},
+			wantLinks: []wantLink{
+				// name=grafana (argocd only)
+				{url: "https://grafana.example.com", title: "grafana", source: "argocd", name: "grafana"},
+				// name=logs, two sources, argocd sorts before holos
+				{url: "https://argo-logs.example.com", title: "logs", source: "argocd", name: "logs"},
+				{url: "https://logs.example.com", title: "Logs", source: "holos", name: "logs"},
+			},
+		},
+		{
+			name: "primary url annotation returned as primary, not in links",
+			annotations: map[string]string{
+				v1alpha2.AnnotationPrimaryURL:                  `{"url":"https://app.example.com","title":"App","description":"Main entrypoint"}`,
+				v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com","title":"Logs"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "https://logs.example.com", title: "Logs", source: "holos", name: "logs"},
+			},
+			wantPrimary: &wantLink{
+				url:         "https://app.example.com",
+				title:       "App",
+				description: "Main entrypoint",
+				source:      "holos",
+				name:        "primary",
+			},
+		},
+		{
+			name: "malformed holos JSON is skipped without aborting the others",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix + "broken": `{not json`,
+				v1alpha2.AnnotationExternalLinkPrefix + "ok":     `{"url":"https://ok.example.com","title":"OK"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "https://ok.example.com", title: "OK", source: "holos", name: "ok"},
+			},
+		},
+		{
+			name: "malformed primary JSON is skipped, links still parse",
+			annotations: map[string]string{
+				v1alpha2.AnnotationPrimaryURL:                  `not-json`,
+				v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com","title":"Logs"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "https://logs.example.com", title: "Logs", source: "holos", name: "logs"},
+			},
+		},
+		{
+			name: "holos link with empty url is skipped",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix + "empty": `{"url":"","title":"Empty"}`,
+				v1alpha2.AnnotationExternalLinkPrefix + "ok":    `{"url":"https://ok.example.com","title":"OK"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "https://ok.example.com", title: "OK", source: "holos", name: "ok"},
+			},
+		},
+		{
+			name: "argocd link with empty value is skipped",
+			annotations: map[string]string{
+				v1alpha2.AnnotationArgoCDLinkPrefix + "blank": "",
+				v1alpha2.AnnotationArgoCDLinkPrefix + "ok":    "https://ok.example.com",
+			},
+			wantLinks: []wantLink{
+				{url: "https://ok.example.com", title: "ok", source: "argocd", name: "ok"},
+			},
+		},
+		{
+			name: "holos link with non-http scheme is skipped",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix + "ftp":  `{"url":"ftp://example.com","title":"FTP"}`,
+				v1alpha2.AnnotationExternalLinkPrefix + "file": `{"url":"file:///etc/passwd","title":"File"}`,
+				v1alpha2.AnnotationExternalLinkPrefix + "ok":   `{"url":"https://ok.example.com","title":"OK"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "https://ok.example.com", title: "OK", source: "holos", name: "ok"},
+			},
+		},
+		{
+			name: "argocd link with non-http scheme is skipped",
+			annotations: map[string]string{
+				v1alpha2.AnnotationArgoCDLinkPrefix + "ftp": "ftp://example.com",
+				v1alpha2.AnnotationArgoCDLinkPrefix + "ok":  "http://ok.example.com",
+			},
+			wantLinks: []wantLink{
+				{url: "http://ok.example.com", title: "ok", source: "argocd", name: "ok"},
+			},
+		},
+		{
+			name: "primary with non-http scheme is skipped",
+			annotations: map[string]string{
+				v1alpha2.AnnotationPrimaryURL: `{"url":"javascript:alert(1)","title":"bad"}`,
+			},
+			wantLinks: nil,
+		},
+		{
+			name: "primary with empty url is skipped",
+			annotations: map[string]string{
+				v1alpha2.AnnotationPrimaryURL: `{"url":"","title":"bad"}`,
+			},
+			wantLinks: nil,
+		},
+		{
+			name: "holos prefix with empty suffix is ignored",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix: `{"url":"https://example.com"}`,
+			},
+			wantLinks: nil,
+		},
+		{
+			name: "argocd prefix with empty suffix is ignored",
+			annotations: map[string]string{
+				v1alpha2.AnnotationArgoCDLinkPrefix: "https://example.com",
+			},
+			wantLinks: nil,
+		},
+		{
+			name: "http scheme is accepted",
+			annotations: map[string]string{
+				v1alpha2.AnnotationExternalLinkPrefix + "plain": `{"url":"http://plain.example.com","title":"Plain"}`,
+			},
+			wantLinks: []wantLink{
+				{url: "http://plain.example.com", title: "Plain", source: "holos", name: "plain"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotLinks, gotPrimary := ParseAnnotations(tt.annotations)
+
+			if got, want := len(gotLinks), len(tt.wantLinks); got != want {
+				t.Fatalf("links count: got %d, want %d (got %+v)", got, want, linksToString(gotLinks))
+			}
+			for i, want := range tt.wantLinks {
+				got := gotLinks[i]
+				if got.GetUrl() != want.url {
+					t.Errorf("links[%d].url: got %q, want %q", i, got.GetUrl(), want.url)
+				}
+				if got.GetTitle() != want.title {
+					t.Errorf("links[%d].title: got %q, want %q", i, got.GetTitle(), want.title)
+				}
+				if got.GetDescription() != want.description {
+					t.Errorf("links[%d].description: got %q, want %q", i, got.GetDescription(), want.description)
+				}
+				if got.GetSource() != want.source {
+					t.Errorf("links[%d].source: got %q, want %q", i, got.GetSource(), want.source)
+				}
+				if got.GetName() != want.name {
+					t.Errorf("links[%d].name: got %q, want %q", i, got.GetName(), want.name)
+				}
+			}
+
+			if tt.wantPrimary == nil {
+				if gotPrimary != nil {
+					t.Errorf("primary: got %+v, want nil", gotPrimary)
+				}
+				return
+			}
+			if gotPrimary == nil {
+				t.Fatalf("primary: got nil, want %+v", tt.wantPrimary)
+			}
+			if gotPrimary.GetUrl() != tt.wantPrimary.url {
+				t.Errorf("primary.url: got %q, want %q", gotPrimary.GetUrl(), tt.wantPrimary.url)
+			}
+			if gotPrimary.GetTitle() != tt.wantPrimary.title {
+				t.Errorf("primary.title: got %q, want %q", gotPrimary.GetTitle(), tt.wantPrimary.title)
+			}
+			if gotPrimary.GetDescription() != tt.wantPrimary.description {
+				t.Errorf("primary.description: got %q, want %q", gotPrimary.GetDescription(), tt.wantPrimary.description)
+			}
+			if gotPrimary.GetSource() != tt.wantPrimary.source {
+				t.Errorf("primary.source: got %q, want %q", gotPrimary.GetSource(), tt.wantPrimary.source)
+			}
+			if gotPrimary.GetName() != tt.wantPrimary.name {
+				t.Errorf("primary.name: got %q, want %q", gotPrimary.GetName(), tt.wantPrimary.name)
+			}
+		})
+	}
+}
+
+// TestParseAnnotations_LargeValueDoesNotPanic guards against callers handing
+// the parser a pathologically large annotation value (for example, a
+// misconfigured template stuffing a megabyte of JSON into a single link
+// entry). The parser is expected to drop unparseable input and keep going,
+// not panic and take the RPC handler with it.
+func TestParseAnnotations_LargeValueDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// 1 MiB of filler; far larger than any realistic annotation but well
+	// within a process's reachable heap. We intentionally exceed the
+	// default Kubernetes 256 KiB annotation cap because the parser is a
+	// pure Go function with no such cap of its own — if a caller manages
+	// to feed it something huge, we want graceful degradation, not a
+	// crash.
+	huge := strings.Repeat("x", 1<<20)
+
+	annotations := map[string]string{
+		v1alpha2.AnnotationExternalLinkPrefix + "huge": huge,
+		v1alpha2.AnnotationExternalLinkPrefix + "ok":   `{"url":"https://ok.example.com","title":"OK"}`,
+		v1alpha2.AnnotationPrimaryURL:                  huge,
+	}
+
+	links, primary := ParseAnnotations(annotations)
+
+	if len(links) != 1 {
+		t.Fatalf("links count: got %d, want 1", len(links))
+	}
+	if links[0].GetName() != "ok" {
+		t.Errorf("links[0].name: got %q, want %q", links[0].GetName(), "ok")
+	}
+	if primary != nil {
+		t.Errorf("primary: got %+v, want nil (huge value must not parse as JSON)", primary)
+	}
+}
+
+// TestParseAnnotations_HolosFallbackTitle verifies that a holos link whose
+// JSON body omits `title` falls back to the annotation suffix — matching
+// the contract of `Link.title` in the proto (see HOL-572), which documents
+// the suffix as the fallback when the authoring annotation omitted a
+// title.
+func TestParseAnnotations_HolosFallbackTitle(t *testing.T) {
+	t.Parallel()
+
+	annotations := map[string]string{
+		v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com"}`,
+	}
+	links, _ := ParseAnnotations(annotations)
+	if len(links) != 1 {
+		t.Fatalf("links count: got %d, want 1", len(links))
+	}
+	if got, want := links[0].GetTitle(), "logs"; got != want {
+		t.Errorf("title fallback: got %q, want %q", got, want)
+	}
+}
+
+// linksToString renders a slice of links in a stable, compact form so a
+// failing subtest can show the full slice without drowning the reader in
+// proto Stringer output.
+func linksToString(links []*consolev1.Link) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, l := range links {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(l.GetName())
+		b.WriteString("/")
+		b.WriteString(l.GetSource())
+		b.WriteString("=")
+		b.WriteString(l.GetUrl())
+	}
+	b.WriteString("]")
+	return b.String()
+}


### PR DESCRIPTION
## Summary

- Add `console/links`, a pure-Go package that turns a raw
  `map[string]string` of Kubernetes annotations into normalised
  `*consolev1.Link` proto messages.
- Recognise all three annotation families established in HOL-572:
  `console.holos.run/external-link.<name>` (JSON body, `source = "holos"`),
  `console.holos.run/primary-url` (JSON body, returned as the out-of-band
  `primary`), and `link.argocd.argoproj.io/<suffix>` (bare URL,
  `source = "argocd"`).
- Drop malformed JSON, empty URLs, and non-http(s) schemes with
  `slog.Warn`; one bad annotation cannot abort the whole parse (parent
  plan HOL-550 best-effort contract).
- Fall back to the annotation suffix for an empty `title` on holos
  links, matching the `Link.title` contract documented in
  `deployments.proto`.
- Sort survivors by `(name, source)` so downstream callers (HOL-574)
  get a deterministic ordering without re-sorting.
- Table-driven tests cover every AC row from the ticket, including a
  1 MiB value no-panic guard and the title-fallback behaviour.

Fixes HOL-573

## Test plan

- [x] `go vet ./console/links/...` is clean.
- [x] `golangci-lint run ./console/links/...` reports 0 issues.
- [x] `CGO_ENABLED=1 go test -race ./console/links/...` passes
      (1.015s, covers all AC subtests).
- [x] `CGO_ENABLED=1 go test -race ./...` passes — the full module
      still builds and tests green.

Local E2E was not run: the change is an isolated new Go package with
no UI hooks, existing RPC handler changes, or new routes — the E2E
decision table in `/implement-sub-issue` step 12a classifies this as
not-E2E-relevant. Relying on CI for any cross-cutting smoke coverage.

Generated with [Claude Code](https://claude.com/claude-code)