### PR TITLE
feat(templatepolicybindings): K8sClient storage layer (HOL-594)

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -38,6 +38,15 @@ const (
 	// because a project owner could otherwise tamper with the very policy the
 	// platform meant to constrain them with.
 	ResourceTypeTemplatePolicy = "template-policy"
+	// ResourceTypeTemplatePolicyBinding is the resource type label value for
+	// TemplatePolicyBinding ConfigMaps. A TemplatePolicyBinding attaches a
+	// single TemplatePolicy to an explicit list of project templates and/or
+	// deployments, replacing the glob-based target selector on
+	// TemplatePolicyRule (ADR 029, HOL-590). Like TemplatePolicy, bindings
+	// live only in organization or folder namespaces; project-scope storage
+	// is forbidden because a project owner could otherwise tamper with the
+	// very binding the platform meant to constrain them with (HOL-554).
+	ResourceTypeTemplatePolicyBinding = "template-policy-binding"
 	// ResourceTypeRenderState is the resource type label value for
 	// applied-render-set ConfigMaps (HOL-557/HOL-567). A render-state
 	// ConfigMap records the effective set of LinkedTemplateRef values last
@@ -126,6 +135,22 @@ const (
 	// this mirrors the AnnotationLinkedTemplates pattern used on Template
 	// ConfigMaps (HOL-556).
 	AnnotationTemplatePolicyRules = "console.holos.run/template-policy-rules"
+	// AnnotationTemplatePolicyBindingPolicyRef stores the JSON-serialized
+	// scope-qualified reference to the TemplatePolicy a
+	// TemplatePolicyBinding attaches. The wire shape is
+	// `{"scope":"organization|folder","scopeName":"<slug>","name":"<slug>"}`.
+	// A binding always references exactly one policy; use multiple
+	// bindings to attach multiple policies to overlapping target sets
+	// (ADR 029, HOL-590).
+	AnnotationTemplatePolicyBindingPolicyRef = "console.holos.run/template-policy-binding-policy-ref"
+	// AnnotationTemplatePolicyBindingTargetRefs stores the JSON-serialized
+	// list of explicit render targets a TemplatePolicyBinding applies its
+	// policy to. The wire shape is a JSON array of
+	// `{"kind":"project-template|deployment","name":"<slug>","projectName":"<slug>"}`
+	// entries. Handlers MUST reject duplicates — two entries with the
+	// same (kind, projectName, name) triple — and MUST reject
+	// UNSPECIFIED kind. Order is not significant (ADR 029, HOL-590).
+	AnnotationTemplatePolicyBindingTargetRefs = "console.holos.run/template-policy-binding-target-refs"
 
 	// AnnotationExternalLinkPrefix is the Holos-authored annotation-key
 	// prefix for external links surfaced on a deployment. Links are keyed

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -42,6 +42,16 @@
 // platform meant to constrain them with.
 #ResourceTypeTemplatePolicy: "template-policy"
 
+// ResourceTypeTemplatePolicyBinding is the resource type label value for
+// TemplatePolicyBinding ConfigMaps. A TemplatePolicyBinding attaches a
+// single TemplatePolicy to an explicit list of project templates and/or
+// deployments, replacing the glob-based target selector on
+// TemplatePolicyRule (ADR 029, HOL-590). Like TemplatePolicy, bindings
+// live only in organization or folder namespaces; project-scope storage
+// is forbidden because a project owner could otherwise tamper with the
+// very binding the platform meant to constrain them with (HOL-554).
+#ResourceTypeTemplatePolicyBinding: "template-policy-binding"
+
 // ResourceTypeRenderState is the resource type label value for
 // applied-render-set ConfigMaps (HOL-557/HOL-567). A render-state
 // ConfigMap records the effective set of LinkedTemplateRef values last
@@ -144,6 +154,24 @@
 // this mirrors the AnnotationLinkedTemplates pattern used on Template
 // ConfigMaps (HOL-556).
 #AnnotationTemplatePolicyRules: "console.holos.run/template-policy-rules"
+
+// AnnotationTemplatePolicyBindingPolicyRef stores the JSON-serialized
+// scope-qualified reference to the TemplatePolicy a
+// TemplatePolicyBinding attaches. The wire shape is
+// `{"scope":"organization|folder","scopeName":"<slug>","name":"<slug>"}`.
+// A binding always references exactly one policy; use multiple
+// bindings to attach multiple policies to overlapping target sets
+// (ADR 029, HOL-590).
+#AnnotationTemplatePolicyBindingPolicyRef: "console.holos.run/template-policy-binding-policy-ref"
+
+// AnnotationTemplatePolicyBindingTargetRefs stores the JSON-serialized
+// list of explicit render targets a TemplatePolicyBinding applies its
+// policy to. The wire shape is a JSON array of
+// `{"kind":"project-template|deployment","name":"<slug>","projectName":"<slug>"}`
+// entries. Handlers MUST reject duplicates — two entries with the
+// same (kind, projectName, name) triple — and MUST reject
+// UNSPECIFIED kind. Order is not significant (ADR 029, HOL-590).
+#AnnotationTemplatePolicyBindingTargetRefs: "console.holos.run/template-policy-binding-target-refs"
 
 // AnnotationExternalLinkPrefix is the Holos-authored annotation-key
 // prefix for external links surfaced on a deployment. Links are keyed

--- a/console/templatepolicybindings/doc.go
+++ b/console/templatepolicybindings/doc.go
@@ -1,0 +1,7 @@
+// Package templatepolicybindings provides storage for TemplatePolicyBinding
+// ConfigMaps. A binding attaches a single TemplatePolicy to an explicit list
+// of project templates and/or deployments, replacing the glob-based target
+// selector on TemplatePolicyRule (ADR 029, HOL-590). Like TemplatePolicy,
+// bindings live only in folder or organization namespaces — never in project
+// namespaces (HOL-554).
+package templatepolicybindings

--- a/console/templatepolicybindings/k8s.go
+++ b/console/templatepolicybindings/k8s.go
@@ -1,0 +1,428 @@
+package templatepolicybindings
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// K8sClient wraps Kubernetes client operations for TemplatePolicyBinding
+// ConfigMap CRUD. TemplatePolicyBinding objects live only in organization or
+// folder namespaces; any attempt to read, write, or delete a binding in a
+// project namespace is rejected before the request reaches the Kubernetes
+// API (HOL-554, ADR 029). The guardrail mirrors
+// console/templatepolicies/k8s.go so platform-owned policy and the bindings
+// that activate it share the same isolation story.
+type K8sClient struct {
+	client   kubernetes.Interface
+	Resolver *resolver.Resolver
+}
+
+// NewK8sClient creates a K8sClient for TemplatePolicyBinding operations.
+func NewK8sClient(client kubernetes.Interface, r *resolver.Resolver) *K8sClient {
+	return &K8sClient{client: client, Resolver: r}
+}
+
+// ProjectNamespaceError is returned whenever a caller attempts to read or
+// write a TemplatePolicyBinding against a namespace the resolver classifies
+// as a project namespace. The offending namespace is exposed on the
+// Namespace field so the handler can surface it in its InvalidArgument
+// response without re-deriving it from string parsing.
+type ProjectNamespaceError struct {
+	Namespace string
+}
+
+func (e *ProjectNamespaceError) Error() string {
+	return fmt.Sprintf("template policy bindings cannot be stored in project namespace %q; use the owning folder or organization namespace", e.Namespace)
+}
+
+// namespaceForScope translates a TemplateScope into a Kubernetes namespace
+// name. This method never returns a project namespace — project scope is
+// rejected with InvalidArgument-equivalent semantics via
+// ProjectNamespaceError.
+//
+// All CRUD methods on K8sClient funnel through this helper so the
+// folder-only-storage invariant lives in exactly one place. The handler
+// must not reach past this function into per-scope namespace derivation;
+// doing so would bypass the classification check.
+func (k *K8sClient) namespaceForScope(scope consolev1.TemplateScope, scopeName string) (string, error) {
+	var ns string
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		ns = k.Resolver.OrgNamespace(scopeName)
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		ns = k.Resolver.FolderNamespace(scopeName)
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT:
+		// Project scope never produces a valid namespace for binding
+		// storage. We intentionally do NOT call the resolver's
+		// project-namespace helper here — the regression test in
+		// k8s_test.go asserts this package never references that
+		// helper. The namespace name we need for the error message is
+		// derived from the raw prefixes directly.
+		projectNs := k.Resolver.NamespacePrefix + k.Resolver.ProjectPrefix + scopeName
+		return "", &ProjectNamespaceError{Namespace: projectNs}
+	default:
+		return "", fmt.Errorf("unknown template scope %v", scope)
+	}
+
+	// Defense in depth: the resolver may classify a non-default prefix
+	// configuration as project even when the caller asked for
+	// org/folder. If that ever happens, reject rather than silently
+	// storing in a project namespace.
+	kind, _, err := k.Resolver.ResourceTypeFromNamespace(ns)
+	if err != nil {
+		// Prefix mismatch means the namespace is not managed by any
+		// known resource type. Let the caller decide; K8s will return
+		// the appropriate error on the subsequent request.
+		return ns, nil
+	}
+	if kind == v1alpha2.ResourceTypeProject {
+		return "", &ProjectNamespaceError{Namespace: ns}
+	}
+	return ns, nil
+}
+
+// ListBindings returns every TemplatePolicyBinding ConfigMap in the scope's
+// namespace.
+func (k *K8sClient) ListBindings(ctx context.Context, scope consolev1.TemplateScope, scopeName string) ([]corev1.ConfigMap, error) {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+	return k.listBindingsInNamespace(ctx, ns)
+}
+
+// ListBindingsInNamespace lists TemplatePolicyBinding ConfigMaps in the given
+// namespace without routing through scope resolution. The caller is
+// responsible for ensuring the namespace is NOT a project namespace — this
+// method deliberately does NOT re-check the resource type, because it is
+// invoked from ancestor walkers that already skipped project-kind
+// namespaces. Re-validating here would duplicate the guard and make the
+// behavior slower than necessary.
+func (k *K8sClient) ListBindingsInNamespace(ctx context.Context, ns string) ([]corev1.ConfigMap, error) {
+	if ns == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	return k.listBindingsInNamespace(ctx, ns)
+}
+
+func (k *K8sClient) listBindingsInNamespace(ctx context.Context, ns string) ([]corev1.ConfigMap, error) {
+	labelSelector := v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeTemplatePolicyBinding
+	slog.DebugContext(ctx, "listing template policy bindings from kubernetes",
+		slog.String("namespace", ns),
+		slog.String("labelSelector", labelSelector),
+	)
+	list, err := k.client.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing template policy bindings in %q: %w", ns, err)
+	}
+	return list.Items, nil
+}
+
+// GetBinding retrieves a single TemplatePolicyBinding ConfigMap by name.
+func (k *K8sClient) GetBinding(ctx context.Context, scope consolev1.TemplateScope, scopeName, name string) (*corev1.ConfigMap, error) {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+	slog.DebugContext(ctx, "getting template policy binding from kubernetes",
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	return k.client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+}
+
+// CreateBinding creates a new TemplatePolicyBinding ConfigMap. The policy
+// reference and target list are serialized as JSON annotations — the
+// ConfigMap has no data payload of its own, mirroring the annotation-only
+// layout used by TemplatePolicy ConfigMaps.
+func (k *K8sClient) CreateBinding(ctx context.Context, scope consolev1.TemplateScope, scopeName, name, displayName, description, creatorEmail string, policyRef *consolev1.LinkedTemplatePolicyRef, targetRefs []*consolev1.TemplatePolicyBindingTargetRef) (*corev1.ConfigMap, error) {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+
+	policyJSON, err := marshalPolicyRef(policyRef)
+	if err != nil {
+		return nil, err
+	}
+	targetsJSON, err := marshalTargetRefs(targetRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicyBinding,
+				v1alpha2.LabelTemplateScope: scopeLabelValue(scope),
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:                     displayName,
+				v1alpha2.AnnotationDescription:                     description,
+				v1alpha2.AnnotationCreatorEmail:                    creatorEmail,
+				v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  string(policyJSON),
+				v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: string(targetsJSON),
+			},
+		},
+	}
+	slog.DebugContext(ctx, "creating template policy binding in kubernetes",
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	return k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+}
+
+// UpdateBinding updates an existing TemplatePolicyBinding ConfigMap in
+// place. Only pointer fields that are non-nil are applied; callers can
+// partial-update display/description by passing nil for fields they want
+// preserved. Policy-ref and target-refs updates are gated on explicit
+// booleans so an empty target list can intentionally replace the existing
+// one.
+func (k *K8sClient) UpdateBinding(ctx context.Context, scope consolev1.TemplateScope, scopeName, name string, displayName, description *string, policyRef *consolev1.LinkedTemplatePolicyRef, updatePolicyRef bool, targetRefs []*consolev1.TemplatePolicyBindingTargetRef, updateTargetRefs bool) (*corev1.ConfigMap, error) {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return nil, err
+	}
+	cm, err := k.client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting template policy binding for update: %w", err)
+	}
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	if displayName != nil {
+		cm.Annotations[v1alpha2.AnnotationDisplayName] = *displayName
+	}
+	if description != nil {
+		cm.Annotations[v1alpha2.AnnotationDescription] = *description
+	}
+	if updatePolicyRef {
+		policyJSON, err := marshalPolicyRef(policyRef)
+		if err != nil {
+			return nil, err
+		}
+		cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef] = string(policyJSON)
+	}
+	if updateTargetRefs {
+		targetsJSON, err := marshalTargetRefs(targetRefs)
+		if err != nil {
+			return nil, err
+		}
+		cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs] = string(targetsJSON)
+	}
+	slog.DebugContext(ctx, "updating template policy binding in kubernetes",
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	return k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+}
+
+// DeleteBinding deletes a TemplatePolicyBinding ConfigMap. Not-found errors
+// propagate from the Kubernetes client so the handler can map them to
+// connect.CodeNotFound.
+func (k *K8sClient) DeleteBinding(ctx context.Context, scope consolev1.TemplateScope, scopeName, name string) error {
+	ns, err := k.namespaceForScope(scope, scopeName)
+	if err != nil {
+		return err
+	}
+	slog.DebugContext(ctx, "deleting template policy binding from kubernetes",
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	return k.client.CoreV1().ConfigMaps(ns).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// UnmarshalPolicyRef exposes the internal policy-ref parser to other
+// packages (notably console/policyresolver) so downstream evaluators can
+// decode stored bindings without re-implementing the JSON wire shape.
+// Returns nil for empty input so callers can treat "no stored ref" as a
+// validation failure rather than a parse failure.
+func UnmarshalPolicyRef(raw string) (*consolev1.LinkedTemplatePolicyRef, error) {
+	return unmarshalPolicyRef(raw)
+}
+
+// UnmarshalTargetRefs exposes the internal target-refs parser to other
+// packages. Returns an empty slice for the empty-string input so callers
+// can iterate without a nil check.
+func UnmarshalTargetRefs(raw string) ([]*consolev1.TemplatePolicyBindingTargetRef, error) {
+	return unmarshalTargetRefs(raw)
+}
+
+// scopeLabelValue returns the label string for a TemplateScope. Only
+// organization and folder values are reachable; project is rejected
+// upstream, so fall through to empty string — which would make any
+// ConfigMap unusable and therefore catch any bug that routed a project
+// scope through this function.
+func scopeLabelValue(scope consolev1.TemplateScope) string {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return v1alpha2.TemplateScopeOrganization
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return v1alpha2.TemplateScopeFolder
+	default:
+		return ""
+	}
+}
+
+// storedPolicyRef is the JSON wire shape for a
+// AnnotationTemplatePolicyBindingPolicyRef annotation. The nested struct
+// carries its own JSON representation so a hand-authored ConfigMap without
+// the latest generated types still round-trips.
+type storedPolicyRef struct {
+	Scope     string `json:"scope"`
+	ScopeName string `json:"scopeName"`
+	Name      string `json:"name"`
+}
+
+// storedTargetRef is the JSON wire shape for one entry in the
+// AnnotationTemplatePolicyBindingTargetRefs annotation.
+type storedTargetRef struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	ProjectName string `json:"projectName"`
+}
+
+func marshalPolicyRef(ref *consolev1.LinkedTemplatePolicyRef) ([]byte, error) {
+	sr := storedPolicyRef{}
+	if ref != nil {
+		if s := ref.GetScopeRef(); s != nil {
+			sr.Scope = templateScopeLabel(s.GetScope())
+			sr.ScopeName = s.GetScopeName()
+		}
+		sr.Name = ref.GetName()
+	}
+	b, err := json.Marshal(sr)
+	if err != nil {
+		return nil, fmt.Errorf("serializing template policy binding policy ref: %w", err)
+	}
+	return b, nil
+}
+
+func unmarshalPolicyRef(raw string) (*consolev1.LinkedTemplatePolicyRef, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var sr storedPolicyRef
+	if err := json.Unmarshal([]byte(raw), &sr); err != nil {
+		return nil, fmt.Errorf("parsing template policy binding policy ref: %w", err)
+	}
+	return &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     scopeFromTemplateLabel(sr.Scope),
+			ScopeName: sr.ScopeName,
+		},
+		Name: sr.Name,
+	}, nil
+}
+
+func marshalTargetRefs(refs []*consolev1.TemplatePolicyBindingTargetRef) ([]byte, error) {
+	stored := make([]storedTargetRef, 0, len(refs))
+	for _, r := range refs {
+		if r == nil {
+			continue
+		}
+		stored = append(stored, storedTargetRef{
+			Kind:        targetKindToString(r.GetKind()),
+			Name:        r.GetName(),
+			ProjectName: r.GetProjectName(),
+		})
+	}
+	b, err := json.Marshal(stored)
+	if err != nil {
+		return nil, fmt.Errorf("serializing template policy binding target refs: %w", err)
+	}
+	return b, nil
+}
+
+func unmarshalTargetRefs(raw string) ([]*consolev1.TemplatePolicyBindingTargetRef, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var stored []storedTargetRef
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		return nil, fmt.Errorf("parsing template policy binding target refs: %w", err)
+	}
+	refs := make([]*consolev1.TemplatePolicyBindingTargetRef, 0, len(stored))
+	for _, s := range stored {
+		refs = append(refs, &consolev1.TemplatePolicyBindingTargetRef{
+			Kind:        targetKindFromString(s.Kind),
+			Name:        s.Name,
+			ProjectName: s.ProjectName,
+		})
+	}
+	return refs, nil
+}
+
+func targetKindToString(k consolev1.TemplatePolicyBindingTargetKind) string {
+	switch k {
+	case consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE:
+		return "project-template"
+	case consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT:
+		return "deployment"
+	default:
+		return ""
+	}
+}
+
+func targetKindFromString(s string) consolev1.TemplatePolicyBindingTargetKind {
+	switch s {
+	case "project-template":
+		return consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE
+	case "deployment":
+		return consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT
+	default:
+		return consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_UNSPECIFIED
+	}
+}
+
+// templateScopeLabel mirrors templatepolicies.templateScopeLabel but lives
+// here so this package does not import console/templatepolicies (avoiding a
+// dependency cycle with future handler wiring).
+func templateScopeLabel(scope consolev1.TemplateScope) string {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return v1alpha2.TemplateScopeOrganization
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return v1alpha2.TemplateScopeFolder
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT:
+		return v1alpha2.TemplateScopeProject
+	default:
+		return ""
+	}
+}
+
+func scopeFromTemplateLabel(label string) consolev1.TemplateScope {
+	switch label {
+	case v1alpha2.TemplateScopeOrganization:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION
+	case v1alpha2.TemplateScopeFolder:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER
+	case v1alpha2.TemplateScopeProject:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT
+	default:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED
+	}
+}

