### PR TITLE
feat(console): aggregate deployment links and surface via RPC

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -420,6 +420,10 @@ func (s *Server) Serve(ctx context.Context) error {
 		var deploymentsApplier deployments.ResourceApplier
 		if dynamicClient != nil {
 			deploymentsApplier = deployments.NewApplier(dynamicClient)
+			// Wire the same dynamic client onto the K8sClient so the
+			// link aggregator (HOL-574) can scan owned resources
+			// across every kind apply.go writes.
+			deploymentsK8s = deploymentsK8s.WithDynamicClient(dynamicClient)
 		}
 		projectFolderResolver := projects.NewProjectFolderResolver(projectsK8s, nsWalker)
 		ancestorTemplateResolver := templates.NewAncestorTemplateResolver(templatesK8s, nsWalker, policyResolverSeam)

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -339,13 +339,14 @@ func (h *Handler) ListDeployments(
 		dep := configMapToDeployment(cm, project)
 		summary, ok := h.summaryFromCache(ns, cm.Name)
 		if !ok {
-			// Synthesize a minimal summary so the cached output-url annotation
-			// still reaches the client even before the informer has observed
-			// the apps/v1.Deployment (first render, empty cluster, etc.).
+			// Synthesize a minimal summary so cached annotation-driven
+			// metadata (output-url, aggregated links) still reaches the
+			// client even before the informer has observed the
+			// apps/v1.Deployment (first render, empty cluster, etc.).
 			// Phase stays UNSPECIFIED exactly as GetDeploymentStatusSummary
 			// does on a cache miss so listing and single-row polling share
 			// the same derivation path.
-			if cm.Annotations[OutputURLAnnotation] != "" {
+			if cm.Annotations[OutputURLAnnotation] != "" || cm.Annotations[v1alpha2.AnnotationAggregatedLinks] != "" {
 				summary = &consolev1.DeploymentStatusSummary{
 					Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_UNSPECIFIED,
 				}
@@ -353,6 +354,7 @@ func (h *Handler) ListDeployments(
 		}
 		if summary != nil {
 			mergeOutputURLAnnotation(summary, cm)
+			mergeAggregatedLinksAnnotation(summary, cm)
 			dep.StatusSummary = summary
 		}
 		deployments = append(deployments, dep)
@@ -409,17 +411,27 @@ func (h *Handler) GetDeployment(
 
 	deployment := configMapToDeployment(cm, project)
 	ns := h.k8s.Resolver.ProjectNamespace(project)
+	// Refresh the aggregated-links cache by scanning owned resources so
+	// links stamped on workloads after the last apply (e.g. an operator
+	// adding `link.argocd.argoproj.io/*` annotations out-of-band) appear
+	// without waiting for the next render. The refresh is best-effort:
+	// scan/write failures fall back to whatever the cached annotation
+	// already held. Compute fresh values up front so they are available
+	// regardless of whether the status cache fired.
+	freshLinks, freshPrimary := h.refreshAggregatedLinksCache(ctx, project, name, cm)
 	summary, ok := h.summaryFromCache(ns, cm.Name)
-	if !ok && cm.Annotations[OutputURLAnnotation] != "" {
-		// Cache miss, but we have a cached output URL to surface. Mirror
+	if !ok && (cm.Annotations[OutputURLAnnotation] != "" || len(freshLinks) > 0 || freshPrimary != "") {
+		// Cache miss, but we have cached metadata to surface (output URL,
+		// aggregated links, or a freshly promoted primary URL). Mirror
 		// ListDeployments and GetDeploymentStatusSummary by synthesizing
-		// an UNSPECIFIED summary so the frontend still receives the URL.
+		// an UNSPECIFIED summary so the frontend still receives them.
 		summary = &consolev1.DeploymentStatusSummary{
 			Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_UNSPECIFIED,
 		}
 	}
 	if summary != nil {
 		mergeOutputURLAnnotation(summary, cm)
+		applyAggregatedLinks(summary, freshLinks, freshPrimary)
 		deployment.StatusSummary = summary
 	}
 
@@ -586,6 +598,12 @@ func (h *Handler) CreateDeployment(
 				)
 			}
 		}
+		// Aggregate `external-link.*`, `primary-url`, and ArgoCD
+		// `link.*` annotations across owned resources and cache the
+		// merged set on the deployment ConfigMap. Sibling of the
+		// SetOutputURLAnnotation cache; failures are logged and
+		// non-fatal for the same reason.
+		h.stampAggregatedLinks(ctx, project, name)
 	}
 
 	slog.InfoContext(ctx, "deployment created",
@@ -777,6 +795,11 @@ func (h *Handler) UpdateDeployment(
 				slog.Any("error", err),
 			)
 		}
+		// Refresh the aggregated-links cache so a template change that
+		// adds, removes, or renames link annotations on the rendered
+		// resources is reflected on the next read without waiting for
+		// the GetDeployment refresh path.
+		h.stampAggregatedLinks(ctx, project, name)
 	}
 
 	slog.InfoContext(ctx, "deployment updated",
@@ -1202,6 +1225,90 @@ func mergeOutputURLAnnotation(summary *consolev1.DeploymentStatusSummary, cm *co
 		return
 	}
 	summary.Output = &consolev1.DeploymentOutput{Url: url}
+}
+
+// mergeAggregatedLinksAnnotation populates summary.Output.Links and (when
+// promoted) summary.Output.Url from the cached AnnotationAggregatedLinks
+// JSON blob on cm. Sibling of mergeOutputURLAnnotation: the two helpers are
+// invoked in sequence so the legacy `output-url` cache fills the URL when
+// no `primary-url` was promoted, and the link aggregator extends the same
+// Output with `links`. Safe to call after mergeOutputURLAnnotation; it
+// allocates Output lazily when the prior helper did not.
+func mergeAggregatedLinksAnnotation(summary *consolev1.DeploymentStatusSummary, cm *corev1.ConfigMap) {
+	if summary == nil || cm == nil {
+		return
+	}
+	links, primaryURL := deserializeAggregatedLinks(cm)
+	applyAggregatedLinks(summary, links, primaryURL)
+}
+
+// refreshAggregatedLinksCache scans every owned resource for the deployment,
+// re-derives the aggregated link set, and rewrites the cached annotation on
+// the deployment ConfigMap when it disagrees with the fresh scan. This is
+// the GetDeployment-time refresh path that lets resources annotated out-of-
+// band (after the last render) surface without requiring a re-render. It is
+// best-effort: any scan/write failure is logged and the previously cached
+// state is returned unchanged so a transient API error never blocks the
+// read RPC. Returns the (links, primaryURL) the caller should use when
+// populating the wire DeploymentOutput.
+func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name string, cm *corev1.ConfigMap) ([]*consolev1.Link, string) {
+	cachedLinks, cachedPrimary := deserializeAggregatedLinks(cm)
+	resources, err := h.k8s.ListDeploymentResources(ctx, project, name)
+	if err != nil {
+		slog.WarnContext(ctx, "could not list owned resources for link refresh; using cached set",
+			slog.String("project", project),
+			slog.String("name", name),
+			slog.Any("error", err),
+		)
+		return cachedLinks, cachedPrimary
+	}
+	if len(resources) == 0 {
+		// Either no dynamic client or no owned resources yet — keep
+		// the cache as-is rather than racing to clear it (a fresh
+		// deployment whose informer hasn't observed its resources
+		// would otherwise momentarily lose its links).
+		return cachedLinks, cachedPrimary
+	}
+	freshLinks, freshPrimary := aggregateLinksFromResources(ctx, project, name, resources)
+	if linksEqual(cachedLinks, freshLinks) && cachedPrimary == freshPrimary {
+		return cachedLinks, cachedPrimary
+	}
+	payload := serializeAggregatedLinks(ctx, project, name, freshLinks, freshPrimary)
+	if err := h.k8s.SetAggregatedLinksAnnotation(ctx, project, name, payload); err != nil {
+		slog.WarnContext(ctx, "failed to update aggregated links cache after drift",
+			slog.String("project", project),
+			slog.String("name", name),
+			slog.Any("error", err),
+		)
+	}
+	return freshLinks, freshPrimary
+}
+
+// stampAggregatedLinks scans every owned resource for the deployment after
+// a successful Apply/Reconcile, derives the aggregated link set, and writes
+// it to the deployment ConfigMap as `console.holos.run/links`. Mirrors the
+// SetOutputURLAnnotation precedent on the create/update write path: a
+// failure here is logged at warn but does not fail the RPC because the
+// deployment itself was applied successfully.
+func (h *Handler) stampAggregatedLinks(ctx context.Context, project, name string) {
+	resources, err := h.k8s.ListDeploymentResources(ctx, project, name)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to list owned resources for aggregated links cache",
+			slog.String("project", project),
+			slog.String("name", name),
+			slog.Any("error", err),
+		)
+		return
+	}
+	aggregated, primaryURL := aggregateLinksFromResources(ctx, project, name, resources)
+	payload := serializeAggregatedLinks(ctx, project, name, aggregated, primaryURL)
+	if err := h.k8s.SetAggregatedLinksAnnotation(ctx, project, name, payload); err != nil {
+		slog.WarnContext(ctx, "failed to set aggregated links annotation after apply",
+			slog.String("project", project),
+			slog.String("name", name),
+			slog.Any("error", err),
+		)
+	}
 }
 
 // checkProjectAccess verifies that the user has the given permission via project cascade grants.

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -1251,8 +1251,21 @@ func mergeAggregatedLinksAnnotation(summary *consolev1.DeploymentStatusSummary, 
 // state is returned unchanged so a transient API error never blocks the
 // read RPC. Returns the (links, primaryURL) the caller should use when
 // populating the wire DeploymentOutput.
+//
+// When the K8sClient has no dynamic client configured (local/dev wiring),
+// the cache is treated as authoritative: there is no way to scan, so a
+// preserve-cache policy avoids wiping legitimate cached metadata simply
+// because the cluster is unreachable. When a dynamic client IS configured
+// and the scan returns zero resources, that is a meaningful "no links"
+// signal — the aggregator clears any stale cached entries so deletions
+// or annotation removals propagate without requiring a re-render.
 func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name string, cm *corev1.ConfigMap) ([]*consolev1.Link, string) {
 	cachedLinks, cachedPrimary := deserializeAggregatedLinks(cm)
+	if !h.k8s.HasDynamicClient() {
+		// No way to scan; keep serving the cache so the dev/local
+		// path (no cluster) still surfaces previously-stamped links.
+		return cachedLinks, cachedPrimary
+	}
 	resources, err := h.k8s.ListDeploymentResources(ctx, project, name)
 	if err != nil {
 		slog.WarnContext(ctx, "could not list owned resources for link refresh; using cached set",
@@ -1262,17 +1275,13 @@ func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name
 		)
 		return cachedLinks, cachedPrimary
 	}
-	if len(resources) == 0 {
-		// Either no dynamic client or no owned resources yet — keep
-		// the cache as-is rather than racing to clear it (a fresh
-		// deployment whose informer hasn't observed its resources
-		// would otherwise momentarily lose its links).
-		return cachedLinks, cachedPrimary
-	}
 	freshLinks, freshPrimary := aggregateLinksFromResources(ctx, project, name, resources)
 	if linksEqual(cachedLinks, freshLinks) && cachedPrimary == freshPrimary {
 		return cachedLinks, cachedPrimary
 	}
+	// Drift detected — empty fresh result clears the annotation; a
+	// non-empty fresh result overwrites it. Either way the cache
+	// converges on what the live cluster actually says.
 	payload := serializeAggregatedLinks(ctx, project, name, freshLinks, freshPrimary)
 	if err := h.k8s.SetAggregatedLinksAnnotation(ctx, project, name, payload); err != nil {
 		slog.WarnContext(ctx, "failed to update aggregated links cache after drift",

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -3,6 +3,7 @@ package deployments
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -11,7 +12,7 @@ import (
 
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
@@ -1259,6 +1260,13 @@ func mergeAggregatedLinksAnnotation(summary *consolev1.DeploymentStatusSummary, 
 // and the scan returns zero resources, that is a meaningful "no links"
 // signal — the aggregator clears any stale cached entries so deletions
 // or annotation removals propagate without requiring a re-render.
+//
+// Partial-scan handling: if `ListDeploymentResources` returns an error
+// wrapping `ErrPartialScan`, at least one per-kind list failed and the
+// returned slice is incomplete. The fresh aggregation is therefore not
+// authoritative — the cache is preserved so a transient API error or a
+// missing optional CRD never silently wipes legitimate cached links
+// (HOL-574 review round 2 P1).
 func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name string, cm *corev1.ConfigMap) ([]*consolev1.Link, string) {
 	cachedLinks, cachedPrimary := deserializeAggregatedLinks(cm)
 	if !h.k8s.HasDynamicClient() {
@@ -1268,7 +1276,16 @@ func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name
 	}
 	resources, err := h.k8s.ListDeploymentResources(ctx, project, name)
 	if err != nil {
-		slog.WarnContext(ctx, "could not list owned resources for link refresh; using cached set",
+		// Partial-scan errors mean some kinds were not observed; the
+		// returned slice is therefore not a faithful view of the
+		// cluster. Preserve the cache rather than wiping it on what
+		// might be a transient or RBAC-shaped failure. Total scan
+		// failures (no slice at all) take the same path.
+		level := slog.LevelWarn
+		if errors.Is(err, ErrPartialScan) {
+			level = slog.LevelDebug
+		}
+		slog.Log(ctx, level, "could not fully list owned resources for link refresh; using cached set",
 			slog.String("project", project),
 			slog.String("name", name),
 			slog.Any("error", err),
@@ -1650,13 +1667,13 @@ func scopeFromLabel(label string) consolev1.TemplateScope {
 
 // mapK8sError converts Kubernetes API errors to ConnectRPC errors.
 func mapK8sError(err error) error {
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		return connect.NewError(connect.CodeNotFound, err)
 	}
-	if errors.IsAlreadyExists(err) {
+	if k8serrors.IsAlreadyExists(err) {
 		return connect.NewError(connect.CodeAlreadyExists, err)
 	}
-	if errors.IsForbidden(err) {
+	if k8serrors.IsForbidden(err) {
 		return connect.NewError(connect.CodePermissionDenied, err)
 	}
 	return connect.NewError(connect.CodeInternal, err)

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 
@@ -1786,6 +1788,343 @@ func TestHandler_OutputURLAnnotation(t *testing.T) {
 		}
 		if resp.Msg.Summary.Output.Url != "https://web-app.example.com" {
 			t.Errorf("output.url: got %q, want %q", resp.Msg.Summary.Output.Url, "https://web-app.example.com")
+		}
+	})
+}
+
+// handlerWithLinks builds a Handler primed with a fake dynamic client so
+// the link aggregator can scan and write the cache annotation. dynObjs is
+// the seed for the dynamic fake; statusEntries seeds the statusCache so
+// summaries are present without needing a live informer.
+func handlerWithLinks(t *testing.T, ns *corev1.Namespace, depCM *corev1.ConfigMap, dynObjs []runtime.Object, statusEntries map[string]*consolev1.DeploymentStatusSummary) (*Handler, *fake.Clientset) {
+	t.Helper()
+	fakeClient := fake.NewClientset(ns, depCM)
+	dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(), dynObjs...)
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+	cache := newFakeStatusCache()
+	for nsName, summary := range statusEntries {
+		cache.set(nsName, depCM.Name, summary)
+	}
+	handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(cache)
+	return handler, fakeClient
+}
+
+// makeOwnedDynamicResource constructs an Unstructured carrying the
+// project+deployment ownership labels and the supplied annotations. Used
+// to seed the fake dynamic client for the aggregator integration tests.
+func makeOwnedDynamicResource(apiVersion, kind, namespace, name, project, deployment string, annotations map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion(apiVersion)
+	u.SetKind(kind)
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetLabels(map[string]string{
+		v1alpha2.LabelProject:         project,
+		v1alpha2.AnnotationDeployment: deployment,
+	})
+	if annotations != nil {
+		u.SetAnnotations(annotations)
+	}
+	return u
+}
+
+// dynamicWithListPanic returns a dynamic.Interface whose List reactor
+// fails the test if invoked. Used to assert ListDeployments stays purely
+// on the cached annotation and never falls through to a per-resource scan.
+func dynamicWithListPanic(t *testing.T) dynamic.Interface {
+	t.Helper()
+	dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme())
+	dyn.PrependReactor("list", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+		t.Errorf("ListDeployments must not list dynamic resources; got %s on %s", action.GetVerb(), action.GetResource().Resource)
+		return true, nil, fmt.Errorf("list not allowed on ListDeployments path")
+	})
+	return dyn
+}
+
+// TestHandler_AggregatedLinks exercises the full HOL-574 contract:
+// ListDeployments and GetDeployment surface links and a promoted primary
+// URL from the cache annotation, GetDeployment refreshes by scanning owned
+// resources when they drift from the cache, and ListDeployments stays
+// purely on the cache (no dynamic List calls on the hot path).
+func TestHandler_AggregatedLinks(t *testing.T) {
+	const project = "my-project"
+	const deployment = "web-app"
+	namespace := "prj-my-project"
+
+	t.Run("ListDeployments: no link annotations leaves output.links nil", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		// Use a dynamic client whose List would panic — proves the list
+		// path does not scan resources.
+		fakeClient := fake.NewClientset(ns, cm)
+		dyn := dynamicWithListPanic(t)
+		k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		cache := newFakeStatusCache()
+		cache.set(namespace, deployment, &consolev1.DeploymentStatusSummary{Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING})
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(cache)
+
+		resp, err := handler.ListDeployments(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.ListDeploymentsRequest{Project: project}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		summary := resp.Msg.Deployments[0].StatusSummary
+		if summary == nil {
+			t.Fatal("expected statusSummary populated from cache")
+		}
+		if summary.Output != nil && len(summary.Output.Links) > 0 {
+			t.Errorf("expected output.links nil, got %+v", summary.Output.Links)
+		}
+	})
+
+	t.Run("ListDeployments: cached aggregated links surface on output.links", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		// Pre-stamp the cache annotation with a single holos link.
+		links := []*consolev1.Link{{Url: "https://logs.example.com", Title: "Logs", Source: "holos", Name: "logs"}}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, links, "")
+		dyn := dynamicWithListPanic(t)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		cache := newFakeStatusCache()
+		cache.set(namespace, deployment, &consolev1.DeploymentStatusSummary{Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING})
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(cache)
+
+		resp, err := handler.ListDeployments(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.ListDeploymentsRequest{Project: project}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		summary := resp.Msg.Deployments[0].StatusSummary
+		if summary == nil || summary.Output == nil {
+			t.Fatal("expected output populated from cache annotation")
+		}
+		if len(summary.Output.Links) != 1 || summary.Output.Links[0].GetUrl() != "https://logs.example.com" {
+			t.Errorf("output.links: got %+v, want one logs link", summary.Output.Links)
+		}
+	})
+
+	t.Run("ListDeployments: cached primary_url promotes into output.url over output-url annotation", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		// Both caches present: the primary-url should win on the wire.
+		cm.Annotations[OutputURLAnnotation] = "https://output-url.example.com"
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, nil, "https://primary.example.com")
+		dyn := dynamicWithListPanic(t)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		cache := newFakeStatusCache()
+		cache.set(namespace, deployment, &consolev1.DeploymentStatusSummary{Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING})
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(cache)
+
+		resp, err := handler.ListDeployments(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.ListDeploymentsRequest{Project: project}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		summary := resp.Msg.Deployments[0].StatusSummary
+		if summary == nil || summary.Output == nil {
+			t.Fatal("expected output populated")
+		}
+		if summary.Output.Url != "https://primary.example.com" {
+			t.Errorf("primary-url should override output-url annotation: got %q", summary.Output.Url)
+		}
+	})
+
+	t.Run("ListDeployments: only cache annotation present synthesizes UNSPECIFIED summary", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		links := []*consolev1.Link{{Url: "https://l.example.com", Name: "l", Source: "holos"}}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, links, "")
+		dyn := dynamicWithListPanic(t)
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		// No status cache entry — verify ListDeployments still synthesizes a summary.
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(newFakeStatusCache())
+
+		resp, err := handler.ListDeployments(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.ListDeploymentsRequest{Project: project}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		summary := resp.Msg.Deployments[0].StatusSummary
+		if summary == nil {
+			t.Fatal("expected synthesized summary on cache miss when annotation is present")
+		}
+		if summary.Output == nil || len(summary.Output.Links) != 1 {
+			t.Errorf("expected output.links populated from cache, got %+v", summary.Output)
+		}
+	})
+
+	t.Run("GetDeployment: link from one resource refreshes cache and surfaces", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		// No cached annotation — fresh scan must populate it.
+		dep := makeOwnedDynamicResource("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com","title":"Logs"}`})
+		handler, fakeClient := handlerWithLinks(t, ns, cm,
+			[]runtime.Object{dep},
+			map[string]*consolev1.DeploymentStatusSummary{namespace: {Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING}})
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		summary := resp.Msg.Deployment.StatusSummary
+		if summary == nil || summary.Output == nil {
+			t.Fatal("expected output populated by fresh scan")
+		}
+		if len(summary.Output.Links) != 1 || summary.Output.Links[0].GetUrl() != "https://logs.example.com" {
+			t.Errorf("expected one logs link, got %+v", summary.Output.Links)
+		}
+		// Verify the cache annotation was written.
+		got, _ := fakeClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
+		if got.Annotations[v1alpha2.AnnotationAggregatedLinks] == "" {
+			t.Error("expected GetDeployment to write the aggregated links cache annotation")
+		}
+	})
+
+	t.Run("GetDeployment: links spread across multiple resources are aggregated", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		dep := makeOwnedDynamicResource("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationExternalLinkPrefix + "zeta": `{"url":"https://zeta.example.com","title":"Zeta"}`})
+		svc := makeOwnedDynamicResource("v1", "Service", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationExternalLinkPrefix + "alpha": `{"url":"https://alpha.example.com","title":"Alpha"}`})
+		handler, _ := handlerWithLinks(t, ns, cm,
+			[]runtime.Object{dep, svc},
+			map[string]*consolev1.DeploymentStatusSummary{namespace: {Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING}})
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		summary := resp.Msg.Deployment.StatusSummary
+		if summary == nil || summary.Output == nil || len(summary.Output.Links) != 2 {
+			t.Fatalf("expected 2 aggregated links, got %+v", summary)
+		}
+		if summary.Output.Links[0].GetName() != "alpha" || summary.Output.Links[1].GetName() != "zeta" {
+			t.Errorf("expected sorted alpha,zeta; got %q,%q", summary.Output.Links[0].GetName(), summary.Output.Links[1].GetName())
+		}
+	})
+
+	t.Run("GetDeployment: primary-url annotation promotes into output.url", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		dep := makeOwnedDynamicResource("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationPrimaryURL: `{"url":"https://app.example.com","title":"App"}`})
+		handler, _ := handlerWithLinks(t, ns, cm,
+			[]runtime.Object{dep},
+			map[string]*consolev1.DeploymentStatusSummary{namespace: {Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING}})
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		summary := resp.Msg.Deployment.StatusSummary
+		if summary == nil || summary.Output == nil {
+			t.Fatal("expected output populated")
+		}
+		if summary.Output.Url != "https://app.example.com" {
+			t.Errorf("expected primary URL promoted: got %q", summary.Output.Url)
+		}
+	})
+
+	t.Run("GetDeployment: primary-url overrides cached output-url annotation", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		cm.Annotations[OutputURLAnnotation] = "https://output-url.example.com"
+		dep := makeOwnedDynamicResource("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationPrimaryURL: `{"url":"https://primary.example.com","title":"Primary"}`})
+		handler, _ := handlerWithLinks(t, ns, cm,
+			[]runtime.Object{dep},
+			map[string]*consolev1.DeploymentStatusSummary{namespace: {Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING}})
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := resp.Msg.Deployment.StatusSummary.Output.Url
+		if got != "https://primary.example.com" {
+			t.Errorf("primary-url should win over output-url; got %q", got)
+		}
+	})
+
+	t.Run("GetDeployment: argocd annotation surfaces with source=argocd", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		dep := makeOwnedDynamicResource("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationArgoCDLinkPrefix + "grafana": "https://grafana.example.com"})
+		handler, _ := handlerWithLinks(t, ns, cm,
+			[]runtime.Object{dep},
+			map[string]*consolev1.DeploymentStatusSummary{namespace: {Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING}})
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		links := resp.Msg.Deployment.StatusSummary.Output.Links
+		if len(links) != 1 || links[0].GetSource() != "argocd" {
+			t.Errorf("expected one argocd-source link, got %+v", links)
+		}
+	})
+
+	t.Run("CreateDeployment stamps aggregated links from owned resources after apply", func(t *testing.T) {
+		ns := projectNS(project)
+		fakeClient := fake.NewClientset(ns)
+		// Pre-seed the dynamic client with a resource carrying the
+		// ownership labels and a holos external-link annotation so the
+		// post-apply scan finds something to cache.
+		dep := makeOwnedDynamicResource("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com","title":"Logs"}`})
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme(), dep)
+		k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{})
+
+		_, err := handler.CreateDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.CreateDeploymentRequest{
+			Project: project, Name: deployment, Image: "nginx", Tag: "1.25", Template: "default",
+		}))
+		if err != nil {
+			t.Fatalf("CreateDeployment failed: %v", err)
+		}
+		got, err := fakeClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("getting created ConfigMap: %v", err)
+		}
+		links, _ := deserializeAggregatedLinks(got)
+		if len(links) != 1 || links[0].GetUrl() != "https://logs.example.com" {
+			t.Errorf("expected logs link in cache, got %+v", links)
+		}
+	})
+
+	t.Run("GetDeployment: drift between cache and live resources rewrites cache", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		// Cache holds an outdated link.
+		stale := []*consolev1.Link{{Url: "https://stale.example.com", Title: "Stale", Source: "holos", Name: "stale"}}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, stale, "")
+		// Live resource carries a different link.
+		dep := makeOwnedDynamicResource("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationExternalLinkPrefix + "fresh": `{"url":"https://fresh.example.com","title":"Fresh"}`})
+		handler, fakeClient := handlerWithLinks(t, ns, cm,
+			[]runtime.Object{dep},
+			map[string]*consolev1.DeploymentStatusSummary{namespace: {Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING}})
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		links := resp.Msg.Deployment.StatusSummary.Output.Links
+		if len(links) != 1 || links[0].GetUrl() != "https://fresh.example.com" {
+			t.Errorf("fresh scan should win: got %+v", links)
+		}
+		// Cache was rewritten with the fresh set.
+		got, _ := fakeClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
+		gotLinks, _ := deserializeAggregatedLinks(got)
+		if len(gotLinks) != 1 || gotLinks[0].GetUrl() != "https://fresh.example.com" {
+			t.Errorf("expected cache rewritten to fresh link, got %+v", gotLinks)
 		}
 	})
 }

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -2128,6 +2128,38 @@ func TestHandler_AggregatedLinks(t *testing.T) {
 		}
 	})
 
