### PR TITLE
docs(proto): clarify enabled flag and REQUIRE rule comments

### DIFF
--- a/frontend/src/gen/holos/console/v1/template_policies_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/template_policies_pb.d.ts
@@ -377,16 +377,22 @@ export enum TemplatePolicyKind {
   UNSPECIFIED = 0,
 
   /**
-   * TEMPLATE_POLICY_KIND_REQUIRE forces the referenced template onto every
-   * project matched by the rule's target.
+   * TEMPLATE_POLICY_KIND_REQUIRE causes the referenced template to be
+   * injected into the effective ref set when a deployment or project template
+   * matching the target is rendered. It does not itself create, apply, or
+   * delete any cluster resources — resources appear only as the output of the
+   * user's deployment or project-template render.
    *
    * @generated from enum value: TEMPLATE_POLICY_KIND_REQUIRE = 1;
    */
   REQUIRE = 1,
 
   /**
-   * TEMPLATE_POLICY_KIND_EXCLUDE blocks the referenced template from matching
-   * projects even when they explicitly link it.
+   * TEMPLATE_POLICY_KIND_EXCLUDE causes the referenced template to be
+   * removed from the effective ref set when a deployment or project template
+   * matching the target is rendered, even if it would otherwise be linked.
+   * Like REQUIRE, it does not itself create, apply, or delete any cluster
+   * resources — it only filters the render-time unification set.
    *
    * @generated from enum value: TEMPLATE_POLICY_KIND_EXCLUDE = 2;
    */

--- a/frontend/src/gen/holos/console/v1/templates_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/templates_pb.d.ts
@@ -198,9 +198,11 @@ export declare type Template = Message<"holos.console.v1.Template"> & {
   linkedTemplates: LinkedTemplateRef[];
 
   /**
-   * enabled indicates whether this template is active. Disabled templates are
-   * not applied to projects by any TemplatePolicy REQUIRE rule and are
-   * filtered out of render-time unification.
+   * enabled controls whether this template is eligible to appear in selection
+   * lists and to participate in render-time unification. Disabled templates
+   * are filtered out of linkable-template pickers and out of the effective
+   * unification set computed when rendering a downstream template or
+   * deployment. The flag never causes resources to be created on its own.
    *
    * @generated from field: bool enabled = 9;
    */

--- a/gen/holos/console/v1/template_policies.pb.go
+++ b/gen/holos/console/v1/template_policies.pb.go
@@ -27,11 +27,17 @@ type TemplatePolicyKind int32
 
 const (
 	TemplatePolicyKind_TEMPLATE_POLICY_KIND_UNSPECIFIED TemplatePolicyKind = 0
-	// TEMPLATE_POLICY_KIND_REQUIRE forces the referenced template onto every
-	// project matched by the rule's target.
+	// TEMPLATE_POLICY_KIND_REQUIRE causes the referenced template to be
+	// injected into the effective ref set when a deployment or project template
+	// matching the target is rendered. It does not itself create, apply, or
+	// delete any cluster resources — resources appear only as the output of the
+	// user's deployment or project-template render.
 	TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE TemplatePolicyKind = 1
-	// TEMPLATE_POLICY_KIND_EXCLUDE blocks the referenced template from matching
-	// projects even when they explicitly link it.
+	// TEMPLATE_POLICY_KIND_EXCLUDE causes the referenced template to be
+	// removed from the effective ref set when a deployment or project template
+	// matching the target is rendered, even if it would otherwise be linked.
+	// Like REQUIRE, it does not itself create, apply, or delete any cluster
+	// resources — it only filters the render-time unification set.
 	TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE TemplatePolicyKind = 2
 )
 

--- a/gen/holos/console/v1/templates.pb.go
+++ b/gen/holos/console/v1/templates.pb.go
@@ -262,9 +262,11 @@ type Template struct {
 	// Ancestor templates forced onto a project by a TemplatePolicy REQUIRE rule
 	// always unify regardless of this list.
 	LinkedTemplates []*LinkedTemplateRef `protobuf:"bytes,7,rep,name=linked_templates,json=linkedTemplates,proto3" json:"linked_templates,omitempty"`
-	// enabled indicates whether this template is active. Disabled templates are
-	// not applied to projects by any TemplatePolicy REQUIRE rule and are
-	// filtered out of render-time unification.
+	// enabled controls whether this template is eligible to appear in selection
+	// lists and to participate in render-time unification. Disabled templates
+	// are filtered out of linkable-template pickers and out of the effective
+	// unification set computed when rendering a downstream template or
+	// deployment. The flag never causes resources to be created on its own.
 	Enabled bool `protobuf:"varint,9,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	// version is the current semver version string (e.g. "1.2.3") of this
 	// template. Empty means the template has no published version yet.

--- a/proto/holos/console/v1/template_policies.proto
+++ b/proto/holos/console/v1/template_policies.proto
@@ -53,11 +53,17 @@ service TemplatePolicyService {
 // TemplatePolicyKind discriminates between REQUIRE and EXCLUDE rules.
 enum TemplatePolicyKind {
   TEMPLATE_POLICY_KIND_UNSPECIFIED = 0;
-  // TEMPLATE_POLICY_KIND_REQUIRE forces the referenced template onto every
-  // project matched by the rule's target.
+  // TEMPLATE_POLICY_KIND_REQUIRE causes the referenced template to be
+  // injected into the effective ref set when a deployment or project template
+  // matching the target is rendered. It does not itself create, apply, or
+  // delete any cluster resources — resources appear only as the output of the
+  // user's deployment or project-template render.
   TEMPLATE_POLICY_KIND_REQUIRE = 1;
-  // TEMPLATE_POLICY_KIND_EXCLUDE blocks the referenced template from matching
-  // projects even when they explicitly link it.
+  // TEMPLATE_POLICY_KIND_EXCLUDE causes the referenced template to be
+  // removed from the effective ref set when a deployment or project template
+  // matching the target is rendered, even if it would otherwise be linked.
+  // Like REQUIRE, it does not itself create, apply, or delete any cluster
+  // resources — it only filters the render-time unification set.
   TEMPLATE_POLICY_KIND_EXCLUDE = 2;
 }
 

--- a/proto/holos/console/v1/templates.proto
+++ b/proto/holos/console/v1/templates.proto
@@ -168,9 +168,11 @@ message Template {
   reserved 8;
   reserved "mandatory";
 
-  // enabled indicates whether this template is active. Disabled templates are
-  // not applied to projects by any TemplatePolicy REQUIRE rule and are
-  // filtered out of render-time unification.
+  // enabled controls whether this template is eligible to appear in selection
+  // lists and to participate in render-time unification. Disabled templates
+  // are filtered out of linkable-template pickers and out of the effective
+  // unification set computed when rendering a downstream template or
+  // deployment. The flag never causes resources to be created on its own.
   bool enabled = 9;
   // version is the current semver version string (e.g. "1.2.3") of this
   // template. Empty means the template has no published version yet.


### PR DESCRIPTION
## Summary

- Rewrites the `Template.enabled` comment in `proto/holos/console/v1/templates.proto` to describe eligibility only — disabled templates are filtered out of linkable-template pickers and out of the render-time unification set, and the flag never causes resources to be created on its own.
- Rewrites the `TEMPLATE_POLICY_KIND_REQUIRE` comment in `proto/holos/console/v1/template_policies.proto` to describe render-time inclusion in the effective ref set, and explicitly states the rule never creates, applies, or deletes cluster resources. Also rewords `TEMPLATE_POLICY_KIND_EXCLUDE` to match the new phrasing (render-time filter, not an apply-time action).
- Regenerated Go (`gen/holos/console/v1/*.pb.go`) and TypeScript (`frontend/src/gen/holos/console/v1/*_pb.d.ts`) bindings via `make generate`.
- No field numbers, message structures, enum values, or RPC signatures change. Phase 1 of HOL-580; no runtime behavior changes.

Companion design note: `holos-garage/Holos Garage v2/Holos/plans/HOL-580-template-policy-enabled-conflation-analysis.md`.

Fixes HOL-581

## Test plan

- [x] `make generate` — bindings regenerated; diff contains only comment-string changes in generated files.
- [x] `make test` — 1023 frontend tests pass; all Go packages pass.
- [x] `git diff` confirms no proto field numbers, message structures, enum values, or RPC signatures were changed.

> Local E2E was not run; this change is comment-only in proto definitions and regenerated doc strings. Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)