### PR TITLE
feat(templatepolicybindings): handler, RBAC cascade, and ConnectRPC wiring

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -44,6 +44,7 @@ import (
 	"github.com/holos-run/holos-console/console/secrets"
 	"github.com/holos-run/holos-console/console/settings"
 	"github.com/holos-run/holos-console/console/templatepolicies"
+	"github.com/holos-run/holos-console/console/templatepolicybindings"
 	"github.com/holos-run/holos-console/console/templates"
 	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
 )
@@ -386,6 +387,27 @@ func (s *Server) Serve(ctx context.Context) error {
 		templatePoliciesPath, templatePoliciesHTTPHandler := consolev1connect.NewTemplatePolicyServiceHandler(templatePoliciesHandler, protectedInterceptors)
 		mux.Handle(templatePoliciesPath, templatePoliciesHTTPHandler)
 
+		// TemplatePolicyBindingService handler — manages the explicit,
+		// non-glob binding of a TemplatePolicy to a list of project
+		// templates and deployments (ADR 029 / HOL-590). Project scope
+		// is rejected for the same storage-isolation reason as policies
+		// (HOL-554): a project owner must not be able to tamper with
+		// the binding list the platform uses to constrain them. The
+		// handler's validation seams (policy-exists, ancestor-chain,
+		// project-exists) are wired via adapters that lean on the
+		// resources already constructed above — templatePoliciesK8s for
+		// policy lookups, nsWalker for ancestor chains, and the shared
+		// k8sClientset for project-namespace existence.
+		templatePolicyBindingsK8s := templatepolicybindings.NewK8sClient(k8sClientset, nsResolver)
+		templatePolicyBindingsHandler := templatepolicybindings.NewHandler(templatePolicyBindingsK8s, nsResolver).
+			WithOrgGrantResolver(orgGrantResolver).
+			WithFolderGrantResolver(folderGrantResolver).
+			WithPolicyExistsResolver(templatepolicybindings.NewPolicyExistsAdapter(templatePoliciesK8s)).
+			WithAncestorChainResolver(templatepolicybindings.NewAncestorChainAdapter(nsWalker)).
+			WithProjectExistsResolver(templatepolicybindings.NewProjectExistsAdapter(k8sClientset, nsResolver))
+		templatePolicyBindingsPath, templatePolicyBindingsHTTPHandler := consolev1connect.NewTemplatePolicyBindingServiceHandler(templatePolicyBindingsHandler, protectedInterceptors)
+		mux.Handle(templatePolicyBindingsPath, templatePolicyBindingsHTTPHandler)
+
 		// Deployment service with project grant fallback.
 		// ancestorTemplateResolver wraps templatesK8s + nsWalker to satisfy
 		// AncestorTemplateProvider for full ancestor-chain template resolution
@@ -441,6 +463,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		consolev1connect.ProjectSettingsServiceName,
 		consolev1connect.TemplateServiceName,
 		consolev1connect.TemplatePolicyServiceName,
+		consolev1connect.TemplatePolicyBindingServiceName,
 		consolev1connect.FolderServiceName,
 		consolev1connect.DeploymentServiceName,
 	)

--- a/console/rbac/template_policy_binding_cascade.go
+++ b/console/rbac/template_policy_binding_cascade.go
@@ -1,0 +1,44 @@
+package rbac
+
+// TemplatePolicyBindingCascadePerms maps roles to the TemplatePolicyBinding
+// permissions each role grants via cascade on the binding's owning scope.
+//
+// TemplatePolicyBinding is the explicit, non-glob successor to
+// TemplatePolicy's target-selector rules (ADR 029, HOL-590). A binding is
+// meaningless without its policy — anyone who can read/write the policy can
+// read/write the set of targets that policy applies to — so bindings reuse
+// the PERMISSION_TEMPLATE_POLICIES_* permission family and share an
+// identical cascade shape with TemplatePolicyCascadePerms.
+//
+// WRITE, DELETE, and ADMIN MUST only be reachable via organization or folder
+// grants (HOL-554 storage-isolation design note). Project-owner roles MAY be
+// granted at most LIST and READ through this table because project-namespace
+// storage is forbidden and projects never own a binding ConfigMap directly —
+// read flows through ancestor traversal to the folder/org binding
+// ConfigMaps.
+//
+// The cascade table itself does not know the scope it is evaluated at; the
+// handler is responsible for choosing the correct grants (org or folder) and
+// rejecting any attempt to evaluate against a project namespace. Keeping the
+// permissions in a single table — rather than a per-scope variant — matches
+// the TemplateCascadePerms / TemplatePolicyCascadePerms pattern (ADR 017
+// Decision 5, ADR 021 Decision 2, ADR 029) and avoids a divergent code path
+// that could accidentally admit a project owner to binding writes.
+var TemplatePolicyBindingCascadePerms = CascadeTable{
+	RoleViewer: {
+		PermissionTemplatePoliciesList: true,
+		PermissionTemplatePoliciesRead: true,
+	},
+	RoleEditor: {
+		PermissionTemplatePoliciesList:  true,
+		PermissionTemplatePoliciesRead:  true,
+		PermissionTemplatePoliciesWrite: true,
+	},
+	RoleOwner: {
+		PermissionTemplatePoliciesList:   true,
+		PermissionTemplatePoliciesRead:   true,
+		PermissionTemplatePoliciesWrite:  true,
+		PermissionTemplatePoliciesDelete: true,
+		PermissionTemplatePoliciesAdmin:  true,
+	},
+}

--- a/console/rbac/template_policy_binding_cascade_test.go
+++ b/console/rbac/template_policy_binding_cascade_test.go
@@ -1,0 +1,67 @@
+package rbac
+
+import "testing"
+
+// TestTemplatePolicyBindingCascadePermsMatchesPolicyTable locks in the
+// invariant that TemplatePolicyBinding cascades grant exactly the same
+// permissions as TemplatePolicy cascades. HOL-595 adopts the policy cascade
+// shape verbatim — a drift here would mean the binding handler and the
+// policy handler interpret the same grant differently, which is the opposite
+// of what ADR 029 intends.
+func TestTemplatePolicyBindingCascadePermsMatchesPolicyTable(t *testing.T) {
+	if len(TemplatePolicyBindingCascadePerms) != len(TemplatePolicyCascadePerms) {
+		t.Fatalf("binding cascade has %d roles, policy cascade has %d",
+			len(TemplatePolicyBindingCascadePerms), len(TemplatePolicyCascadePerms))
+	}
+	for role, policyPerms := range TemplatePolicyCascadePerms {
+		bindingPerms, ok := TemplatePolicyBindingCascadePerms[role]
+		if !ok {
+			t.Errorf("role %v missing from binding cascade", role)
+			continue
+		}
+		if len(bindingPerms) != len(policyPerms) {
+			t.Errorf("role %v: binding cascade has %d perms, policy cascade has %d",
+				role, len(bindingPerms), len(policyPerms))
+			continue
+		}
+		for perm, want := range policyPerms {
+			if got := bindingPerms[perm]; got != want {
+				t.Errorf("role %v perm %v: binding cascade has %v, policy cascade has %v",
+					role, perm, got, want)
+			}
+		}
+	}
+}
+
+// TestTemplatePolicyBindingCascadeOnlyPolicyPerms keeps the cascade focused
+// on the PERMISSION_TEMPLATE_POLICIES_* family. If someone later tries to
+// attach, e.g., PERMISSION_TEMPLATES_WRITE here, the check below fails —
+// binding cascades must not leak authority into other resource families.
+func TestTemplatePolicyBindingCascadeOnlyPolicyPerms(t *testing.T) {
+	allowed := map[Permission]bool{
+		PermissionTemplatePoliciesList:   true,
+		PermissionTemplatePoliciesRead:   true,
+		PermissionTemplatePoliciesWrite:  true,
+		PermissionTemplatePoliciesDelete: true,
+		PermissionTemplatePoliciesAdmin:  true,
+	}
+	for role, perms := range TemplatePolicyBindingCascadePerms {
+		for perm := range perms {
+			if !allowed[perm] {
+				t.Errorf("role %v: unexpected permission %v in binding cascade", role, perm)
+			}
+		}
+	}
+}
+
+// TestTemplatePolicyBindingCascadeRoleCoverage asserts that the three roles
+// the rest of the RBAC subsystem understands (Viewer, Editor, Owner) each
+// appear in the cascade. A missing role would silently deny all bindings
+// access for users who only hold that role at the scope.
+func TestTemplatePolicyBindingCascadeRoleCoverage(t *testing.T) {
+	for _, role := range []Role{RoleViewer, RoleEditor, RoleOwner} {
+		if _, ok := TemplatePolicyBindingCascadePerms[role]; !ok {
+			t.Errorf("binding cascade missing role %v", role)
+		}
+	}
+}