+	t.Run("GetDeploymentStatusSummary surfaces cached aggregated links", func(t *testing.T) {
+		// Polling clients use GetDeploymentStatusSummary; the
+		// aggregated-links cache must be merged here too so all three
+		// read paths (list / detail / status-summary) stay observably
+		// consistent (HOL-574 review round 5).
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		links := []*consolev1.Link{{Url: "https://l.example.com", Title: "L", Source: "holos", Name: "l"}}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, links, "https://primary.example.com")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		cache := newFakeStatusCache()
+		cache.set(namespace, deployment, &consolev1.DeploymentStatusSummary{Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING})
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(cache)
+
+		resp, err := handler.GetDeploymentStatusSummary(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentStatusSummaryRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := resp.Msg.Summary.Output
+		if out == nil {
+			t.Fatal("expected output populated from cache")
+		}
+		if len(out.Links) != 1 || out.Links[0].GetUrl() != "https://l.example.com" {
+			t.Errorf("expected aggregated link surfaced, got %+v", out.Links)
+		}
+		if out.Url != "https://primary.example.com" {
+			t.Errorf("expected promoted primary URL, got %q", out.Url)
+		}
+	})
+
 	t.Run("GetDeployment: empty fresh scan clears stale cached links", func(t *testing.T) {
 		ns := projectNS(project)
 		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -2160,6 +2160,42 @@ func TestHandler_AggregatedLinks(t *testing.T) {
 		}
 	})
 
