### PR TITLE
docs(console): point template authors at external-link annotations (HOL-576)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,16 @@ curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
 
 See [docs/dev-token-endpoint.md](docs/dev-token-endpoint.md) for the full API reference.
 
+## Annotation Keys for External Links
+
+When working in `console/deployments/` or `console/links/`, refer to
+[ADR 028: External Link Annotations on Deployment Resources](https://github.com/holos-run/cartographer/blob/main/docs/adrs/028-external-link-annotations.md)
+and the template-author guide at
+[CUE Template Guide → External Links](https://github.com/holos-run/cartographer/blob/main/docs/cue-template-guide.md#external-links).
+The annotation key constants — `AnnotationExternalLinkPrefix`,
+`AnnotationPrimaryURL`, `AnnotationAggregatedLinks`,
+`AnnotationArgoCDLinkPrefix` — live in `api/v1alpha2/annotations.go`.
+
 ## Commit Messages
 
 All commit messages must follow this format and include the root-cause analysis for why the issue happened, with citations to sources (for example, deep links to GitHub issues that describe the problem and its cause):

--- a/console/templates/default_template.cue
+++ b/console/templates/default_template.cue
@@ -105,6 +105,41 @@ projectResources: {
 			}
 
 			// Deployment runs the container image.
+			//
+			// External links (HOL-550) can be attached to any rendered
+			// resource by adding `console.holos.run/external-link.<name>`
+			// annotations whose values are JSON `{url, title, description}`.
+			// A `console.holos.run/primary-url` annotation marks the single
+			// primary link surfaced on the deployment list page (and fills
+			// `DeploymentOutput.url`). Argo CD's
+			// `link.argocd.argoproj.io/<suffix>` convention is honored
+			// read-only; never write that key from Holos templates.
+			//
+			// Uncomment the block below to publish a primary URL plus
+			// "Logs" and "Metrics" links on this Deployment. The console
+			// aggregator will surface them on both the list and detail
+			// pages. See ADR 028 for the design rationale and the CUE
+			// Template Guide ("External Links") for the full reference:
+			//   https://github.com/holos-run/cartographer/blob/main/docs/adrs/028-external-link-annotations.md
+			//   https://github.com/holos-run/cartographer/blob/main/docs/cue-template-guide.md#external-links
+			//
+			// The annotation values are the JSON-encoded link objects
+			// themselves — written as CUE raw strings (`#"..."#`) so inner
+			// double-quotes don't need backslash escapes. `\#(input.name)`
+			// is CUE raw-string interpolation; it splices the deployment
+			// name into the URL at render time. Templates cannot add
+			// `import "encoding/json"` here because the renderer prepends
+			// the generated schema before compiling, so the raw-string
+			// pattern is the idiomatic form:
+			//
+			//   Deployment: (input.name): metadata: annotations: _annotations & {
+			//       "console.holos.run/primary-url":
+			//           #"{"url":"https://\#(input.name).apps.example.com","title":"\#(input.name)","description":"Application URL"}"#
+			//       "console.holos.run/external-link.logs":
+			//           #"{"url":"https://logs.example.com/deployments/\#(input.name)","title":"Logs","description":"Application logs in Datadog"}"#
+			//       "console.holos.run/external-link.metrics":
+			//           #"{"url":"https://grafana.example.com/d/\#(input.name)","title":"Metrics","description":"Service-level metrics dashboard"}"#
+			//   }
 			Deployment: (input.name): {
 				apiVersion: "apps/v1"
 				kind:       "Deployment"


### PR DESCRIPTION
## Summary
- Add a brief "Annotation Keys for External Links" pointer in `CONTRIBUTING.md` so future agents working in `console/deployments/` and `console/links/` know where to find the annotation contract (ADR 028) and the template-author guide.
- Add a commented-out authoring example to `console/templates/default_template.cue` showing the primary-url annotation plus two regular external links. The example uses CUE raw strings (`#"..."#`) with `\#(input.name)` interpolation because the renderer prepends the generated schema before `CompileString` — `import "encoding/json"` is therefore not available at the top of template source. The raw-string pattern compiles cleanly through the same render path; verified end-to-end against the renderer logic.

The companion ADR 028 and the matching `cue-template-guide.md` "External Links" section land in https://github.com/holos-run/cartographer in a separate PR (the previous in-tree `docs/` directory was moved to that repo in commit ddc60e0, "move docs to project planning location"). Cross-link: holos-run/cartographer feature branch `feat/hol-576-external-link-annotations`.

Fixes HOL-576

## Test plan
- [x] `go test ./console/templates/... ./console/links/... ./console/deployments/...` — all pass
- [x] `make test` — all 1059 frontend + Go tests pass
- [x] CUE example pattern verified end-to-end against the actual renderer (`cuecontext.New().CompileString(schema + template)`) so the commented block, when uncommented, will render successfully

Generated with [Claude Code](https://claude.com/claude-code)