### PR TITLE
fix(console): move Kind REQUIRE/EXCLUDE help into a label tooltip

### DIFF
--- a/frontend/src/components/template-policies/RuleEditor.test.tsx
+++ b/frontend/src/components/template-policies/RuleEditor.test.tsx
@@ -1,0 +1,118 @@
+import { act, render, screen, within } from '@testing-library/react'
+import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { RuleEditor } from './RuleEditor'
+import type { RuleDraft } from './rule-draft'
+import { TemplatePolicyKind } from '@/queries/templatePolicies'
+import {
+  REQUIRE_RULE_DESCRIPTION,
+  EXCLUDE_RULE_DESCRIPTION,
+} from '@/components/platform-template-copy'
+
+// RED (HOL-588): The verbose REQUIRE/EXCLUDE copy previously rendered inside
+// each `<SelectItem>` and overflowed the popover. The tooltip on a button
+// trigger next to the Kind `<Label>` is now the single surface for that copy.
+// These tests pin:
+//
+//   1. Kind <SelectItem> rows render only the short `REQUIRE` / `EXCLUDE`
+//      label and do not carry any fragment of the long rule descriptions.
+//   2. A focusable `<button>` sits next to the Kind label with
+//      `aria-label="Explain REQUIRE and EXCLUDE"`, and its tooltip surfaces
+//      text from both REQUIRE_RULE_DESCRIPTION and EXCLUDE_RULE_DESCRIPTION.
+//
+// Polyfills for jsdom — Radix Select / Tooltip use pointer capture APIs that
+// are absent in jsdom and must exist for `userEvent` interactions to dispatch
+// cleanly. We also polyfill scrollIntoView (already installed globally by
+// src/test/setup.ts but repeated here so the test is readable in isolation).
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+
+function makeRule(overrides: Partial<RuleDraft> = {}): RuleDraft {
+  return {
+    kind: TemplatePolicyKind.REQUIRE,
+    templateKey: '',
+    versionConstraint: '',
+    projectPattern: '*',
+    deploymentPattern: '*',
+    ...overrides,
+  }
+}
+
+describe('RuleEditor — Kind help tooltip (HOL-588)', () => {
+  it('renders SelectItem rows with only the short REQUIRE/EXCLUDE labels', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+
+    render(
+      <RuleEditor
+        rules={[makeRule()]}
+        onChange={vi.fn()}
+        linkableTemplates={[]}
+      />,
+    )
+
+    const row = screen.getByTestId('rule-editor-row-0')
+    const trigger = within(row).getByRole('combobox', { name: /rule 1 kind/i })
+    await user.click(trigger)
+
+    // Radix renders SelectItem with role="option" only when the popover is
+    // open, so we match by role to avoid false positives from hidden nodes.
+    const options = await screen.findAllByRole('option')
+    const labels = options.map((o) => o.textContent?.trim() ?? '')
+    expect(labels).toEqual(expect.arrayContaining(['REQUIRE', 'EXCLUDE']))
+
+    // Neither option row should carry the long description copy anymore.
+    // We assert against a stable fragment of REQUIRE_RULE_DESCRIPTION so the
+    // test stays meaningful even if the copy is edited lightly.
+    for (const option of options) {
+      expect(option.textContent ?? '').not.toMatch(
+        /include this platform template in the effective ref set/i,
+      )
+      expect(option.textContent ?? '').not.toMatch(
+        /remove this platform template from the effective ref set/i,
+      )
+    }
+  })
+
+  it('exposes a focusable tooltip trigger next to the Kind label with both descriptions', async () => {
+    render(
+      <RuleEditor
+        rules={[makeRule()]}
+        onChange={vi.fn()}
+        linkableTemplates={[]}
+      />,
+    )
+
+    const row = screen.getByTestId('rule-editor-row-0')
+    const triggerButton = within(row).getByRole('button', {
+      name: /explain require and exclude/i,
+    })
+    // AC: must be a focusable <button type="button"> (not a <span>) so it
+    // participates in Tab order without extra tabIndex and does not submit
+    // the surrounding form when Enter is pressed.
+    expect(triggerButton.tagName).toBe('BUTTON')
+    expect(triggerButton).toHaveAttribute('type', 'button')
+    // A <button> has tabIndex 0 by default; asserting the button is focusable
+    // via `.focus()` pins the observable contract without depending on
+    // user-event's synthetic tab order in jsdom. Wrapping in act silences
+    // Radix Tooltip's internal state update that fires on focus.
+    act(() => {
+      triggerButton.focus()
+    })
+    expect(triggerButton).toHaveFocus()
+
+    // Radix Tooltip opens on focus and portals the content; findByRole
+    // handles the async mount.
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip).toHaveTextContent(REQUIRE_RULE_DESCRIPTION)
+    expect(tooltip).toHaveTextContent(EXCLUDE_RULE_DESCRIPTION)
+  })
+})