+	t.Run("GetDeployment: partial-scan failure preserves cached links", func(t *testing.T) {
+		// One per-kind list fails (transient API error or RBAC gap)
+		// — ListDeploymentResources signals via ErrPartialScan that
+		// the returned slice is not authoritative. The handler must
+		// preserve the cache rather than wiping it on a partial view.
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		cached := []*consolev1.Link{{Url: "https://cached.example.com", Title: "Cached", Source: "holos", Name: "cached"}}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, cached, "")
+		fakeClient := fake.NewClientset(ns, cm)
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicScheme())
+		// Make every list fail so the scan is fully partial.
+		dyn.PrependReactor("list", "*", func(_ ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("simulated transient failure")
+		})
+		k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		cache := newFakeStatusCache()
+		cache.set(namespace, deployment, &consolev1.DeploymentStatusSummary{Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING})
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(cache)
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		links := resp.Msg.Deployment.StatusSummary.Output.Links
+		if len(links) != 1 || links[0].GetUrl() != "https://cached.example.com" {
+			t.Errorf("expected cached link preserved on partial scan, got %+v", links)
+		}
+		// Cache annotation untouched.
+		got, _ := fakeClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
+		if got.Annotations[v1alpha2.AnnotationAggregatedLinks] == "" {
+			t.Error("expected cache annotation preserved on partial scan failure")
+		}
+	})
+
 	t.Run("GetDeployment: no dynamic client preserves cached links", func(t *testing.T) {
 		// Local/dev wiring: K8sClient has no dynamic. The cache must
 		// be served as-is — there is no way to scan, so wiping the

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -2127,4 +2127,67 @@ func TestHandler_AggregatedLinks(t *testing.T) {
 			t.Errorf("expected cache rewritten to fresh link, got %+v", gotLinks)
 		}
 	})
+
+	t.Run("GetDeployment: empty fresh scan clears stale cached links", func(t *testing.T) {
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		// Cache holds links, but the live cluster has nothing — e.g.
+		// the deployment was scaled to zero or a template change
+		// removed every annotation source. Drift must clear the cache.
+		stale := []*consolev1.Link{{Url: "https://stale.example.com", Title: "Stale", Source: "holos", Name: "stale"}}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, stale, "https://stale-primary.example.com")
+		// No owned resources seeded into the dynamic client.
+		handler, fakeClient := handlerWithLinks(t, ns, cm,
+			nil,
+			map[string]*consolev1.DeploymentStatusSummary{namespace: {Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING}})
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Output should be either nil or have no links/url because the
+		// live scan returned nothing.
+		summary := resp.Msg.Deployment.StatusSummary
+		if summary != nil && summary.Output != nil {
+			if len(summary.Output.Links) != 0 {
+				t.Errorf("expected stale links cleared, got %+v", summary.Output.Links)
+			}
+		}
+		// Cache annotation should be gone.
+		got, _ := fakeClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
+		if val := got.Annotations[v1alpha2.AnnotationAggregatedLinks]; val != "" {
+			t.Errorf("expected cache annotation cleared, got %q", val)
+		}
+	})
+
+	t.Run("GetDeployment: no dynamic client preserves cached links", func(t *testing.T) {
+		// Local/dev wiring: K8sClient has no dynamic. The cache must
+		// be served as-is — there is no way to scan, so wiping the
+		// cache would silently lose data.
+		ns := projectNS(project)
+		cm := deploymentConfigMap(project, deployment, "nginx", "1.25", "default", "Web", "")
+		cached := []*consolev1.Link{{Url: "https://cached.example.com", Title: "Cached", Source: "holos", Name: "cached"}}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = serializeAggregatedLinks(context.Background(), project, deployment, cached, "")
+		fakeClient := fake.NewClientset(ns, cm)
+		// Note: WithDynamicClient is intentionally not called.
+		k8s := NewK8sClient(fakeClient, testResolver())
+		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
+		cache := newFakeStatusCache()
+		cache.set(namespace, deployment, &consolev1.DeploymentStatusSummary{Phase: consolev1.DeploymentPhase_DEPLOYMENT_PHASE_RUNNING})
+		handler := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).WithStatusCache(cache)
+
+		resp, err := handler.GetDeployment(authedCtx("alice@example.com", nil), connect.NewRequest(&consolev1.GetDeploymentRequest{Project: project, Name: deployment}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		links := resp.Msg.Deployment.StatusSummary.Output.Links
+		if len(links) != 1 || links[0].GetUrl() != "https://cached.example.com" {
+			t.Errorf("expected cached link preserved without dynamic client, got %+v", links)
+		}
+		// Cache annotation untouched.
+		got, _ := fakeClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
+		if got.Annotations[v1alpha2.AnnotationAggregatedLinks] == "" {
+			t.Error("expected cache annotation preserved when no dynamic client is configured")
+		}
+	})
 }

--- a/console/deployments/k8s.go
+++ b/console/deployments/k8s.go
@@ -55,6 +55,17 @@ func (k *K8sClient) WithDynamicClient(d dynamic.Interface) *K8sClient {
 	return k
 }
 
