### PR TITLE
chore(console): cleanup after external-link feature lands (HOL-577)

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -131,36 +131,49 @@ const (
 	// prefix for external links surfaced on a deployment. Links are keyed
 	// by suffix (for example, `console.holos.run/external-link.logs`),
 	// where the suffix serves as a stable per-deployment identity for
-	// de-duplication across resources. The annotation value is the link
-	// URL; optional title and description can be supplied via
-	// `<prefix><name>.title` and `<prefix><name>.description` variants
-	// (the aggregator, added in HOL-573, is the canonical consumer of this
-	// convention). Introduced in HOL-572 as part of the parent deployment
-	// links plan HOL-550.
+	// de-duplication across resources. The annotation value is a JSON
+	// object of the form `{"url": "...", "title": "...", "description":
+	// "..."}`; only `url` is required. Title falls back to the suffix when
+	// omitted; description is optional. Parsed by `console/links` and
+	// aggregated by `console/deployments` (the cached set is stored on the
+	// deployment ConfigMap as AnnotationAggregatedLinks). See ADR 028 in
+	// the cartographer repo for the design rationale and HOL-550 for the
+	// parent plan.
 	AnnotationExternalLinkPrefix = "console.holos.run/external-link."
 	// AnnotationPrimaryURL names the single "primary" deployment URL a
-	// template wants the UI to treat as canonical when more than one link
-	// is available. Attached to the deployment ConfigMap. Optional — when
-	// unset, the aggregator falls back to the legacy `DeploymentOutput.url`
-	// value and then to the first Holos-authored link in annotation order.
-	// Introduced in HOL-572.
+	// template wants the UI to treat as canonical. May be attached to any
+	// resource owned by the deployment (the aggregator picks the first
+	// occurrence in scan order and warns on conflicts). The value is a
+	// JSON object of the form `{"url": "...", "title": "...",
+	// "description": "..."}`; only `url` is required. The promoted URL
+	// fills `DeploymentOutput.url` so list-page renderers that only
+	// consume the primary URL keep working. When no resource publishes a
+	// primary-url annotation, `DeploymentOutput.url` is whatever the
+	// template's `output.url` (cached as `console.holos.run/output-url` on
+	// the deployment ConfigMap) holds. See ADR 028 in the cartographer
+	// repo and HOL-550 for the parent plan.
 	AnnotationPrimaryURL = "console.holos.run/primary-url"
 	// AnnotationAggregatedLinks is the optional JSON cache of the fully
 	// resolved Link list for a deployment, written onto the deployment
 	// ConfigMap by the Create/UpdateDeployment handlers so list-view RPCs
 	// (ListDeployments, GetDeploymentStatusSummary) can return links
-	// without re-walking the workload annotations. Treated as a cache, not
+	// without re-walking the workload annotations. The cached payload is
+	// `{"links": [...], "primary_url": "..."}`. Treated as a cache, not
 	// the source of truth: the authoritative links still live on the
-	// resources themselves. Introduced in HOL-572.
+	// resources themselves and the GetDeployment refresh path
+	// re-aggregates and rewrites this annotation when it disagrees with
+	// the live resources.
 	AnnotationAggregatedLinks = "console.holos.run/links"
 	// AnnotationArgoCDLinkPrefix is the annotation-key prefix Argo CD uses
-	// to attach external links to Kubernetes resources. Values are URLs
-	// (see https://argo-cd.readthedocs.io/en/stable/user-guide/external-url/
-	// and the `link.argocd.argoproj.io/*` convention). Holos harvests
-	// these alongside its own
-	// `console.holos.run/external-link.*` annotations so clusters running
-	// both tools do not force template authors to duplicate links.
-	// Introduced in HOL-572.
+	// to attach external links to Kubernetes resources. Values are bare
+	// URL strings (no JSON envelope); the suffix doubles as the link
+	// title. See
+	// https://argo-cd.readthedocs.io/en/stable/user-guide/external-url/
+	// for the upstream convention. Holos harvests these alongside its own
+	// `console.holos.run/external-link.*` annotations on read; templates
+	// MUST NOT write to this prefix from Holos because Argo CD would
+	// render Holos's JSON-valued external-link annotations as broken
+	// URLs.
 	AnnotationArgoCDLinkPrefix = "link.argocd.argoproj.io/"
 
 	// Release ConfigMap labels and annotations (ADR 024).

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -149,39 +149,52 @@
 // prefix for external links surfaced on a deployment. Links are keyed
 // by suffix (for example, `console.holos.run/external-link.logs`),
 // where the suffix serves as a stable per-deployment identity for
-// de-duplication across resources. The annotation value is the link
-// URL; optional title and description can be supplied via
-// `<prefix><name>.title` and `<prefix><name>.description` variants
-// (the aggregator, added in HOL-573, is the canonical consumer of this
-// convention). Introduced in HOL-572 as part of the parent deployment
-// links plan HOL-550.
+// de-duplication across resources. The annotation value is a JSON
+// object of the form `{"url": "...", "title": "...", "description":
+// "..."}`; only `url` is required. Title falls back to the suffix when
+// omitted; description is optional. Parsed by `console/links` and
+// aggregated by `console/deployments` (the cached set is stored on the
+// deployment ConfigMap as AnnotationAggregatedLinks). See ADR 028 in
+// the cartographer repo for the design rationale and HOL-550 for the
+// parent plan.
 #AnnotationExternalLinkPrefix: "console.holos.run/external-link."
 
 // AnnotationPrimaryURL names the single "primary" deployment URL a
-// template wants the UI to treat as canonical when more than one link
-// is available. Attached to the deployment ConfigMap. Optional — when
-// unset, the aggregator falls back to the legacy `DeploymentOutput.url`
-// value and then to the first Holos-authored link in annotation order.
-// Introduced in HOL-572.
+// template wants the UI to treat as canonical. May be attached to any
+// resource owned by the deployment (the aggregator picks the first
+// occurrence in scan order and warns on conflicts). The value is a
+// JSON object of the form `{"url": "...", "title": "...",
+// "description": "..."}`; only `url` is required. The promoted URL
+// fills `DeploymentOutput.url` so list-page renderers that only
+// consume the primary URL keep working. When no resource publishes a
+// primary-url annotation, `DeploymentOutput.url` is whatever the
+// template's `output.url` (cached as `console.holos.run/output-url` on
+// the deployment ConfigMap) holds. See ADR 028 in the cartographer
+// repo and HOL-550 for the parent plan.
 #AnnotationPrimaryURL: "console.holos.run/primary-url"
 
 // AnnotationAggregatedLinks is the optional JSON cache of the fully
 // resolved Link list for a deployment, written onto the deployment
 // ConfigMap by the Create/UpdateDeployment handlers so list-view RPCs
 // (ListDeployments, GetDeploymentStatusSummary) can return links
-// without re-walking the workload annotations. Treated as a cache, not
+// without re-walking the workload annotations. The cached payload is
+// `{"links": [...], "primary_url": "..."}`. Treated as a cache, not
 // the source of truth: the authoritative links still live on the
-// resources themselves. Introduced in HOL-572.
+// resources themselves and the GetDeployment refresh path
+// re-aggregates and rewrites this annotation when it disagrees with
+// the live resources.
 #AnnotationAggregatedLinks: "console.holos.run/links"
 
 // AnnotationArgoCDLinkPrefix is the annotation-key prefix Argo CD uses
-// to attach external links to Kubernetes resources. Values are URLs
-// (see https://argo-cd.readthedocs.io/en/stable/user-guide/external-url/
-// and the `link.argocd.argoproj.io/*` convention). Holos harvests
-// these alongside its own
-// `console.holos.run/external-link.*` annotations so clusters running
-// both tools do not force template authors to duplicate links.
-// Introduced in HOL-572.
+// to attach external links to Kubernetes resources. Values are bare
+// URL strings (no JSON envelope); the suffix doubles as the link
+// title. See
+// https://argo-cd.readthedocs.io/en/stable/user-guide/external-url/
+// for the upstream convention. Holos harvests these alongside its own
+// `console.holos.run/external-link.*` annotations on read; templates
+// MUST NOT write to this prefix from Holos because Argo CD would
+// render Holos's JSON-valued external-link annotations as broken
+// URLs.
 #AnnotationArgoCDLinkPrefix: "link.argocd.argoproj.io/"
 
 // ResourceTypeTemplateRelease is the resource type label value for release

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -1134,12 +1134,13 @@ func (h *Handler) GetDeploymentRenderPreview(
 // object (e.g. `{}`) produces a non-nil DeploymentOutput with zero values so
 // the frontend — not the backend — decides whether to render.
 //
-// Both the primary `url` and the additive `links` list (HOL-572) are
-// preserved: templates that publish `output.links` alongside `output.url`
-// have the full list surfaced on the render-preview path without requiring
-// the HOL-573/HOL-574 aggregator to be in place. The links are passed
-// through verbatim; normalization and annotation harvesting belong to the
-// follow-on aggregator.
+// Both the primary `url` and the additive `links` list are preserved:
+// templates that publish `output.links` alongside `output.url` have the
+// full list surfaced on the render-preview path even before the
+// annotation aggregator runs. The links are passed through verbatim;
+// normalization and live-resource annotation harvesting belong to the
+// `console/links` parser and the aggregator helpers in this package
+// (`aggregateLinksFromResources`, `applyAggregatedLinks`).
 func deploymentOutputFromJSON(ctx context.Context, project, name string, outputJSON *string) *consolev1.DeploymentOutput {
 	if outputJSON == nil {
 		return nil

--- a/frontend/src/gen/holos/console/v1/deployments_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/deployments_pb.d.ts
@@ -1290,9 +1290,12 @@ export declare const GetDeploymentRenderPreviewResponseSchema: GenMessage<GetDep
 export declare type DeploymentOutput = Message<"holos.console.v1.DeploymentOutput"> & {
   /**
    * url is the primary URL the UI should show for the deployment. Empty when
-   * the template has no meaningful URL to publish. Preserved unchanged from
-   * the pre-HOL-572 wire format; treated as the canonical primary link when
-   * no entry in `links` is flagged as primary.
+   * the template has no meaningful URL to publish. The backend populates this
+   * field from (in order of precedence) the `console.holos.run/primary-url`
+   * annotation harvested from any owned resource, the cached
+   * `console.holos.run/output-url` annotation written from the template's
+   * `output.url`, or the rendered `output.url` itself when no annotation is
+   * available.
    *
    * @generated from field: string url = 1;
    */

--- a/gen/holos/console/v1/deployments.pb.go
+++ b/gen/holos/console/v1/deployments.pb.go
@@ -2502,9 +2502,12 @@ func (x *GetDeploymentRenderPreviewResponse) GetOutput() *DeploymentOutput {
 type DeploymentOutput struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// url is the primary URL the UI should show for the deployment. Empty when
-	// the template has no meaningful URL to publish. Preserved unchanged from
-	// the pre-HOL-572 wire format; treated as the canonical primary link when
-	// no entry in `links` is flagged as primary.
+	// the template has no meaningful URL to publish. The backend populates this
+	// field from (in order of precedence) the `console.holos.run/primary-url`
+	// annotation harvested from any owned resource, the cached
+	// `console.holos.run/output-url` annotation written from the template's
+	// `output.url`, or the rendered `output.url` itself when no annotation is
+	// available.
 	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	// links carries the full set of external links surfaced for a deployment,
 	// aggregated from both Holos-authored annotations

--- a/proto/holos/console/v1/deployments.proto
+++ b/proto/holos/console/v1/deployments.proto
@@ -437,9 +437,12 @@ message GetDeploymentRenderPreviewResponse {
 // annotations or labels.
 message DeploymentOutput {
   // url is the primary URL the UI should show for the deployment. Empty when
-  // the template has no meaningful URL to publish. Preserved unchanged from
-  // the pre-HOL-572 wire format; treated as the canonical primary link when
-  // no entry in `links` is flagged as primary.
+  // the template has no meaningful URL to publish. The backend populates this
+  // field from (in order of precedence) the `console.holos.run/primary-url`
+  // annotation harvested from any owned resource, the cached
+  // `console.holos.run/output-url` annotation written from the template's
+  // `output.url`, or the rendered `output.url` itself when no annotation is
+  // available.
   string url = 1;
   // links carries the full set of external links surfaced for a deployment,
   // aggregated from both Holos-authored annotations


### PR DESCRIPTION
## Summary

Final cleanup phase of the HOL-550 external-link feature plan. No transitional scaffolding, feature flags, dual-write paths, or `TODO(HOL-550)` / `FIXME(HOL-550)` markers were found in the codebase, so this PR is intentionally small. It refreshes the in-source documentation for the new annotation constants so they accurately describe the shipped contract:

- `api/v1alpha2/annotations.go` — rewrote the godoc on `AnnotationExternalLinkPrefix`, `AnnotationPrimaryURL`, `AnnotationAggregatedLinks`, and `AnnotationArgoCDLinkPrefix`. The previous text described an old draft where titles/descriptions lived in sibling `<prefix><name>.title` annotations; the actual implementation in `console/links` parses a single JSON-valued annotation `{url, title, description}`.
- `proto/holos/console/v1/deployments.proto` — clarified `DeploymentOutput.url`. The old comment claimed the field was the canonical primary "when no entry in `links` is flagged as primary" — but `Link` has no `primary` flag. New comment lists the actual precedence: primary-url annotation -> cached output-url annotation -> rendered `output.url`.
- `console/deployments/handler.go` — removed the "without requiring the HOL-573/HOL-574 aggregator to be in place" caveat from `deploymentOutputFromJSON`. The aggregator landed in HOL-573/HOL-574; the caveat is no longer accurate.
- `api/v1alpha2/schema_gen.cue`, `gen/holos/console/v1/deployments.pb.go`, `frontend/src/gen/holos/console/v1/deployments_pb.d.ts` — regenerated via `make generate` so the CUE schema and TypeScript / Go bindings reflect the Go-source godoc rewrites.

### Decision on the HOL-575 round-2 follow-up

HOL-575's review surfaced that the aggregator dedups on `(name, source)`, which collapses two distinct URLs that share the same suffix on different resources (for example, `console.holos.run/external-link.logs` on both a Deployment and a Service). The aggregator's godoc explicitly documents this: "the same logical link appearing twice is expected (Service + Ingress, etc.)". A template author who actually wants two distinct URLs uses two distinct suffixes (`external-link.logs-deployment`, `external-link.logs-service`).

After re-reading the aggregator code, this is intentional and acceptable for now. The dedup contract treats the suffix as the per-deployment link identity, which is the documented behavior in `aggregateLinksFromResources`. **No follow-up ticket is needed.** If real-world templates surface a need to disambiguate on URL rather than suffix, we can revisit, but the current design lines up with the parent-plan goal of "the same link appearing on multiple resources should not cause UI noise." ADR 028 in cartographer already lists this in its Open Questions / Follow-ups for visibility.

### End-to-end verification of HOL-550 acceptance criteria

- AC: Template authors can attach zero or more external links via `console.holos.run/external-link.<name>` JSON annotations -> `console/links/parser.go` parses; `default_template.cue` shows the canonical example.
- AC: Template authors can mark one link as primary via `console.holos.run/primary-url` -> parser surfaces it; aggregator promotes it.
- AC: Console aggregates links from all owned resources and returns them in `DeploymentOutput.links` with the primary URL in `DeploymentOutput.url` (backwards-compat preserved) -> `aggregateLinksFromResources` walks resources; `applyAggregatedLinks` populates the wire types; `mergeOutputURLAnnotation` keeps the legacy URL path working.
- AC: ArgoCD `link.argocd.argoproj.io/<suffix>` interop, no writes -> parser handles it as `source="argocd"`; no apply.go path writes that prefix.
- AC: List page renders the primary URL first; detail page renders a Links section -> `frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx` and `$deploymentName.tsx`.
- AC: Proto changes are additive; `DeploymentOutput.url` stays at field 1 -> verified in `proto/holos/console/v1/deployments.proto` (url=1, links=2).
- AC: Go tests with `kubernetes/fake` -> `console/links/parser_test.go` (100% coverage), `console/deployments/links_test.go`, `console/deployments/k8s_test.go`, `console/deployments/handler_test.go`.
- AC: Frontend Vitest + RTL tests with mocked hooks -> `-index.test.tsx` and `-$deploymentName.test.tsx`.
- AC: `make lint && make test` pass -> `make test` passes (Go: all packages ok; frontend: 66 files / 1059 tests). `make lint` reports only pre-existing warnings in files this PR does not touch.
- AC: ADR + template-author docs -> ADR 028 in cartographer (PR #1, merged); template-author guidance in `console/templates/default_template.cue` and the cartographer CUE template guide.

Fixes HOL-577

## Test plan

- [x] `make generate` succeeds.
- [x] `make test` passes (backend + frontend).
- [ ] Manual smoke on a local cluster: deferred — no behavioral changes in this PR (comments / godoc only). The end-to-end smoke remains a parent-HOL-550 follow-up note; the underlying behavior was already exercised in HOL-573/HOL-574/HOL-575 unit tests.

> Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)