--- a/frontend/src/components/template-policies/RuleEditor.tsx
+++ b/frontend/src/components/template-policies/RuleEditor.tsx
@@ -35,20 +35,13 @@ export type RuleEditorProps = {
   disabled?: boolean
 }
 
-// Kind options shown in the kind picker. Descriptions describe render-time
-// inclusion semantics and come from the shared platform-template copy module
-// so the wording stays in sync with the rest of the UI.
-const KIND_OPTIONS: Array<{ value: TemplatePolicyKind; label: string; description: string }> = [
-  {
-    value: TemplatePolicyKind.REQUIRE,
-    label: 'REQUIRE',
-    description: REQUIRE_RULE_DESCRIPTION,
-  },
-  {
-    value: TemplatePolicyKind.EXCLUDE,
-    label: 'EXCLUDE',
-    description: EXCLUDE_RULE_DESCRIPTION,
-  },
+// Kind options shown in the kind picker. The long REQUIRE/EXCLUDE copy is
+// rendered once in a tooltip next to the Kind label (see JSX below) rather
+// than inlined into every popover row — previously the inline description
+// overflowed the `<Select>` popover at narrow widths (HOL-588).
+const KIND_OPTIONS: Array<{ value: TemplatePolicyKind; label: string }> = [
+  { value: TemplatePolicyKind.REQUIRE, label: 'REQUIRE' },
+  { value: TemplatePolicyKind.EXCLUDE, label: 'EXCLUDE' },
 ]
 
 /**
@@ -142,7 +135,26 @@ export function RuleEditor({
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
-                <Label htmlFor={`rule-kind-${index}`}>Kind</Label>
+                <Label htmlFor={`rule-kind-${index}`} className="flex items-center gap-1">
+                  Kind
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="Explain REQUIRE and EXCLUDE"
+                          className="inline-flex"
+                        >
+                          <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm space-y-2">
+                        <p>{REQUIRE_RULE_DESCRIPTION}</p>
+                        <p>{EXCLUDE_RULE_DESCRIPTION}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </Label>
                 <Select
                   value={String(rule.kind)}
                   onValueChange={(v) => handleUpdate(index, { kind: Number(v) as TemplatePolicyKind })}
@@ -154,10 +166,7 @@ export function RuleEditor({
                   <SelectContent>
                     {KIND_OPTIONS.map((opt) => (
                       <SelectItem key={opt.value} value={String(opt.value)}>
-                        <div className="flex flex-col">
-                          <span className="font-medium">{opt.label}</span>
-                          <span className="text-xs text-muted-foreground">{opt.description}</span>
-                        </div>
+                        {opt.label}
                       </SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
## Summary

- Move the verbose `REQUIRE_RULE_DESCRIPTION` / `EXCLUDE_RULE_DESCRIPTION` copy out of the Kind `<SelectItem>` children in `RuleEditor.tsx` and into a shadcn `Tooltip` attached to a focusable `<button>` next to the Kind `<Label>`.
- `<SelectItem>` rows now render only the short `REQUIRE` / `EXCLUDE` labels, matching the tidy Project pattern / Deployment pattern tooltip style already used elsewhere in the same component.
- Simplifies `KIND_OPTIONS` to drop the now-unused `description` field. Copy constants in `@/components/platform-template-copy` remain byte-identical.
- Adds `frontend/src/components/template-policies/RuleEditor.test.tsx` covering both the popover content and the tooltip trigger contract.

Fixes HOL-588

## Test plan

- [x] `make test` (Go + UI) passes: 67 test files, 1061 UI tests, all Go packages green.
- [x] New unit test file pins the behavior:
  - [x] Kind `<SelectItem>` rows carry only `REQUIRE` / `EXCLUDE` and no fragment of the long descriptions.
  - [x] A focusable `<button type=\"button\" aria-label=\"Explain REQUIRE and EXCLUDE\">` exposes a Radix tooltip containing both `REQUIRE_RULE_DESCRIPTION` and `EXCLUDE_RULE_DESCRIPTION`.
- [x] `platform-template-copy.test.ts` passes unchanged (copy constants untouched).
- [x] Folder and org `template-policies` route tests pass unchanged.
- [x] `npx tsc --noEmit` and `eslint` on the changed files are clean.

> Local E2E was not run (no TLS certs / k3d cluster provisioned in this worktree). Relying on CI E2E check. The change is a focused tooltip refactor inside `RuleEditor.tsx` with no route or server changes.

Generated with [Claude Code](https://claude.com/claude-code)