+// HasDynamicClient reports whether a dynamic client is configured. The link
+// aggregator needs this to distinguish "scan returned zero resources"
+// (legitimate empty drift — clear the cache) from "no dynamic client"
+// (cannot scan at all — preserve cache as-is). Without the distinction the
+// GetDeployment refresh path would either never clear stale entries
+// (always preserve on empty) or wrongly wipe them on local/dev wiring
+// where the dynamic client is intentionally nil.
+func (k *K8sClient) HasDynamicClient() bool {
+	return k.dynamic != nil
+}
+
 // ListDeployments returns all deployment ConfigMaps in the project namespace.
 func (k *K8sClient) ListDeployments(ctx context.Context, project string) ([]corev1.ConfigMap, error) {
 	ns := k.Resolver.ProjectNamespace(project)
@@ -185,20 +196,31 @@ func (k *K8sClient) UpdateDeployment(ctx context.Context, project, name string, 
 }
 
 // ListDeploymentResources returns every resource currently owned by the given
-// deployment, scanned across every kind apply.go writes. The lookup uses the
-// same `LabelProject=<project>,console.holos.run/deployment=<deployment>`
-// selector applied at apply time so results are exactly the set Reconcile and
-// Cleanup operate on. Returned objects are the live cluster representation —
-// each carries its own annotations, labels, kind, namespace, and name — and
-// are intended to be passed straight to links.ParseAnnotations by the
-// aggregator (HOL-574).
+// deployment within the project namespace, scanned across every kind
+// apply.go writes. The lookup uses the same
+// `LabelProject=<project>,console.holos.run/deployment=<deployment>`
+// selector applied at apply time so results are exactly the in-namespace
+// subset Reconcile and Cleanup operate on. Returned objects are the live
+// cluster representation — each carries its own annotations, labels,
+// kind, namespace, and name — and are intended to be passed straight to
+// links.ParseAnnotations by the aggregator (HOL-574).
 //
-// When no dynamic client is configured the method returns (nil, nil) so the
-// handler degrades gracefully on local/dev wiring without a cluster (mirrors
-// the SetOutputURLAnnotation precedent of "best-effort cache, never block
-// the RPC"). List failures for individual GVRs are logged and skipped — some
-// CRDs may be absent from the cluster — so a missing optional kind never
-// breaks aggregation for the kinds that are present.
+// Scope: namespace-scoped (the project namespace returned by Resolver).
+// This deliberately matches the existing console RBAC posture, which is
+// namespaced — a cluster-wide list would silently fail in any cluster
+// where the console service account does not have cluster-level list
+// permissions, dropping links without a visible error and leaving the
+// "RBAC unchanged" guarantee unmet. Cross-namespace owned resources
+// (e.g. an HTTPRoute landing in istio-ingress) are intentionally not
+// scanned here; templates that want to surface links from cross-
+// namespace resources should attach `external-link.*` /`primary-url`
+// annotations to a project-namespace resource instead.
+//
+// When no dynamic client is configured the method returns (nil, nil) so
+// the handler degrades gracefully on local/dev wiring without a cluster.
+// List failures for individual GVRs are logged and skipped — some
+// optional CRDs may be absent from the cluster — so a missing optional
+// kind never breaks aggregation for the kinds that are present.
 func (k *K8sClient) ListDeploymentResources(ctx context.Context, project, deployment string) ([]unstructured.Unstructured, error) {
 	if k.dynamic == nil {
 		return nil, nil
@@ -206,25 +228,24 @@ func (k *K8sClient) ListDeploymentResources(ctx context.Context, project, deploy
 	if project == "" || deployment == "" {
 		return nil, fmt.Errorf("project and deployment are required")
 	}
+	ns := k.Resolver.ProjectNamespace(project)
 	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
 		v1alpha2.LabelProject, project,
 		v1alpha2.AnnotationDeployment, deployment)
 
 	var out []unstructured.Unstructured
 	for kind, gvr := range allowedKinds {
-		// List across all namespaces — apply.go places resources in their
-		// own metadata.namespace, so cross-namespace fans-out (e.g. an
-		// HTTPRoute landing in istio-ingress) are surfaced too.
-		list, err := k.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{
+		list, err := k.dynamic.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 		if err != nil {
 			// Some optional CRDs may not be installed; treat as empty
 			// and continue rather than failing the whole aggregator
-			// (mirrors the apply.go DiscoverNamespaces / Reconcile
-			// orphan-scan precedent).
+			// (mirrors the apply.go Cleanup / Reconcile orphan-scan
+			// precedent of skip-and-log on per-kind list failures).
 			slog.DebugContext(ctx, "list deployment resources: skipping kind",
 				slog.String("kind", kind),
+				slog.String("namespace", ns),
 				slog.String("project", project),
 				slog.String("deployment", deployment),
 				slog.Any("error", err),

--- a/console/deployments/k8s.go
+++ b/console/deployments/k8s.go
@@ -11,6 +11,8 @@ import (
 	"github.com/holos-run/holos-console/console/resolver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -27,13 +29,30 @@ const (
 
 // K8sClient wraps Kubernetes client operations for deployments.
 type K8sClient struct {
-	client   kubernetes.Interface
+	client kubernetes.Interface
+	// dynamic, when non-nil, enables multi-kind queries used by the link
+	// aggregator (HOL-574) to scan resources owned by a deployment across
+	// every kind apply.go writes. A nil dynamic client makes
+	// ListDeploymentResources a no-op so local/dev wiring without a cluster
+	// dynamic client (and unit tests that only need typed reads) keep
+	// working.
+	dynamic  dynamic.Interface
 	Resolver *resolver.Resolver
 }
 
 // NewK8sClient creates a client for deployment operations.
 func NewK8sClient(client kubernetes.Interface, r *resolver.Resolver) *K8sClient {
 	return &K8sClient{client: client, Resolver: r}
+}
+
+// WithDynamicClient configures the K8sClient with a dynamic client used by
+// ListDeploymentResources to scan owned resources across every allowed kind
+// (HOL-574). Returns the receiver for fluent chaining alongside the existing
+// constructor so callers do not have to thread a new positional arg through
+// every test that builds a K8sClient.
+func (k *K8sClient) WithDynamicClient(d dynamic.Interface) *K8sClient {
+	k.dynamic = d
+	return k
 }
 
 // ListDeployments returns all deployment ConfigMaps in the project namespace.
@@ -163,6 +182,94 @@ func (k *K8sClient) UpdateDeployment(ctx context.Context, project, name string, 
 		}
 	}
 	return k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+}
+
+// ListDeploymentResources returns every resource currently owned by the given
+// deployment, scanned across every kind apply.go writes. The lookup uses the
+// same `LabelProject=<project>,console.holos.run/deployment=<deployment>`
+// selector applied at apply time so results are exactly the set Reconcile and
+// Cleanup operate on. Returned objects are the live cluster representation —
+// each carries its own annotations, labels, kind, namespace, and name — and
+// are intended to be passed straight to links.ParseAnnotations by the
+// aggregator (HOL-574).
+//
+// When no dynamic client is configured the method returns (nil, nil) so the
+// handler degrades gracefully on local/dev wiring without a cluster (mirrors
+// the SetOutputURLAnnotation precedent of "best-effort cache, never block
+// the RPC"). List failures for individual GVRs are logged and skipped — some
+// CRDs may be absent from the cluster — so a missing optional kind never
+// breaks aggregation for the kinds that are present.
+func (k *K8sClient) ListDeploymentResources(ctx context.Context, project, deployment string) ([]unstructured.Unstructured, error) {
+	if k.dynamic == nil {
+		return nil, nil
+	}
+	if project == "" || deployment == "" {
+		return nil, fmt.Errorf("project and deployment are required")
+	}
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		v1alpha2.LabelProject, project,
+		v1alpha2.AnnotationDeployment, deployment)
+
+	var out []unstructured.Unstructured
+	for kind, gvr := range allowedKinds {
+		// List across all namespaces — apply.go places resources in their
+		// own metadata.namespace, so cross-namespace fans-out (e.g. an
+		// HTTPRoute landing in istio-ingress) are surfaced too.
+		list, err := k.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			// Some optional CRDs may not be installed; treat as empty
+			// and continue rather than failing the whole aggregator
+			// (mirrors the apply.go DiscoverNamespaces / Reconcile
+			// orphan-scan precedent).
+			slog.DebugContext(ctx, "list deployment resources: skipping kind",
+				slog.String("kind", kind),
+				slog.String("project", project),
+				slog.String("deployment", deployment),
+				slog.Any("error", err),
+			)
+			continue
+		}
+		out = append(out, list.Items...)
+	}
+	return out, nil
+}
+
+// SetAggregatedLinksAnnotation sets (or clears) the aggregated-links cache
+// annotation on the deployment ConfigMap. An empty payload removes the
+// annotation so stale link sets from previous renders do not persist when a
+// template edit drops every link source. A missing ConfigMap surfaces the
+// underlying NotFound so the handler can decide whether to log or surface
+// the error. Mirrors SetOutputURLAnnotation exactly so the two cached
+// surfaces share one operational shape (HOL-574).
+func (k *K8sClient) SetAggregatedLinksAnnotation(ctx context.Context, project, name, payload string) error {
+	ns := k.Resolver.ProjectNamespace(project)
+	cm, err := k.client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting deployment for aggregated-links annotation update: %w", err)
+	}
+	if cm.Annotations == nil {
+		cm.Annotations = map[string]string{}
+	}
+	if payload == "" {
+		if _, ok := cm.Annotations[v1alpha2.AnnotationAggregatedLinks]; !ok {
+			// No-op: annotation not present and nothing to clear.
+			return nil
+		}
+		delete(cm.Annotations, v1alpha2.AnnotationAggregatedLinks)
+	} else {
+		if cm.Annotations[v1alpha2.AnnotationAggregatedLinks] == payload {
+			// Already up to date; avoid a needless write.
+			return nil
+		}
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = payload
+	}
+	_, err = k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating deployment aggregated-links annotation: %w", err)
+	}
+	return nil
 }
 
 // SetOutputURLAnnotation sets (or clears) the output-url annotation on the

--- a/console/deployments/k8s.go
+++ b/console/deployments/k8s.go
@@ -3,8 +3,10 @@ package deployments
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
@@ -15,6 +17,14 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
+
+// ErrPartialScan is returned by ListDeploymentResources when at least one
+// per-kind List call failed. The returned slice still contains every
+// resource the successful kinds produced — callers may surface a partial
+// view — but the error signals "do not treat this slice as authoritative
+// drift evidence" so cache-rewrite paths can preserve their existing
+// state instead of wiping it on a transient failure.
+var ErrPartialScan = errors.New("list deployment resources: partial scan")
 
 const (
 	// Data keys in the ConfigMap.
@@ -213,14 +223,24 @@ func (k *K8sClient) UpdateDeployment(ctx context.Context, project, name string, 
 // "RBAC unchanged" guarantee unmet. Cross-namespace owned resources
 // (e.g. an HTTPRoute landing in istio-ingress) are intentionally not
 // scanned here; templates that want to surface links from cross-
-// namespace resources should attach `external-link.*` /`primary-url`
+// namespace resources should attach `external-link.*` / `primary-url`
 // annotations to a project-namespace resource instead.
+//
+// Determinism: kinds are iterated in lexicographic GVR order so the
+// resource slice — and therefore the first-wins selection in the
+// aggregator (de-duplication and `primary-url` promotion) — is stable
+// across requests. Iterating the `allowedKinds` map directly would
+// scramble the order on every call and cause cached values to flap
+// even when the live cluster did not change (HOL-574 review round 2 P2).
+//
+// Partial-failure handling: if any per-kind list fails (transient API
+// error, missing optional CRD, RBAC gap on a single resource type) the
+// successful items are still returned but the error wraps `ErrPartialScan`
+// so callers can preserve their cached state instead of treating an
+// incomplete view as authoritative drift (HOL-574 review round 2 P1).
 //
 // When no dynamic client is configured the method returns (nil, nil) so
 // the handler degrades gracefully on local/dev wiring without a cluster.
-// List failures for individual GVRs are logged and skipped — some
-// optional CRDs may be absent from the cluster — so a missing optional
-// kind never breaks aggregation for the kinds that are present.
 func (k *K8sClient) ListDeploymentResources(ctx context.Context, project, deployment string) ([]unstructured.Unstructured, error) {
 	if k.dynamic == nil {
 		return nil, nil
@@ -233,16 +253,29 @@ func (k *K8sClient) ListDeploymentResources(ctx context.Context, project, deploy
 		v1alpha2.LabelProject, project,
 		v1alpha2.AnnotationDeployment, deployment)
 
+	// Walk allowedKinds in a deterministic order so the aggregator's
+	// first-wins de-duplication is stable across calls.
+	kinds := make([]string, 0, len(allowedKinds))
+	for kind := range allowedKinds {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+
 	var out []unstructured.Unstructured
-	for kind, gvr := range allowedKinds {
+	var listErrors []error
+	for _, kind := range kinds {
+		gvr := allowedKinds[kind]
 		list, err := k.dynamic.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 		if err != nil {
-			// Some optional CRDs may not be installed; treat as empty
-			// and continue rather than failing the whole aggregator
-			// (mirrors the apply.go Cleanup / Reconcile orphan-scan
-			// precedent of skip-and-log on per-kind list failures).
+			// Some optional CRDs may not be installed and some
+			// transient errors are recoverable; record and continue
+			// rather than aborting the whole aggregator (mirrors the
+			// apply.go Cleanup / Reconcile orphan-scan precedent of
+			// skip-and-log on per-kind list failures). Track the
+			// error so the caller can downgrade authority on the
+			// returned slice (see ErrPartialScan).
 			slog.DebugContext(ctx, "list deployment resources: skipping kind",
 				slog.String("kind", kind),
 				slog.String("namespace", ns),
@@ -250,9 +283,14 @@ func (k *K8sClient) ListDeploymentResources(ctx context.Context, project, deploy
 				slog.String("deployment", deployment),
 				slog.Any("error", err),
 			)
+			listErrors = append(listErrors, fmt.Errorf("listing %s: %w", kind, err))
 			continue
 		}
 		out = append(out, list.Items...)
+	}
+	if len(listErrors) > 0 {
+		return out, fmt.Errorf("%w (%d/%d kinds failed): %w",
+			ErrPartialScan, len(listErrors), len(allowedKinds), listErrors[0])
 	}
 	return out, nil
 }

--- a/console/deployments/k8s.go
+++ b/console/deployments/k8s.go
@@ -12,6 +12,8 @@ import (
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -269,13 +271,24 @@ func (k *K8sClient) ListDeploymentResources(ctx context.Context, project, deploy
 			LabelSelector: labelSelector,
 		})
 		if err != nil {
-			// Some optional CRDs may not be installed and some
-			// transient errors are recoverable; record and continue
-			// rather than aborting the whole aggregator (mirrors the
-			// apply.go Cleanup / Reconcile orphan-scan precedent of
-			// skip-and-log on per-kind list failures). Track the
-			// error so the caller can downgrade authority on the
-			// returned slice (see ErrPartialScan).
+			// Optional CRDs (HTTPRoute, ReferenceGrant, etc.) may
+			// not be installed on every cluster: the API server
+			// returns NotFound or NoKindMatchError for those GVRs.
+			// Treat that as a successful empty result rather than a
+			// partial-scan signal, otherwise the cache would never
+			// be seeded in clusters without Gateway API installed
+			// (HOL-574 review round 4). Other errors (transient
+			// connectivity, RBAC) still downgrade authority via
+			// ErrPartialScan so the cache is preserved.
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				slog.DebugContext(ctx, "list deployment resources: optional kind absent, skipping",
+					slog.String("kind", kind),
+					slog.String("namespace", ns),
+					slog.String("project", project),
+					slog.String("deployment", deployment),
+				)
+				continue
+			}
 			slog.DebugContext(ctx, "list deployment resources: skipping kind",
 				slog.String("kind", kind),
 				slog.String("namespace", ns),

--- a/console/deployments/k8s_test.go
+++ b/console/deployments/k8s_test.go
@@ -3,6 +3,8 @@ package deployments
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
@@ -650,6 +653,88 @@ func TestListDeploymentResources(t *testing.T) {
 			t.Errorf("expected resource in prj-my-project, got %q", got[0].GetNamespace())
 		}
 	})
+}
+
+// TestListDeploymentResources_PartialScan verifies that ListDeployment
+// Resources signals a partial scan (via ErrPartialScan) when at least
+// one per-kind list call fails. Without this the GetDeployment refresh
+// path would treat a transient failure as authoritative drift and wipe
+// legitimate cached links (HOL-574 review round 2 P1).
+func TestListDeploymentResources_PartialScan(t *testing.T) {
+	project := "my-project"
+	deployment := "web-app"
+	namespace := "prj-my-project"
+
+	owned := makeOwnedUnstructured("apps/v1", "Deployment", namespace, deployment, project, deployment, nil)
+	dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest(), owned)
+	// Make Service list calls fail to simulate a transient API error
+	// or RBAC gap on a single resource type. The Deployment list
+	// should still succeed, so the returned slice carries the
+	// successful items but the error wraps ErrPartialScan.
+	dyn.PrependReactor("list", "services", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated transient failure")
+	})
+
+	k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+	got, err := k8s.ListDeploymentResources(context.Background(), project, deployment)
+	if !errors.Is(err, ErrPartialScan) {
+		t.Fatalf("expected ErrPartialScan, got %v", err)
+	}
+	// Successful kinds still surface so the caller may render a
+	// partial view if it chooses.
+	if len(got) != 1 || got[0].GetKind() != "Deployment" {
+		t.Errorf("expected Deployment item to surface despite partial failure, got %+v", got)
+	}
+}
+
+// TestListDeploymentResources_DeterministicOrder verifies that the
+// resource slice ordering does not depend on Go's randomized map
+// iteration (HOL-574 review round 2 P2). A stable order keeps the
+// aggregator's first-wins de-duplication and primary-url promotion
+// repeatable so cached values do not flap across requests.
+func TestListDeploymentResources_DeterministicOrder(t *testing.T) {
+	project := "my-project"
+	deployment := "web-app"
+	namespace := "prj-my-project"
+
+	// Seed one resource per kind we care about. Stable iteration
+	// across allowedKinds means the slice ordering is identical from
+	// run to run.
+	dep := makeOwnedUnstructured("apps/v1", "Deployment", namespace, deployment, project, deployment, nil)
+	svc := makeOwnedUnstructured("v1", "Service", namespace, deployment, project, deployment, nil)
+	sa := makeOwnedUnstructured("v1", "ServiceAccount", namespace, deployment, project, deployment, nil)
+
+	dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest(), dep, svc, sa)
+	k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+
+	// Run the scan multiple times; the slice ordering must be
+	// identical across calls. If allowedKinds were iterated as a map
+	// this would flake under -count.
+	const runs = 8
+	var first []string
+	for i := 0; i < runs; i++ {
+		got, err := k8s.ListDeploymentResources(context.Background(), project, deployment)
+		if err != nil {
+			t.Fatalf("run %d: unexpected error: %v", i, err)
+		}
+		order := make([]string, 0, len(got))
+		for _, r := range got {
+			order = append(order, r.GetKind())
+		}
+		if i == 0 {
+			first = order
+			continue
+		}
+		if len(order) != len(first) {
+			t.Fatalf("run %d: ordering length differs from run 0", i)
+		}
+		for j := range order {
+			if order[j] != first[j] {
+				t.Errorf("run %d: ordering differs at index %d (got %q, want %q from run 0)", i, j, order[j], first[j])
+				break
+			}
+		}
+	}
 }
 
 // TestHasDynamicClient covers the boolean accessor used by the handler to

--- a/console/deployments/k8s_test.go
+++ b/console/deployments/k8s_test.go
@@ -7,6 +7,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
@@ -444,6 +447,183 @@ func TestDeleteDeployment(t *testing.T) {
 		err := k8s.DeleteDeployment(context.Background(), "my-project", "does-not-exist")
 		if err == nil {
 			t.Fatal("expected error for non-existent deployment")
+		}
+	})
+}
+
+// TestSetAggregatedLinksAnnotation covers the cache-write path used by the
+// link aggregator (HOL-574). Mirrors the SetOutputURLAnnotation tests:
+// non-empty payload writes, empty payload clears, identical payload is a
+// no-op (avoids a needless Update), and a missing ConfigMap surfaces an
+// error so the handler can decide what to log.
+func TestSetAggregatedLinksAnnotation(t *testing.T) {
+	t.Run("writes payload to annotation when previously absent", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "", "")
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		err := k8s.SetAggregatedLinksAnnotation(context.Background(), "my-project", "web-app", `{"primary_url":"https://app.example.com"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got, err := k8s.GetDeployment(context.Background(), "my-project", "web-app")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Annotations[v1alpha2.AnnotationAggregatedLinks] != `{"primary_url":"https://app.example.com"}` {
+			t.Errorf("annotation mismatch, got %q", got.Annotations[v1alpha2.AnnotationAggregatedLinks])
+		}
+	})
+
+	t.Run("empty payload clears existing annotation", func(t *testing.T) {
+		ns := projectNS("my-project")
+		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "", "")
+		cm.Annotations[v1alpha2.AnnotationAggregatedLinks] = `{"primary_url":"https://stale.example.com"}`
+		fakeClient := fake.NewClientset(ns, cm)
+		k8s := NewK8sClient(fakeClient, testResolver())
+
+		err := k8s.SetAggregatedLinksAnnotation(context.Background(), "my-project", "web-app", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got, err := k8s.GetDeployment(context.Background(), "my-project", "web-app")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := got.Annotations[v1alpha2.AnnotationAggregatedLinks]; ok {
+			t.Errorf("expected annotation to be cleared, got %q", got.Annotations[v1alpha2.AnnotationAggregatedLinks])
+		}
+	})
+
+	t.Run("missing deployment surfaces an error", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		err := k8s.SetAggregatedLinksAnnotation(context.Background(), "my-project", "missing", "payload")
+		if err == nil {
+			t.Fatal("expected error for missing deployment")
+		}
+	})
+}
+
+// fakeDynamicSchemeForK8sTest builds a scheme that knows about every kind
+// the dynamic client may be asked to list. It mirrors fakeDynamicScheme in
+// apply_test.go but lives next to the k8s tests so this file does not
+// reach into apply test fixtures.
+func fakeDynamicSchemeForK8sTest() *runtime.Scheme {
+	return fakeDynamicScheme()
+}
+
+// makeOwnedUnstructured constructs an Unstructured with the deployment
+// ownership labels and the supplied per-resource annotations. Used by the
+// ListDeploymentResources tests so the same selector apply.go writes is
+// exercised by the read path.
+func makeOwnedUnstructured(apiVersion, kind, namespace, name, project, deployment string, annotations map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion(apiVersion)
+	u.SetKind(kind)
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetLabels(map[string]string{
+		v1alpha2.LabelProject:         project,
+		v1alpha2.AnnotationDeployment: deployment,
+	})
+	if annotations != nil {
+		u.SetAnnotations(annotations)
+	}
+	return u
+}
+
+// TestListDeploymentResources covers the HOL-574 multi-kind scan. The scan
+// must (a) return resources matching the project + deployment labels, (b)
+// span every kind apply.go writes, (c) ignore resources that do not match
+// the ownership selector, and (d) return (nil, nil) when no dynamic client
+// is configured (local/dev wiring).
+func TestListDeploymentResources(t *testing.T) {
+	t.Run("nil dynamic client returns nil without error", func(t *testing.T) {
+		ns := projectNS("my-project")
+		fakeClient := fake.NewClientset(ns)
+		k8s := NewK8sClient(fakeClient, testResolver())
+		got, err := k8s.ListDeploymentResources(context.Background(), "my-project", "web-app")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil resources, got %v", got)
+		}
+	})
+
+	t.Run("validates project and deployment", func(t *testing.T) {
+		fakeClient := fake.NewClientset()
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest())
+		k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+		if _, err := k8s.ListDeploymentResources(context.Background(), "", "x"); err == nil {
+			t.Error("expected error for empty project")
+		}
+		if _, err := k8s.ListDeploymentResources(context.Background(), "x", ""); err == nil {
+			t.Error("expected error for empty deployment")
+		}
+	})
+
+	t.Run("returns owned resources matching the selector", func(t *testing.T) {
+		project := "my-project"
+		deployment := "web-app"
+		namespace := "prj-my-project"
+
+		owned := makeOwnedUnstructured("apps/v1", "Deployment", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com","title":"Logs"}`})
+		ownedSvc := makeOwnedUnstructured("v1", "Service", namespace, deployment, project, deployment,
+			map[string]string{v1alpha2.AnnotationArgoCDLinkPrefix + "grafana": "https://grafana.example.com"})
+		// Same labels but different deployment — must not appear.
+		other := makeOwnedUnstructured("apps/v1", "Deployment", namespace, "other", project, "other-deployment", nil)
+
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest(), owned, ownedSvc, other)
+		k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+
+		got, err := k8s.ListDeploymentResources(context.Background(), project, deployment)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Two resources match (Deployment + Service); the "other"
+		// deployment must be filtered out by the label selector.
+		if len(got) != 2 {
+			t.Fatalf("expected 2 owned resources, got %d: %+v", len(got), got)
+		}
+		// Verify both kinds are represented.
+		kinds := map[string]bool{}
+		for _, r := range got {
+			kinds[r.GetKind()] = true
+		}
+		if !kinds["Deployment"] || !kinds["Service"] {
+			t.Errorf("expected both Deployment and Service, got kinds %v", kinds)
+		}
+	})
+
+	t.Run("returns empty when no resources match", func(t *testing.T) {
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest())
+		k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+		got, err := k8s.ListDeploymentResources(context.Background(), "p", "d")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected 0 resources, got %d", len(got))
+		}
+	})
+
+	t.Run("uses the ownership label selector with project+deployment", func(t *testing.T) {
+		// Stamp the deployment label but a different project — must not
+		// surface (HOL-571 disjoint-selector semantics).
+		other := makeOwnedUnstructured("apps/v1", "Deployment", "prj-other", "web-app", "other-project", "web-app", nil)
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest(), other)
+		k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+		got, err := k8s.ListDeploymentResources(context.Background(), "my-project", "web-app")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected 0 cross-project matches, got %d", len(got))
 		}
 	})
 }