--- a/console/templatepolicybindings/adapters.go
+++ b/console/templatepolicybindings/adapters.go
@@ -1,0 +1,145 @@
+package templatepolicybindings
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// PolicyExistsGetter is the narrow interface this package asks of the
+// TemplatePolicy storage layer. *templatepolicies.K8sClient satisfies it
+// via its GetPolicy method; defining the interface here means console.go
+// can wire the adapter without this package importing
+// console/templatepolicies (which would create a cycle once the policy
+// resolver also imports bindings in HOL-596).
+type PolicyExistsGetter interface {
+	GetPolicy(ctx context.Context, scope consolev1.TemplateScope, scopeName, name string) (*corev1.ConfigMap, error)
+}
+
+// PolicyExistsAdapter implements PolicyExistsResolver over a
+// PolicyExistsGetter. A K8s NotFound is translated to (false, nil); any
+// other error is returned as-is so the handler can distinguish "policy
+// missing" (user-input error) from "cluster probe failed" (internal
+// error).
+type PolicyExistsAdapter struct {
+	Getter PolicyExistsGetter
+}
+
+// NewPolicyExistsAdapter returns a PolicyExistsAdapter backed by the given
+// getter.
+func NewPolicyExistsAdapter(g PolicyExistsGetter) *PolicyExistsAdapter {
+	return &PolicyExistsAdapter{Getter: g}
+}
+
+// PolicyExists reports whether a TemplatePolicy with the given scope and
+// name exists. Returns (false, nil) for K8s NotFound so the handler can
+// cleanly reject with CodeInvalidArgument.
+func (a *PolicyExistsAdapter) PolicyExists(ctx context.Context, scope consolev1.TemplateScope, scopeName, name string) (bool, error) {
+	if a == nil || a.Getter == nil {
+		return false, fmt.Errorf("policy-exists adapter is not configured")
+	}
+	_, err := a.Getter.GetPolicy(ctx, scope, scopeName, name)
+	if err == nil {
+		return true, nil
+	}
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// WalkerInterface is the subset of the resolver walker used by the
+// ancestor-chain adapter. *resolver.Walker satisfies it, as does its
+// cached variant. Declaring the local interface keeps this package free
+// of concrete walker construction details and keeps tests simple.
+type WalkerInterface interface {
+	WalkAncestors(ctx context.Context, startNs string) ([]*corev1.Namespace, error)
+}
+
+// AncestorChainAdapter implements AncestorChainResolver over a walker. The
+// walker's result is a child→parent chain of namespaces; the adapter
+// scans that chain for `wantNs` and returns true on the first match.
+type AncestorChainAdapter struct {
+	Walker WalkerInterface
+}
+
+// NewAncestorChainAdapter returns an AncestorChainAdapter backed by the
+// given walker.
+func NewAncestorChainAdapter(w WalkerInterface) *AncestorChainAdapter {
+	return &AncestorChainAdapter{Walker: w}
+}
+
+// AncestorChainContains reports whether `wantNs` appears anywhere in the
+// ancestor chain starting at `startNs`. Walker errors propagate to the
+// caller — a transient cluster failure must not silently admit a binding
+// whose policy_ref cannot be confirmed in-chain.
+func (a *AncestorChainAdapter) AncestorChainContains(ctx context.Context, startNs, wantNs string) (bool, error) {
+	if a == nil || a.Walker == nil {
+		return false, fmt.Errorf("ancestor-chain adapter is not configured")
+	}
+	chain, err := a.Walker.WalkAncestors(ctx, startNs)
+	if err != nil {
+		return false, err
+	}
+	for _, ns := range chain {
+		if ns != nil && ns.Name == wantNs {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ProjectExistsAdapter implements ProjectExistsResolver against a live
+// kubernetes.Interface. A project exists iff a namespace with the
+// expected prefix carries the console's managed-by +
+// resource-type=project labels and is not being deleted. The adapter
+// does NOT enforce that the project's ancestor chain passes through the
+// binding's owning scope — that belongs to HOL-596 (render-time
+// evaluation); at authoring time we only confirm the project exists
+// somewhere under the resolver's naming conventions so a typo fails
+// loud.
+type ProjectExistsAdapter struct {
+	Client   kubernetes.Interface
+	Resolver *resolver.Resolver
+}
+
+// NewProjectExistsAdapter returns a ProjectExistsAdapter.
+func NewProjectExistsAdapter(client kubernetes.Interface, r *resolver.Resolver) *ProjectExistsAdapter {
+	return &ProjectExistsAdapter{Client: client, Resolver: r}
+}
+
+// ProjectExists reports whether a managed project namespace with the
+// given project slug exists. Returns (false, nil) if the namespace is
+// absent or unmanaged; returns an error only for unexpected K8s
+// failures.
+func (a *ProjectExistsAdapter) ProjectExists(ctx context.Context, _ consolev1.TemplateScope, _, projectName string) (bool, error) {
+	if a == nil || a.Client == nil || a.Resolver == nil {
+		return false, fmt.Errorf("project-exists adapter is not configured")
+	}
+	nsName := a.Resolver.NamespacePrefix + a.Resolver.ProjectPrefix + projectName
+	ns, err := a.Client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if ns.DeletionTimestamp != nil {
+		return false, nil
+	}
+	if ns.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+		return false, nil
+	}
+	if ns.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeProject {
+		return false, nil
+	}
+	return true, nil
+}

--- a/console/templatepolicybindings/adapters.go
+++ b/console/templatepolicybindings/adapters.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"

--- a/console/templatepolicybindings/adapters_test.go
+++ b/console/templatepolicybindings/adapters_test.go
@@ -102,13 +102,12 @@ func TestAncestorChainAdapter(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		walker   WalkerInterface
-		startNs  string
-		wantNs   string
-		want     bool
-		wantErr  bool
-		contains string
+		name    string
+		walker  WalkerInterface
+		startNs string
+		wantNs  string
+		want    bool
+		wantErr bool
 	}{
 		{name: "hit at self", walker: &stubWalker{chain: chain}, startNs: "holos-fld-payments", wantNs: "holos-fld-payments", want: true},
 		{name: "hit at parent", walker: &stubWalker{chain: chain}, startNs: "holos-fld-payments", wantNs: "holos-org-acme", want: true},

--- a/console/templatepolicybindings/adapters_test.go
+++ b/console/templatepolicybindings/adapters_test.go
@@ -1,0 +1,192 @@
+package templatepolicybindings
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// policyGetterStub satisfies PolicyExistsGetter for the PolicyExistsAdapter
+// tests. The err field drives the result; when nil and found is true the
+// getter returns an empty ConfigMap.
+type policyGetterStub struct {
+	err   error
+	found bool
+}
+
+func (p *policyGetterStub) GetPolicy(_ context.Context, _ consolev1.TemplateScope, _, _ string) (*corev1.ConfigMap, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	if !p.found {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "missing")
+	}
+	return &corev1.ConfigMap{}, nil
+}
+
+// TestPolicyExistsAdapter covers the NotFound / found / other-error cases.
+// NotFound must degrade to (false, nil) so the handler returns
+// CodeInvalidArgument to the caller; any other error must propagate so
+// the handler surfaces CodeInternal.
+func TestPolicyExistsAdapter(t *testing.T) {
+	tests := []struct {
+		name       string
+		getter     PolicyExistsGetter
+		wantExists bool
+		wantErr    bool
+	}{
+		{
+			name:       "policy found",
+			getter:     &policyGetterStub{found: true},
+			wantExists: true,
+		},
+		{
+			name:       "not found",
+			getter:     &policyGetterStub{found: false},
+			wantExists: false,
+		},
+		{
+			name:       "probe error",
+			getter:     &policyGetterStub{err: errors.New("api down")},
+			wantExists: false,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewPolicyExistsAdapter(tt.getter)
+			got, err := a.PolicyExists(context.Background(), consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, "payments", "policy")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantExists {
+				t.Errorf("exists = %v, want %v", got, tt.wantExists)
+			}
+		})
+	}
+}
+
+// stubWalker returns a canned ancestor chain so the adapter's scan logic
+// can be exercised without touching the K8s API.
+type stubWalker struct {
+	chain []*corev1.Namespace
+	err   error
+}
+
+func (s *stubWalker) WalkAncestors(_ context.Context, _ string) ([]*corev1.Namespace, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.chain, nil
+}
+
+func TestAncestorChainAdapter(t *testing.T) {
+	chain := []*corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "holos-fld-payments"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "holos-org-acme"}},
+	}
+
+	tests := []struct {
+		name     string
+		walker   WalkerInterface
+		startNs  string
+		wantNs   string
+		want     bool
+		wantErr  bool
+		contains string
+	}{
+		{name: "hit at self", walker: &stubWalker{chain: chain}, startNs: "holos-fld-payments", wantNs: "holos-fld-payments", want: true},
+		{name: "hit at parent", walker: &stubWalker{chain: chain}, startNs: "holos-fld-payments", wantNs: "holos-org-acme", want: true},
+		{name: "miss", walker: &stubWalker{chain: chain}, startNs: "holos-fld-payments", wantNs: "holos-org-other", want: false},
+		{name: "walker error", walker: &stubWalker{err: errors.New("boom")}, startNs: "holos-fld-payments", wantNs: "holos-org-acme", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewAncestorChainAdapter(tt.walker)
+			got, err := a.AncestorChainContains(context.Background(), tt.startNs, tt.wantNs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectExistsAdapter(t *testing.T) {
+	managedProject := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-payments-web",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+			},
+		},
+	}
+	unmanaged := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-forged",
+			Labels: map[string]string{
+				// No managed-by label.
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+			},
+		},
+	}
+	deleting := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-retired",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+			},
+			DeletionTimestamp: &metav1.Time{},
+		},
+	}
+
+	client := fake.NewClientset(managedProject, unmanaged, deleting)
+	a := NewProjectExistsAdapter(client, newTestResolver())
+
+	tests := []struct {
+		name    string
+		project string
+		want    bool
+	}{
+		{name: "managed project", project: "payments-web", want: true},
+		{name: "unmanaged is ignored", project: "forged", want: false},
+		{name: "deleting is ignored", project: "retired", want: false},
+		{name: "absent namespace", project: "no-such-project", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := a.ProjectExists(context.Background(), consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, "payments", tt.project)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/console/templatepolicybindings/authz.go
+++ b/console/templatepolicybindings/authz.go
@@ -1,0 +1,68 @@
+package templatepolicybindings
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"connectrpc.com/connect"
+
+	"github.com/holos-run/holos-console/console/rbac"
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// OrgGrantResolver resolves organization-level grants for access checks. The
+// handler accepts the same interface shape used by console/templatepolicies
+// so the wiring in console.go can pass the existing organizations resolver
+// without an adapter.
+type OrgGrantResolver interface {
+	GetOrgGrants(ctx context.Context, org string) (users, roles map[string]string, err error)
+}
+
+// FolderGrantResolver resolves folder-level grants for access checks.
+type FolderGrantResolver interface {
+	GetFolderGrants(ctx context.Context, folder string) (users, roles map[string]string, err error)
+}
+
+// checkAccess enforces the TemplatePolicyBindingCascadePerms RBAC table on
+// the binding's owning scope. Project scope is rejected up front — the
+// cascade table exists only at org/folder, so any attempt to check a
+// project-scope binding here is a programming error that earlier handler
+// validation should have caught.
+func (h *Handler) checkAccess(ctx context.Context, claims *rpc.Claims, scope consolev1.TemplateScope, scopeName string, perm rbac.Permission) error {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return h.checkOrgAccess(ctx, claims, scopeName, perm)
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return h.checkFolderAccess(ctx, claims, scopeName, perm)
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT:
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template policy bindings cannot be scoped to a project; use an organization or folder scope"))
+	default:
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unknown scope %v", scope))
+	}
+}
+
+func (h *Handler) checkOrgAccess(ctx context.Context, claims *rpc.Claims, org string, perm rbac.Permission) error {
+	if h.orgGrantResolver == nil {
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	users, roles, err := h.orgGrantResolver.GetOrgGrants(ctx, org)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve org grants", slog.String("org", org), slog.Any("error", err))
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	return rbac.CheckCascadeAccess(claims.Email, claims.Roles, users, roles, perm, rbac.TemplatePolicyBindingCascadePerms)
+}
+
+func (h *Handler) checkFolderAccess(ctx context.Context, claims *rpc.Claims, folder string, perm rbac.Permission) error {
+	if h.folderGrantResolver == nil {
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	users, roles, err := h.folderGrantResolver.GetFolderGrants(ctx, folder)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve folder grants", slog.String("folder", folder), slog.Any("error", err))
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	}
+	return rbac.CheckCascadeAccess(claims.Email, claims.Roles, users, roles, perm, rbac.TemplatePolicyBindingCascadePerms)
+}

--- a/console/templatepolicybindings/handler.go
+++ b/console/templatepolicybindings/handler.go
@@ -35,11 +35,13 @@ var dnsLabelRe = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
 // experience than a silent no-op at render time.
 //
 // Returning (false, nil) means "policy not found" — the handler rejects
-// with a precise InvalidArgument. Returning (false, err) means the probe
-// itself failed; the handler treats a transient error the same as "not
-// found" because there is no reason to lock in a binding whose policy
-// cannot be confirmed — but it logs the error so operators can diagnose a
-// misconfigured K8s API.
+// with CodeInvalidArgument so the caller sees a precise user-input
+// error. Returning (false, err) means the probe itself failed — the
+// handler rejects with CodeInternal and logs the underlying error so
+// operators can distinguish "policy is missing" (user bug) from "the
+// cluster is unreachable" (infrastructure problem). The tests
+// (TestCreateRejectsMissingPolicy, TestPolicyProbeErrorFailsInternal) pin
+// both mappings.
 //
 // This interface lets the handler decouple from console/templatepolicies to
 // avoid an import cycle; the policyresolver package consumes bindings

--- a/console/templatepolicybindings/handler.go
+++ b/console/templatepolicybindings/handler.go
@@ -1,0 +1,809 @@
+package templatepolicybindings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rbac"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
+)
+
+const auditResourceType = "template-policy-binding"
+
+// dnsLabelRe validates binding names as DNS labels (mirrors
+// console/templatepolicies).
+var dnsLabelRe = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
+
+// PolicyExistsResolver reports whether a TemplatePolicy exists at a given
+// scope. The handler calls this to validate a binding's policy_ref points
+// at a policy that actually lives in the ancestor chain reachable from the
+// binding's own scope — a binding without an existing policy is useless at
+// render time, so failing at authoring time is a better developer
+// experience than a silent no-op at render time.
+//
+// Returning (false, nil) means "policy not found" — the handler rejects
+// with a precise InvalidArgument. Returning (false, err) means the probe
+// itself failed; the handler treats a transient error the same as "not
+// found" because there is no reason to lock in a binding whose policy
+// cannot be confirmed — but it logs the error so operators can diagnose a
+// misconfigured K8s API.
+//
+// This interface lets the handler decouple from console/templatepolicies to
+// avoid an import cycle; the policyresolver package consumes bindings
+// transitively via HOL-596.
+type PolicyExistsResolver interface {
+	PolicyExists(ctx context.Context, scope consolev1.TemplateScope, scopeName, name string) (bool, error)
+}
+
+// AncestorChainResolver reports whether a target namespace is on the
+// ancestor chain starting from a given source namespace. The handler uses
+// this to verify that a binding's policy_ref points at a policy stored in
+// a scope the binding can reach — ancestor traversal is the only way a
+// policy takes effect on the binding's render targets, so a ref outside
+// the chain cannot fire at render time and should be rejected at
+// authoring time.
+//
+// A nil resolver disables the ancestor-chain check (unit tests that only
+// exercise same-scope policies may skip the wiring). A non-nil resolver
+// that returns (false, nil) causes the handler to reject with
+// CodeFailedPrecondition; a resolver that errors causes CodeInternal so
+// operators can distinguish "policy is out of chain" from "the cluster
+// couldn't tell us whether the policy is in chain".
+type AncestorChainResolver interface {
+	AncestorChainContains(ctx context.Context, startNs, wantNs string) (bool, error)
+}
+
+// ProjectExistsResolver reports whether a project slug exists under a given
+// scope. The handler uses this to validate every target_ref carries a
+// real project_name before the binding is stored; a stale project_name
+// would never match at render time, so surfacing the typo at authoring
+// time keeps the failure loud.
+//
+// A nil resolver disables the per-target project existence check (tests
+// that only cover the non-target-validation paths may skip the wiring).
+type ProjectExistsResolver interface {
+	ProjectExists(ctx context.Context, scope consolev1.TemplateScope, scopeName, projectName string) (bool, error)
+}
+
+// Handler implements the TemplatePolicyBindingService.
+type Handler struct {
+	consolev1connect.UnimplementedTemplatePolicyBindingServiceHandler
+	k8s                 *K8sClient
+	resolver            *resolver.Resolver
+	orgGrantResolver    OrgGrantResolver
+	folderGrantResolver FolderGrantResolver
+	policyResolver      PolicyExistsResolver
+	ancestorResolver    AncestorChainResolver
+	projectResolver     ProjectExistsResolver
+}
+
+// NewHandler creates a TemplatePolicyBindingService handler.
+func NewHandler(k8s *K8sClient, r *resolver.Resolver) *Handler {
+	return &Handler{k8s: k8s, resolver: r}
+}
+
+// WithOrgGrantResolver configures organization grant resolution.
+func (h *Handler) WithOrgGrantResolver(ogr OrgGrantResolver) *Handler {
+	h.orgGrantResolver = ogr
+	return h
+}
+
+// WithFolderGrantResolver configures folder grant resolution.
+func (h *Handler) WithFolderGrantResolver(fgr FolderGrantResolver) *Handler {
+	h.folderGrantResolver = fgr
+	return h
+}
+
+// WithPolicyExistsResolver configures the policy-existence check applied to
+// a binding's policy_ref.
+func (h *Handler) WithPolicyExistsResolver(per PolicyExistsResolver) *Handler {
+	h.policyResolver = per
+	return h
+}
+
+// WithAncestorChainResolver configures the ancestor-chain check applied to a
+// binding's policy_ref.
+func (h *Handler) WithAncestorChainResolver(acr AncestorChainResolver) *Handler {
+	h.ancestorResolver = acr
+	return h
+}
+
+// WithProjectExistsResolver configures the project-existence check applied
+// to each target_ref's project_name.
+func (h *Handler) WithProjectExistsResolver(per ProjectExistsResolver) *Handler {
+	h.projectResolver = per
+	return h
+}
+
+// ListTemplatePolicyBindings returns all bindings visible in the given
+// scope.
+func (h *Handler) ListTemplatePolicyBindings(
+	ctx context.Context,
+	req *connect.Request[consolev1.ListTemplatePolicyBindingsRequest],
+) (*connect.Response[consolev1.ListTemplatePolicyBindingsResponse], error) {
+	scope, scopeName, err := h.extractBindingScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatePoliciesList); err != nil {
+		return nil, err
+	}
+
+	cms, err := h.k8s.ListBindings(ctx, scope, scopeName)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	bindings := make([]*consolev1.TemplatePolicyBinding, 0, len(cms))
+	for i := range cms {
+		bindings = append(bindings, configMapToBinding(&cms[i], scope, scopeName))
+	}
+
+	slog.InfoContext(ctx, "template policy bindings listed",
+		slog.String("action", "template_policy_binding_list"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+		slog.Int("count", len(bindings)),
+	)
+
+	return connect.NewResponse(&consolev1.ListTemplatePolicyBindingsResponse{Bindings: bindings}), nil
+}
+
+// GetTemplatePolicyBinding returns a single binding by name.
+func (h *Handler) GetTemplatePolicyBinding(
+	ctx context.Context,
+	req *connect.Request[consolev1.GetTemplatePolicyBindingRequest],
+) (*connect.Response[consolev1.GetTemplatePolicyBindingResponse], error) {
+	scope, scopeName, err := h.extractBindingScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	name := req.Msg.GetName()
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatePoliciesRead); err != nil {
+		return nil, err
+	}
+
+	cm, err := h.k8s.GetBinding(ctx, scope, scopeName, name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "template policy binding read",
+		slog.String("action", "template_policy_binding_read"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("name", name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.GetTemplatePolicyBindingResponse{
+		Binding: configMapToBinding(cm, scope, scopeName),
+	}), nil
+}
+
+// CreateTemplatePolicyBinding creates a new binding.
+func (h *Handler) CreateTemplatePolicyBinding(
+	ctx context.Context,
+	req *connect.Request[consolev1.CreateTemplatePolicyBindingRequest],
+) (*connect.Response[consolev1.CreateTemplatePolicyBindingResponse], error) {
+	scope, scopeName, err := h.extractBindingScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	binding := req.Msg.GetBinding()
+	if binding == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding is required"))
+	}
+	if err := validateBindingScopeRef(binding.GetScopeRef(), scope, scopeName); err != nil {
+		return nil, err
+	}
+	if err := validateBindingName(binding.GetName()); err != nil {
+		return nil, err
+	}
+	if err := validatePolicyRef(binding.GetPolicyRef()); err != nil {
+		return nil, err
+	}
+	if err := validateTargetRefs(binding.GetTargetRefs()); err != nil {
+		return nil, err
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatePoliciesWrite); err != nil {
+		return nil, err
+	}
+
+	// HOL-595: a binding's policy_ref MUST point at a policy that exists
+	// in the binding's own scope or an ancestor scope. Rejecting an
+	// out-of-chain ref at authoring time surfaces the mistake immediately
+	// rather than silently no-op'ing at render time. The check runs AFTER
+	// checkAccess so an unauthorized caller can't use the error to probe
+	// which policies exist in which scope.
+	if err := h.validatePolicyRefReachable(ctx, scope, scopeName, binding.GetPolicyRef()); err != nil {
+		return nil, err
+	}
+
+	// HOL-595: every target_ref's project_name must reference a real
+	// project under the binding's owning scope. Runs AFTER checkAccess
+	// for the same probe-oracle reason as the policy-ref check.
+	if err := h.validateTargetProjects(ctx, scope, scopeName, binding.GetTargetRefs()); err != nil {
+		return nil, err
+	}
+
+	_, err = h.k8s.CreateBinding(
+		ctx,
+		scope,
+		scopeName,
+		binding.GetName(),
+		binding.GetDisplayName(),
+		binding.GetDescription(),
+		claims.Email,
+		binding.GetPolicyRef(),
+		binding.GetTargetRefs(),
+	)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "template policy binding created",
+		slog.String("action", "template_policy_binding_create"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("name", binding.GetName()),
+		slog.Int("targets", len(binding.GetTargetRefs())),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.CreateTemplatePolicyBindingResponse{
+		Name: binding.GetName(),
+	}), nil
+}
+
+// UpdateTemplatePolicyBinding updates an existing binding. Immutable fields
+// (name, scope_ref, created_at, creator_email) are preserved from the
+// stored ConfigMap; display_name, description, policy_ref, and target_refs
+// are replaced from the request. Proto3 does not give us presence
+// semantics on scalars, so display_name and description are always
+// replaced — callers that want to preserve them must send them back
+// verbatim. Policy_ref and target_refs are always re-validated; an update
+// that introduces an out-of-chain policy_ref or a bad target_ref is
+// rejected before the write.
+func (h *Handler) UpdateTemplatePolicyBinding(
+	ctx context.Context,
+	req *connect.Request[consolev1.UpdateTemplatePolicyBindingRequest],
+) (*connect.Response[consolev1.UpdateTemplatePolicyBindingResponse], error) {
+	scope, scopeName, err := h.extractBindingScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	binding := req.Msg.GetBinding()
+	if binding == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding is required"))
+	}
+	if err := validateBindingScopeRef(binding.GetScopeRef(), scope, scopeName); err != nil {
+		return nil, err
+	}
+	name := binding.GetName()
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+	if err := validatePolicyRef(binding.GetPolicyRef()); err != nil {
+		return nil, err
+	}
+	if err := validateTargetRefs(binding.GetTargetRefs()); err != nil {
+		return nil, err
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatePoliciesWrite); err != nil {
+		return nil, err
+	}
+
+	// Fetch the existing binding so we can surface NotFound before we
+	// attempt the Update (the K8s API would otherwise return a less
+	// informative error) and also preserve unset immutable fields. The
+	// reachability and target-project checks below run AFTER this read so
+	// an Update to a non-existent binding still returns
+	// connect.CodeNotFound regardless of the submitted policy_ref — clients
+	// rely on that distinction for idempotent upsert flows.
+	existing, err := h.k8s.GetBinding(ctx, scope, scopeName, name)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	if err := h.validatePolicyRefReachable(ctx, scope, scopeName, binding.GetPolicyRef()); err != nil {
+		return nil, err
+	}
+	if err := h.validateTargetProjects(ctx, scope, scopeName, binding.GetTargetRefs()); err != nil {
+		return nil, err
+	}
+
+	// Proto3 scalar fields default to "" which we intentionally treat as
+	// "no change" here so UI clients can send a targets-only update
+	// without clobbering display name and description. A future API
+	// revision may introduce field masks for explicit clears.
+	var displayName, description *string
+	if binding.GetDisplayName() != "" {
+		dn := binding.GetDisplayName()
+		displayName = &dn
+	} else if _, ok := existing.Annotations[v1alpha2.AnnotationDisplayName]; !ok {
+		empty := ""
+		displayName = &empty
+	}
+	if binding.GetDescription() != "" {
+		d := binding.GetDescription()
+		description = &d
+	} else if _, ok := existing.Annotations[v1alpha2.AnnotationDescription]; !ok {
+		empty := ""
+		description = &empty
+	}
+
+	_, err = h.k8s.UpdateBinding(
+		ctx,
+		scope,
+		scopeName,
+		name,
+		displayName,
+		description,
+		binding.GetPolicyRef(), true,
+		binding.GetTargetRefs(), true,
+	)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "template policy binding updated",
+		slog.String("action", "template_policy_binding_update"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("name", name),
+		slog.Int("targets", len(binding.GetTargetRefs())),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.UpdateTemplatePolicyBindingResponse{}), nil
+}
+
+// DeleteTemplatePolicyBinding deletes a binding.
+func (h *Handler) DeleteTemplatePolicyBinding(
+	ctx context.Context,
+	req *connect.Request[consolev1.DeleteTemplatePolicyBindingRequest],
+) (*connect.Response[consolev1.DeleteTemplatePolicyBindingResponse], error) {
+	scope, scopeName, err := h.extractBindingScope(req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	name := req.Msg.GetName()
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatePoliciesDelete); err != nil {
+		return nil, err
+	}
+
+	if err := h.k8s.DeleteBinding(ctx, scope, scopeName, name); err != nil {
+		return nil, mapK8sError(err)
+	}
+
+	slog.InfoContext(ctx, "template policy binding deleted",
+		slog.String("action", "template_policy_binding_delete"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("scope", scope.String()),
+		slog.String("scopeName", scopeName),
+		slog.String("name", name),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+	)
+
+	return connect.NewResponse(&consolev1.DeleteTemplatePolicyBindingResponse{}), nil
+}
+
+// extractBindingScope validates a TemplateScopeRef for the
+// TemplatePolicyBindingService. Beyond the basic checks, this function also
+// rejects TEMPLATE_SCOPE_PROJECT directly and reports the would-be project
+// namespace in the error message so operators can debug misrouted clients.
+// The same rejection applies on read and write so probing a project
+// namespace cannot leak data.
+func (h *Handler) extractBindingScope(ref *consolev1.TemplateScopeRef) (consolev1.TemplateScope, string, error) {
+	if ref == nil {
+		return 0, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scope is required"))
+	}
+	switch ref.GetScope() {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED:
+		return 0, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scope must be specified"))
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT:
+		// Derive the project namespace name for the error message from
+		// the raw resolver prefixes. The k8s layer performs the
+		// authoritative ResourceTypeFromNamespace check and will
+		// re-reject there; this is the fast path so we can emit a
+		// precise diagnostic without a K8s round trip.
+		projectNs := h.resolver.NamespacePrefix + h.resolver.ProjectPrefix + ref.GetScopeName()
+		return 0, "", connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("template policy bindings cannot be stored in project namespace %q; use an organization or folder scope", projectNs))
+	}
+	if ref.GetScopeName() == "" {
+		return 0, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scope.scope_name is required"))
+	}
+	return ref.GetScope(), ref.GetScopeName(), nil
+}
+
+// validateBindingScopeRef enforces the proto contract that every binding
+// carries a scope_ref and that it exactly matches the outer request scope.
+// Silently accepting a nil or mismatched scope_ref would let a client
+// believe a binding was stored at one scope when it was actually stored at
+// another. Project scope is rejected here too so the storage-isolation
+// guardrail (HOL-554) holds at the proto boundary and not only via the
+// downstream namespace check.
+func validateBindingScopeRef(ref *consolev1.TemplateScopeRef, reqScope consolev1.TemplateScope, reqScopeName string) error {
+	if ref == nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding.scope_ref is required"))
+	}
+	if ref.GetScope() == consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED || ref.GetScopeName() == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding.scope_ref.scope and binding.scope_ref.scope_name are required"))
+	}
+	if ref.GetScope() == consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("binding.scope_ref cannot be TEMPLATE_SCOPE_PROJECT; template policy bindings must live at folder or organization scope"))
+	}
+	if ref.GetScope() != reqScope || ref.GetScopeName() != reqScopeName {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("binding.scope_ref (%s/%s) must match request scope (%s/%s)",
+				ref.GetScope(), ref.GetScopeName(), reqScope, reqScopeName))
+	}
+	return nil
+}
+
+// validateBindingName enforces DNS-label rules and the 63-character limit so
+// the generated ConfigMap name is always valid Kubernetes.
+func validateBindingName(name string) error {
+	if name == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+	if len(name) > 63 {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name must be at most 63 characters"))
+	}
+	if !dnsLabelRe.MatchString(name) {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name must be a valid DNS label (lowercase alphanumeric and hyphens, starting with a letter)"))
+	}
+	return nil
+}
+
+// validatePolicyRef enforces the proto contract on the LinkedTemplatePolicyRef
+// carried by a binding. Every binding must reference exactly one policy; a
+// half-populated ref (missing scope, scope_name, or name) cannot be bound
+// against any real policy so the handler rejects it up front. Project scope
+// is rejected too because a TemplatePolicy cannot live at project scope in
+// the first place — a ref that targets a project scope is unusable.
+func validatePolicyRef(ref *consolev1.LinkedTemplatePolicyRef) error {
+	if ref == nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding.policy_ref is required"))
+	}
+	scope := ref.GetScopeRef()
+	if scope == nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding.policy_ref.scope_ref is required"))
+	}
+	if scope.GetScope() == consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding.policy_ref.scope_ref.scope is required"))
+	}
+	if scope.GetScope() == consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("binding.policy_ref.scope_ref cannot be TEMPLATE_SCOPE_PROJECT; template policies live at organization or folder scope"))
+	}
+	if scope.GetScopeName() == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding.policy_ref.scope_ref.scope_name is required"))
+	}
+	if ref.GetName() == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding.policy_ref.name is required"))
+	}
+	return nil
+}
+
+// validateTargetRefs enforces the invariants common to every target_ref:
+// kind must be set to one of the two legal values, name must be a DNS
+// label, project_name must be present (required for both PROJECT_TEMPLATE
+// and DEPLOYMENT kinds per the proto comment). Duplicate (kind,
+// project_name, name) triples are rejected — two entries with the same
+// triple make the binding semantically ambiguous and most likely signal a
+// UI bug that submitted the same target twice.
+func validateTargetRefs(refs []*consolev1.TemplatePolicyBindingTargetRef) error {
+	if len(refs) == 0 {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding must have at least one target_ref"))
+	}
+	seen := make(map[string]int, len(refs))
+	for i, ref := range refs {
+		if ref == nil {
+			return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("target_refs[%d]: target_ref is required", i))
+		}
+		switch ref.GetKind() {
+		case consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+			consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT:
+		default:
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("target_refs[%d]: kind must be PROJECT_TEMPLATE or DEPLOYMENT, got %v", i, ref.GetKind()))
+		}
+		if ref.GetName() == "" {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("target_refs[%d]: name is required", i))
+		}
+		if !dnsLabelRe.MatchString(ref.GetName()) {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("target_refs[%d]: name must be a valid DNS label, got %q", i, ref.GetName()))
+		}
+		if ref.GetProjectName() == "" {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("target_refs[%d]: project_name is required", i))
+		}
+		if !dnsLabelRe.MatchString(ref.GetProjectName()) {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("target_refs[%d]: project_name must be a valid DNS label, got %q", i, ref.GetProjectName()))
+		}
+		key := targetKindToString(ref.GetKind()) + "|" + ref.GetProjectName() + "|" + ref.GetName()
+		if prev, ok := seen[key]; ok {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("target_refs[%d]: duplicate of target_refs[%d] (kind=%s, project=%s, name=%s)",
+					i, prev, targetKindToString(ref.GetKind()), ref.GetProjectName(), ref.GetName()))
+		}
+		seen[key] = i
+	}
+	return nil
+}
+
+// validatePolicyRefReachable confirms the binding's policy_ref points at a
+// TemplatePolicy that (a) actually exists and (b) lives in a scope the
+// binding can reach via ancestor traversal. A wired
+// PolicyExistsResolver makes (a) enforceable; a wired AncestorChainResolver
+// makes (b) enforceable. When either resolver is nil the corresponding
+// check is skipped — tests that don't exercise the seam do not need to
+// stub it, mirroring the handler/topology pattern used in
+// console/templatepolicies.
+//
+// The binding's own scope trivially reaches itself; the resolver is only
+// consulted when the policy lives in a different scope.
+func (h *Handler) validatePolicyRefReachable(
+	ctx context.Context,
+	scope consolev1.TemplateScope,
+	scopeName string,
+	ref *consolev1.LinkedTemplatePolicyRef,
+) error {
+	if ref == nil {
+		// validatePolicyRef would have already rejected this; belt-and-
+		// suspenders in case a caller reaches past the common entry
+		// points in the future.
+		return nil
+	}
+	refScope := ref.GetScopeRef().GetScope()
+	refScopeName := ref.GetScopeRef().GetScopeName()
+
+	// First, confirm the policy exists. A missing policy is a definitive
+	// authoring-time error regardless of whether the binding and policy
+	// share a scope.
+	if h.policyResolver != nil {
+		exists, err := h.policyResolver.PolicyExists(ctx, refScope, refScopeName, ref.GetName())
+		if err != nil {
+			slog.WarnContext(ctx, "policy existence probe failed; rejecting binding",
+				slog.String("policy_scope", refScope.String()),
+				slog.String("policy_scope_name", refScopeName),
+				slog.String("policy_name", ref.GetName()),
+				slog.Any("error", err),
+			)
+			return connect.NewError(connect.CodeInternal,
+				fmt.Errorf("resolving policy %s/%s/%s: %w", refScope, refScopeName, ref.GetName(), err))
+		}
+		if !exists {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("binding.policy_ref points at unknown policy %s/%s/%s",
+					refScope, refScopeName, ref.GetName()))
+		}
+	}
+
+	// Same scope means the binding trivially reaches the policy via the
+	// zero-length ancestor path — no resolver call needed.
+	if refScope == scope && refScopeName == scopeName {
+		return nil
+	}
+
+	if h.ancestorResolver == nil {
+		return nil
+	}
+
+	startNs, err := h.scopeNamespace(scope, scopeName)
+	if err != nil {
+		return err
+	}
+	wantNs, err := h.scopeNamespace(refScope, refScopeName)
+	if err != nil {
+		return err
+	}
+
+	contained, err := h.ancestorResolver.AncestorChainContains(ctx, startNs, wantNs)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal,
+			fmt.Errorf("resolving ancestor chain for binding scope %s/%s: %w", scope, scopeName, err))
+	}
+	if !contained {
+		return connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("binding.policy_ref scope %s/%s is not reachable from binding scope %s/%s via ancestor chain",
+				refScope, refScopeName, scope, scopeName))
+	}
+	return nil
+}
+
+// validateTargetProjects confirms each target_ref's project_name names a
+// project that exists under the binding's owning scope. When no
+// ProjectExistsResolver is wired the check is a no-op — tests that only
+// exercise the earlier validation paths may skip the wiring. An error
+// from the resolver is converted to CodeInternal; a false return is
+// converted to CodeInvalidArgument with the index and the offending
+// project_name so the UI can highlight the bad row.
+func (h *Handler) validateTargetProjects(
+	ctx context.Context,
+	scope consolev1.TemplateScope,
+	scopeName string,
+	refs []*consolev1.TemplatePolicyBindingTargetRef,
+) error {
+	if h.projectResolver == nil {
+		return nil
+	}
+	// Cache lookups by project_name so a binding that targets many
+	// resources inside the same project does not hammer the resolver.
+	checked := make(map[string]bool, len(refs))
+	for i, ref := range refs {
+		project := ref.GetProjectName()
+		if project == "" {
+			continue // validateTargetRefs already rejected this
+		}
+		if checked[project] {
+			continue
+		}
+		exists, err := h.projectResolver.ProjectExists(ctx, scope, scopeName, project)
+		if err != nil {
+			return connect.NewError(connect.CodeInternal,
+				fmt.Errorf("target_refs[%d]: resolving project %q: %w", i, project, err))
+		}
+		if !exists {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("target_refs[%d]: project %q does not exist under binding scope %s/%s",
+					i, project, scope, scopeName))
+		}
+		checked[project] = true
+	}
+	return nil
+}
+
+// scopeNamespace mirrors K8sClient.namespaceForScope for validation use in
+// this file. It intentionally does not go through the K8sClient helper
+// because that helper carries a ProjectNamespaceError contract the handler
+// layer would otherwise need to re-map; the handler rejects project scope
+// at extractBindingScope, so this helper refuses project scope with a
+// plain error for any other path that might reach it.
+func (h *Handler) scopeNamespace(scope consolev1.TemplateScope, scopeName string) (string, error) {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return h.resolver.OrgNamespace(scopeName), nil
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return h.resolver.FolderNamespace(scopeName), nil
+	default:
+		return "", connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("unsupported scope %v for binding storage", scope))
+	}
+}
+
+// configMapToBinding converts a stored ConfigMap into a TemplatePolicyBinding
+// proto. The caller supplies the authoritative scope/scopeName pair because
+// the ConfigMap namespace alone is not enough to reconstruct the scope name
+// in all cases (cluster installers may configure non-default prefixes).
+func configMapToBinding(cm *corev1.ConfigMap, scope consolev1.TemplateScope, scopeName string) *consolev1.TemplatePolicyBinding {
+	binding := &consolev1.TemplatePolicyBinding{
+		Name:         cm.Name,
+		DisplayName:  cm.Annotations[v1alpha2.AnnotationDisplayName],
+		Description:  cm.Annotations[v1alpha2.AnnotationDescription],
+		CreatorEmail: cm.Annotations[v1alpha2.AnnotationCreatorEmail],
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     scope,
+			ScopeName: scopeName,
+		},
+		CreatedAt: timestamppb.New(cm.CreationTimestamp.Time),
+	}
+	if raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef]; raw != "" {
+		parsed, err := unmarshalPolicyRef(raw)
+		if err != nil {
+			slog.Warn("failed to parse template policy binding policy ref annotation",
+				slog.String("name", cm.Name),
+				slog.String("namespace", cm.Namespace),
+				slog.Any("error", err),
+			)
+		} else if parsed != nil {
+			binding.PolicyRef = parsed
+		}
+	}
+	if raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs]; raw != "" {
+		parsed, err := unmarshalTargetRefs(raw)
+		if err != nil {
+			slog.Warn("failed to parse template policy binding target refs annotation",
+				slog.String("name", cm.Name),
+				slog.String("namespace", cm.Namespace),
+				slog.Any("error", err),
+			)
+		} else {
+			binding.TargetRefs = parsed
+		}
+	}
+	return binding
+}
+
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The
+// function also recognises the package-level ProjectNamespaceError and
+// maps it to CodeInvalidArgument so the handler does not have to
+// duplicate the type switch at every call site.
+func mapK8sError(err error) error {
+	var pne *ProjectNamespaceError
+	if errors.As(err, &pne) {
+		return connect.NewError(connect.CodeInvalidArgument, pne)
+	}
+	if k8serrors.IsNotFound(err) {
+		return connect.NewError(connect.CodeNotFound, err)
+	}
+	if k8serrors.IsAlreadyExists(err) {
+		return connect.NewError(connect.CodeAlreadyExists, err)
+	}
+	if k8serrors.IsForbidden(err) {
+		return connect.NewError(connect.CodePermissionDenied, err)
+	}
+	if k8serrors.IsUnauthorized(err) {
+		return connect.NewError(connect.CodeUnauthenticated, err)
+	}
+	if k8serrors.IsBadRequest(err) {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	return connect.NewError(connect.CodeInternal, err)
+}

--- a/console/templatepolicybindings/handler_test.go
+++ b/console/templatepolicybindings/handler_test.go
@@ -479,6 +479,38 @@ func TestCreateValidation(t *testing.T) {
 			wantMsg: "name is required",
 		},
 		{
+			name: "target project_name invalid DNS label",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:      "bad",
+				ScopeRef:  folder,
+				PolicyRef: validPolicyRef(),
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+					{
+						Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+						Name:        "api",
+						ProjectName: "Bad_Project",
+					},
+				},
+			},
+			wantMsg: "project_name must be a valid DNS label",
+		},
+		{
+			name: "target name invalid DNS label",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:      "bad",
+				ScopeRef:  folder,
+				PolicyRef: validPolicyRef(),
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+					{
+						Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+						Name:        "Bad_Name",
+						ProjectName: "payments-web",
+					},
+				},
+			},
+			wantMsg: "name must be a valid DNS label",
+		},
+		{
 			name: "target project_name missing",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:      "bad",

--- a/console/templatepolicybindings/handler_test.go
+++ b/console/templatepolicybindings/handler_test.go
@@ -1,0 +1,1037 @@
+package templatepolicybindings
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// stubOrgGrantResolver echoes per-user role grants for the organization
+// passed to its constructor. The two stubs below mirror the shape used in
+// console/templatepolicies/handler_test.go so readers can move between the
+// two tests without relearning the scaffolding.
+type stubOrgGrantResolver struct {
+	users map[string]string
+	roles map[string]string
+	err   error
+}
+
+func (s *stubOrgGrantResolver) GetOrgGrants(_ context.Context, _ string) (map[string]string, map[string]string, error) {
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+	return s.users, s.roles, nil
+}
+
+type stubFolderGrantResolver struct {
+	users map[string]string
+	roles map[string]string
+	err   error
+}
+
+func (s *stubFolderGrantResolver) GetFolderGrants(_ context.Context, _ string) (map[string]string, map[string]string, error) {
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+	return s.users, s.roles, nil
+}
+
+// stubPolicyResolver implements PolicyExistsResolver. Tests that pin
+// existence set `exists` directly; tests that want to simulate a transient
+// probe failure set `err`.
+type stubPolicyResolver struct {
+	exists bool
+	err    error
+	calls  int
+}
+
+func (s *stubPolicyResolver) PolicyExists(_ context.Context, _ consolev1.TemplateScope, _, _ string) (bool, error) {
+	s.calls++
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.exists, nil
+}
+
+// stubAncestorResolver implements AncestorChainResolver. `contains` drives
+// the boolean answer; `err` simulates a walker failure.
+type stubAncestorResolver struct {
+	contains bool
+	err      error
+	calls    int
+}
+
+func (s *stubAncestorResolver) AncestorChainContains(_ context.Context, _, _ string) (bool, error) {
+	s.calls++
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.contains, nil
+}
+
+// stubProjectResolver implements ProjectExistsResolver. `exists` is checked
+// first so a test can return false without also setting err.
+type stubProjectResolver struct {
+	exists map[string]bool
+	err    error
+	calls  int
+}
+
+func (s *stubProjectResolver) ProjectExists(_ context.Context, _ consolev1.TemplateScope, _, project string) (bool, error) {
+	s.calls++
+	if s.err != nil {
+		return false, s.err
+	}
+	if s.exists == nil {
+		return true, nil
+	}
+	return s.exists[project], nil
+}
+
+func authedCtx(email string, roles []string) context.Context {
+	return rpc.ContextWithClaims(context.Background(), &rpc.Claims{
+		Sub:   "user-test",
+		Email: email,
+		Roles: roles,
+	})
+}
+
+// newTestHandler builds a Handler wired to fake K8s and grant resolvers that
+// return the supplied `shareUsers` map for both org and folder lookups.
+// Tests that need to override individual resolvers can do so by calling the
+// `With*` builders on the returned Handler.
+func newTestHandler(t *testing.T, shareUsers map[string]string) (*Handler, *fake.Clientset) {
+	t.Helper()
+	fakeClient := fake.NewClientset()
+	r := newTestResolver()
+	k := NewK8sClient(fakeClient, r)
+	h := NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: shareUsers}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: shareUsers})
+	return h, fakeClient
+}
+
+// newFolderScopeRef, newOrgScopeRef, and newProjectScopeRef are short
+// constructors for proto types used in every table-driven case below.
+func newFolderScopeRef(name string) *consolev1.TemplateScopeRef {
+	return &consolev1.TemplateScopeRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER,
+		ScopeName: name,
+	}
+}
+
+func newOrgScopeRef(name string) *consolev1.TemplateScopeRef {
+	return &consolev1.TemplateScopeRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+		ScopeName: name,
+	}
+}
+
+func newProjectScopeRef(name string) *consolev1.TemplateScopeRef {
+	return &consolev1.TemplateScopeRef{
+		Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT,
+		ScopeName: name,
+	}
+}
+
+// basicBinding builds a binding whose scope_ref matches the supplied
+// request scope with a default policy_ref + single target_ref. The outer
+// request scope and the embedded binding scope must line up for the
+// handler to accept the request; this helper keeps the invariant in one
+// place.
+func basicBinding(scope *consolev1.TemplateScopeRef) *consolev1.TemplatePolicyBinding {
+	return &consolev1.TemplatePolicyBinding{
+		Name:        "bind-reference-grant",
+		DisplayName: "Bind reference grant",
+		Description: "Attach reference-grant policy to payments-web",
+		ScopeRef:    scope,
+		PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+			ScopeRef: newOrgScopeRef("acme"),
+			Name:     "require-reference-grant",
+		},
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+			{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        "api",
+				ProjectName: "payments-web",
+			},
+		},
+	}
+}
+
+func containsString(haystack, needle string) bool {
+	return strings.Contains(haystack, needle)
+}
+
+// TestCreateRejectsProjectScope is the dedicated negative test called out
+// by the HOL-595 acceptance criteria. The handler must refuse the request
+// before any ConfigMap is written, and the InvalidArgument message must
+// name the offending project namespace so operators can debug routing
+// mistakes.
+func TestCreateRejectsProjectScope(t *testing.T) {
+	h, fakeClient := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+
+	req := connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   newProjectScopeRef("billing-web"),
+		Binding: basicBinding(newProjectScopeRef("billing-web")),
+	})
+	ctx := authedCtx("owner@example.com", nil)
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, req)
+	if err == nil {
+		t.Fatal("expected project-scope rejection")
+	}
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+	}
+	if want := "holos-prj-billing-web"; !containsString(err.Error(), want) {
+		t.Errorf("expected error to name %q, got %v", want, err)
+	}
+
+	cms, _ := fakeClient.CoreV1().ConfigMaps("holos-prj-billing-web").List(context.Background(), metav1.ListOptions{})
+	if len(cms.Items) != 0 {
+		t.Errorf("expected no ConfigMaps in project namespace, got %d", len(cms.Items))
+	}
+}
+
+// TestReadPathsRejectProjectScope covers the symmetric case for the read
+// paths. A project-scope request on Get, List, Update, or Delete must
+// fail without performing a K8s round trip so probing a project
+// namespace cannot leak data.
+func TestReadPathsRejectProjectScope(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"viewer@example.com": "viewer"})
+	ctx := authedCtx("viewer@example.com", nil)
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "list",
+			run: func() error {
+				_, err := h.ListTemplatePolicyBindings(ctx, connect.NewRequest(&consolev1.ListTemplatePolicyBindingsRequest{
+					Scope: newProjectScopeRef("billing-web"),
+				}))
+				return err
+			},
+		},
+		{
+			name: "get",
+			run: func() error {
+				_, err := h.GetTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.GetTemplatePolicyBindingRequest{
+					Scope: newProjectScopeRef("billing-web"),
+					Name:  "any",
+				}))
+				return err
+			},
+		},
+		{
+			name: "update",
+			run: func() error {
+				_, err := h.UpdateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyBindingRequest{
+					Scope:   newProjectScopeRef("billing-web"),
+					Binding: basicBinding(newProjectScopeRef("billing-web")),
+				}))
+				return err
+			},
+		},
+		{
+			name: "delete",
+			run: func() error {
+				_, err := h.DeleteTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyBindingRequest{
+					Scope: newProjectScopeRef("billing-web"),
+					Name:  "any",
+				}))
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil {
+				t.Fatal("expected rejection")
+			}
+			if connect.CodeOf(err) != connect.CodeInvalidArgument {
+				t.Errorf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+			}
+		})
+	}
+}
+
+// TestCreateHappyPath exercises the full happy path: authenticated owner,
+// valid folder scope, folder-local policy reference, one deployment target
+// under an existing project. Verifies a ConfigMap lands in the folder
+// namespace with the expected labels and annotations, and the response
+// carries the binding name.
+func TestCreateHappyPath(t *testing.T) {
+	h, fakeClient := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+
+	ctx := authedCtx("owner@example.com", nil)
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	// Override policy_ref to stay in the same folder so the reachability
+	// check does not depend on the ancestor resolver.
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: folder,
+		Name:     "local-policy",
+	}
+
+	resp, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Msg.GetName() != binding.GetName() {
+		t.Errorf("expected response name %q, got %q", binding.GetName(), resp.Msg.GetName())
+	}
+
+	cm, err := fakeClient.CoreV1().ConfigMaps("holos-fld-payments").Get(context.Background(), binding.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("fetching created binding: %v", err)
+	}
+	if cm.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeTemplatePolicyBinding {
+		t.Errorf("expected resource type label, got %q", cm.Labels[v1alpha2.LabelResourceType])
+	}
+	if cm.Annotations[v1alpha2.AnnotationCreatorEmail] != "owner@example.com" {
+		t.Errorf("expected creator email annotation to be set from claims, got %q", cm.Annotations[v1alpha2.AnnotationCreatorEmail])
+	}
+}
+
+// TestCreateRBACDenial confirms a caller with no grants sees
+// PermissionDenied and never writes a ConfigMap. The stub grant resolver
+// returns an empty map so the cascade evaluation yields
+// RoleUnspecified -> no permissions.
+func TestCreateRBACDenial(t *testing.T) {
+	h, fakeClient := newTestHandler(t, map[string]string{}) // no grants
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+
+	ctx := authedCtx("nobody@example.com", nil)
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: folder,
+		Name:     "local-policy",
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err == nil {
+		t.Fatal("expected permission denied")
+	}
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("expected CodePermissionDenied, got %v: %v", connect.CodeOf(err), err)
+	}
+
+	cms, _ := fakeClient.CoreV1().ConfigMaps("holos-fld-payments").List(context.Background(), metav1.ListOptions{})
+	if len(cms.Items) != 0 {
+		t.Errorf("expected no ConfigMaps on RBAC denial, got %d", len(cms.Items))
+	}
+}
+
+// TestCreateUnauthenticated confirms a missing Claims context yields
+// Unauthenticated — not a silent no-op. The handler must reject an
+// unauthenticated call *after* the proto-shape validation so the error
+// hierarchy surfaces the right reason.
+func TestCreateUnauthenticated(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: folder,
+		Name:     "local-policy",
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(context.Background(), connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err == nil {
+		t.Fatal("expected unauthenticated rejection")
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("expected CodeUnauthenticated, got %v: %v", connect.CodeOf(err), err)
+	}
+}
+
+// TestCreateValidation is the main table-driven proto-shape validation
+// test. Every case here must be rejected with CodeInvalidArgument before
+// any K8s write occurs — the fake clientset is ignored by these cases
+// because the handler should fail up front.
+func TestCreateValidation(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	validPolicyRef := func() *consolev1.LinkedTemplatePolicyRef {
+		return &consolev1.LinkedTemplatePolicyRef{
+			ScopeRef: folder,
+			Name:     "local-policy",
+		}
+	}
+	validTarget := func() *consolev1.TemplatePolicyBindingTargetRef {
+		return &consolev1.TemplatePolicyBindingTargetRef{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+			Name:        "api",
+			ProjectName: "payments-web",
+		}
+	}
+
+	tests := []struct {
+		name    string
+		binding *consolev1.TemplatePolicyBinding
+		wantMsg string
+	}{
+		{
+			name: "missing policy_ref",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:       "bad",
+				ScopeRef:   folder,
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
+			},
+			wantMsg: "policy_ref is required",
+		},
+		{
+			name: "policy_ref missing scope_ref",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:       "bad",
+				ScopeRef:   folder,
+				PolicyRef:  &consolev1.LinkedTemplatePolicyRef{Name: "x"},
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
+			},
+			wantMsg: "policy_ref.scope_ref is required",
+		},
+		{
+			name: "policy_ref project scope",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:     "bad",
+				ScopeRef: folder,
+				PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+					ScopeRef: newProjectScopeRef("p"),
+					Name:     "x",
+				},
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
+			},
+			wantMsg: "policy_ref.scope_ref cannot be TEMPLATE_SCOPE_PROJECT",
+		},
+		{
+			name: "target_refs empty",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:       "bad",
+				ScopeRef:   folder,
+				PolicyRef:  validPolicyRef(),
+				TargetRefs: nil,
+			},
+			wantMsg: "at least one target_ref",
+		},
+		{
+			name: "target kind unspecified",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:      "bad",
+				ScopeRef:  folder,
+				PolicyRef: validPolicyRef(),
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+					{
+						Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_UNSPECIFIED,
+						Name:        "api",
+						ProjectName: "payments-web",
+					},
+				},
+			},
+			wantMsg: "PROJECT_TEMPLATE or DEPLOYMENT",
+		},
+		{
+			name: "target name missing",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:      "bad",
+				ScopeRef:  folder,
+				PolicyRef: validPolicyRef(),
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+					{
+						Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+						ProjectName: "payments-web",
+					},
+				},
+			},
+			wantMsg: "name is required",
+		},
+		{
+			name: "target project_name missing",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:      "bad",
+				ScopeRef:  folder,
+				PolicyRef: validPolicyRef(),
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+					{
+						Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+						Name: "api",
+					},
+				},
+			},
+			wantMsg: "project_name is required",
+		},
+		{
+			name: "duplicate target triples",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:      "bad",
+				ScopeRef:  folder,
+				PolicyRef: validPolicyRef(),
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+					validTarget(),
+					validTarget(),
+				},
+			},
+			wantMsg: "duplicate of target_refs[0]",
+		},
+		{
+			name: "invalid name",
+			binding: &consolev1.TemplatePolicyBinding{
+				Name:       "Bad_Name",
+				ScopeRef:   folder,
+				PolicyRef:  validPolicyRef(),
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
+			},
+			wantMsg: "valid DNS label",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+				Scope:   folder,
+				Binding: tt.binding,
+			}))
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if connect.CodeOf(err) != connect.CodeInvalidArgument {
+				t.Errorf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+			}
+			if !containsString(err.Error(), tt.wantMsg) {
+				t.Errorf("expected error to contain %q, got %v", tt.wantMsg, err)
+			}
+		})
+	}
+}
+
+// TestCreateScopeRefMismatch covers the proto-contract check on
+// binding.scope_ref. The reviewer called out in the sibling
+// templatepolicies handler tests that the handler previously accepted
+// mismatched scope_ref values; the binding handler must fail the same
+// way so a stored binding cannot claim a scope different from its
+// actual namespace.
+func TestCreateScopeRefMismatch(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	tests := []struct {
+		name    string
+		reqRef  *consolev1.TemplateScopeRef
+		bindRef *consolev1.TemplateScopeRef
+		wantMsg string
+	}{
+		{
+			name:    "nil binding scope_ref",
+			reqRef:  newFolderScopeRef("payments"),
+			bindRef: nil,
+			wantMsg: "binding.scope_ref is required",
+		},
+		{
+			name:    "mismatched folder name",
+			reqRef:  newFolderScopeRef("payments"),
+			bindRef: newFolderScopeRef("identity"),
+			wantMsg: "must match request scope",
+		},
+		{
+			name:    "mismatched org vs folder",
+			reqRef:  newFolderScopeRef("payments"),
+			bindRef: newOrgScopeRef("acme"),
+			wantMsg: "must match request scope",
+		},
+		{
+			name:    "project scope_ref at folder request",
+			reqRef:  newFolderScopeRef("payments"),
+			bindRef: newProjectScopeRef("payments-web"),
+			wantMsg: "cannot be TEMPLATE_SCOPE_PROJECT",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := basicBinding(tt.bindRef)
+			b.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+				ScopeRef: tt.reqRef,
+				Name:     "p",
+			}
+			_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+				Scope:   tt.reqRef,
+				Binding: b,
+			}))
+			if err == nil {
+				t.Fatal("expected rejection")
+			}
+			if connect.CodeOf(err) != connect.CodeInvalidArgument {
+				t.Errorf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+			}
+			if !containsString(err.Error(), tt.wantMsg) {
+				t.Errorf("expected error to contain %q, got %v", tt.wantMsg, err)
+			}
+		})
+	}
+}
+
+// TestCreateRejectsMissingPolicy validates that a policy_ref pointing at a
+// policy the PolicyExistsResolver says does not exist is rejected with
+// CodeInvalidArgument. This is the HOL-595 "missing policy_ref rejection"
+// acceptance-criteria item.
+func TestCreateRejectsMissingPolicy(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	missing := &stubPolicyResolver{exists: false}
+	h = h.
+		WithPolicyExistsResolver(missing).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: folder,
+		Name:     "does-not-exist",
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err == nil {
+		t.Fatal("expected missing-policy rejection")
+	}
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+	}
+	if !containsString(err.Error(), "unknown policy") {
+		t.Errorf("expected error to mention unknown policy, got %v", err)
+	}
+	if missing.calls == 0 {
+		t.Error("expected PolicyExists to be called")
+	}
+}
+
+// TestCreateRejectsOutOfChainPolicy validates the ancestor-chain check:
+// when the binding lives in folder "payments" and the policy lives in an
+// unrelated org that the ancestor resolver reports as out-of-chain, the
+// create is rejected with CodeFailedPrecondition.
+func TestCreateRejectsOutOfChainPolicy(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	ancestor := &stubAncestorResolver{contains: false}
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithAncestorChainResolver(ancestor).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	// Policy lives in a different organization scope than the binding's
+	// folder; the ancestor walker says "not reachable".
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: newOrgScopeRef("other-org"),
+		Name:     "platform-policy",
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err == nil {
+		t.Fatal("expected out-of-chain rejection")
+	}
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("expected CodeFailedPrecondition, got %v: %v", connect.CodeOf(err), err)
+	}
+	if !containsString(err.Error(), "not reachable") {
+		t.Errorf("expected error to mention reachability, got %v", err)
+	}
+	if ancestor.calls == 0 {
+		t.Error("expected ancestor resolver to be consulted")
+	}
+}
+
+// TestCreateAcceptsAncestorPolicy verifies that a policy one hop up the
+// ancestor chain (folder binds against a policy in its parent org) is
+// accepted — the contains-in-chain resolver returning true should let the
+// create succeed.
+func TestCreateAcceptsAncestorPolicy(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	ancestor := &stubAncestorResolver{contains: true}
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithAncestorChainResolver(ancestor).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: newOrgScopeRef("acme"),
+		Name:     "platform-policy",
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ancestor.calls == 0 {
+		t.Error("expected ancestor resolver to be consulted for cross-scope policy")
+	}
+}
+
+// TestCreateRejectsBadProjectName covers the target-ref project existence
+// check. When the ProjectExistsResolver reports the project_name is
+// unknown the create is rejected with CodeInvalidArgument and the error
+// names the offending target index and project.
+func TestCreateRejectsBadProjectName(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{exists: map[string]bool{"payments-web": true}})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: folder,
+		Name:     "local-policy",
+	}
+	binding.TargetRefs = []*consolev1.TemplatePolicyBindingTargetRef{
+		{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+			Name:        "api",
+			ProjectName: "no-such-project",
+		},
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err == nil {
+		t.Fatal("expected bad-project rejection")
+	}
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+	}
+	if !containsString(err.Error(), "no-such-project") {
+		t.Errorf("expected error to name the missing project, got %v", err)
+	}
+}
+
+// TestUpdatePreservesImmutableFields verifies UpdateTemplatePolicyBinding
+// preserves created_at / creator_email from the stored ConfigMap: the
+// handler must never rewrite those annotations even if the inbound
+// binding carries different values. Also asserts policy_ref and
+// target_refs are replaced when present.
+func TestUpdatePreservesImmutableFields(t *testing.T) {
+	existingTime := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bind-a",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicyBinding,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:                     "Existing Display",
+				v1alpha2.AnnotationDescription:                     "Existing Description",
+				v1alpha2.AnnotationCreatorEmail:                    "original@example.com",
+				v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  `{"scope":"organization","scopeName":"acme","name":"old-policy"}`,
+				v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: `[]`,
+			},
+			CreationTimestamp: metav1.Time{Time: existingTime},
+		},
+	}
+	fakeClient := fake.NewClientset(existing)
+	r := newTestResolver()
+	k := NewK8sClient(fakeClient, r)
+	h := NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+
+	ctx := authedCtx("owner@example.com", nil)
+	folder := newFolderScopeRef("payments")
+	inbound := &consolev1.TemplatePolicyBinding{
+		Name:     "bind-a",
+		ScopeRef: folder,
+		// Attempt to overwrite immutable fields — the handler must
+		// discard these (creator_email is not carried into the k8s
+		// client's Update at all; created_at is a k8s-managed field).
+		CreatorEmail: "attacker@example.com",
+		DisplayName:  "Updated Display",
+		// Description intentionally left empty to confirm the handler
+		// preserves the stored value when the request carries "".
+		PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+			ScopeRef: folder,
+			Name:     "new-local-policy",
+		},
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+			{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        "api",
+				ProjectName: "payments-web",
+			},
+		},
+	}
+
+	_, err := h.UpdateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: inbound,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated, err := fakeClient.CoreV1().ConfigMaps("holos-fld-payments").Get(context.Background(), "bind-a", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("fetching updated binding: %v", err)
+	}
+	if updated.Annotations[v1alpha2.AnnotationCreatorEmail] != "original@example.com" {
+		t.Errorf("creator_email clobbered: %q", updated.Annotations[v1alpha2.AnnotationCreatorEmail])
+	}
+	if !updated.CreationTimestamp.Time.Equal(existingTime) {
+		t.Errorf("creation timestamp drifted: got %v, want %v", updated.CreationTimestamp.Time, existingTime)
+	}
+	if updated.Annotations[v1alpha2.AnnotationDisplayName] != "Updated Display" {
+		t.Errorf("display_name not applied: %q", updated.Annotations[v1alpha2.AnnotationDisplayName])
+	}
+	if updated.Annotations[v1alpha2.AnnotationDescription] != "Existing Description" {
+		t.Errorf("description clobbered when request left it empty: %q", updated.Annotations[v1alpha2.AnnotationDescription])
+	}
+	parsedPolicy, err := unmarshalPolicyRef(updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef])
+	if err != nil {
+		t.Fatalf("parsing updated policy_ref: %v", err)
+	}
+	if parsedPolicy.GetName() != "new-local-policy" {
+		t.Errorf("policy_ref not replaced: got %q", parsedPolicy.GetName())
+	}
+	parsedTargets, err := unmarshalTargetRefs(updated.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs])
+	if err != nil {
+		t.Fatalf("parsing updated target_refs: %v", err)
+	}
+	if len(parsedTargets) != 1 || parsedTargets[0].GetName() != "api" {
+		t.Errorf("target_refs not replaced as expected: %+v", parsedTargets)
+	}
+}
+
+// TestUpdateMissingReturnsNotFound confirms Update against a non-existent
+// binding yields CodeNotFound so clients can rely on the
+// create-or-update-if-exists pattern.
+func TestUpdateMissingReturnsNotFound(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: folder,
+		Name:     "local-policy",
+	}
+
+	_, err := h.UpdateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err == nil {
+		t.Fatal("expected NotFound")
+	}
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("expected CodeNotFound, got %v: %v", connect.CodeOf(err), err)
+	}
+}
+
+// TestGetRoundTripsAnnotations seeds a ConfigMap with a populated policy-
+// ref and targets annotation, then reads it back through the handler to
+// confirm the proto-level conversion is lossless.
+func TestGetRoundTripsAnnotations(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bind-a",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicyBinding,
+				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:                     "Existing",
+				v1alpha2.AnnotationDescription:                     "Desc",
+				v1alpha2.AnnotationCreatorEmail:                    "original@example.com",
+				v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  `{"scope":"organization","scopeName":"acme","name":"require-reference-grant"}`,
+				v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: `[{"kind":"deployment","name":"api","projectName":"payments-web"}]`,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(existing)
+	r := newTestResolver()
+	h := NewHandler(NewK8sClient(fakeClient, r), r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}})
+	ctx := authedCtx("viewer@example.com", nil)
+
+	resp, err := h.GetTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.GetTemplatePolicyBindingRequest{
+		Scope: newFolderScopeRef("payments"),
+		Name:  "bind-a",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := resp.Msg.GetBinding()
+	if got.GetCreatorEmail() != "original@example.com" {
+		t.Errorf("creator email lost: %q", got.GetCreatorEmail())
+	}
+	if got.GetPolicyRef().GetName() != "require-reference-grant" {
+		t.Errorf("policy_ref name lost: %q", got.GetPolicyRef().GetName())
+	}
+	if len(got.GetTargetRefs()) != 1 || got.GetTargetRefs()[0].GetProjectName() != "payments-web" {
+		t.Errorf("target_refs lost: %+v", got.GetTargetRefs())
+	}
+}
+
+// TestListReturnsOnlyBindings is a regression test for the label selector
+// on ListBindings; if the handler's List path accidentally matched other
+// resource types in the same namespace, this test would fail.
+func TestListReturnsOnlyBindings(t *testing.T) {
+	binding := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bind-a",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicyBinding,
+			},
+		},
+	}
+	policy := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy-a",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(binding, policy)
+	r := newTestResolver()
+	h := NewHandler(NewK8sClient(fakeClient, r), r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"viewer@example.com": "viewer"}})
+	ctx := authedCtx("viewer@example.com", nil)
+
+	resp, err := h.ListTemplatePolicyBindings(ctx, connect.NewRequest(&consolev1.ListTemplatePolicyBindingsRequest{
+		Scope: newFolderScopeRef("payments"),
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Msg.GetBindings()) != 1 || resp.Msg.GetBindings()[0].GetName() != "bind-a" {
+		t.Errorf("expected only the binding, got %+v", resp.Msg.GetBindings())
+	}
+}
+
+// TestDeleteRemovesConfigMap covers the happy-path Delete: the ConfigMap
+// must disappear from the fake clientset after the call, and the response
+// must succeed.
+func TestDeleteRemovesConfigMap(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bind-a",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicyBinding,
+			},
+		},
+	}
+	fakeClient := fake.NewClientset(existing)
+	r := newTestResolver()
+	h := NewHandler(NewK8sClient(fakeClient, r), r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"owner@example.com": "owner"}})
+	ctx := authedCtx("owner@example.com", nil)
+
+	_, err := h.DeleteTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyBindingRequest{
+		Scope: newFolderScopeRef("payments"),
+		Name:  "bind-a",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, getErr := fakeClient.CoreV1().ConfigMaps("holos-fld-payments").Get(context.Background(), "bind-a", metav1.GetOptions{})
+	if getErr == nil {
+		t.Error("expected binding to be deleted")
+	}
+}
+
+// TestPolicyProbeErrorFailsInternal confirms the handler surfaces a
+// transient PolicyExists probe failure as CodeInternal, not
+// CodeInvalidArgument. Locking this in prevents a regression that would
+// map a flaky K8s API to a user-input error.
+func TestPolicyProbeErrorFailsInternal(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{err: errors.New("api down")}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := basicBinding(folder)
+	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: folder,
+		Name:     "whatever",
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Scope:   folder,
+		Binding: binding,
+	}))
+	if err == nil {
+		t.Fatal("expected probe failure to surface as error")
+	}
+	if connect.CodeOf(err) != connect.CodeInternal {
+		t.Errorf("expected CodeInternal, got %v: %v", connect.CodeOf(err), err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `TemplatePolicyBindingService` handler (`console/templatepolicybindings/handler.go`) covering Create / Get / List / Update / Delete with full proto-shape validation, policy-ref reachability checks, target-ref project existence checks, and RBAC cascade via `TemplatePolicyBindingCascadePerms`.
- Add the matching RBAC cascade table (`console/rbac/template_policy_binding_cascade.go`) that mirrors `TemplatePolicyCascadePerms`; WRITE/DELETE/ADMIN remain reachable only at org/folder scope.
- Wire the service into `console/console.go` so it mounts on the mux and is reflected via grpcreflect; ancestor-chain, policy-exists, and project-exists adapters live in `console/templatepolicybindings/adapters.go` to avoid import cycles with the upcoming policyresolver work in HOL-596.
- Table-driven tests using `k8s.io/client-go/kubernetes/fake` cover happy-path create, project-scope rejection, missing policy_ref rejection, out-of-chain policy rejection, bad target_ref rejection, RBAC denial, and an Update that preserves creator_email / created_at.

Fixes HOL-595

## Test plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] `make lint` introduces no new findings in `console/templatepolicybindings/` or `console/rbac/`
- [ ] grpcurl can list the new service once running: `grpcurl -plaintext localhost:xxxx list holos.console.v1.TemplatePolicyBindingService`

Generated with [Claude Code](https://claude.com/claude-code)