### PR TITLE
fix(frontend): centralize platform-template copy (HOL-583)

### DIFF
--- a/frontend/src/components/platform-template-copy.test.ts
+++ b/frontend/src/components/platform-template-copy.test.ts
@@ -1,0 +1,72 @@
+import {
+  ENABLED_TOGGLE_ACTIVE_DESCRIPTION,
+  ENABLED_TOGGLE_INACTIVE_DESCRIPTION,
+  ORG_SCOPE_INDEX_DESCRIPTION,
+  FOLDER_SCOPE_INDEX_DESCRIPTION,
+  REQUIRE_RULE_DESCRIPTION,
+  EXCLUDE_RULE_DESCRIPTION,
+  enabledToggleDescription,
+} from './platform-template-copy'
+
+describe('platform-template-copy', () => {
+  const constants: Record<string, string> = {
+    ENABLED_TOGGLE_ACTIVE_DESCRIPTION,
+    ENABLED_TOGGLE_INACTIVE_DESCRIPTION,
+    ORG_SCOPE_INDEX_DESCRIPTION,
+    FOLDER_SCOPE_INDEX_DESCRIPTION,
+    REQUIRE_RULE_DESCRIPTION,
+    EXCLUDE_RULE_DESCRIPTION,
+  }
+
+  it('exports non-empty strings for every copy constant', () => {
+    for (const [name, value] of Object.entries(constants)) {
+      expect(value, name).toEqual(expect.any(String))
+      expect(value.trim().length, name).toBeGreaterThan(0)
+    }
+  })
+
+  it('describes the active enabled state with eligibility and render-time language', () => {
+    expect(ENABLED_TOGGLE_ACTIVE_DESCRIPTION.toLowerCase()).toContain('eligible')
+    expect(ENABLED_TOGGLE_ACTIVE_DESCRIPTION.toLowerCase()).toContain('render')
+  })
+
+  it('describes the inactive enabled state with exclusion language', () => {
+    const lower = ENABLED_TOGGLE_INACTIVE_DESCRIPTION.toLowerCase()
+    expect(lower).toContain('disabled')
+    expect(lower).toMatch(/hidden|excluded/)
+  })
+
+  it('does not contain the misleading "applied to" phrase anywhere', () => {
+    for (const [name, value] of Object.entries(constants)) {
+      expect(value.toLowerCase(), name).not.toContain('applied to')
+    }
+  })
+
+  it('scopes org and folder index descriptions to their respective scopes', () => {
+    expect(ORG_SCOPE_INDEX_DESCRIPTION.toLowerCase()).toContain('organization')
+    expect(FOLDER_SCOPE_INDEX_DESCRIPTION.toLowerCase()).toContain('folder')
+  })
+
+  it('describes REQUIRE rules as affecting render-time inclusion only', () => {
+    const lower = REQUIRE_RULE_DESCRIPTION.toLowerCase()
+    expect(lower).toContain('require')
+    expect(lower).toContain('render')
+    expect(lower).not.toContain('force')
+  })
+
+  it('describes EXCLUDE rules as affecting render-time ref removal', () => {
+    const lower = EXCLUDE_RULE_DESCRIPTION.toLowerCase()
+    expect(lower).toContain('exclude')
+    expect(lower).toContain('render')
+  })
+
+  describe('enabledToggleDescription', () => {
+    it('returns the active description when enabled is true', () => {
+      expect(enabledToggleDescription(true)).toBe(ENABLED_TOGGLE_ACTIVE_DESCRIPTION)
+    })
+
+    it('returns the inactive description when enabled is false', () => {
+      expect(enabledToggleDescription(false)).toBe(ENABLED_TOGGLE_INACTIVE_DESCRIPTION)
+    })
+  })
+})