--- a/console/deployments/k8s_test.go
+++ b/console/deployments/k8s_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
@@ -684,6 +686,41 @@ func TestListDeploymentResources_PartialScan(t *testing.T) {
 	// partial view if it chooses.
 	if len(got) != 1 || got[0].GetKind() != "Deployment" {
 		t.Errorf("expected Deployment item to surface despite partial failure, got %+v", got)
+	}
+}
+
+// TestListDeploymentResources_OptionalCRDsNotPartialScan verifies that
+// per-kind NotFound (or NoKindMatch) errors — which the API server
+// returns when an optional CRD like HTTPRoute or ReferenceGrant is not
+// installed on the cluster — do NOT trigger ErrPartialScan. Treating a
+// missing optional CRD as a partial scan would prevent the cache from
+// ever being seeded on clusters without Gateway API installed (HOL-574
+// review round 4).
+func TestListDeploymentResources_OptionalCRDsNotPartialScan(t *testing.T) {
+	project := "my-project"
+	deployment := "web-app"
+	namespace := "prj-my-project"
+
+	owned := makeOwnedUnstructured("apps/v1", "Deployment", namespace, deployment, project, deployment, nil)
+	dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest(), owned)
+	// Simulate a cluster without the Gateway API CRDs — list calls
+	// for HTTPRoute / ReferenceGrant return NotFound from the API
+	// server. The aggregator must treat this as "kind is absent" not
+	// "partial scan".
+	dyn.PrependReactor("list", "httproutes", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "httproutes"}, "")
+	})
+	dyn.PrependReactor("list", "referencegrants", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "referencegrants"}, "")
+	})
+
+	k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+	got, err := k8s.ListDeploymentResources(context.Background(), project, deployment)
+	if err != nil {
+		t.Fatalf("optional missing CRDs must not surface as ErrPartialScan, got %v", err)
+	}
+	if len(got) != 1 || got[0].GetKind() != "Deployment" {
+		t.Errorf("expected only the Deployment surfaced, got %+v", got)
 	}
 }
 

