### PR TITLE
feat(policyresolver): evaluate TemplatePolicyBindings alongside legacy globs

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -304,11 +304,26 @@ func (s *Server) Serve(ctx context.Context) error {
 		// through a namespace-direct lister that never consults a project
 		// namespace (HOL-554 storage-isolation).
 		templatePoliciesK8s := templatepolicies.NewK8sClient(k8sClientset, nsResolver)
-		policyResolverSeam := policyresolver.NewFolderResolver(
+		templatePolicyBindingsK8s := templatepolicybindings.NewK8sClient(k8sClientset, nsResolver)
+		// HOL-596 wires the TemplatePolicyBinding evaluation path into the
+		// render-time resolver. Bindings take precedence on conflict: a
+		// binding whose target_refs match the current render target
+		// dereferences its policy_ref and injects (REQUIRE) / removes
+		// (EXCLUDE) the bound policy's template refs, and the rule's
+		// glob Target is ignored for that render target. Rules in
+		// policies with no matching binding for the target continue to
+		// use their glob Target fallback, so this is additive until
+		// HOL-599/HOL-600 complete the migration.
+		policyResolverSeam := policyresolver.NewFolderResolverWithBindings(
 			templatePoliciesK8s,
 			nsWalker,
 			nsResolver,
 			policyresolver.RuleUnmarshalerFunc(templatepolicies.UnmarshalRules),
+			templatePolicyBindingsK8s,
+			policyresolver.BindingUnmarshalerAdapter{
+				PolicyRefFunc:  templatepolicybindings.UnmarshalPolicyRef,
+				TargetRefsFunc: templatepolicybindings.UnmarshalTargetRefs,
+			},
 		)
 		// AppliedRenderStateClient persists the effective render set to the
 		// owning folder namespace on successful Create/Update of a deployment
@@ -397,8 +412,10 @@ func (s *Server) Serve(ctx context.Context) error {
 		// project-exists) are wired via adapters that lean on the
 		// resources already constructed above — templatePoliciesK8s for
 		// policy lookups, nsWalker for ancestor chains, and the shared
-		// k8sClientset for project-namespace existence.
-		templatePolicyBindingsK8s := templatepolicybindings.NewK8sClient(k8sClientset, nsResolver)
+		// k8sClientset for project-namespace existence. The K8sClient
+		// itself is constructed alongside the render-time resolver
+		// (HOL-596) so both the handler and the resolver share a single
+		// client instance.
 		templatePolicyBindingsHandler := templatepolicybindings.NewHandler(templatePolicyBindingsK8s, nsResolver).
 			WithOrgGrantResolver(orgGrantResolver).
 			WithFolderGrantResolver(folderGrantResolver).

--- a/console/policyresolver/ancestor_bindings.go
+++ b/console/policyresolver/ancestor_bindings.go
@@ -1,0 +1,212 @@
+package policyresolver
+
+import (
+	"context"
+	"log/slog"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// BindingListerInNamespace reports the TemplatePolicyBinding ConfigMaps stored
+// in a specific Kubernetes namespace. The folderResolver uses this to fetch
+// bindings from each folder or organization namespace in the ancestor chain
+// without importing console/templatepolicybindings directly (which would
+// create an import cycle once that package depends on console/policyresolver).
+//
+// Implementations MUST only read from folder and organization namespaces.
+// The folderResolver guarantees it never passes a project namespace to this
+// method because the ancestor walk skips project-kind namespaces before
+// calling the lister, but implementations should still treat a project
+// namespace as a programming error and return an empty list.
+type BindingListerInNamespace interface {
+	ListBindingsInNamespace(ctx context.Context, ns string) ([]corev1.ConfigMap, error)
+}
+
+// BindingUnmarshaler decodes the JSON-serialized policy_ref and target_refs
+// annotations on a TemplatePolicyBinding ConfigMap into proto values. The
+// folderResolver delegates decoding to console/templatepolicybindings so the
+// resolver never hard-codes the wire shape.
+type BindingUnmarshaler interface {
+	UnmarshalPolicyRef(raw string) (*consolev1.LinkedTemplatePolicyRef, error)
+	UnmarshalTargetRefs(raw string) ([]*consolev1.TemplatePolicyBindingTargetRef, error)
+}
+
+// BindingUnmarshalerAdapter adapts a pair of free-standing functions into a
+// BindingUnmarshaler. Use it at wire-up time to pass
+// templatepolicybindings.UnmarshalPolicyRef and .UnmarshalTargetRefs without
+// defining a one-shot type at the call site.
+type BindingUnmarshalerAdapter struct {
+	PolicyRefFunc  func(raw string) (*consolev1.LinkedTemplatePolicyRef, error)
+	TargetRefsFunc func(raw string) ([]*consolev1.TemplatePolicyBindingTargetRef, error)
+}
+
+// UnmarshalPolicyRef satisfies BindingUnmarshaler.
+func (a BindingUnmarshalerAdapter) UnmarshalPolicyRef(raw string) (*consolev1.LinkedTemplatePolicyRef, error) {
+	if a.PolicyRefFunc == nil {
+		return nil, nil
+	}
+	return a.PolicyRefFunc(raw)
+}
+
+// UnmarshalTargetRefs satisfies BindingUnmarshaler.
+func (a BindingUnmarshalerAdapter) UnmarshalTargetRefs(raw string) ([]*consolev1.TemplatePolicyBindingTargetRef, error) {
+	if a.TargetRefsFunc == nil {
+		return nil, nil
+	}
+	return a.TargetRefsFunc(raw)
+}
+
+// ResolvedBinding is the decoded form of a TemplatePolicyBinding ConfigMap,
+// keyed with the owning namespace so downstream evaluation can locate the
+// bound policy and record which binding contributed a ref. The folder
+// resolver consumes a slice of these from AncestorBindingLister.ListBindings.
+type ResolvedBinding struct {
+	// Name is the binding's DNS-label slug. Stable across updates.
+	Name string
+	// Namespace is the folder or organization namespace that owns the
+	// binding ConfigMap. Used by the resolver when it logs a warning for
+	// a binding whose policy_ref does not resolve.
+	Namespace string
+	// PolicyRef identifies the TemplatePolicy the binding attaches. May
+	// be nil if the annotation is missing or malformed — the caller
+	// treats that as "no-op" (a warning is logged by the lister).
+	PolicyRef *consolev1.LinkedTemplatePolicyRef
+	// TargetRefs enumerates the explicit render targets this binding
+	// applies its policy to. May be empty; an empty list means the
+	// binding does not cover any render target and contributes no refs.
+	TargetRefs []*consolev1.TemplatePolicyBindingTargetRef
+}
+
+// AncestorBindingLister walks the ancestor chain of a starting namespace and
+// collects every TemplatePolicyBinding ConfigMap stored in the folder and
+// organization namespaces on that chain. Project namespaces are skipped to
+// mirror the HOL-554 storage-isolation guardrail already enforced for
+// TemplatePolicy — a binding in a project namespace is a misconfiguration
+// that must never be consumed at render time.
+//
+// This helper is used by the render-time `folderResolver` (HOL-596) to
+// evaluate binding-driven REQUIRE/EXCLUDE semantics alongside the legacy
+// glob-based TemplatePolicyRule.Target fallback. Centralizing the ancestor
+// walk here — and the slog-based error-logging contract that goes with it —
+// means the storage-isolation guardrail lives in exactly one place for
+// binding reads, matching the shape used by AncestorPolicyLister.
+type AncestorBindingLister struct {
+	bindingLister BindingListerInNamespace
+	walker        WalkerInterface
+	resolver      *resolver.Resolver
+	unmarshaler   BindingUnmarshaler
+}
+
+// NewAncestorBindingLister returns a lister wired with the given dependencies.
+// Any nil dependency yields a lister whose ListBindings method returns an
+// empty slice without error (fail-open behavior — misconfigured bootstraps
+// must not block project creation or render).
+func NewAncestorBindingLister(
+	bindingLister BindingListerInNamespace,
+	walker WalkerInterface,
+	r *resolver.Resolver,
+	unmarshaler BindingUnmarshaler,
+) *AncestorBindingLister {
+	return &AncestorBindingLister{
+		bindingLister: bindingLister,
+		walker:        walker,
+		resolver:      r,
+		unmarshaler:   unmarshaler,
+	}
+}
+
+// ListBindings returns every TemplatePolicyBinding declared in a folder or
+// organization namespace on the ancestor chain starting from startNs. The
+// returned bindings preserve the walker's order (closest ancestor first)
+// within each namespace and the lister's order within each namespace;
+// callers that need a deterministic evaluation order should dedupe or sort
+// after.
+//
+// A misconfigured lister (any nil dependency) returns (nil, nil) — the
+// fail-open contract mirrors folderResolver.Resolve so a bootstrap
+// misconfiguration degrades to "no bindings" rather than "render errors on
+// every call".
+//
+// A walker failure returns (nil, err) so render-time callers can decide
+// whether to fall back to the legacy glob path (same behavior as
+// AncestorPolicyLister) or surface the failure.
+//
+// Individual per-namespace lister or parse errors do not abort traversal;
+// they are logged and the namespace (or individual binding) is skipped. A
+// single corrupted TemplatePolicyBinding ConfigMap must not prevent
+// legitimate bindings in peer namespaces from being honored.
+func (a *AncestorBindingLister) ListBindings(ctx context.Context, startNs string) ([]*ResolvedBinding, error) {
+	if a == nil || a.bindingLister == nil || a.walker == nil || a.resolver == nil || a.unmarshaler == nil {
+		slog.WarnContext(ctx, "ancestor binding lister is misconfigured; returning no bindings",
+			slog.String("startNs", startNs),
+			slog.Bool("bindingListerNil", a == nil || a.bindingLister == nil),
+			slog.Bool("walkerNil", a == nil || a.walker == nil),
+			slog.Bool("resolverNil", a == nil || a.resolver == nil),
+			slog.Bool("unmarshalerNil", a == nil || a.unmarshaler == nil),
+		)
+		return nil, nil
+	}
+
+	ancestors, err := a.walker.WalkAncestors(ctx, startNs)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*ResolvedBinding
+	for _, ns := range ancestors {
+		if ns == nil {
+			continue
+		}
+		kind, _, kErr := a.resolver.ResourceTypeFromNamespace(ns.Name)
+		if kErr != nil {
+			continue
+		}
+		if kind == v1alpha2.ResourceTypeProject {
+			continue
+		}
+		cms, listErr := a.bindingLister.ListBindingsInNamespace(ctx, ns.Name)
+		if listErr != nil {
+			slog.WarnContext(ctx, "failed to list template policy bindings in ancestor namespace",
+				slog.String("namespace", ns.Name),
+				slog.Any("error", listErr),
+			)
+			continue
+		}
+		for i := range cms {
+			cm := &cms[i]
+			policyRaw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef]
+			targetsRaw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs]
+
+			policyRef, policyErr := a.unmarshaler.UnmarshalPolicyRef(policyRaw)
+			if policyErr != nil {
+				slog.WarnContext(ctx, "failed to parse template policy binding policy_ref; skipping binding",
+					slog.String("namespace", ns.Name),
+					slog.String("binding", cm.Name),
+					slog.Any("error", policyErr),
+				)
+				continue
+			}
+			targetRefs, targetsErr := a.unmarshaler.UnmarshalTargetRefs(targetsRaw)
+			if targetsErr != nil {
+				slog.WarnContext(ctx, "failed to parse template policy binding target_refs; skipping binding",
+					slog.String("namespace", ns.Name),
+					slog.String("binding", cm.Name),
+					slog.Any("error", targetsErr),
+				)
+				continue
+			}
+
+			out = append(out, &ResolvedBinding{
+				Name:       cm.Name,
+				Namespace:  ns.Name,
+				PolicyRef:  policyRef,
+				TargetRefs: targetRefs,
+			})
+		}
+	}
+	return out, nil
+}

--- a/console/policyresolver/ancestor_bindings_test.go
+++ b/console/policyresolver/ancestor_bindings_test.go
@@ -1,0 +1,239 @@
+package policyresolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// errorBindingLister returns a hardcoded error for a given namespace and
+// forwards all other namespaces to inner. Mirrors errorPolicyLister.
+type errorBindingLister struct {
+	inner   BindingListerInNamespace
+	failFor string
+	err     error
+}
+
+func (e *errorBindingLister) ListBindingsInNamespace(ctx context.Context, ns string) ([]corev1.ConfigMap, error) {
+	if ns == e.failFor {
+		return nil, e.err
+	}
+	return e.inner.ListBindingsInNamespace(ctx, ns)
+}
+
+// TestAncestorBindingLister_SkipsProjectNamespaces is the HOL-554
+// storage-isolation guardrail for bindings: even if a (forbidden) binding
+// ConfigMap is seeded in a project namespace, the lister must not pick it
+// up. Mirrors the guardrail already covered for TemplatePolicy rules.
+func TestAncestorBindingLister_SkipsProjectNamespaces(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	// A forbidden binding stashed in a project namespace and a legitimate
+	// binding in the org namespace. Only the org-namespace binding should
+	// be returned.
+	bindings := map[string][]corev1.ConfigMap{
+		ns["projectLilies"]: {
+			bindingCM(ns["projectLilies"], "pwned",
+				storedPolicyRefTest{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit"},
+				[]storedTargetRefTest{{Kind: "deployment", Name: "api", ProjectName: "lilies"}},
+				t,
+			),
+		},
+		ns["org"]: {
+			bindingCM(ns["org"], "legit",
+				storedPolicyRefTest{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit"},
+				[]storedTargetRefTest{{Kind: "deployment", Name: "api", ProjectName: "lilies"}},
+				t,
+			),
+		},
+	}
+
+	lister := NewAncestorBindingLister(
+		&bindingListerFromMap{items: bindings},
+		walker,
+		r,
+		BindingUnmarshalerAdapter{
+			PolicyRefFunc:  testUnmarshalPolicyRef,
+			TargetRefsFunc: testUnmarshalTargetRefs,
+		},
+	)
+
+	got, err := lister.ListBindings(context.Background(), ns["projectLilies"])
+	if err != nil {
+		t.Fatalf("ListBindings: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 binding (the org-namespace one), got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "legit" {
+		t.Errorf("expected the legit org-namespace binding; got %q", got[0].Name)
+	}
+	if got[0].Namespace != ns["org"] {
+		t.Errorf("expected binding namespace %q; got %q", ns["org"], got[0].Namespace)
+	}
+}
+
+// TestAncestorBindingLister_PerNamespaceErrorIsLogged: a lister error for
+// one namespace should not break traversal. The peer namespace's bindings
+// are still returned. Mirrors TestFolderResolver_PolicyListerErrorIsLogged.
+func TestAncestorBindingLister_PerNamespaceErrorIsLogged(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	inner := &bindingListerFromMap{items: map[string][]corev1.ConfigMap{
+		ns["org"]: {
+			bindingCM(ns["org"], "org-bind",
+				storedPolicyRefTest{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit"},
+				[]storedTargetRefTest{{Kind: "deployment", Name: "api", ProjectName: "lilies"}},
+				t,
+			),
+		},
+	}}
+	wrapped := &errorBindingLister{inner: inner, failFor: ns["folderEng"], err: errors.New("boom")}
+
+	lister := NewAncestorBindingLister(
+		wrapped,
+		walker,
+		r,
+		BindingUnmarshalerAdapter{
+			PolicyRefFunc:  testUnmarshalPolicyRef,
+			TargetRefsFunc: testUnmarshalTargetRefs,
+		},
+	)
+
+	got, err := lister.ListBindings(context.Background(), ns["projectLilies"])
+	if err != nil {
+		t.Fatalf("ListBindings: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "org-bind" {
+		t.Errorf("expected org-bind to survive folder-namespace error; got %+v", got)
+	}
+}
+
+// TestAncestorBindingLister_Misconfigured returns nil without error on any
+// nil dependency — the fail-open contract mirrors AncestorPolicyLister.
+func TestAncestorBindingLister_Misconfigured(t *testing.T) {
+	l := NewAncestorBindingLister(nil, nil, nil, nil)
+	got, err := l.ListBindings(context.Background(), "holos-prj-x")
+	if err != nil {
+		t.Fatalf("expected nil error on misconfigured lister; got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result on misconfigured lister; got %v", got)
+	}
+}
+
+// TestAncestorBindingLister_ParseErrorSkipsBinding verifies that a binding
+// whose policy_ref annotation fails to decode is skipped but does not abort
+// the traversal. A second well-formed binding in the same namespace is
+// returned unchanged.
+func TestAncestorBindingLister_ParseErrorSkipsBinding(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	bad := bindingCM(ns["org"], "bad",
+		storedPolicyRefTest{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit"},
+		[]storedTargetRefTest{{Kind: "deployment", Name: "api", ProjectName: "lilies"}},
+		t,
+	)
+	bad.Annotations[v1alpha2.AnnotationTemplatePolicyBindingPolicyRef] = "{not valid json"
+
+	good := bindingCM(ns["org"], "good",
+		storedPolicyRefTest{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit"},
+		[]storedTargetRefTest{{Kind: "deployment", Name: "api", ProjectName: "lilies"}},
+		t,
+	)
+
+	bindings := map[string][]corev1.ConfigMap{
+		ns["org"]: {bad, good},
+	}
+
+	lister := NewAncestorBindingLister(
+		&bindingListerFromMap{items: bindings},
+		walker,
+		r,
+		BindingUnmarshalerAdapter{
+			PolicyRefFunc:  testUnmarshalPolicyRef,
+			TargetRefsFunc: testUnmarshalTargetRefs,
+		},
+	)
+
+	got, err := lister.ListBindings(context.Background(), ns["projectLilies"])
+	if err != nil {
+		t.Fatalf("ListBindings: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Errorf("expected parse-error binding to be skipped and the good one returned; got %+v", got)
+	}
+}
+
+// TestAncestorBindingLister_DecodesPolicyRefAndTargets asserts end-to-end
+// decoding: the returned ResolvedBinding carries a decoded policy_ref and
+// a decoded target_refs slice. This pins the wire-shape contract between
+// the resolver and the templatepolicybindings package.
+func TestAncestorBindingLister_DecodesPolicyRefAndTargets(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	bindings := map[string][]corev1.ConfigMap{
+		ns["folderEng"]: {
+			bindingCM(ns["folderEng"], "eng-bind",
+				storedPolicyRefTest{Scope: v1alpha2.TemplateScopeFolder, ScopeName: "eng", Name: "eng-audit"},
+				[]storedTargetRefTest{
+					{Kind: "deployment", Name: "api", ProjectName: "lilies"},
+					{Kind: "project-template", Name: "baseline", ProjectName: "lilies"},
+				},
+				t,
+			),
+		},
+	}
+
+	lister := NewAncestorBindingLister(
+		&bindingListerFromMap{items: bindings},
+		walker,
+		r,
+		BindingUnmarshalerAdapter{
+			PolicyRefFunc:  testUnmarshalPolicyRef,
+			TargetRefsFunc: testUnmarshalTargetRefs,
+		},
+	)
+
+	got, err := lister.ListBindings(context.Background(), ns["projectLilies"])
+	if err != nil {
+		t.Fatalf("ListBindings: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 binding; got %d", len(got))
+	}
+	rb := got[0]
+	if rb.PolicyRef == nil || rb.PolicyRef.GetScopeRef() == nil {
+		t.Fatalf("expected decoded policy ref; got %+v", rb.PolicyRef)
+	}
+	if rb.PolicyRef.GetScopeRef().GetScope() != consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER {
+		t.Errorf("expected folder scope; got %v", rb.PolicyRef.GetScopeRef().GetScope())
+	}
+	if rb.PolicyRef.GetScopeRef().GetScopeName() != "eng" {
+		t.Errorf("expected scope_name=eng; got %q", rb.PolicyRef.GetScopeRef().GetScopeName())
+	}
+	if rb.PolicyRef.GetName() != "eng-audit" {
+		t.Errorf("expected policy name=eng-audit; got %q", rb.PolicyRef.GetName())
+	}
+	if len(rb.TargetRefs) != 2 {
+		t.Fatalf("expected 2 target refs; got %d", len(rb.TargetRefs))
+	}
+	kinds := map[consolev1.TemplatePolicyBindingTargetKind]int{}
+	for _, tr := range rb.TargetRefs {
+		kinds[tr.GetKind()]++
+	}
+	if kinds[consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT] != 1 ||
+		kinds[consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE] != 1 {
+		t.Errorf("expected one deployment and one project-template target; got %+v", kinds)
+	}
+}

--- a/console/policyresolver/ancestor_policies.go
+++ b/console/policyresolver/ancestor_policies.go
@@ -9,6 +9,32 @@ import (
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
 
+// ResolvedPolicy is the decoded form of a TemplatePolicy ConfigMap bundled
+// with the scope identity the resolver needs to match against a binding's
+// policy_ref. The resolver uses this shape (rather than a flat rule slice)
+// so a binding can select the exact policy it targets — two policies in the
+// same ancestor chain can share rule template names, and the binding chooses
+// among them by (scope, scope_name, name).
+type ResolvedPolicy struct {
+	// Name is the policy's DNS-label slug (the ConfigMap's metadata.name).
+	Name string
+	// Namespace is the folder or organization namespace that owns the
+	// policy ConfigMap. Used as the authoritative source of (scope,
+	// scope_name) via the resolver's prefix classification — the scope
+	// label on the ConfigMap is advisory.
+	Namespace string
+	// Scope is the TemplateScope derived from Namespace (organization or
+	// folder). Project scope is unreachable because project namespaces
+	// are skipped during the ancestor walk.
+	Scope consolev1.TemplateScope
+	// ScopeName is the folder or organization name derived from
+	// Namespace.
+	ScopeName string
+	// Rules are the parsed REQUIRE/EXCLUDE rules on this policy,
+	// preserving the authored order.
+	Rules []*consolev1.TemplatePolicyRule
+}
+
 // AncestorPolicyLister walks the ancestor chain of a starting namespace and
 // collects every TemplatePolicy rule stored in the folder and organization
 // namespaces on that chain. Project namespaces are skipped — storing a
@@ -137,4 +163,110 @@ func (a *AncestorPolicyLister) ListRules(ctx context.Context, startNs string) ([
 		}
 	}
 	return rules, nil
+}
+
+// ListPolicies returns the parsed TemplatePolicy records declared in each
+// folder or organization namespace on the ancestor chain starting from
+// startNs. Each returned entry bundles the policy's rules with the (scope,
+// scope_name, name) triple derived from its owning namespace so downstream
+// consumers can match a binding's policy_ref to the policy it references.
+//
+// Ordering matches ListRules: closest ancestor first, list order within each
+// namespace. Project namespaces are skipped (HOL-554 storage-isolation).
+//
+// Fail-open and per-namespace error behavior mirrors ListRules. A policy
+// whose rules annotation is empty or malformed is skipped with a warning,
+// but a malformed scope-prefix classification on the namespace causes the
+// whole namespace to be skipped — the resolver has no way to report a
+// policy whose scope it cannot identify.
+func (a *AncestorPolicyLister) ListPolicies(ctx context.Context, startNs string) ([]*ResolvedPolicy, error) {
+	if a == nil || a.policyLister == nil || a.walker == nil || a.resolver == nil || a.unmarshaler == nil {
+		slog.WarnContext(ctx, "ancestor policy lister is misconfigured; returning no policies",
+			slog.String("startNs", startNs),
+			slog.Bool("policyListerNil", a == nil || a.policyLister == nil),
+			slog.Bool("walkerNil", a == nil || a.walker == nil),
+			slog.Bool("resolverNil", a == nil || a.resolver == nil),
+			slog.Bool("unmarshalerNil", a == nil || a.unmarshaler == nil),
+		)
+		return nil, nil
+	}
+
+	ancestors, err := a.walker.WalkAncestors(ctx, startNs)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*ResolvedPolicy
+	for _, ns := range ancestors {
+		if ns == nil {
+			continue
+		}
+		kind, scopeName, kErr := a.resolver.ResourceTypeFromNamespace(ns.Name)
+		if kErr != nil {
+			continue
+		}
+		if kind == v1alpha2.ResourceTypeProject {
+			continue
+		}
+		scope := templateScopeForResourceType(kind)
+		if scope == consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED {
+			// Non-policy-bearing resource type (e.g. the render-state or
+			// template-policy-binding kind itself); skip quietly.
+			continue
+		}
+		cms, listErr := a.policyLister.ListPoliciesInNamespace(ctx, ns.Name)
+		if listErr != nil {
+			slog.WarnContext(ctx, "failed to list template policies in ancestor namespace",
+				slog.String("namespace", ns.Name),
+				slog.Any("error", listErr),
+			)
+			continue
+		}
+		for i := range cms {
+			cm := &cms[i]
+			raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyRules]
+			if raw == "" {
+				continue
+			}
+			parsed, parseErr := a.unmarshaler.UnmarshalRules(raw)
+			if parseErr != nil {
+				slog.WarnContext(ctx, "failed to parse template policy rules; skipping policy",
+					slog.String("namespace", ns.Name),
+					slog.String("policy", cm.Name),
+					slog.Any("error", parseErr),
+				)
+				continue
+			}
+			rules := make([]*consolev1.TemplatePolicyRule, 0, len(parsed))
+			for _, rule := range parsed {
+				if rule == nil {
+					continue
+				}
+				rules = append(rules, rule)
+			}
+			out = append(out, &ResolvedPolicy{
+				Name:      cm.Name,
+				Namespace: ns.Name,
+				Scope:     scope,
+				ScopeName: scopeName,
+				Rules:     rules,
+			})
+		}
+	}
+	return out, nil
+}
+
+// templateScopeForResourceType maps the resolver's resource-type classification
+// of a namespace onto the TemplateScope enum used by binding policy_refs.
+// Only organization and folder namespaces store TemplatePolicy objects;
+// every other type maps to UNSPECIFIED so callers can skip the entry.
+func templateScopeForResourceType(kind string) consolev1.TemplateScope {
+	switch kind {
+	case v1alpha2.ResourceTypeOrganization:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION
+	case v1alpha2.ResourceTypeFolder:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER
+	default:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED
+	}
 }

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -50,14 +50,25 @@ func (f RuleUnmarshalerFunc) UnmarshalRules(raw string) ([]*consolev1.TemplatePo
 // a project owner cannot tamper with the policies the platform means to
 // constrain them with (HOL-554 storage-isolation guardrail).
 //
-// Wildcard matching uses the same `path.Match` semantics as
-// validatePolicyRules so the resolver honors the glob forms already accepted
-// at policy-create time.
+// HOL-596 extended the resolver to honor TemplatePolicyBinding objects
+// alongside the legacy glob-based TemplatePolicyRule.Target selector. A
+// binding whose target_refs match the current render target contributes
+// every rule in its bound policy; the bound policy's glob Target filter is
+// ignored for targets the binding covers (bindings win on conflict). Rules
+// in policies that are NOT covered by any matching binding for this target
+// continue to be evaluated via their glob Target, so the resolver is safely
+// additive against existing fixtures.
+//
+// Wildcard matching (legacy glob path) uses the same `path.Match` semantics
+// as validatePolicyRules so the resolver honors the glob forms already
+// accepted at policy-create time.
 type folderResolver struct {
-	policyLister PolicyListerInNamespace
-	walker       WalkerInterface
-	resolver     *resolver.Resolver
-	unmarshaler  RuleUnmarshaler
+	policyLister       PolicyListerInNamespace
+	walker             WalkerInterface
+	resolver           *resolver.Resolver
+	unmarshaler        RuleUnmarshaler
+	bindingLister      BindingListerInNamespace
+	bindingUnmarshaler BindingUnmarshaler
 	// ancestorLister encapsulates the ancestor-chain traversal and
 	// folder-namespace-only filter used by render-time REQUIRE/EXCLUDE
 	// evaluation. HOL-582 removed the project-creation-time resolver that
@@ -66,13 +77,27 @@ type folderResolver struct {
 	// fail-open branch in Resolve short-circuits before ancestorLister is
 	// consulted, so it is safe to construct from possibly-nil deps here.
 	ancestorLister *AncestorPolicyLister
+	// ancestorBindings encapsulates the same ancestor walk for
+	// TemplatePolicyBinding ConfigMaps. Nil when bindingLister or
+	// bindingUnmarshaler is nil; Resolve treats a nil ancestorBindings
+	// as "no bindings exist" and falls back to the pure legacy glob
+	// evaluation path. This lets the resolver stay backward-compatible
+	// with wire-ups that have not yet rolled in binding support (tests,
+	// pre-HOL-595 fixtures).
+	ancestorBindings *AncestorBindingLister
 }
 
 // NewFolderResolver returns a folderResolver wired with the given dependencies.
-// All four arguments are required; passing nil for any of them yields a
-// resolver that falls back to returning the caller's explicit refs unchanged
-// (equivalent to noopResolver) so tests and test-only wire-ups continue to
-// work without crashing.
+// All four rule-side arguments are required; passing nil for any of them
+// yields a resolver that falls back to returning the caller's explicit refs
+// unchanged (equivalent to noopResolver) so tests and test-only wire-ups
+// continue to work without crashing.
+//
+// For binding support, use NewFolderResolverWithBindings to additionally
+// attach a BindingListerInNamespace and BindingUnmarshaler. A resolver
+// constructed via NewFolderResolver skips the binding evaluation path
+// entirely and behaves exactly as it did before HOL-596 — every rule is
+// evaluated via its glob TemplatePolicyRule.Target.
 func NewFolderResolver(
 	policyLister PolicyListerInNamespace,
 	walker WalkerInterface,
@@ -86,6 +111,42 @@ func NewFolderResolver(
 		unmarshaler:    unmarshaler,
 		ancestorLister: NewAncestorPolicyLister(policyLister, walker, r, unmarshaler),
 	}
+}
+
+// NewFolderResolverWithBindings wires a resolver that evaluates both
+// TemplatePolicyBinding objects (HOL-596) and the legacy
+// TemplatePolicyRule.Target glob fallback. The binding path takes precedence:
+// any rule in a policy that a matching binding covers is evaluated as if
+// the binding re-selected its own targets, and the glob Target on that rule
+// is ignored for the render targets the binding names. Rules in policies
+// with no matching binding for the current render target continue to fall
+// back to the glob evaluation, so the two paths coexist through HOL-599 /
+// HOL-600 without breaking existing fixtures.
+//
+// Passing a nil binding lister or unmarshaler degrades cleanly to the
+// legacy-only behavior returned by NewFolderResolver. Passing a nil rule
+// stack falls through to noopResolver semantics as before.
+func NewFolderResolverWithBindings(
+	policyLister PolicyListerInNamespace,
+	walker WalkerInterface,
+	r *resolver.Resolver,
+	unmarshaler RuleUnmarshaler,
+	bindingLister BindingListerInNamespace,
+	bindingUnmarshaler BindingUnmarshaler,
+) PolicyResolver {
+	fr := &folderResolver{
+		policyLister:       policyLister,
+		walker:             walker,
+		resolver:           r,
+		unmarshaler:        unmarshaler,
+		bindingLister:      bindingLister,
+		bindingUnmarshaler: bindingUnmarshaler,
+		ancestorLister:     NewAncestorPolicyLister(policyLister, walker, r, unmarshaler),
+	}
+	if bindingLister != nil && bindingUnmarshaler != nil && walker != nil && r != nil {
+		fr.ancestorBindings = NewAncestorBindingLister(bindingLister, walker, r, bindingUnmarshaler)
+	}
+	return fr
 }
 
 // Resolve returns the effective set of LinkedTemplateRef values for the
@@ -145,15 +206,17 @@ func (r *folderResolver) Resolve(
 		project = ""
 	}
 
-	// Collect every TemplatePolicy rule declared in a folder or
-	// organization namespace on the ancestor chain. The ancestor-policy
-	// lister handles the HOL-554 storage-isolation skip (project
-	// namespaces are never read) and per-namespace parse/list errors.
-	// Classify the returned rules by kind here because the resolver's
-	// REQUIRE/EXCLUDE evaluation cares about the distinction; the shared
-	// lister stays kind-agnostic so alternate future consumers (if any)
-	// need not pull EXCLUDE semantics they do not evaluate.
-	allRules, walkErr := r.ancestorLister.ListRules(ctx, projectNs)
+	// Collect every TemplatePolicy declared in a folder or organization
+	// namespace on the ancestor chain, bundled with the (scope, scope_name,
+	// name) triple a binding uses to reference a specific policy. The
+	// ancestor-policy lister handles the HOL-554 storage-isolation skip
+	// (project namespaces are never read) and per-namespace parse/list
+	// errors. The returned slice preserves closest-ancestor-first order so
+	// REQUIRE injections closer to the project continue to appear later
+	// in the effective set (the dedup key is stable, so ordering only
+	// affects first-seen wins for explicit refs — which are set before
+	// this loop).
+	policies, walkErr := r.ancestorLister.ListPolicies(ctx, projectNs)
 	if walkErr != nil {
 		// Degrade gracefully: a walker failure at resolve time should
 		// not block the render. Log and return the explicit refs so the
@@ -165,15 +228,136 @@ func (r *folderResolver) Resolve(
 		return explicitRefs, nil
 	}
 
-	var requireRules []*consolev1.TemplatePolicyRule
-	var excludeRules []*consolev1.TemplatePolicyRule
-	for _, rule := range allRules {
-		switch rule.GetKind() {
-		case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE:
-			requireRules = append(requireRules, rule)
-		case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE:
-			excludeRules = append(excludeRules, rule)
+	// Collect the bindings from the same ancestor chain. A nil
+	// ancestorBindings (no WithBindings wire-up) means we skip the
+	// binding-driven path entirely and fall back to the legacy glob
+	// evaluation — behavior identical to the pre-HOL-596 resolver.
+	var bindings []*ResolvedBinding
+	if r.ancestorBindings != nil {
+		bs, bErr := r.ancestorBindings.ListBindings(ctx, projectNs)
+		if bErr != nil {
+			slog.WarnContext(ctx, "ancestor binding walk failed during policy resolution; falling back to legacy glob path",
+				slog.String("projectNs", projectNs),
+				slog.Any("error", bErr),
+			)
+		} else {
+			bindings = bs
 		}
+	}
+
+	// Classify which (policy, binding) pairs select the current render
+	// target. coveredPolicies records every (policyScope, policyScopeName,
+	// policyName) triple that at least one matching binding names — those
+	// policies' rules are evaluated under binding semantics (glob Target
+	// ignored for this render target). Every other policy's rules fall
+	// back to their glob Target filter, preserving the legacy behavior
+	// until HOL-599 migrates existing globs and HOL-600 removes the
+	// fallback entirely.
+	coveredPolicies := make(map[policyKey]struct{})
+	for _, b := range bindings {
+		if b == nil || b.PolicyRef == nil {
+			continue
+		}
+		if !bindingAppliesTo(b, project, targetKind, targetName) {
+			continue
+		}
+		scopeRef := b.PolicyRef.GetScopeRef()
+		if scopeRef == nil {
+			continue
+		}
+		coveredPolicies[policyKey{
+			scope:     scopeRef.GetScope(),
+			scopeName: scopeRef.GetScopeName(),
+			name:      b.PolicyRef.GetName(),
+		}] = struct{}{}
+	}
+
+	// Validate each covered-policy entry actually resolves to a real
+	// policy in the ancestor chain. A binding that points at a
+	// nonexistent policy is a misconfiguration; logging once per
+	// offending binding (rather than per-render) would require tracking
+	// recent warnings — the ticket's contract is that such a binding is
+	// a no-op and does not fail the render, which the per-render log
+	// here already satisfies. We do not remove the entry from
+	// coveredPolicies because a missing policy contributes no rules
+	// anyway; the loop below simply finds no matching ResolvedPolicy.
+	existingPolicyKeys := make(map[policyKey]struct{}, len(policies))
+	for _, p := range policies {
+		if p == nil {
+			continue
+		}
+		existingPolicyKeys[policyKey{scope: p.Scope, scopeName: p.ScopeName, name: p.Name}] = struct{}{}
+	}
+	for _, b := range bindings {
+		if b == nil || b.PolicyRef == nil {
+			continue
+		}
+		if !bindingAppliesTo(b, project, targetKind, targetName) {
+			continue
+		}
+		scopeRef := b.PolicyRef.GetScopeRef()
+		if scopeRef == nil {
+			slog.WarnContext(ctx, "template policy binding has no policy_ref scope; treating as no-op",
+				slog.String("bindingNamespace", b.Namespace),
+				slog.String("binding", b.Name),
+			)
+			continue
+		}
+		key := policyKey{
+			scope:     scopeRef.GetScope(),
+			scopeName: scopeRef.GetScopeName(),
+			name:      b.PolicyRef.GetName(),
+		}
+		if _, ok := existingPolicyKeys[key]; !ok {
+			slog.WarnContext(ctx, "template policy binding references a policy that does not exist in the ancestor chain; treating as no-op",
+				slog.String("bindingNamespace", b.Namespace),
+				slog.String("binding", b.Name),
+				slog.String("policyScope", key.scope.String()),
+				slog.String("policyScopeName", key.scopeName),
+				slog.String("policyName", key.name),
+			)
+		}
+	}
+
+	// Classify rules into REQUIRE and EXCLUDE lists. Rules are tagged
+	// with their parent policy so the evaluation loop below can decide
+	// whether to honor the glob Target filter (no covering binding) or
+	// ignore it (binding covers this target for this policy).
+	type scopedRule struct {
+		rule             *consolev1.TemplatePolicyRule
+		policyCoveredVia bool // true iff this rule's parent policy is covered by a matching binding
+	}
+	var requireRules []scopedRule
+	var excludeRules []scopedRule
+	for _, p := range policies {
+		if p == nil {
+			continue
+		}
+		_, covered := coveredPolicies[policyKey{scope: p.Scope, scopeName: p.ScopeName, name: p.Name}]
+		for _, rule := range p.Rules {
+			if rule == nil {
+				continue
+			}
+			sr := scopedRule{rule: rule, policyCoveredVia: covered}
+			switch rule.GetKind() {
+			case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE:
+				requireRules = append(requireRules, sr)
+			case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE:
+				excludeRules = append(excludeRules, sr)
+			}
+		}
+	}
+
+	// ruleAppliesForRender is the unified predicate: if a binding covers
+	// this policy for the current render target, the rule's own glob
+	// Target is bypassed and the rule applies unconditionally (the
+	// binding already made the selection decision). Otherwise fall
+	// back to legacy glob evaluation.
+	ruleAppliesForRender := func(sr scopedRule) bool {
+		if sr.policyCoveredVia {
+			return true
+		}
+		return ruleAppliesTo(sr.rule, project, targetKind, targetName)
 	}
 
 	// Start the effective set with the caller's explicit refs, deduped
@@ -181,16 +365,17 @@ func (r *folderResolver) Resolve(
 	// rule also matches stays in the set; we only add new entries.
 	effective, effectiveSet, explicitKeys := dedupRefs(explicitRefs)
 
-	// Inject REQUIRE matches. Each rule that matches `(project,
-	// targetKind, targetName)` contributes its template ref. The
-	// injected ref carries the rule-author-declared version constraint
-	// (if any) so a REQUIRE rule can pin the platform-forced template
-	// to a specific semver band.
-	for _, rule := range requireRules {
-		if !ruleAppliesTo(rule, project, targetKind, targetName) {
+	// Inject REQUIRE matches. Each rule that applies to the current
+	// render target (either via a matching binding or via a matching
+	// glob Target) contributes its template ref. The injected ref
+	// carries the rule-author-declared version constraint (if any) so
+	// a REQUIRE rule can pin the platform-forced template to a specific
+	// semver band.
+	for _, sr := range requireRules {
+		if !ruleAppliesForRender(sr) {
 			continue
 		}
-		tmpl := rule.GetTemplate()
+		tmpl := sr.rule.GetTemplate()
 		if tmpl == nil || tmpl.GetName() == "" {
 			continue
 		}
@@ -231,11 +416,11 @@ func (r *folderResolver) Resolve(
 			continue
 		}
 		excluded := false
-		for _, rule := range excludeRules {
-			if !ruleAppliesTo(rule, project, targetKind, targetName) {
+		for _, sr := range excludeRules {
+			if !ruleAppliesForRender(sr) {
 				continue
 			}
-			tmpl := rule.GetTemplate()
+			tmpl := sr.rule.GetTemplate()
 			if tmpl == nil {
 				continue
 			}
@@ -249,6 +434,63 @@ func (r *folderResolver) Resolve(
 		}
 	}
 	return filtered, nil
+}
+
+// policyKey is the lookup key a binding's policy_ref resolves to: the
+// (scope, scope_name, name) triple derived from the owning policy's
+// namespace + metadata.name. The resolver uses it to decide which policies
+// are covered by at least one matching binding for a render target.
+type policyKey struct {
+	scope     consolev1.TemplateScope
+	scopeName string
+	name      string
+}
+
+// bindingAppliesTo reports whether any of a binding's target_refs selects
+// the render target at `(project, targetKind, targetName)`. Match semantics
+// (AC bullet in HOL-596):
+//
+//   - kind=PROJECT_TEMPLATE: matches when the render target is a
+//     project-scope template with the same name AND the binding's
+//     project_name equals the target's project name. The proto contract
+//     (HOL-593) requires project_name on PROJECT_TEMPLATE target refs;
+//     binding handlers reject empty project_name on create/update, so
+//     the match is sound.
+//   - kind=DEPLOYMENT: matches when the render target is a Deployment
+//     with the same name AND the binding's project_name equals the
+//     target's project name.
+//
+// A binding with no target_refs never matches (correctly — an empty target
+// list declares intent to attach zero render targets).
+func bindingAppliesTo(b *ResolvedBinding, project string, targetKind TargetKind, targetName string) bool {
+	if b == nil {
+		return false
+	}
+	var wantKind consolev1.TemplatePolicyBindingTargetKind
+	switch targetKind {
+	case TargetKindProjectTemplate:
+		wantKind = consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE
+	case TargetKindDeployment:
+		wantKind = consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT
+	default:
+		return false
+	}
+	for _, tr := range b.TargetRefs {
+		if tr == nil {
+			continue
+		}
+		if tr.GetKind() != wantKind {
+			continue
+		}
+		if tr.GetName() != targetName {
+			continue
+		}
+		if tr.GetProjectName() != project {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // RefKey is the dedup/comparison key for a LinkedTemplateRef. Exposed so

--- a/console/policyresolver/folder_resolver_bindings_test.go
+++ b/console/policyresolver/folder_resolver_bindings_test.go
@@ -1,0 +1,680 @@
+package policyresolver
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// storedPolicyRefTest mirrors the templatepolicybindings.storedPolicyRef wire
+// shape. Keeping a vendored copy in test code avoids a cross-package import
+// (and, more importantly, makes the test's assertions fail loudly if the
+// production wire shape drifts from what the resolver consumes).
+type storedPolicyRefTest struct {
+	Scope     string `json:"scope"`
+	ScopeName string `json:"scopeName"`
+	Name      string `json:"name"`
+}
+
+type storedTargetRefTest struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	ProjectName string `json:"projectName"`
+}
+
+// testUnmarshalPolicyRef mirrors templatepolicybindings.UnmarshalPolicyRef.
+// A drift between the two would silently change test assertions, so the
+// minimal decoder is vendored here.
+func testUnmarshalPolicyRef(raw string) (*consolev1.LinkedTemplatePolicyRef, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var sr storedPolicyRefTest
+	if err := json.Unmarshal([]byte(raw), &sr); err != nil {
+		return nil, err
+	}
+	return &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     scopeFromTemplateLabelTest(sr.Scope),
+			ScopeName: sr.ScopeName,
+		},
+		Name: sr.Name,
+	}, nil
+}
+
+// testUnmarshalTargetRefs mirrors templatepolicybindings.UnmarshalTargetRefs.
+func testUnmarshalTargetRefs(raw string) ([]*consolev1.TemplatePolicyBindingTargetRef, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var stored []storedTargetRefTest
+	if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+		return nil, err
+	}
+	refs := make([]*consolev1.TemplatePolicyBindingTargetRef, 0, len(stored))
+	for _, s := range stored {
+		refs = append(refs, &consolev1.TemplatePolicyBindingTargetRef{
+			Kind:        targetKindFromStringTest(s.Kind),
+			Name:        s.Name,
+			ProjectName: s.ProjectName,
+		})
+	}
+	return refs, nil
+}
+
+func scopeFromTemplateLabelTest(label string) consolev1.TemplateScope {
+	switch label {
+	case v1alpha2.TemplateScopeOrganization:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION
+	case v1alpha2.TemplateScopeFolder:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER
+	case v1alpha2.TemplateScopeProject:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT
+	default:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED
+	}
+}
+
+func targetKindFromStringTest(s string) consolev1.TemplatePolicyBindingTargetKind {
+	switch s {
+	case "project-template":
+		return consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE
+	case "deployment":
+		return consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT
+	default:
+		return consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_UNSPECIFIED
+	}
+}
+
+// bindingListerFromMap adapts an in-memory map to BindingListerInNamespace.
+// Mirrors policyListerFromClient — tests feed per-namespace binding
+// ConfigMaps and the resolver reads them through the same ancestor-walking
+// lister production uses.
+type bindingListerFromMap struct {
+	items map[string][]corev1.ConfigMap
+}
+
+func (b *bindingListerFromMap) ListBindingsInNamespace(_ context.Context, ns string) ([]corev1.ConfigMap, error) {
+	return b.items[ns], nil
+}
+
+// bindingCM returns a fake TemplatePolicyBinding ConfigMap with the given
+// policy_ref and target_refs encoded into the annotations. Mirrors policyCM
+// but populates the binding's JSON annotation wire shape.
+func bindingCM(namespace, name string, policyRef storedPolicyRefTest, targets []storedTargetRefTest, t *testing.T) corev1.ConfigMap {
+	policyJSON, err := json.Marshal(policyRef)
+	if err != nil {
+		t.Fatalf("marshal policy ref: %v", err)
+	}
+	targetsJSON, err := json.Marshal(targets)
+	if err != nil {
+		t.Fatalf("marshal target refs: %v", err)
+	}
+	return corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicyBinding,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  string(policyJSON),
+				v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: string(targetsJSON),
+			},
+		},
+	}
+}
+
+// newFolderResolverWithBindingsForTest constructs a resolver wired with both
+// rule-side and binding-side deps, so the tests in this file exercise the
+// HOL-596 binding evaluation path.
+func newFolderResolverWithBindingsForTest(
+	policies *policyListerFromClient,
+	bindings *bindingListerFromMap,
+	walker WalkerInterface,
+	r *resolver.Resolver,
+) PolicyResolver {
+	return NewFolderResolverWithBindings(
+		policies,
+		walker,
+		r,
+		RuleUnmarshalerFunc(testUnmarshalRules),
+		bindings,
+		BindingUnmarshalerAdapter{
+			PolicyRefFunc:  testUnmarshalPolicyRef,
+			TargetRefsFunc: testUnmarshalTargetRefs,
+		},
+	)
+}
+
+// TestFolderResolver_Bindings covers the HOL-596 acceptance criteria:
+//   - Binding + no rule.Target → binding matches.
+//   - Binding + matching rule.Target → binding wins (glob ignored).
+//   - No binding + matching rule.Target → glob still applies.
+//   - Binding targets nonexistent policy → resolver logs and no-ops.
+func TestFolderResolver_Bindings(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	requireRule := func(scope, scopeName, templateName, projectPattern, deploymentPattern string) storedRuleTest {
+		sr := storedRuleTest{Kind: "require"}
+		sr.Template.Scope = scope
+		sr.Template.ScopeName = scopeName
+		sr.Template.Name = templateName
+		sr.Target.ProjectPattern = projectPattern
+		sr.Target.DeploymentPattern = deploymentPattern
+		return sr
+	}
+	excludeRule := func(scope, scopeName, templateName, projectPattern, deploymentPattern string) storedRuleTest {
+		sr := storedRuleTest{Kind: "exclude"}
+		sr.Template.Scope = scope
+		sr.Template.ScopeName = scopeName
+		sr.Template.Name = templateName
+		sr.Target.ProjectPattern = projectPattern
+		sr.Target.DeploymentPattern = deploymentPattern
+		return sr
+	}
+	orgPolicyRef := func(policyName string) storedPolicyRefTest {
+		return storedPolicyRefTest{
+			Scope:     v1alpha2.TemplateScopeOrganization,
+			ScopeName: "acme",
+			Name:      policyName,
+		}
+	}
+	folderPolicyRef := func(folder, policyName string) storedPolicyRefTest {
+		return storedPolicyRefTest{
+			Scope:     v1alpha2.TemplateScopeFolder,
+			ScopeName: folder,
+			Name:      policyName,
+		}
+	}
+	deploymentTarget := func(project, name string) storedTargetRefTest {
+		return storedTargetRefTest{Kind: "deployment", Name: name, ProjectName: project}
+	}
+	projectTemplateTarget := func(project, name string) storedTargetRefTest {
+		return storedTargetRefTest{Kind: "project-template", Name: name, ProjectName: project}
+	}
+
+	type wantRes struct {
+		names []string
+	}
+
+	tests := []struct {
+		name       string
+		projectNs  string
+		target     TargetKind
+		targetName string
+		explicit   []*consolev1.LinkedTemplateRef
+		policies   map[string][]corev1.ConfigMap
+		bindings   map[string][]corev1.ConfigMap
+		want       wantRes
+	}{
+		{
+			// AC: Binding + no matching rule.Target → binding matches. The
+			// policy's glob Target is narrowed so the rule would NOT apply
+			// on its own; only the binding can select this render target.
+			// The test proves the binding path wires the policy onto the
+			// render target independently of the glob.
+			name:       "binding covers target with non-matching rule glob; REQUIRE injected via binding",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "audit", []storedRuleTest{
+						// project_pattern that does not match lilies.
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "roses", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "audit-to-lilies-api",
+						orgPolicyRef("audit"),
+						[]storedTargetRefTest{deploymentTarget("lilies", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: []string{"audit-policy"}},
+		},
+		{
+			// AC: Binding covers a peer target but the current render
+			// target is not on the binding's target list. The policy
+			// has a non-matching glob (roses), so the legacy glob path
+			// contributes nothing either; the render target sees an
+			// empty set.
+			name:       "binding covers peer target and glob does not match; no refs",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "worker",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "audit", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "roses", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "audit-to-lilies-api",
+						orgPolicyRef("audit"),
+						[]storedTargetRefTest{deploymentTarget("lilies", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: nil},
+		},
+		{
+			// AC: Binding + matching rule.Target → binding wins. The
+			// rule's glob Target is "different" than the binding's
+			// explicit selection — but because the binding covers the
+			// current target, the rule applies regardless of whether
+			// the glob would have matched. Using a glob that would
+			// otherwise NOT match this target proves "binding wins".
+			name:       "binding wins over rule glob that would not have matched",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "audit", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "nomatch", "nomatch"),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "audit-to-lilies-api",
+						orgPolicyRef("audit"),
+						[]storedTargetRefTest{deploymentTarget("lilies", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: []string{"audit-policy"}},
+		},
+		{
+			// AC: No binding + matching rule.Target → glob still applies.
+			// The policy's rule names a template and carries a glob that
+			// matches the render target; no binding exists for this
+			// policy, so legacy evaluation runs.
+			name:       "no binding covering target; matching rule glob still applies",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "audit", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "*", ""),
+					}, t),
+				},
+			},
+			bindings: nil,
+			want:     wantRes{names: []string{"audit-policy"}},
+		},
+		{
+			// AC: No binding + matching rule.Target → glob still applies
+			// even when a binding exists for a different policy. The
+			// binding for policy-A covers this target but does NOT cover
+			// policy-B, so policy-B's glob Target is consulted normally.
+			name:       "binding for other policy does not suppress a different policy's glob",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "policy-a", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "tmpl-a", "", ""),
+					}, t),
+					policyCM(ns["org"], "policy-b", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "tmpl-b", "*", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "a-only",
+						orgPolicyRef("policy-a"),
+						[]storedTargetRefTest{deploymentTarget("lilies", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: []string{"tmpl-a", "tmpl-b"}},
+		},
+		{
+			// AC: Binding targets nonexistent policy → no-op. The
+			// binding names "missing" which is not in the ancestor
+			// chain; the resolver logs a warning and contributes no
+			// refs. A legacy glob rule on an unrelated policy still
+			// applies — proving the bad binding did not short-circuit
+			// the whole evaluation.
+			name:       "binding references nonexistent policy; no-op and legacy glob still runs",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "legacy", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "legacy-tmpl", "*", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "bad-binding",
+						orgPolicyRef("missing"),
+						[]storedTargetRefTest{deploymentTarget("lilies", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: []string{"legacy-tmpl"}},
+		},
+		{
+			// PROJECT_TEMPLATE match semantics: a binding with
+			// project_name matches only when the render target's
+			// project matches.
+			name:       "binding matches PROJECT_TEMPLATE by name+project",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindProjectTemplate,
+			targetName: "baseline",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "prj-audit", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "baseline-policy", "", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "prj-audit-bind",
+						orgPolicyRef("prj-audit"),
+						[]storedTargetRefTest{projectTemplateTarget("lilies", "baseline")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: []string{"baseline-policy"}},
+		},
+		{
+			// PROJECT_TEMPLATE match semantics: wrong project_name does
+			// not match even when the template name matches. The policy's
+			// glob is narrowed to a project that does not include lilies,
+			// so the legacy fallback also contributes nothing; the render
+			// target sees an empty set.
+			name:       "binding PROJECT_TEMPLATE project_name mismatch does not apply",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindProjectTemplate,
+			targetName: "baseline",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "prj-audit", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "baseline-policy", "roses", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "prj-audit-bind",
+						orgPolicyRef("prj-audit"),
+						[]storedTargetRefTest{projectTemplateTarget("roses", "baseline")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: nil},
+		},
+		{
+			// DEPLOYMENT match semantics: wrong project_name does not
+			// match even when name matches. The policy's glob is narrowed
+			// to a project that does not include lilies, so the legacy
+			// fallback also contributes nothing.
+			name:       "binding DEPLOYMENT project_name mismatch does not apply",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "audit", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "roses", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "audit-to-roses-api",
+						orgPolicyRef("audit"),
+						[]storedTargetRefTest{deploymentTarget("roses", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: nil},
+		},
+		{
+			// EXCLUDE via binding: a binding covers an EXCLUDE policy,
+			// so the EXCLUDE rule removes a REQUIRE-injected template
+			// regardless of the EXCLUDE rule's glob. This verifies the
+			// binding path applies to both rule kinds.
+			name:       "binding covers EXCLUDE policy; removes REQUIRE-added ref",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					policyCM(ns["org"], "req", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "*", ""),
+					}, t),
+					policyCM(ns["org"], "exc", []storedRuleTest{
+						excludeRule(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy", "nomatch", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["org"]: {
+					bindingCM(ns["org"], "exc-to-lilies-api",
+						orgPolicyRef("exc"),
+						[]storedTargetRefTest{deploymentTarget("lilies", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: nil},
+		},
+		{
+			// Folder-scoped binding and folder-scoped policy: a binding
+			// stored in the eng folder references a folder-scoped
+			// policy, covering a deployment in a project directly under
+			// that folder. Ancestor walk picks both up; binding
+			// evaluation unifies them.
+			name:       "folder-scoped binding and policy match nested project deployment",
+			projectNs:  ns["projectLilies"],
+			target:     TargetKindDeployment,
+			targetName: "api",
+			policies: map[string][]corev1.ConfigMap{
+				ns["folderEng"]: {
+					policyCM(ns["folderEng"], "eng-audit", []storedRuleTest{
+						requireRule(v1alpha2.TemplateScopeFolder, "eng", "eng-audit-tmpl", "", ""),
+					}, t),
+				},
+			},
+			bindings: map[string][]corev1.ConfigMap{
+				ns["folderEng"]: {
+					bindingCM(ns["folderEng"], "eng-bind",
+						folderPolicyRef("eng", "eng-audit"),
+						[]storedTargetRefTest{deploymentTarget("lilies", "api")},
+						t,
+					),
+				},
+			},
+			want: wantRes{names: []string{"eng-audit-tmpl"}},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pl := &policyListerFromClient{items: tc.policies}
+			bl := &bindingListerFromMap{items: tc.bindings}
+			fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
+
+			got, err := fr.Resolve(context.Background(), tc.projectNs, tc.target, tc.targetName, tc.explicit)
+			if err != nil {
+				t.Fatalf("Resolve returned error: %v", err)
+			}
+			gotNames := refNames(got)
+			sort.Strings(gotNames)
+			wantNames := append([]string(nil), tc.want.names...)
+			sort.Strings(wantNames)
+			if !equalStringSlices(gotNames, wantNames) {
+				t.Errorf("names mismatch: got %v, want %v", gotNames, wantNames)
+			}
+		})
+	}
+}
+
+// TestFolderResolver_BindingsNonexistentPolicyIsNoopAndDoesNotError asserts
+// a binding whose policy_ref does not resolve to any policy in the ancestor
+// chain is treated as a no-op: the resolver does not error, no refs are
+// injected, and the explicit refs passed by the caller are returned
+// unchanged. This is the degrade-gracefully contract from the HOL-596 AC:
+// "resolver logs a warning and treats as no-op (does not fail render)".
+func TestFolderResolver_BindingsNonexistentPolicyIsNoopAndDoesNotError(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	// No policies exist — the binding points at "missing" which has
+	// nothing to resolve to.
+	bindings := map[string][]corev1.ConfigMap{
+		ns["org"]: {
+			bindingCM(ns["org"], "orphan",
+				storedPolicyRefTest{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "missing"},
+				[]storedTargetRefTest{{Kind: "deployment", Name: "api", ProjectName: "lilies"}},
+				t,
+			),
+		},
+	}
+
+	explicit := []*consolev1.LinkedTemplateRef{
+		{
+			Scope:     consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION,
+			ScopeName: "acme",
+			Name:      "explicit",
+		},
+	}
+	pl := &policyListerFromClient{items: nil}
+	bl := &bindingListerFromMap{items: bindings}
+	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
+
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", explicit)
+	if err != nil {
+		t.Fatalf("Resolve returned error on nonexistent policy; expected no-op: %v", err)
+	}
+	names := refNames(got)
+	if len(names) != 1 || names[0] != "explicit" {
+		t.Errorf("expected explicit refs passed through, got %v", names)
+	}
+}
+
+// TestFolderResolver_BindingsBackwardCompatibleWithoutBindingWireup asserts
+// that a resolver constructed via NewFolderResolver (no binding lister or
+// unmarshaler) continues to behave exactly like the pre-HOL-596 resolver:
+// every rule is evaluated via its glob Target. This keeps pre-binding
+// fixtures and wire-ups working unchanged.
+func TestFolderResolver_BindingsBackwardCompatibleWithoutBindingWireup(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	policies := map[string][]corev1.ConfigMap{
+		ns["org"]: {
+			policyCM(ns["org"], "audit", []storedRuleTest{
+				{Kind: "require",
+					Template: struct {
+						Scope             string `json:"scope"`
+						ScopeName         string `json:"scope_name"`
+						Name              string `json:"name"`
+						VersionConstraint string `json:"version_constraint,omitempty"`
+					}{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy"},
+					Target: struct {
+						ProjectPattern    string `json:"project_pattern"`
+						DeploymentPattern string `json:"deployment_pattern,omitempty"`
+					}{ProjectPattern: "*"}},
+			}, t),
+		},
+	}
+
+	pl := &policyListerFromClient{items: policies}
+	fr := NewFolderResolver(pl, walker, r, RuleUnmarshalerFunc(testUnmarshalRules))
+
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(got) != 1 || got[0].GetName() != "audit-policy" {
+		t.Errorf("expected legacy glob to still apply: got %v", refNames(got))
+	}
+}
+
+// TestFolderResolver_BindingsEmptyTargetListNeverMatches asserts a binding
+// with no target_refs never covers any render target — an empty target list
+// contributes zero render targets. The bound policy's rules then fall
+// through to legacy glob evaluation.
+func TestFolderResolver_BindingsEmptyTargetListNeverMatches(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	policies := map[string][]corev1.ConfigMap{
+		ns["org"]: {
+			policyCM(ns["org"], "audit", []storedRuleTest{
+				{Kind: "require",
+					Template: struct {
+						Scope             string `json:"scope"`
+						ScopeName         string `json:"scope_name"`
+						Name              string `json:"name"`
+						VersionConstraint string `json:"version_constraint,omitempty"`
+					}{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy"},
+					Target: struct {
+						ProjectPattern    string `json:"project_pattern"`
+						DeploymentPattern string `json:"deployment_pattern,omitempty"`
+					}{ProjectPattern: "*"}},
+			}, t),
+		},
+	}
+	// Binding with empty target_refs. The JSON wire shape is "[]" which
+	// decodes to an empty slice. The binding exists but covers nothing.
+	bindings := map[string][]corev1.ConfigMap{
+		ns["org"]: {
+			bindingCM(ns["org"], "empty-bind",
+				storedPolicyRefTest{Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit"},
+				nil, // zero targets
+				t,
+			),
+		},
+	}
+
+	pl := &policyListerFromClient{items: policies}
+	bl := &bindingListerFromMap{items: bindings}
+	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
+
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// The empty binding does not cover the render target; legacy glob
+	// fallback fires for policy "audit" whose rule has project_pattern=*.
+	if len(got) != 1 || got[0].GetName() != "audit-policy" {
+		t.Errorf("expected legacy glob to fire when binding covers nothing: got %v", refNames(got))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `AncestorBindingLister` that walks the ancestor chain from a project namespace and decodes every `TemplatePolicyBinding` ConfigMap stored in folder and organization namespaces (project namespaces are skipped to preserve the HOL-554 storage-isolation guardrail).
- Extend `AncestorPolicyLister` with `ListPolicies`, returning `ResolvedPolicy` records (scope, scope_name, name, rules) so a binding's `policy_ref` can be matched to a specific policy in the chain.
- Teach `folderResolver.Resolve` to honor bindings: a binding whose `target_refs` match the current render target (kind + name + project_name) dereferences its `policy_ref`, injects REQUIRE template refs, and removes EXCLUDE template refs. Bindings win on conflict — the rule's glob `Target` is ignored for render targets the binding covers. Rules in policies with no matching binding for the current target continue to use their glob `Target`, so the change is safely additive through HOL-599/HOL-600.
- A binding pointing at a nonexistent policy logs a warning and contributes no refs (does not fail the render).
- Wire the production resolver in `console.go` via a new `NewFolderResolverWithBindings` constructor; the `TemplatePolicyBinding` `K8sClient` is now shared between the handler and the resolver.

Fixes HOL-596

## Test plan

- [x] `go test ./console/policyresolver/...` — new `folder_resolver_bindings_test.go` covers every AC bullet (binding + no matching glob, binding + matching glob wins, no binding + matching glob still applies, binding targets nonexistent policy, EXCLUDE via binding, PROJECT_TEMPLATE and DEPLOYMENT project_name semantics, folder-scoped binding + policy).
- [x] `go test ./console/policyresolver/...` — new `ancestor_bindings_test.go` covers project-namespace skip, per-namespace error isolation, misconfigured fail-open, parse-error skip, and end-to-end policy_ref/target_refs decoding.
- [x] Backward-compat test pins that a resolver constructed via `NewFolderResolver` (no binding wire-up) behaves exactly as it did before HOL-596.
- [x] `make test-go` — full Go suite passes with `-race`.
- [x] `make lint` — 27 pre-existing issues; no new issues introduced by this change.
- [ ] CI green (Lint, Unit Tests, E2E).

> Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)