### PR TITLE
refactor(frontend): extract PlatformTemplateEnabledToggle shared component

### DIFF
--- a/frontend/src/components/platform-template-enabled-toggle.test.tsx
+++ b/frontend/src/components/platform-template-enabled-toggle.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { PlatformTemplateEnabledToggle } from './platform-template-enabled-toggle'
+import {
+  ENABLED_TOGGLE_ACTIVE_DESCRIPTION,
+  ENABLED_TOGGLE_INACTIVE_DESCRIPTION,
+} from './platform-template-copy'
+
+describe('PlatformTemplateEnabledToggle', () => {
+  describe('description text', () => {
+    it('renders the active description when enabled=true', () => {
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={true}
+          canWrite={true}
+          isUpdating={false}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByText(ENABLED_TOGGLE_ACTIVE_DESCRIPTION),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(ENABLED_TOGGLE_INACTIVE_DESCRIPTION),
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders the inactive description when enabled=false', () => {
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={false}
+          canWrite={true}
+          isUpdating={false}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByText(ENABLED_TOGGLE_INACTIVE_DESCRIPTION),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(ENABLED_TOGGLE_ACTIVE_DESCRIPTION),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('switch state', () => {
+    it('switch reflects data-state=checked when enabled=true', () => {
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={true}
+          canWrite={true}
+          isUpdating={false}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByRole('switch', { name: /enabled/i }),
+      ).toHaveAttribute('data-state', 'checked')
+    })
+
+    it('switch reflects data-state=unchecked when enabled=false', () => {
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={false}
+          canWrite={true}
+          isUpdating={false}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByRole('switch', { name: /enabled/i }),
+      ).toHaveAttribute('data-state', 'unchecked')
+    })
+  })
+
+  describe('onChange', () => {
+    it('calls onChange(true) when toggled from off to on', async () => {
+      const onChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={false}
+          canWrite={true}
+          isUpdating={false}
+          onChange={onChange}
+        />,
+      )
+      await user.click(screen.getByRole('switch', { name: /enabled/i }))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(true)
+    })
+
+    it('calls onChange(false) when toggled from on to off', async () => {
+      const onChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={true}
+          canWrite={true}
+          isUpdating={false}
+          onChange={onChange}
+        />,
+      )
+      await user.click(screen.getByRole('switch', { name: /enabled/i }))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('permission gating', () => {
+    it('disables the switch when canWrite=false', () => {
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={false}
+          canWrite={false}
+          isUpdating={false}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByRole('switch', { name: /enabled/i }),
+      ).toBeDisabled()
+    })
+
+    it('does not call onChange when disabled switch is clicked', async () => {
+      const onChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={false}
+          canWrite={false}
+          isUpdating={false}
+          onChange={onChange}
+        />,
+      )
+      await user.click(screen.getByRole('switch', { name: /enabled/i }))
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pending state', () => {
+    it('disables the switch when isUpdating=true (matches existing pattern)', () => {
+      render(
+        <PlatformTemplateEnabledToggle
+          enabled={true}
+          canWrite={true}
+          isUpdating={true}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByRole('switch', { name: /enabled/i }),
+      ).toBeDisabled()
+    })
+
+    it('re-enables the switch once isUpdating flips back to false', () => {
+      const { rerender } = render(
+        <PlatformTemplateEnabledToggle
+          enabled={true}
+          canWrite={true}
+          isUpdating={true}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByRole('switch', { name: /enabled/i }),
+      ).toBeDisabled()
+
+      rerender(
+        <PlatformTemplateEnabledToggle
+          enabled={true}
+          canWrite={true}
+          isUpdating={false}
+          onChange={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByRole('switch', { name: /enabled/i }),
+      ).not.toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/components/platform-template-enabled-toggle.tsx
+++ b/frontend/src/components/platform-template-enabled-toggle.tsx
@@ -1,0 +1,53 @@
+import { Switch } from '@/components/ui/switch'
+import { enabledToggleDescription } from '@/components/platform-template-copy'
+
+/**
+ * PlatformTemplateEnabledToggle renders the shared "Enabled" row used on
+ * platform-template detail pages at both org and folder scope.
+ *
+ * The row is: a fixed-width "Enabled" label, the switch itself, and the
+ * scope-agnostic description text sourced from platform-template-copy so
+ * there is exactly one place the wording can drift (HOL-580, HOL-583).
+ *
+ * The component is intentionally scope-agnostic: it takes only the minimum
+ * state needed to render and emit changes. The permission-denied hint
+ * (org Owner vs folder Owner) is rendered by the parent route because the
+ * exact wording differs between scopes and the hint is displayed in a
+ * different region of the page (above the CUE editor, not next to the
+ * toggle). Keeping the hint outside this component means the component
+ * contains zero scope-specific branching.
+ */
+export interface PlatformTemplateEnabledToggleProps {
+  /** Current enabled state of the platform template. */
+  enabled: boolean
+  /** Whether the current user has permission to toggle enabled. */
+  canWrite: boolean
+  /** Whether an update mutation is currently in flight. */
+  isUpdating: boolean
+  /** Invoked with the next enabled state when the user toggles the switch. */
+  onChange: (next: boolean) => void
+}
+
+export function PlatformTemplateEnabledToggle({
+  enabled,
+  canWrite,
+  isUpdating,
+  onChange,
+}: PlatformTemplateEnabledToggleProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-36 text-sm text-muted-foreground shrink-0">
+        Enabled
+      </span>
+      <Switch
+        aria-label="Enabled"
+        checked={enabled}
+        onCheckedChange={onChange}
+        disabled={!canWrite || isUpdating}
+      />
+      <span className="text-sm text-muted-foreground">
+        {enabledToggleDescription(enabled)}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -8,7 +8,6 @@ import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
 import {
   Dialog,
   DialogContent,
@@ -29,7 +28,7 @@ import {
 import { useGetFolder } from '@/queries/folders'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateReleases } from '@/components/template-releases'
-import { enabledToggleDescription } from '@/components/platform-template-copy'
+import { PlatformTemplateEnabledToggle } from '@/components/platform-template-enabled-toggle'
 
 export const Route = createFileRoute(
   '/_authenticated/folders/$folderName/templates/$templateName',
@@ -245,18 +244,12 @@ export function FolderTemplateDetailPage({
               </div>
             )}
 
-            <div className="flex items-center gap-2">
-              <span className="w-36 text-sm text-muted-foreground shrink-0">Enabled</span>
-              <Switch
-                aria-label="Enabled"
-                checked={template?.enabled ?? false}
-                onCheckedChange={handleToggleEnabled}
-                disabled={!canWrite || updateMutation.isPending}
-              />
-              <span className="text-sm text-muted-foreground">
-                {enabledToggleDescription(template?.enabled ?? false)}
-              </span>
-            </div>
+            <PlatformTemplateEnabledToggle
+              enabled={template?.enabled ?? false}
+              canWrite={canWrite}
+              isUpdating={updateMutation.isPending}
+              onChange={handleToggleEnabled}
+            />
           </div>
 
           <div className="space-y-4">

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
@@ -8,7 +8,6 @@ import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
 import {
   Dialog,
   DialogContent,
@@ -23,7 +22,7 @@ import { useGetTemplate, useUpdateTemplate, useCloneTemplate, makeOrgScope } fro
 import { useGetOrganization } from '@/queries/organizations'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateReleases } from '@/components/template-releases'
-import { enabledToggleDescription } from '@/components/platform-template-copy'
+import { PlatformTemplateEnabledToggle } from '@/components/platform-template-enabled-toggle'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/settings/org-templates/$templateName')({
   component: OrgTemplateDetailRoute,
@@ -183,18 +182,12 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
               </div>
             )}
 
-            <div className="flex items-center gap-2">
-              <span className="w-36 text-sm text-muted-foreground shrink-0">Enabled</span>
-              <Switch
-                aria-label="Enabled"
-                checked={template?.enabled ?? false}
-                onCheckedChange={handleToggleEnabled}
-                disabled={!canWrite || updateMutation.isPending}
-              />
-              <span className="text-sm text-muted-foreground">
-                {enabledToggleDescription(template?.enabled ?? false)}
-              </span>
-            </div>
+            <PlatformTemplateEnabledToggle
+              enabled={template?.enabled ?? false}
+              canWrite={canWrite}
+              isUpdating={updateMutation.isPending}
+              onChange={handleToggleEnabled}
+            />
           </div>
 
           <div className="space-y-4">


### PR DESCRIPTION
## Summary

- Introduces `PlatformTemplateEnabledToggle` in `frontend/src/components/platform-template-enabled-toggle.tsx` — a scope-agnostic shared component that renders the label + `Switch` + description text (sourced from `platform-template-copy.ts`) with permission gating and pending-state handling.
- Replaces the duplicated inline JSX blocks on the org-scope and folder-scope template detail pages with a single `<PlatformTemplateEnabledToggle ... />` call, dropping the direct `Switch` and `enabledToggleDescription` imports from both routes.
- Adds a Vitest + React Testing Library suite (10 tests) that covers active/inactive description text, `onChange(true)` / `onChange(false)` transitions, `canWrite=false` disables the switch (and prevents `onChange`), and `isUpdating=true` disables the switch and re-enables once the flag flips back.
- Existing route-level tests in `-detail.test.tsx` / `-org-templates.test.tsx` continue to query the switch by `aria-label="Enabled"` and keep passing unchanged — the shared component preserves the aria-label and DOM shape.

**Design choice:** the permission-denied hint ("You need org Owner permissions..." vs "You need folder Owner permissions...") stays in the parent route. It is rendered above the CUE editor, not next to the toggle, and the wording differs by scope; keeping it outside the component preserves the zero-scope-branching contract per the ticket's first option.

**Non-goal (scope guardrail from HOL-580):** did not extract the CUE editor, releases, clone, or danger-zone sections — stopped at the Enabled toggle row as required.

Fixes HOL-584

## Test plan

- [x] `cd frontend && npx vitest run` — 66 files, 1042 tests pass (including the new `platform-template-enabled-toggle.test.tsx` with 10 tests).
- [x] `cd frontend && npx eslint` on the four touched files — clean.
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `make test` — Go packages all `ok`, frontend 1042/1042.
- [x] Verified org-scope detail toggle still queryable by `screen.getByRole('switch', { name: /enabled/i })` in existing `-org-templates.test.tsx`.
- [x] Verified folder-scope detail toggle still queryable in existing `-detail.test.tsx`.

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)