--- a/console/deployments/k8s_test.go
+++ b/console/deployments/k8s_test.go
@@ -626,6 +626,49 @@ func TestListDeploymentResources(t *testing.T) {
 			t.Errorf("expected 0 cross-project matches, got %d", len(got))
 		}
 	})
+
+	t.Run("scoped to project namespace - cross-namespace resources are not surfaced", func(t *testing.T) {
+		// Same project + deployment labels but in a different
+		// namespace (e.g. an HTTPRoute landing in istio-ingress).
+		// The scan is namespace-scoped to align with the existing
+		// console RBAC posture (HOL-574 review round 1 P1) — cross-
+		// namespace resources are intentionally not harvested.
+		project := "my-project"
+		deployment := "web-app"
+		inProj := makeOwnedUnstructured("apps/v1", "Deployment", "prj-my-project", deployment, project, deployment, nil)
+		crossNS := makeOwnedUnstructured("apps/v1", "Deployment", "istio-ingress", deployment, project, deployment, nil)
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest(), inProj, crossNS)
+		k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+		got, err := k8s.ListDeploymentResources(context.Background(), project, deployment)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected exactly 1 in-namespace resource, got %d (cross-NS leak?): %+v", len(got), got)
+		}
+		if got[0].GetNamespace() != "prj-my-project" {
+			t.Errorf("expected resource in prj-my-project, got %q", got[0].GetNamespace())
+		}
+	})
+}
+
+// TestHasDynamicClient covers the boolean accessor used by the handler to
+// distinguish "no scan possible" (preserve cache) from "scan returned
+// nothing" (clear cache). HOL-574 review round 1 P2.
+func TestHasDynamicClient(t *testing.T) {
+	t.Run("returns false when no dynamic client is configured", func(t *testing.T) {
+		k8s := NewK8sClient(fake.NewClientset(), testResolver())
+		if k8s.HasDynamicClient() {
+			t.Error("expected HasDynamicClient to return false on default constructor")
+		}
+	})
+	t.Run("returns true after WithDynamicClient", func(t *testing.T) {
+		dyn := dynamicfake.NewSimpleDynamicClient(fakeDynamicSchemeForK8sTest())
+		k8s := NewK8sClient(fake.NewClientset(), testResolver()).WithDynamicClient(dyn)
+		if !k8s.HasDynamicClient() {
+			t.Error("expected HasDynamicClient to return true after WithDynamicClient")
+		}
+	})
 }
 
 func TestListNamespaceSecrets(t *testing.T) {

--- a/console/deployments/links.go
+++ b/console/deployments/links.go
@@ -150,32 +150,44 @@ func deserializeAggregatedLinks(cm *corev1.ConfigMap) ([]*consolev1.Link, string
 }
 
 // applyAggregatedLinks mirrors mergeOutputURLAnnotation but for the link
-// aggregator: it populates summary.Output.Links from the cached set and
-// promotes a non-empty primary URL into summary.Output.Url. The promoted
-// URL takes precedence over an existing Output.Url because the
-// `primary-url` annotation is a deliberate per-resource override published
-// by a template author who wants the UI to highlight a specific link
-// regardless of what the rendered `output.url` claims; an empty primaryURL
-// preserves whatever Url the prior caller set so the legacy
-// `OutputURLAnnotation` cache continues to work for templates that have
-// not adopted `primary-url`.
+// aggregator: it populates summary.Output.Links from the aggregated set and
+// promotes a non-empty primary URL into summary.Output.Url. The aggregated
+// list is the authoritative source for `Output.Links` — if it is empty
+// (a deployment that never had link annotations or one whose annotations
+// were just removed) the field is reset to nil so a previously-served
+// link list cannot leak across requests when the caller reuses a
+// `DeploymentStatusSummary` pointer (HOL-574 review round 3 P1).
 //
-// If no Output exists yet on the summary one is allocated lazily so a
-// caller does not have to check for nil before invoking this helper. A nil
-// summary or empty inputs are no-ops.
+// URL precedence: a non-empty primaryURL ALWAYS wins over whatever Url
+// the prior caller (e.g. mergeOutputURLAnnotation) set, because the
+// `primary-url` annotation is a deliberate per-resource override.
+// An empty primaryURL preserves the existing Url so the legacy
+// `OutputURLAnnotation` cache continues to work for templates that have
+// not adopted `primary-url`. Callers that need to clear a stale
+// promoted URL must do so before invoking this helper (the legacy URL
+// has multiple sources, so a per-call clear here would wipe legitimate
+// `OutputURLAnnotation` content).
+//
+// If no Output exists yet on the summary, one is allocated only when
+// there is something to populate; a nil summary or no aggregated links
+// AND no primaryURL on a summary with no existing Output is a no-op so
+// callers do not have to special-case the "nothing to do" path.
 func applyAggregatedLinks(summary *consolev1.DeploymentStatusSummary, aggregated []*consolev1.Link, primaryURL string) {
 	if summary == nil {
 		return
 	}
-	if len(aggregated) == 0 && primaryURL == "" {
+	// Nothing to write and nothing to clear — leave the summary
+	// entirely untouched. This avoids allocating an empty Output
+	// just to record "no links" for a deployment that never had any.
+	if len(aggregated) == 0 && primaryURL == "" && summary.Output == nil {
 		return
 	}
 	if summary.Output == nil {
 		summary.Output = &consolev1.DeploymentOutput{}
 	}
-	if len(aggregated) > 0 {
-		summary.Output.Links = aggregated
-	}
+	// Links: aggregated is authoritative — assign even when empty so
+	// a previously-promoted list does not persist across calls.
+	summary.Output.Links = aggregated
 	if primaryURL != "" {
 		summary.Output.Url = primaryURL
 	}

--- a/console/deployments/links.go
+++ b/console/deployments/links.go
@@ -1,0 +1,204 @@
+package deployments
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sort"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/links"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// aggregatedLinksCache is the on-disk JSON shape of the
+// `console.holos.run/links` annotation written to the deployment ConfigMap
+// by the Create/UpdateDeployment write paths. It carries both the de-
+// duplicated link set and the promoted primary URL so a single annotation
+// reload restores everything ListDeployments / GetDeployment need to fill
+// the wire DeploymentOutput. The shape is internal to the handler — the
+// authoritative links still live on the resources themselves and are
+// re-derivable on every GetDeployment refresh.
+type aggregatedLinksCache struct {
+	Links      []*consolev1.Link `json:"links,omitempty"`
+	PrimaryURL string            `json:"primary_url,omitempty"`
+}
+
+// aggregateLinksFromResources walks every owned Kubernetes resource for a
+// deployment, runs the phase-2 link annotation parser against each, and
+// returns the merged result.
+//
+// De-duplication: links are keyed by (name, source). The first occurrence
+// of a given key wins — subsequent duplicates are dropped silently. This
+// keeps the wire shape stable when the same link annotation is stamped on
+// more than one owned resource (for example a Deployment + its Service
+// both carrying `console.holos.run/external-link.logs`).
+//
+// Primary promotion: if any owned resource carries the
+// `console.holos.run/primary-url` annotation, the first one wins (in scan
+// order — which is non-deterministic across kinds, hence the warning) and
+// its URL becomes primaryURL. Subsequent primary annotations log a warn
+// so operators can spot the conflict; they are otherwise ignored. An empty
+// primaryURL means no resource published a primary URL.
+//
+// The returned link list is sorted deterministically by (name, source) so
+// callers can compare two aggregations byte-for-byte to detect drift
+// between the cached annotation and a fresh scan.
+func aggregateLinksFromResources(ctx context.Context, project, deployment string, resources []unstructured.Unstructured) (aggregated []*consolev1.Link, primaryURL string) {
+	type dedupKey struct {
+		name   string
+		source string
+	}
+	seen := make(map[dedupKey]struct{})
+	var primarySource string
+
+	for i := range resources {
+		r := &resources[i]
+		ann := r.GetAnnotations()
+		if len(ann) == 0 {
+			continue
+		}
+		parsedLinks, parsedPrimary := links.ParseAnnotations(ann)
+		for _, l := range parsedLinks {
+			k := dedupKey{name: l.GetName(), source: l.GetSource()}
+			if _, ok := seen[k]; ok {
+				// Duplicate across resources — drop without
+				// noise. The contract is that annotations on
+				// any resource may surface, so the same logical
+				// link appearing twice is expected (Service +
+				// Ingress, etc.).
+				continue
+			}
+			seen[k] = struct{}{}
+			aggregated = append(aggregated, l)
+		}
+		if parsedPrimary != nil && parsedPrimary.GetUrl() != "" {
+			origin := r.GetKind() + "/" + r.GetName()
+			if primaryURL == "" {
+				primaryURL = parsedPrimary.GetUrl()
+				primarySource = origin
+			} else {
+				slog.WarnContext(ctx, "multiple primary-url annotations found for deployment; keeping first",
+					slog.String("project", project),
+					slog.String("deployment", deployment),
+					slog.String("kept", primarySource),
+					slog.String("ignored", origin),
+					slog.String("ignored_url", parsedPrimary.GetUrl()),
+				)
+			}
+		}
+	}
+
+	sort.Slice(aggregated, func(i, j int) bool {
+		if aggregated[i].GetName() != aggregated[j].GetName() {
+			return aggregated[i].GetName() < aggregated[j].GetName()
+		}
+		return aggregated[i].GetSource() < aggregated[j].GetSource()
+	})
+	return aggregated, primaryURL
+}
+
+// serializeAggregatedLinks produces the JSON payload stored on the
+// deployment ConfigMap as `console.holos.run/links`. Returns an empty
+// string when both the link list and the primary URL are empty so the
+// caller can distinguish "have something to cache" from "clear the
+// annotation" without re-checking field-by-field. A marshal failure
+// returns the empty string with a warning rather than failing the whole
+// write path because the cache is best-effort by design.
+func serializeAggregatedLinks(ctx context.Context, project, deployment string, aggregated []*consolev1.Link, primaryURL string) string {
+	if len(aggregated) == 0 && primaryURL == "" {
+		return ""
+	}
+	payload, err := json.Marshal(aggregatedLinksCache{Links: aggregated, PrimaryURL: primaryURL})
+	if err != nil {
+		slog.WarnContext(ctx, "failed to marshal aggregated links cache",
+			slog.String("project", project),
+			slog.String("deployment", deployment),
+			slog.Any("error", err),
+		)
+		return ""
+	}
+	return string(payload)
+}
+
+// deserializeAggregatedLinks reads the cached `console.holos.run/links`
+// annotation off a deployment ConfigMap. Returns (nil, "") on a missing
+// annotation, on an empty payload, or on a parse error — the cache is
+// authoritative-at-time-of-render but never load-bearing: a malformed blob
+// just means the next write will overwrite it. A parse error is logged at
+// warn so misauthored caches are visible to operators.
+func deserializeAggregatedLinks(cm *corev1.ConfigMap) ([]*consolev1.Link, string) {
+	if cm == nil || cm.Annotations == nil {
+		return nil, ""
+	}
+	raw := cm.Annotations[v1alpha2.AnnotationAggregatedLinks]
+	if raw == "" {
+		return nil, ""
+	}
+	var cache aggregatedLinksCache
+	if err := json.Unmarshal([]byte(raw), &cache); err != nil {
+		slog.Warn("failed to unmarshal aggregated links cache",
+			slog.String("name", cm.Name),
+			slog.String("namespace", cm.Namespace),
+			slog.Any("error", err),
+		)
+		return nil, ""
+	}
+	return cache.Links, cache.PrimaryURL
+}
+
+// applyAggregatedLinks mirrors mergeOutputURLAnnotation but for the link
+// aggregator: it populates summary.Output.Links from the cached set and
+// promotes a non-empty primary URL into summary.Output.Url. The promoted
+// URL takes precedence over an existing Output.Url because the
+// `primary-url` annotation is a deliberate per-resource override published
+// by a template author who wants the UI to highlight a specific link
+// regardless of what the rendered `output.url` claims; an empty primaryURL
+// preserves whatever Url the prior caller set so the legacy
+// `OutputURLAnnotation` cache continues to work for templates that have
+// not adopted `primary-url`.
+//
+// If no Output exists yet on the summary one is allocated lazily so a
+// caller does not have to check for nil before invoking this helper. A nil
+// summary or empty inputs are no-ops.
+func applyAggregatedLinks(summary *consolev1.DeploymentStatusSummary, aggregated []*consolev1.Link, primaryURL string) {
+	if summary == nil {
+		return
+	}
+	if len(aggregated) == 0 && primaryURL == "" {
+		return
+	}
+	if summary.Output == nil {
+		summary.Output = &consolev1.DeploymentOutput{}
+	}
+	if len(aggregated) > 0 {
+		summary.Output.Links = aggregated
+	}
+	if primaryURL != "" {
+		summary.Output.Url = primaryURL
+	}
+}
+
+// linksEqual reports whether two link slices represent the same wire
+// content. Links from the parser arrive sorted by (name, source) and the
+// cache stores them in the same order, so the comparison is a straight
+// element-by-element walk. Used by GetDeployment to decide whether a
+// fresh scan agrees with the cached annotation; on disagreement the fresh
+// result wins and the cache is updated.
+func linksEqual(a, b []*consolev1.Link) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].GetUrl() != b[i].GetUrl() ||
+			a[i].GetTitle() != b[i].GetTitle() ||
+			a[i].GetDescription() != b[i].GetDescription() ||
+			a[i].GetSource() != b[i].GetSource() ||
+			a[i].GetName() != b[i].GetName() {
+			return false
+		}
+	}
+	return true
+}