--- a/frontend/src/components/platform-template-copy.ts
+++ b/frontend/src/components/platform-template-copy.ts
@@ -1,0 +1,40 @@
+/**
+ * Centralized UI copy for platform-template surfaces.
+ *
+ * Platform templates describe eligibility and render-time inclusion; they do
+ * not directly "apply" resources to project namespaces. Drift between the org
+ * and folder wordings previously claimed the opposite, which was the root
+ * cause of the misdescription bug tracked under HOL-580. Consolidating the
+ * copy here prevents the wordings from diverging again.
+ *
+ * The `enabled` flag only controls pickability and render-time unification.
+ * Template policies with REQUIRE or EXCLUDE rules control inclusion at
+ * render time and do not themselves create, apply, or delete resources.
+ */
+
+export const ENABLED_TOGGLE_ACTIVE_DESCRIPTION =
+  'Enabled — eligible to appear in linked-template pickers and to be included when rendering downstream templates and deployments.'
+
+export const ENABLED_TOGGLE_INACTIVE_DESCRIPTION =
+  'Disabled — hidden from linked-template pickers and excluded from render-time unification. Existing linked references to this template render as no-ops.'
+
+export const ORG_SCOPE_INDEX_DESCRIPTION =
+  'Platform templates authored at organization scope are available for inclusion by project templates and deployments throughout the organization.'
+
+export const FOLDER_SCOPE_INDEX_DESCRIPTION =
+  'Platform templates authored at this folder scope are available for inclusion by project templates and deployments in this folder and its descendants.'
+
+export const REQUIRE_RULE_DESCRIPTION =
+  'REQUIRE — when a project template or deployment matching the target is rendered, include this platform template in the effective ref set. The rule affects render-time ref selection only; it does not itself create, apply, or delete resources.'
+
+export const EXCLUDE_RULE_DESCRIPTION =
+  'EXCLUDE — when a project template or deployment matching the target is rendered, remove this platform template from the effective ref set even if explicitly linked.'
+
+/**
+ * Returns the description for the enabled toggle based on the template state.
+ */
+export function enabledToggleDescription(enabled: boolean): string {
+  return enabled
+    ? ENABLED_TOGGLE_ACTIVE_DESCRIPTION
+    : ENABLED_TOGGLE_INACTIVE_DESCRIPTION
+}

--- a/frontend/src/components/template-policies/RuleEditor.tsx
+++ b/frontend/src/components/template-policies/RuleEditor.tsx
@@ -23,6 +23,10 @@ import { TemplatePolicyKind } from '@/queries/templatePolicies'
 import { TemplateScope, linkableKey } from '@/queries/templates'
 import type { LinkableTemplate } from '@/queries/templates'
 import type { RuleDraft } from '@/components/template-policies/rule-draft'