--- a/console/templatepolicybindings/k8s_test.go
+++ b/console/templatepolicybindings/k8s_test.go
@@ -1,0 +1,643 @@
+package templatepolicybindings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+func newTestResolver() *resolver.Resolver {
+	return &resolver.Resolver{
+		NamespacePrefix:    "holos-",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
+}
+
+func newTestK8s() *K8sClient {
+	return NewK8sClient(fake.NewClientset(), newTestResolver())
+}
+
+// TestNamespaceForScopeRejectsProject is the core guardrail for HOL-554:
+// bindings must never resolve to a project namespace. The table covers the
+// two valid scopes and the project scope that must always fail.
+func TestNamespaceForScopeRejectsProject(t *testing.T) {
+	k := newTestK8s()
+	tests := []struct {
+		name      string
+		scope     consolev1.TemplateScope
+		scopeName string
+		wantErr   bool
+		wantNs    string
+	}{
+		{
+			name:      "org scope resolves to org namespace",
+			scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+			scopeName: "acme",
+			wantNs:    "holos-org-acme",
+		},
+		{
+			name:      "folder scope resolves to folder namespace",
+			scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+			scopeName: "payments",
+			wantNs:    "holos-fld-payments",
+		},
+		{
+			name:      "project scope is rejected as ProjectNamespaceError",
+			scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+			scopeName: "payments-web",
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, err := k.namespaceForScope(tt.scope, tt.scopeName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got namespace %q", ns)
+				}
+				var pne *ProjectNamespaceError
+				if !errors.As(err, &pne) {
+					t.Fatalf("expected ProjectNamespaceError, got %T: %v", err, err)
+				}
+				if pne.Namespace != "holos-prj-"+tt.scopeName {
+					t.Errorf("expected offending namespace to include project ns, got %q", pne.Namespace)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ns != tt.wantNs {
+				t.Errorf("expected namespace %q, got %q", tt.wantNs, ns)
+			}
+		})
+	}
+}
+
+// TestCreateBindingRejectsProjectNamespace locks in the folder-only-storage
+// invariant: a CreateBinding call targeting a project scope must fail
+// before it ever touches the Kubernetes API. The fake clientset records
+// every request, so we can also assert no ConfigMap was created in the
+// project namespace as a belt-and-suspenders check.
+func TestCreateBindingRejectsProjectNamespace(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	k := NewK8sClient(fakeClient, newTestResolver())
+
+	_, err := k.CreateBinding(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+		"billing-web",
+		"binding-test",
+		"Test",
+		"",
+		"creator@example.com",
+		samplePolicyRef(),
+		[]*consolev1.TemplatePolicyBindingTargetRef{sampleTargetRef()},
+	)
+	if err == nil {
+		t.Fatal("expected project-namespace rejection, got nil")
+	}
+	var pne *ProjectNamespaceError
+	if !errors.As(err, &pne) {
+		t.Fatalf("expected ProjectNamespaceError, got %T: %v", err, err)
+	}
+	if pne.Namespace != "holos-prj-billing-web" {
+		t.Errorf("expected error to name the project namespace, got %q", pne.Namespace)
+	}
+
+	cms, listErr := fakeClient.CoreV1().ConfigMaps("holos-prj-billing-web").List(context.Background(), metav1.ListOptions{})
+	if listErr != nil {
+		t.Fatalf("listing project ns configmaps: %v", listErr)
+	}
+	if len(cms.Items) != 0 {
+		t.Errorf("expected 0 configmaps created in project namespace, got %d", len(cms.Items))
+	}
+}
+
+func TestUpdateBindingRejectsProjectNamespace(t *testing.T) {
+	k := newTestK8s()
+	_, err := k.UpdateBinding(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+		"billing-web",
+		"binding-test",
+		nil, nil, nil, false, nil, false,
+	)
+	if err == nil {
+		t.Fatal("expected project-namespace rejection")
+	}
+	var pne *ProjectNamespaceError
+	if !errors.As(err, &pne) {
+		t.Fatalf("expected ProjectNamespaceError, got %T", err)
+	}
+}
+
+func TestDeleteBindingRejectsProjectNamespace(t *testing.T) {
+	k := newTestK8s()
+	err := k.DeleteBinding(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+		"billing-web",
+		"binding-test",
+	)
+	if err == nil {
+		t.Fatal("expected project-namespace rejection")
+	}
+	var pne *ProjectNamespaceError
+	if !errors.As(err, &pne) {
+		t.Fatalf("expected ProjectNamespaceError, got %T", err)
+	}
+}
+
+func TestListBindingsRejectsProjectNamespace(t *testing.T) {
+	k := newTestK8s()
+	_, err := k.ListBindings(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+		"billing-web",
+	)
+	if err == nil {
+		t.Fatal("expected project-namespace rejection on list")
+	}
+	var pne *ProjectNamespaceError
+	if !errors.As(err, &pne) {
+		t.Fatalf("expected ProjectNamespaceError, got %T", err)
+	}
+}
+
+func TestGetBindingRejectsProjectNamespace(t *testing.T) {
+	k := newTestK8s()
+	_, err := k.GetBinding(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+		"billing-web",
+		"binding-test",
+	)
+	if err == nil {
+		t.Fatal("expected project-namespace rejection on get")
+	}
+	var pne *ProjectNamespaceError
+	if !errors.As(err, &pne) {
+		t.Fatalf("expected ProjectNamespaceError, got %T", err)
+	}
+}
+
+// TestCreateBindingWritesConfigMap verifies the happy path: a create at
+// folder scope produces a ConfigMap with the managed-by /
+// template-policy-binding labels and JSON policy-ref + target-refs
+// annotations that round-trip via the package unmarshal helpers.
+func TestCreateBindingWritesConfigMap(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	k := NewK8sClient(fakeClient, newTestResolver())
+
+	policy := samplePolicyRef()
+	targets := []*consolev1.TemplatePolicyBindingTargetRef{sampleTargetRef()}
+	cm, err := k.CreateBinding(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+		"payments",
+		"bind-reference-grant",
+		"Bind reference grant",
+		"Attach reference-grant to payments web deployments",
+		"creator@example.com",
+		policy,
+		targets,
+	)
+	if err != nil {
+		t.Fatalf("CreateBinding: %v", err)
+	}
+	if cm.Namespace != "holos-fld-payments" {
+		t.Errorf("expected namespace holos-fld-payments, got %q", cm.Namespace)
+	}
+	if cm.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		t.Errorf("expected managed-by label, got %q", cm.Labels[v1alpha2.LabelManagedBy])
+	}
+	if cm.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeTemplatePolicyBinding {
+		t.Errorf("expected resource-type=template-policy-binding, got %q", cm.Labels[v1alpha2.LabelResourceType])
+	}
+	if cm.Labels[v1alpha2.LabelTemplateScope] != v1alpha2.TemplateScopeFolder {
+		t.Errorf("expected scope label 'folder', got %q", cm.Labels[v1alpha2.LabelTemplateScope])
+	}
+	if cm.Annotations[v1alpha2.AnnotationCreatorEmail] != "creator@example.com" {
+		t.Errorf("creator annotation missing: %q", cm.Annotations[v1alpha2.AnnotationCreatorEmail])
+	}
+
+	rawPolicy := cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef]
+	if rawPolicy == "" {
+		t.Fatal("expected non-empty policy-ref annotation")
+	}
+	parsedPolicy, err := unmarshalPolicyRef(rawPolicy)
+	if err != nil {
+		t.Fatalf("round-tripping policy-ref annotation: %v", err)
+	}
+	if parsedPolicy.GetName() != "require-http-route" {
+		t.Errorf("expected policy name require-http-route, got %q", parsedPolicy.GetName())
+	}
+	if parsedPolicy.GetScopeRef().GetScope() != consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION {
+		t.Errorf("expected org scope, got %v", parsedPolicy.GetScopeRef().GetScope())
+	}
+	if parsedPolicy.GetScopeRef().GetScopeName() != "acme" {
+		t.Errorf("expected policy scope name acme, got %q", parsedPolicy.GetScopeRef().GetScopeName())
+	}
+
+	rawTargets := cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs]
+	if rawTargets == "" {
+		t.Fatal("expected non-empty target-refs annotation")
+	}
+	parsedTargets, err := unmarshalTargetRefs(rawTargets)
+	if err != nil {
+		t.Fatalf("round-tripping target-refs annotation: %v", err)
+	}
+	if len(parsedTargets) != 1 {
+		t.Fatalf("expected 1 target after round trip, got %d", len(parsedTargets))
+	}
+	if parsedTargets[0].GetKind() != consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT {
+		t.Errorf("expected DEPLOYMENT kind, got %v", parsedTargets[0].GetKind())
+	}
+	if parsedTargets[0].GetProjectName() != "payments-web" {
+		t.Errorf("expected project payments-web, got %q", parsedTargets[0].GetProjectName())
+	}
+	if parsedTargets[0].GetName() != "api" {
+		t.Errorf("expected target name api, got %q", parsedTargets[0].GetName())
+	}
+}
+
+// TestUpdateBindingPreservesExistingAnnotations confirms partial updates
+// keep unspecified fields intact; this is the property relied on by the
+// handler when the UI sends a display-only or target-only update.
+func TestUpdateBindingPreservesExistingAnnotations(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "binding",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicyBinding,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:                     "Existing Name",
+				v1alpha2.AnnotationDescription:                     "Existing Desc",
+				v1alpha2.AnnotationCreatorEmail:                    "creator@example.com",
+				v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  `{"scope":"organization","scopeName":"acme","name":"require-http-route"}`,
+				v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: `[]`,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(existing)
+	k := NewK8sClient(fakeClient, newTestResolver())
+
+	// Update only target-refs; display name, description, and policy-ref
+	// should remain intact.
+	updated, err := k.UpdateBinding(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+		"payments",
+		"binding",
+		nil, nil,
+		nil, false,
+		[]*consolev1.TemplatePolicyBindingTargetRef{sampleTargetRef()}, true,
+	)
+	if err != nil {
+		t.Fatalf("UpdateBinding: %v", err)
+	}
+	if updated.Annotations[v1alpha2.AnnotationDisplayName] != "Existing Name" {
+		t.Errorf("display name clobbered: %q", updated.Annotations[v1alpha2.AnnotationDisplayName])
+	}
+	if updated.Annotations[v1alpha2.AnnotationDescription] != "Existing Desc" {
+		t.Errorf("description clobbered: %q", updated.Annotations[v1alpha2.AnnotationDescription])
+	}
+	if updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef] != `{"scope":"organization","scopeName":"acme","name":"require-http-route"}` {
+		t.Errorf("policy-ref clobbered: %q", updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef])
+	}
+	rawTargets := updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs]
+	targets, err := unmarshalTargetRefs(rawTargets)
+	if err != nil {
+		t.Fatalf("unmarshalTargetRefs: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected targets to be replaced with 1 entry, got %d", len(targets))
+	}
+}
+
+// TestUpdateBindingPolicyRef verifies the policy-ref update path swaps the
+// stored annotation without disturbing other fields.
+func TestUpdateBindingPolicyRef(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "binding",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicyBinding,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:                     "Name",
+				v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  `{"scope":"organization","scopeName":"acme","name":"old-policy"}`,
+				v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: `[]`,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(existing)
+	k := NewK8sClient(fakeClient, newTestResolver())
+
+	newRef := &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+			ScopeName: "payments",
+		},
+		Name: "new-policy",
+	}
+	updated, err := k.UpdateBinding(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+		"payments",
+		"binding",
+		nil, nil,
+		newRef, true,
+		nil, false,
+	)
+	if err != nil {
+		t.Fatalf("UpdateBinding: %v", err)
+	}
+	parsed, err := unmarshalPolicyRef(updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef])
+	if err != nil {
+		t.Fatalf("unmarshalPolicyRef: %v", err)
+	}
+	if parsed.GetName() != "new-policy" {
+		t.Errorf("expected policy name new-policy after update, got %q", parsed.GetName())
+	}
+	if parsed.GetScopeRef().GetScope() != consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER {
+		t.Errorf("expected scope folder after update, got %v", parsed.GetScopeRef().GetScope())
+	}
+	if updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs] != `[]` {
+		t.Errorf("target-refs clobbered: %q", updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs])
+	}
+}
+
+// TestListBindingsReturnsManagedBindings verifies the label selector on
+// List matches only TemplatePolicyBinding ConfigMaps and ignores other
+// resources in the same namespace (templates, policies, etc.).
+func TestListBindingsReturnsManagedBindings(t *testing.T) {
+	ns := "holos-fld-payments"
+	binding := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bind-a",
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicyBinding,
+			},
+		},
+	}
+	// A policy in the same namespace must NOT be returned.
+	policy := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy-a",
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(binding, policy)
+	k := NewK8sClient(fakeClient, newTestResolver())
+
+	list, err := k.ListBindings(
+		context.Background(),
+		consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+		"payments",
+	)
+	if err != nil {
+		t.Fatalf("ListBindings: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(list))
+	}
+	if list[0].Name != "bind-a" {
+		t.Errorf("expected bind-a, got %q", list[0].Name)
+	}
+}
+
+// TestListBindingsInNamespace verifies the namespace-direct variant skips
+// scope resolution and refuses an empty namespace.
+func TestListBindingsInNamespace(t *testing.T) {
+	k := newTestK8s()
+	if _, err := k.ListBindingsInNamespace(context.Background(), ""); err == nil {
+		t.Fatal("expected error on empty namespace")
+	}
+	if _, err := k.ListBindingsInNamespace(context.Background(), "holos-fld-payments"); err != nil {
+		t.Fatalf("unexpected error on populated namespace: %v", err)
+	}
+}
+
+// TestPolicyRefAnnotationRoundtrip locks in the JSON wire format for the
+// policy-ref annotation so external tooling (or future migrations) see a
+// stable shape.
+func TestPolicyRefAnnotationRoundtrip(t *testing.T) {
+	ref := &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+			ScopeName: "payments",
+		},
+		Name: "policy-a",
+	}
+	raw, err := marshalPolicyRef(ref)
+	if err != nil {
+		t.Fatalf("marshalPolicyRef: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decoding JSON: %v", err)
+	}
+	if decoded["scope"] != "folder" {
+		t.Errorf("expected scope=folder, got %v", decoded["scope"])
+	}
+	if decoded["scopeName"] != "payments" {
+		t.Errorf("expected scopeName=payments, got %v", decoded["scopeName"])
+	}
+	if decoded["name"] != "policy-a" {
+		t.Errorf("expected name=policy-a, got %v", decoded["name"])
+	}
+	parsed, err := unmarshalPolicyRef(string(raw))
+	if err != nil {
+		t.Fatalf("unmarshalPolicyRef: %v", err)
+	}
+	if parsed.GetScopeRef().GetScope() != consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER {
+		t.Errorf("scope lost on round trip: %v", parsed.GetScopeRef().GetScope())
+	}
+}
+
+// TestPolicyRefEmptyString verifies that the empty-string input decodes as
+// a nil ref so callers can treat "no stored ref" as a validation failure.
+func TestPolicyRefEmptyString(t *testing.T) {
+	parsed, err := unmarshalPolicyRef("")
+	if err != nil {
+		t.Fatalf("unmarshalPolicyRef(\"\"): %v", err)
+	}
+	if parsed != nil {
+		t.Errorf("expected nil for empty input, got %+v", parsed)
+	}
+}
+
+// TestTargetRefsAnnotationRoundtrip locks in the JSON wire format for the
+// target-refs annotation, including both PROJECT_TEMPLATE and DEPLOYMENT
+// kinds and a project_name disambiguator.
+func TestTargetRefsAnnotationRoundtrip(t *testing.T) {
+	refs := []*consolev1.TemplatePolicyBindingTargetRef{
+		{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+			Name:        "shared-service",
+			ProjectName: "payments-web",
+		},
+		{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+			Name:        "api",
+			ProjectName: "payments-web",
+		},
+	}
+	raw, err := marshalTargetRefs(refs)
+	if err != nil {
+		t.Fatalf("marshalTargetRefs: %v", err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decoding JSON: %v", err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(decoded))
+	}
+	if decoded[0]["kind"] != "project-template" {
+		t.Errorf("expected kind=project-template, got %v", decoded[0]["kind"])
+	}
+	if decoded[1]["kind"] != "deployment" {
+		t.Errorf("expected kind=deployment, got %v", decoded[1]["kind"])
+	}
+	if decoded[0]["projectName"] != "payments-web" {
+		t.Errorf("expected projectName=payments-web, got %v", decoded[0]["projectName"])
+	}
+	if decoded[1]["name"] != "api" {
+		t.Errorf("expected name=api, got %v", decoded[1]["name"])
+	}
+	parsed, err := unmarshalTargetRefs(string(raw))
+	if err != nil {
+		t.Fatalf("unmarshalTargetRefs: %v", err)
+	}
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 parsed refs, got %d", len(parsed))
+	}
+	if parsed[0].GetKind() != consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE {
+		t.Errorf("kind lost on round trip: %v", parsed[0].GetKind())
+	}
+}
+
+// TestTargetRefsEmptyString verifies that the empty-string input decodes
+// as nil so callers don't crash on freshly-initialized annotations.
+func TestTargetRefsEmptyString(t *testing.T) {
+	parsed, err := unmarshalTargetRefs("")
+	if err != nil {
+		t.Fatalf("unmarshalTargetRefs(\"\"): %v", err)
+	}
+	if parsed != nil {
+		t.Errorf("expected nil for empty input, got %+v", parsed)
+	}
+}
+
+// TestTargetRefsSkipsNilEntries ensures nil entries in the input slice do
+// not produce JSON null entries in the serialized annotation.
+func TestTargetRefsSkipsNilEntries(t *testing.T) {
+	refs := []*consolev1.TemplatePolicyBindingTargetRef{
+		nil,
+		sampleTargetRef(),
+		nil,
+	}
+	raw, err := marshalTargetRefs(refs)
+	if err != nil {
+		t.Fatalf("marshalTargetRefs: %v", err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decoding JSON: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Errorf("expected nil entries to be skipped, got %d entries", len(decoded))
+	}
+}
+
+// TestPackageDoesNotCallProjectNamespace is the grep-based regression test
+// called out by the HOL-594 acceptance criteria. It walks every Go source
+// file in this package and fails if any file references
+// Resolver.ProjectNamespace. The test itself intentionally contains only
+// the literal substring it searches for in this comment; bare references
+// in other files would still be caught because the test excludes the test
+// file itself from the search.
+func TestPackageDoesNotCallProjectNamespace(t *testing.T) {
+	const target = "Resolver.ProjectNamespace"
+	matches := []string{}
+	err := filepath.Walk(".", func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Skip this test file since its doc comment references the exact
+		// identifier being searched for.
+		if strings.HasSuffix(path, "k8s_test.go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(data), target) {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking package sources: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("package must not call %s — found in: %v", target, matches)
+	}
+}
+
+// samplePolicyRef returns a minimal valid policy ref suitable for fixtures.
+func samplePolicyRef() *consolev1.LinkedTemplatePolicyRef {
+	return &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+			ScopeName: "acme",
+		},
+		Name: "require-http-route",
+	}
+}
+
+// sampleTargetRef returns a minimal valid target ref suitable for fixtures.
+func sampleTargetRef() *consolev1.TemplatePolicyBindingTargetRef {
+	return &consolev1.TemplatePolicyBindingTargetRef{
+		Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+		Name:        "api",
+		ProjectName: "payments-web",
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new `console/templatepolicybindings` package with a `K8sClient` that persists `TemplatePolicyBinding` as a ConfigMap, mirroring `console/templatepolicies/k8s.go`.
- Preserve the HOL-554 folder-only-storage guardrail: `ProjectNamespaceError` is returned for `TEMPLATE_SCOPE_PROJECT`, with a defense-in-depth re-check via `Resolver.ResourceTypeFromNamespace` so non-default prefix configurations cannot route a binding into a project namespace.
- Carry the binding's policy reference and explicit target list as two new annotations (`policy-ref`, `target-refs`) with stable JSON wire shapes; the ConfigMap itself has no data payload.
- Add three `v1alpha2` constants (`ResourceTypeTemplatePolicyBinding`, `AnnotationTemplatePolicyBindingPolicyRef`, `AnnotationTemplatePolicyBindingTargetRefs`) and regenerate `schema_gen.cue`.
- Table-driven Go tests using `k8s.io/client-go/kubernetes/fake` cover happy-path CRUD, project-namespace rejection on every method, partial-update preservation, stable annotation wire shape, and a grep-based regression test asserting the package source never references `Resolver.ProjectNamespace`.

No handler wiring is added in this PR; HOL-595 picks up that phase.

Fixes HOL-594

## Test plan
- [x] `go test -race ./console/templatepolicybindings/` passes
- [x] `go test ./api/v1alpha2/... ./console/templatepolicies/...` passes
- [x] `golangci-lint run ./console/templatepolicybindings/...` reports 0 issues
- [x] Project-scope requests on every CRUD method return `ProjectNamespaceError`
- [x] Regression test asserts package source never references `Resolver.ProjectNamespace`

> Local E2E was not run. The change introduces a new Go-only storage package with no handler wiring, frontend, or OIDC surface area, so E2E is not relevant per the E2E relevance decision table.

Generated with [Claude Code](https://claude.com/claude-code)