--- a/console/deployments/links_test.go
+++ b/console/deployments/links_test.go
@@ -1,0 +1,286 @@
+package deployments
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeOwnedResource produces an unstructured Kubernetes resource carrying
+// the deployment ownership labels and the supplied annotations. Used to
+// drive the link aggregator across multi-resource scenarios.
+func makeOwnedResource(kind, namespace, name string, annotations map[string]string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind(kind)
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetAnnotations(annotations)
+	return u
+}
+
+// TestAggregateLinksFromResources covers the dedup, sort, and primary-url
+// promotion contract for the new aggregator helper. The helper takes the
+// raw owned-resource set and returns the wire-shape link list plus the
+// promoted primary URL — the values the caller will write into the cache
+// annotation and surface on `DeploymentOutput`.
+func TestAggregateLinksFromResources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty resources returns nil links and empty primary", func(t *testing.T) {
+		links, primary := aggregateLinksFromResources(context.Background(), "p", "d", nil)
+		if links != nil {
+			t.Errorf("expected nil links, got %v", links)
+		}
+		if primary != "" {
+			t.Errorf("expected empty primary, got %q", primary)
+		}
+	})
+
+	t.Run("single resource with one holos link surfaces", func(t *testing.T) {
+		r := makeOwnedResource("Deployment", "ns", "web", map[string]string{
+			v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://logs.example.com","title":"Logs"}`,
+		})
+		links, primary := aggregateLinksFromResources(context.Background(), "p", "d", []unstructured.Unstructured{r})
+		if len(links) != 1 || links[0].GetUrl() != "https://logs.example.com" {
+			t.Fatalf("unexpected links: %+v", links)
+		}
+		if primary != "" {
+			t.Errorf("expected no primary, got %q", primary)
+		}
+	})
+
+	t.Run("links across multiple resources are aggregated and sorted", func(t *testing.T) {
+		r1 := makeOwnedResource("Deployment", "ns", "web", map[string]string{
+			v1alpha2.AnnotationExternalLinkPrefix + "zeta": `{"url":"https://zeta.example.com","title":"Zeta"}`,
+		})
+		r2 := makeOwnedResource("Service", "ns", "web", map[string]string{
+			v1alpha2.AnnotationExternalLinkPrefix + "alpha": `{"url":"https://alpha.example.com","title":"Alpha"}`,
+		})
+		links, _ := aggregateLinksFromResources(context.Background(), "p", "d", []unstructured.Unstructured{r1, r2})
+		if len(links) != 2 {
+			t.Fatalf("expected 2 links, got %d", len(links))
+		}
+		// Sorted by name (alpha < zeta) regardless of resource order.
+		if links[0].GetName() != "alpha" || links[1].GetName() != "zeta" {
+			t.Errorf("expected alpha before zeta, got %q then %q", links[0].GetName(), links[1].GetName())
+		}
+	})
+
+	t.Run("duplicate (name, source) across resources is deduplicated first-wins", func(t *testing.T) {
+		r1 := makeOwnedResource("Deployment", "ns", "web", map[string]string{
+			v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://first.example.com","title":"First"}`,
+		})
+		r2 := makeOwnedResource("Service", "ns", "web", map[string]string{
+			v1alpha2.AnnotationExternalLinkPrefix + "logs": `{"url":"https://second.example.com","title":"Second"}`,
+		})
+		links, _ := aggregateLinksFromResources(context.Background(), "p", "d", []unstructured.Unstructured{r1, r2})
+		if len(links) != 1 {
+			t.Fatalf("expected 1 dedup'd link, got %d", len(links))
+		}
+		if links[0].GetUrl() != "https://first.example.com" {
+			t.Errorf("expected first-wins, got %q", links[0].GetUrl())
+		}
+	})
+
+	t.Run("primary-url annotation is promoted to primary", func(t *testing.T) {
+		r := makeOwnedResource("Service", "ns", "web", map[string]string{
+			v1alpha2.AnnotationPrimaryURL: `{"url":"https://app.example.com","title":"App"}`,
+		})
+		_, primary := aggregateLinksFromResources(context.Background(), "p", "d", []unstructured.Unstructured{r})
+		if primary != "https://app.example.com" {
+			t.Errorf("primary: got %q, want %q", primary, "https://app.example.com")
+		}
+	})
+
+	t.Run("multiple primary annotations: first wins", func(t *testing.T) {
+		r1 := makeOwnedResource("Deployment", "ns", "first", map[string]string{
+			v1alpha2.AnnotationPrimaryURL: `{"url":"https://first.example.com","title":"First"}`,
+		})
+		r2 := makeOwnedResource("Service", "ns", "second", map[string]string{
+			v1alpha2.AnnotationPrimaryURL: `{"url":"https://second.example.com","title":"Second"}`,
+		})
+		_, primary := aggregateLinksFromResources(context.Background(), "p", "d", []unstructured.Unstructured{r1, r2})
+		// The first resource walked in slice order wins.
+		if primary != "https://first.example.com" {
+			t.Errorf("primary: got %q, want %q (first wins)", primary, "https://first.example.com")
+		}
+	})
+
+	t.Run("argocd link surfaces with source=argocd", func(t *testing.T) {
+		r := makeOwnedResource("Deployment", "ns", "web", map[string]string{
+			v1alpha2.AnnotationArgoCDLinkPrefix + "grafana": "https://grafana.example.com",
+		})
+		links, _ := aggregateLinksFromResources(context.Background(), "p", "d", []unstructured.Unstructured{r})
+		if len(links) != 1 {
+			t.Fatalf("expected 1 link, got %d", len(links))
+		}
+		if links[0].GetSource() != "argocd" {
+			t.Errorf("source: got %q, want %q", links[0].GetSource(), "argocd")
+		}
+	})
+
+	t.Run("resources without annotations are skipped without panic", func(t *testing.T) {
+		r := makeOwnedResource("Deployment", "ns", "bare", nil)
+		links, primary := aggregateLinksFromResources(context.Background(), "p", "d", []unstructured.Unstructured{r})
+		if links != nil || primary != "" {
+			t.Errorf("expected empty result for no-annotation resource, got links=%v primary=%q", links, primary)
+		}
+	})
+}
+
+// TestSerializeAndDeserializeAggregatedLinks asserts the JSON shape stored
+// on the `console.holos.run/links` annotation round-trips through the
+// public API: write produces an empty payload when there is nothing to
+// cache, read returns nil/empty when the annotation is missing, and a
+// non-empty cache survives a serialize/deserialize cycle byte-equivalent.
+func TestSerializeAndDeserializeAggregatedLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty aggregation returns empty payload", func(t *testing.T) {
+		got := serializeAggregatedLinks(context.Background(), "p", "d", nil, "")
+		if got != "" {
+			t.Errorf("expected empty payload for empty aggregation, got %q", got)
+		}
+	})
+
+	t.Run("non-empty aggregation round-trips", func(t *testing.T) {
+		links := []*consolev1.Link{
+			{Url: "https://logs.example.com", Title: "Logs", Source: "holos", Name: "logs"},
+		}
+		payload := serializeAggregatedLinks(context.Background(), "p", "d", links, "https://app.example.com")
+		if payload == "" {
+			t.Fatal("expected non-empty payload")
+		}
+		// Deserialize via a real ConfigMap so the function under test
+		// uses its annotation-key contract.
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1alpha2.AnnotationAggregatedLinks: payload}},
+		}
+		gotLinks, gotPrimary := deserializeAggregatedLinks(cm)
+		if len(gotLinks) != 1 || gotLinks[0].GetUrl() != "https://logs.example.com" {
+			t.Errorf("links round-trip mismatch: %+v", gotLinks)
+		}
+		if gotPrimary != "https://app.example.com" {
+			t.Errorf("primary round-trip: got %q, want %q", gotPrimary, "https://app.example.com")
+		}
+	})
+
+	t.Run("missing annotation returns nil/empty", func(t *testing.T) {
+		links, primary := deserializeAggregatedLinks(&corev1.ConfigMap{})
+		if links != nil || primary != "" {
+			t.Errorf("expected nil/empty for missing annotation, got %+v / %q", links, primary)
+		}
+	})
+
+	t.Run("malformed payload is dropped without panic", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1alpha2.AnnotationAggregatedLinks: `{`}},
+		}
+		links, primary := deserializeAggregatedLinks(cm)
+		if links != nil || primary != "" {
+			t.Errorf("expected nil/empty for malformed payload, got %+v / %q", links, primary)
+		}
+	})
+
+	t.Run("payload shape matches the documented JSON keys", func(t *testing.T) {
+		links := []*consolev1.Link{{Url: "https://x.example.com", Name: "x", Source: "holos"}}
+		payload := serializeAggregatedLinks(context.Background(), "p", "d", links, "https://primary.example.com")
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+			t.Fatalf("payload not valid JSON: %v", err)
+		}
+		if _, ok := raw["links"]; !ok {
+			t.Errorf("expected 'links' key in cache payload, got keys: %v", keys(raw))
+		}
+		if raw["primary_url"] != "https://primary.example.com" {
+			t.Errorf("primary_url key: got %v", raw["primary_url"])
+		}
+	})
+}
+
+// TestApplyAggregatedLinks asserts the merge contract used by both
+// ListDeployments and GetDeployment: empty inputs are no-ops, links
+// populate `Output.Links`, primary URL promotes into `Output.Url`, and an
+// existing Url is overwritten by a non-empty primary because the
+// `primary-url` annotation is a deliberate authoring override.
+func TestApplyAggregatedLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil summary is a no-op", func(t *testing.T) {
+		applyAggregatedLinks(nil, []*consolev1.Link{{Url: "x"}}, "y")
+		// reaching here without a panic is the assertion
+	})
+
+	t.Run("empty inputs leave summary unchanged", func(t *testing.T) {
+		s := &consolev1.DeploymentStatusSummary{}
+		applyAggregatedLinks(s, nil, "")
+		if s.Output != nil {
+			t.Errorf("expected Output to remain nil, got %+v", s.Output)
+		}
+	})
+
+	t.Run("links populate Output.Links", func(t *testing.T) {
+		s := &consolev1.DeploymentStatusSummary{}
+		applyAggregatedLinks(s, []*consolev1.Link{{Url: "https://l.example.com", Name: "l"}}, "")
+		if s.Output == nil || len(s.Output.Links) != 1 {
+			t.Fatalf("expected Output.Links populated, got %+v", s.Output)
+		}
+	})
+
+	t.Run("primary URL overrides existing Output.Url", func(t *testing.T) {
+		s := &consolev1.DeploymentStatusSummary{Output: &consolev1.DeploymentOutput{Url: "https://old.example.com"}}
+		applyAggregatedLinks(s, nil, "https://primary.example.com")
+		if s.Output.Url != "https://primary.example.com" {
+			t.Errorf("expected primary to override, got %q", s.Output.Url)
+		}
+	})
+
+	t.Run("empty primary preserves existing Output.Url", func(t *testing.T) {
+		s := &consolev1.DeploymentStatusSummary{Output: &consolev1.DeploymentOutput{Url: "https://old.example.com"}}
+		applyAggregatedLinks(s, []*consolev1.Link{{Url: "https://l.example.com", Name: "l"}}, "")
+		if s.Output.Url != "https://old.example.com" {
+			t.Errorf("expected existing URL to survive, got %q", s.Output.Url)
+		}
+	})
+}
+
+// TestLinksEqual exercises the comparison used by the GetDeployment
+// refresh loop to decide whether the cached annotation matches a fresh
+// scan — drift between the two triggers a cache rewrite.
+func TestLinksEqual(t *testing.T) {
+	t.Parallel()
+
+	a := []*consolev1.Link{{Url: "u", Title: "t", Source: "holos", Name: "n"}}
+	b := []*consolev1.Link{{Url: "u", Title: "t", Source: "holos", Name: "n"}}
+	if !linksEqual(a, b) {
+		t.Error("identical link slices should compare equal")
+	}
+
+	c := []*consolev1.Link{{Url: "u", Title: "different", Source: "holos", Name: "n"}}
+	if linksEqual(a, c) {
+		t.Error("title-different slices should compare unequal")
+	}
+
+	if linksEqual(a, nil) {
+		t.Error("non-empty vs nil should compare unequal")
+	}
+	if !linksEqual(nil, nil) {
+		t.Error("two nil slices should compare equal")
+	}
+}
+
+// keys returns the sorted key set of m for stable test output.
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/console/deployments/links_test.go
+++ b/console/deployments/links_test.go
@@ -249,6 +249,28 @@ func TestApplyAggregatedLinks(t *testing.T) {
 			t.Errorf("expected existing URL to survive, got %q", s.Output.Url)
 		}
 	})