+import {
+  REQUIRE_RULE_DESCRIPTION,
+  EXCLUDE_RULE_DESCRIPTION,
+} from '@/components/platform-template-copy'
 
 export type RuleEditorProps = {
   rules: RuleDraft[]
@@ -31,19 +35,19 @@ export type RuleEditorProps = {
   disabled?: boolean
 }
 
-// Kind options shown in the kind picker. Localized labels for the UI.
+// Kind options shown in the kind picker. Descriptions describe render-time
+// inclusion semantics and come from the shared platform-template copy module
+// so the wording stays in sync with the rest of the UI.
 const KIND_OPTIONS: Array<{ value: TemplatePolicyKind; label: string; description: string }> = [
   {
     value: TemplatePolicyKind.REQUIRE,
     label: 'REQUIRE',
-    description:
-      'Force this template onto every project and deployment matched by the target patterns.',
+    description: REQUIRE_RULE_DESCRIPTION,
   },
   {
     value: TemplatePolicyKind.EXCLUDE,
     label: 'EXCLUDE',
-    description:
-      'Block this template from matching projects and deployments even if a project explicitly links it.',
+    description: EXCLUDE_RULE_DESCRIPTION,
   },
 ]
 

--- a/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
@@ -35,6 +35,7 @@ import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders, useUpda
 import { useGetOrganization } from '@/queries/organizations'
 import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { FOLDER_SCOPE_INDEX_DESCRIPTION } from '@/components/platform-template-copy'
 
 export const Route = createFileRoute(
   '/_authenticated/folders/$folderName/settings/',
@@ -522,9 +523,7 @@ export function FolderDetailPage({
           <div className="space-y-4">
             <h3 className="text-sm font-medium">Platform Templates</h3>
             <Separator />
-            <p className="text-sm text-muted-foreground">
-              Platform templates authored at this folder scope are applied to projects in this folder.
-            </p>
+            <p className="text-sm text-muted-foreground">{FOLDER_SCOPE_INDEX_DESCRIPTION}</p>
             <Link
               to="/folders/$folderName/templates"
               params={{ folderName }}

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -29,6 +29,7 @@ import {
 import { useGetFolder } from '@/queries/folders'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateReleases } from '@/components/template-releases'
+import { enabledToggleDescription } from '@/components/platform-template-copy'
 
 export const Route = createFileRoute(
   '/_authenticated/folders/$folderName/templates/$templateName',
@@ -253,9 +254,7 @@ export function FolderTemplateDetailPage({
                 disabled={!canWrite || updateMutation.isPending}
               />
               <span className="text-sm text-muted-foreground">
-                {template?.enabled
-                  ? 'Active — applied to projects in this folder'
-                  : 'Inactive — not applied to projects in this folder'}
+                {enabledToggleDescription(template?.enabled ?? false)}
               </span>
             </div>
           </div>

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/index.tsx
@@ -25,6 +25,7 @@ import {
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useListTemplates, makeFolderScope } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
+import { FOLDER_SCOPE_INDEX_DESCRIPTION } from '@/components/platform-template-copy'
 
 /** Row type for the template table. */
 type TemplateRow = {
@@ -190,9 +191,7 @@ export function FolderTemplatesIndexPage({
           )}
         </CardHeader>
         <CardContent className="space-y-4">
-          <p className="text-sm text-muted-foreground">
-            Platform templates at folder scope are applied to projects within this folder hierarchy.
-          </p>
+          <p className="text-sm text-muted-foreground">{FOLDER_SCOPE_INDEX_DESCRIPTION}</p>
           <Alert>
             <AlertDescription>
               To require or exclude a template from matching projects and deployments, create a{' '}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
@@ -32,6 +32,7 @@ import {
   useDeleteOrganization,
 } from '@/queries/organizations'
 import { useListFolders } from '@/queries/folders'
+import { ORG_SCOPE_INDEX_DESCRIPTION } from '@/components/platform-template-copy'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/')({
   component: OrgSettingsRoute,
@@ -374,10 +375,7 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
             <div className="space-y-4">
               <h3 className="text-sm font-medium">Platform Templates</h3>
               <Separator />
-              <p className="text-sm text-muted-foreground">
-                Platform templates are authored at organization scope and are applied to
-                projects in this organization.
-              </p>
+              <p className="text-sm text-muted-foreground">{ORG_SCOPE_INDEX_DESCRIPTION}</p>
               <Link
                 to="/orgs/$orgName/settings/org-templates"
                 params={{ orgName }}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
@@ -23,6 +23,7 @@ import { useGetTemplate, useUpdateTemplate, useCloneTemplate, makeOrgScope } fro
 import { useGetOrganization } from '@/queries/organizations'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateReleases } from '@/components/template-releases'
+import { enabledToggleDescription } from '@/components/platform-template-copy'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/org-templates/$templateName')({
   component: OrgTemplateDetailRoute,
@@ -191,7 +192,7 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
                 disabled={!canWrite || updateMutation.isPending}
               />
               <span className="text-sm text-muted-foreground">
-                {template?.enabled ? 'Active — applied to new project namespaces' : 'Inactive — not applied to new project namespaces'}
+                {enabledToggleDescription(template?.enabled ?? false)}
               </span>
             </div>
           </div>

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/index.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useListTemplates, makeOrgScope } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
+import { ORG_SCOPE_INDEX_DESCRIPTION } from '@/components/platform-template-copy'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/org-templates/')({
   component: OrgTemplatesListRoute,
@@ -73,10 +74,7 @@ export function OrgTemplatesListPage({ orgName: propOrgName }: { orgName?: strin
         )}
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-sm text-muted-foreground">
-          Platform templates are authored at organization scope and are applied to projects in
-          this organization.
-        </p>
+        <p className="text-sm text-muted-foreground">{ORG_SCOPE_INDEX_DESCRIPTION}</p>
         <Alert>
           <AlertDescription>
             To require or exclude a template from matching projects and deployments, create a{' '}


### PR DESCRIPTION
## Summary

- Introduces `frontend/src/components/platform-template-copy.ts` as the single source of truth for platform-template UI language (enabled toggle, org/folder index descriptions, REQUIRE/EXCLUDE rule descriptions).
- Reworks all six frontend surfaces plus `RuleEditor` to import from the shared module. Strings now describe eligibility and render-time inclusion, matching the proto comments clarified in HOL-581. No structural component extraction (tracked under HOL-584).
- Adds a regression-guard unit test that asserts the constants are non-empty, contain expected keywords, and explicitly forbids the misleading "applied to" phrase from reappearing.

Fixes HOL-583

## Files updated

- `frontend/src/components/platform-template-copy.ts` (new) + `.test.ts` (new).
- `frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx`
- `frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx`
- `frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/index.tsx`
- `frontend/src/routes/_authenticated/folders/$folderName/templates/index.tsx`
- `frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx`
- `frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx`
- `frontend/src/components/template-policies/RuleEditor.tsx`

## Test plan

- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd frontend && npx vitest run` — 65 files / 1032 tests pass
- [x] `make test` — Go + frontend tests pass
- [ ] Local E2E not run (strings-only change; no route/handler semantics affected). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)