### PR TITLE
chore(console): refresh stale KIND_OPTIONS comment after Kind tooltip lands

### DIFF
--- a/frontend/src/components/template-policies/RuleEditor.tsx
+++ b/frontend/src/components/template-policies/RuleEditor.tsx
@@ -35,10 +35,9 @@ export type RuleEditorProps = {
   disabled?: boolean
 }
 
-// Kind options shown in the kind picker. The long REQUIRE/EXCLUDE copy is
-// rendered once in a tooltip next to the Kind label (see JSX below) rather
-// than inlined into every popover row — previously the inline description
-// overflowed the `<Select>` popover at narrow widths (HOL-588).
+// Intentionally only the short enum label — the long REQUIRE/EXCLUDE copy is
+// sourced from `platform-template-copy` and surfaced once via the tooltip next
+// to the Kind `<Label>` so it does not overflow the Radix Select popover.
 const KIND_OPTIONS: Array<{ value: TemplatePolicyKind; label: string }> = [
   { value: TemplatePolicyKind.REQUIRE, label: 'REQUIRE' },
   { value: TemplatePolicyKind.EXCLUDE, label: 'EXCLUDE' },


### PR DESCRIPTION
## Summary

- Refresh the `KIND_OPTIONS` comment in `frontend/src/components/template-policies/RuleEditor.tsx` to describe the current invariant (short enum labels only; long REQUIRE/EXCLUDE copy is sourced from `platform-template-copy` and surfaced via the Kind-label tooltip) instead of narrating the pre-refactor overflow behavior future readers will not see in the code.
- No behavioral changes, no new primitives, no changes to `platform-template-copy.ts`, no test modifications.

## Context

Cleanup phase after HOL-588 (PR #991) moved the REQUIRE/EXCLUDE help copy out of the Kind `<SelectItem>` children and into a `<Label>` tooltip. Per HOL-589's acceptance criteria:

- `KIND_OPTIONS` already carries only the fields it uses (`value`, `label`) — HOL-588 removed the transitional `description` field.
- No unused imports remain in `RuleEditor.tsx` (verified by grepping every named import).
- `grep REQUIRE_RULE_DESCRIPTION` / `EXCLUDE_RULE_DESCRIPTION` turns up only: the definitions in `platform-template-copy.ts`, the tooltip consumer in `RuleEditor.tsx`, the `platform-template-copy.test.ts` assertions, and the `RuleEditor.test.tsx` assertions added by HOL-588.

The only remaining stale wiring was the comment block above `KIND_OPTIONS`, which led with "previously the inline description overflowed..." — a historical narrative rather than a current invariant. Per project convention ("don't explain what the code does; only capture non-obvious invariants"), the comment now calls out the design choice directly: someone tempted to re-add a `description` field and loop it into each `<SelectItem>` should see why the option shape is deliberately minimal.

Fixes HOL-589

## Test plan

- [x] `make vet` — clean
- [x] `make test` — 67 test files, 1061 tests, all pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/components/template-policies/RuleEditor.tsx` — clean
- [x] Focused re-run of `RuleEditor.test.tsx` and `platform-template-copy.test.ts` — 11 tests pass, both files unchanged

Local E2E was not run (no k3d cluster available in this worktree). The change is a comment-only edit and does not affect runtime behavior, so CI E2E coverage is sufficient.

Generated with [Claude Code](https://claude.com/claude-code)