+
+	t.Run("empty aggregated clears previously-set Links on shared summary", func(t *testing.T) {
+		// Regression for HOL-574 review round 3 P1: callers that
+		// reuse a *DeploymentStatusSummary across requests (test
+		// fakes, future cache implementations) MUST observe a fresh
+		// empty link set instead of a stale list lingering from a
+		// prior call.
+		s := &consolev1.DeploymentStatusSummary{
+			Output: &consolev1.DeploymentOutput{
+				Url:   "https://output-url.example.com",
+				Links: []*consolev1.Link{{Url: "https://stale.example.com", Name: "stale"}},
+			},
+		}
+		applyAggregatedLinks(s, nil, "")
+		if len(s.Output.Links) != 0 {
+			t.Errorf("expected stale Links cleared, got %+v", s.Output.Links)
+		}
+		// Existing Url preserved (legacy OutputURLAnnotation source).
+		if s.Output.Url != "https://output-url.example.com" {
+			t.Errorf("expected legacy Url preserved, got %q", s.Output.Url)
+		}
+	})
 }
 
 // TestLinksEqual exercises the comparison used by the GetDeployment

--- a/console/deployments/status.go
+++ b/console/deployments/status.go
@@ -68,9 +68,14 @@ func (h *Handler) GetDeploymentStatusSummary(
 	// shows. The handler reads the ConfigMap directly (cheap single GET) —
 	// the status cache stays focused on apps/v1.Deployment state only. A
 	// missing ConfigMap or annotation simply leaves summary.Output unset.
+	// Aggregated links (HOL-574) are merged from the same cache so polling
+	// clients receive the same `output.links` and promoted primary URL
+	// the list/detail RPCs serve, keeping the three read paths
+	// observably consistent.
 	var explicitRefs []*consolev1.LinkedTemplateRef
 	if cm, cmErr := h.k8s.GetDeployment(ctx, project, name); cmErr == nil {
 		mergeOutputURLAnnotation(summary, cm)
+		mergeAggregatedLinksAnnotation(summary, cm)
 		explicitRefs = linkedTemplateRefsFromAnnotation(cm)
 	} else {
 		slog.DebugContext(ctx, "could not read deployment ConfigMap for output-url merge",


### PR DESCRIPTION
## Summary

- Wires the HOL-573 link annotation parser into the Deployment RPC surface.
- Adds `K8sClient.ListDeploymentResources` (multi-kind scan via dynamic client) and `K8sClient.SetAggregatedLinksAnnotation` (cache writer mirroring `SetOutputURLAnnotation`).
- Introduces a deployments-package aggregator (`aggregateLinksFromResources`) that de-duplicates by (name, source) and promotes the first `console.holos.run/primary-url` annotation found (warning logged on subsequent ones).
- `CreateDeployment` and `UpdateDeployment` cache the aggregated set on the deployment ConfigMap as `console.holos.run/links` after a successful Apply/Reconcile.
- `ListDeployments` reads the cache verbatim — no per-resource scan on the hot path (verified by a panic-on-list dynamic stub).
- `GetDeployment` reads the cache **and** refreshes by scanning owned resources, rewriting the cache when the fresh scan disagrees so out-of-band annotation changes surface without a re-render.
- Promoted `primary-url` overrides both the legacy `OutputURLAnnotation` cache and any pre-existing `output.url`; an empty primary preserves the existing URL.

Fixes HOL-574

## Test plan

- [x] `go test ./console/deployments/...` — all suites pass including new `TestSetAggregatedLinksAnnotation`, `TestListDeploymentResources`, `TestAggregateLinksFromResources`, `TestSerializeAndDeserializeAggregatedLinks`, `TestApplyAggregatedLinks`, `TestLinksEqual`, and `TestHandler_AggregatedLinks` (12 subtests).
- [x] `make test` — full Go + 1023 frontend tests pass.
- [x] `make vet` clean; lint shows only pre-existing issues unrelated to this change.
- [ ] Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)