### PR TITLE
feat(frontend): TemplatePolicyBinding routes, forms, and query hooks

### DIFF
--- a/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
@@ -1,0 +1,378 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
+
+// Polyfills for jsdom — Radix Select / Combobox / Popover use pointer capture
+// APIs that jsdom does not implement. Mirror the RuleEditor.test.tsx pattern.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+
+vi.mock('@/queries/templatePolicies', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templatePolicies')>(
+    '@/queries/templatePolicies',
+  )
+  return {
+    ...actual,
+    useListTemplatePolicies: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/projects', () => ({
+  useListProjects: vi.fn(),
+}))
+
+vi.mock('@/queries/deployments', () => ({
+  useListDeployments: vi.fn(),
+}))
+
+vi.mock('@/queries/templates', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templates')>(
+    '@/queries/templates',
+  )
+  return {
+    ...actual,
+    useListTemplates: vi.fn(),
+  }
+})
+
+import { BindingForm } from './BindingForm'
+import { useListTemplatePolicies } from '@/queries/templatePolicies'
+import { useListProjects } from '@/queries/projects'
+import { useListDeployments } from '@/queries/deployments'
+import { useListTemplates, TemplateScope, makeOrgScope } from '@/queries/templates'
+import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
+
+const ORG_SCOPE = makeOrgScope('test-org')
+
+function stubQueries({
+  policies = [],
+  projects = [],
+  deployments = [],
+  projectTemplates = [],
+}: {
+  policies?: Array<{
+    name: string
+    displayName: string
+    description: string
+    scopeRef?: { scope: number; scopeName: string }
+  }>
+  projects?: Array<{ name: string; displayName: string }>
+  deployments?: Array<{ name: string; displayName: string }>
+  projectTemplates?: Array<{
+    name: string
+    displayName: string
+    scopeRef: { scope: number; scopeName: string }
+  }>
+}) {
+  ;(useListTemplatePolicies as Mock).mockReturnValue({
+    data: policies,
+    isPending: false,
+    error: null,
+  })
+  ;(useListProjects as Mock).mockReturnValue({
+    data: { projects },
+    isPending: false,
+    error: null,
+  })
+  ;(useListDeployments as Mock).mockReturnValue({
+    data: deployments,
+    isPending: false,
+    error: null,
+  })
+  ;(useListTemplates as Mock).mockReturnValue({
+    data: projectTemplates,
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('BindingForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stubQueries({})
+  })
+
+  it('renders the name, display name, description, policy, and targets fields', () => {
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        scopeRef={ORG_SCOPE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/name slug/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+    // The Policy picker is exposed via a Combobox trigger (role=combobox).
+    expect(
+      screen.getByRole('combobox', { name: /template policy/i }),
+    ).toBeInTheDocument()
+    // TargetRefEditor always renders one empty row on create.
+    expect(screen.getByTestId('target-ref-editor')).toBeInTheDocument()
+    expect(screen.getByTestId('target-ref-row-0')).toBeInTheDocument()
+  })
+
+  it('rejects submission when the name is empty', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        scopeRef={ORG_SCOPE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => {
+      expect(
+        screen.getByText(/binding name is required/i),
+      ).toBeInTheDocument()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('rejects submission when no policy is selected', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        scopeRef={ORG_SCOPE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'Bind HTTPRoute' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/policy selection is required/i),
+      ).toBeInTheDocument()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('rejects submission when the target is missing a name', async () => {
+    stubQueries({
+      policies: [
+        {
+          name: 'require-http',
+          displayName: 'Require HTTP',
+          description: '',
+          scopeRef: { scope: TemplateScope.ORGANIZATION, scopeName: 'test-org' },
+        },
+      ],
+      projects: [{ name: 'proj-a', displayName: 'Project A' }],
+    })
+
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        scopeRef={ORG_SCOPE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'Bind HTTPRoute' },
+    })
+
+    // Pick the policy via the Combobox.
+    const policyTrigger = screen.getByRole('combobox', { name: /template policy/i })
+    await user.click(policyTrigger)
+    await user.click(
+      await screen.findByText(/org \/ test-org \/ require-http/),
+    )
+
+    // Pick a project via the target row Combobox.
+    const row = screen.getByTestId('target-ref-row-0')
+    const projectTrigger = within(row).getByRole('combobox', {
+      name: /target 1 project/i,
+    })
+    await user.click(projectTrigger)
+    await user.click(await screen.findByText(/Project A \(proj-a\)/))
+
+    // Submit without picking a name — client-side validation should reject.
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('binding-form-error')).toHaveTextContent(
+        /name is required/i,
+      )
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits a valid draft with the expected mutation shape', async () => {
+    stubQueries({
+      policies: [
+        {
+          name: 'require-http',
+          displayName: 'Require HTTP',
+          description: '',
+          scopeRef: { scope: TemplateScope.ORGANIZATION, scopeName: 'test-org' },
+        },
+      ],
+      projects: [{ name: 'proj-a', displayName: 'Project A' }],
+      projectTemplates: [
+        {
+          name: 'ingress',
+          displayName: 'Ingress',
+          scopeRef: { scope: TemplateScope.PROJECT, scopeName: 'proj-a' },
+        },
+      ],
+    })
+
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        scopeRef={ORG_SCOPE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'Bind HTTPRoute' },
+    })
+    fireEvent.change(screen.getByLabelText(/^description$/i), {
+      target: { value: 'Attach on proj-a ingress' },
+    })
+
+    // Policy picker.
+    await user.click(
+      screen.getByRole('combobox', { name: /template policy/i }),
+    )
+    await user.click(
+      await screen.findByText(/org \/ test-org \/ require-http/),
+    )
+
+    // Target project.
+    const row = screen.getByTestId('target-ref-row-0')
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 project/i }),
+    )
+    await user.click(await screen.findByText(/Project A \(proj-a\)/))
+
+    // Kind defaults to PROJECT_TEMPLATE, so pick an ingress template.
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 name/i }),
+    )
+    await user.click(await screen.findByText(/Ingress \(ingress\)/))
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    const arg = onSubmit.mock.calls[0][0]
+    expect(arg.name).toBe('bind-httproute')
+    expect(arg.displayName).toBe('Bind HTTPRoute')
+    expect(arg.description).toBe('Attach on proj-a ingress')
+    expect(arg.policyRef?.name).toBe('require-http')
+    expect(arg.policyRef?.scopeRef?.scopeName).toBe('test-org')
+    expect(arg.targetRefs).toHaveLength(1)
+    expect(arg.targetRefs[0]).toMatchObject({
+      kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+      projectName: 'proj-a',
+      name: 'ingress',
+    })
+  })
+
+  it('blocks submission when the resolved scope is project (contrived URL)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="project"
+        scopeRef={ORG_SCOPE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'Would-be' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('binding-form-error')).toHaveTextContent(
+        /only be created at folder or organization scope/i,
+      )
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('disables form controls for VIEWER', () => {
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        scopeRef={ORG_SCOPE}
+        organization="test-org"
+        canWrite={false}
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByLabelText(/display name/i)).toBeDisabled()
+    expect(screen.getByLabelText(/^description$/i)).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/template-policy-bindings/BindingForm.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.tsx
@@ -14,6 +14,7 @@ import {
   policyKey,
   validateBindingDraft,
   type BindingDraft,
+  type BindingMutationParams,
 } from './binding-draft'
 import { useListTemplatePolicies } from '@/queries/templatePolicies'
 import { TemplateScope } from '@/queries/templates'
@@ -40,7 +41,7 @@ export type BindingFormProps = {
   pendingLabel: string
   isPending?: boolean
   lockName?: boolean
-  onSubmit: (values: ReturnType<typeof draftToMutationParams>) => Promise<void>
+  onSubmit: (values: BindingMutationParams) => Promise<void>
   onCancel: () => void
 }
 

--- a/frontend/src/components/template-policy-bindings/BindingForm.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.tsx
@@ -1,0 +1,261 @@
+import { useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Separator } from '@/components/ui/separator'
+import { Combobox, type ComboboxItem } from '@/components/ui/combobox'
+import { TargetRefEditor } from './TargetRefEditor'
+import {
+  applyPolicyKey,
+  draftToMutationParams,
+  newEmptyBindingDraft,
+  policyKey,
+  validateBindingDraft,
+  type BindingDraft,
+} from './binding-draft'
+import { useListTemplatePolicies } from '@/queries/templatePolicies'
+import { TemplateScope } from '@/queries/templates'
+import type { TemplateScopeRef } from '@/queries/templates'
+
+/**
+ * BindingScope captures the allowed scope types for a TemplatePolicyBinding.
+ * The form-level guard rejects any value other than ORGANIZATION or FOLDER.
+ * Mirrors the PolicyScope type in PolicyForm.tsx — bindings live only where
+ * their referenced policy can live.
+ */
+export type BindingScope = 'organization' | 'folder' | 'project' | 'unknown'
+
+export type BindingFormProps = {
+  mode: 'create' | 'edit'
+  scopeType: BindingScope
+  scopeRef: TemplateScopeRef
+  /** Organization that owns the scope — required to populate the per-row
+   * project picker. */
+  organization: string
+  canWrite: boolean
+  initialValues?: BindingDraft
+  submitLabel: string
+  pendingLabel: string
+  isPending?: boolean
+  lockName?: boolean
+  onSubmit: (values: ReturnType<typeof draftToMutationParams>) => Promise<void>
+  onCancel: () => void
+}
+
+/**
+ * BindingForm renders the shared create/edit form for a TemplatePolicyBinding.
+ * It enforces the same scope guard as PolicyForm: the form refuses to submit
+ * when `scopeType` is not `organization` or `folder`, regardless of what the
+ * URL or caller supplied.
+ */
+export function BindingForm({
+  mode,
+  scopeType,
+  scopeRef,
+  organization,
+  canWrite,
+  initialValues,
+  submitLabel,
+  pendingLabel,
+  isPending = false,
+  lockName = false,
+  onSubmit,
+  onCancel,
+}: BindingFormProps) {
+  const [draft, setDraft] = useState<BindingDraft>(
+    initialValues ?? newEmptyBindingDraft(),
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  // Policies visible from this scope. A binding can only reference policies
+  // its scope can reach — same scope or an ancestor (verified by the backend).
+  // The list RPC already applies the ancestor-chain walk so the Combobox
+  // receives the authoritative set.
+  const { data: policies = [] } = useListTemplatePolicies(scopeRef)
+
+  const policyItems: ComboboxItem[] = useMemo(() => {
+    return policies.map((p) => {
+      const scope = p.scopeRef?.scope ?? TemplateScope.UNSPECIFIED
+      const scopeName = p.scopeRef?.scopeName ?? ''
+      const scopeLabel =
+        scope === TemplateScope.ORGANIZATION
+          ? 'org'
+          : scope === TemplateScope.FOLDER
+            ? 'folder'
+            : 'unknown'
+      return {
+        value: policyKey(scope, scopeName, p.name),
+        label: `${scopeLabel} / ${scopeName} / ${p.name}`,
+      }
+    })
+  }, [policies])
+
+  const selectedPolicyKey = useMemo(
+    () =>
+      draft.policyName
+        ? policyKey(draft.policyScope, draft.policyScopeName, draft.policyName)
+        : '',
+    [draft.policyScope, draft.policyScopeName, draft.policyName],
+  )
+
+  const slugify = (val: string) =>
+    val
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+
+  const handleDisplayNameChange = (val: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      displayName: val,
+      name: mode === 'create' && !lockName ? slugify(val) : prev.name,
+    }))
+  }
+
+  const handleSubmit = async () => {
+    setError(null)
+
+    // Scope guard: bindings can only be authored at folder or organization
+    // scope. Matches PolicyForm's guard.
+    if (scopeType !== 'organization' && scopeType !== 'folder') {
+      setError(
+        'Template policy bindings can only be created at folder or organization scope. Navigate to a folder or organization to manage bindings.',
+      )
+      return
+    }
+
+    const validationError = validateBindingDraft(draft)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    try {
+      await onSubmit(draftToMutationParams(draft))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-border p-3 text-sm text-muted-foreground">
+        Template policy bindings attach a single policy to an explicit list of
+        project templates and deployments. No glob patterns — every target is
+        named directly.
+      </div>
+
+      <div>
+        <Label htmlFor="binding-display-name">Display Name</Label>
+        <Input
+          id="binding-display-name"
+          aria-label="Display Name"
+          autoFocus
+          value={draft.displayName}
+          onChange={(e) => handleDisplayNameChange(e.target.value)}
+          placeholder="My Binding"
+          disabled={!canWrite}
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="binding-name">Name (slug)</Label>
+        <Input
+          id="binding-name"
+          aria-label="Name slug"
+          value={draft.name}
+          onChange={(e) => setDraft((prev) => ({ ...prev, name: e.target.value }))}
+          placeholder="my-binding"
+          disabled={!canWrite || lockName}
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          {lockName
+            ? 'Binding names are immutable after creation.'
+            : 'Auto-derived from display name. Lowercase alphanumeric and hyphens only.'}
+        </p>
+      </div>
+
+      <div>
+        <Label htmlFor="binding-description">Description</Label>
+        <Textarea
+          id="binding-description"
+          aria-label="Description"
+          value={draft.description}
+          onChange={(e) =>
+            setDraft((prev) => ({ ...prev, description: e.target.value }))
+          }
+          placeholder="What does this binding attach and why?"
+          disabled={!canWrite}
+          rows={3}
+        />
+      </div>
+
+      <Separator />
+
+      <div>
+        <Label htmlFor="binding-policy">Policy</Label>
+        <Combobox
+          items={policyItems}
+          value={selectedPolicyKey}
+          onValueChange={(v) => {
+            if (!canWrite) return
+            setDraft((prev) => applyPolicyKey(prev, v))
+          }}
+          placeholder="Select a template policy..."
+          searchPlaceholder="Search policies..."
+          aria-label="Template policy"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Pick the TemplatePolicy this binding attaches. Policies in this scope
+          and its ancestors are offered.
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Targets</Label>
+          <p className="text-xs text-muted-foreground">
+            Scope:{' '}
+            {scopeType === 'folder'
+              ? 'Folder'
+              : scopeType === 'organization'
+                ? 'Organization'
+                : 'Invalid'}
+          </p>
+        </div>
+        <TargetRefEditor
+          organization={organization}
+          targets={draft.targetRefs}
+          onChange={(targetRefs) =>
+            setDraft((prev) => ({ ...prev, targetRefs }))
+          }
+          disabled={!canWrite}
+        />
+      </div>
+
+      {error && (
+        <Alert variant="destructive" data-testid="binding-form-error">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-center gap-3 pt-2">
+        <Button onClick={handleSubmit} disabled={isPending || !canWrite}>
+          {isPending ? pendingLabel : submitLabel}
+        </Button>
+        <Button
+          variant="ghost"
+          type="button"
+          aria-label="Cancel"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
@@ -1,0 +1,325 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+
+vi.mock('@/queries/projects', () => ({
+  useListProjects: vi.fn(),
+}))
+
+vi.mock('@/queries/deployments', () => ({
+  useListDeployments: vi.fn(),
+}))
+
+vi.mock('@/queries/templates', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templates')>(
+    '@/queries/templates',
+  )
+  return {
+    ...actual,
+    useListTemplates: vi.fn(),
+  }
+})
+
+import { TargetRefEditor } from './TargetRefEditor'
+import { useListProjects } from '@/queries/projects'
+import { useListDeployments } from '@/queries/deployments'
+import { useListTemplates, TemplateScope } from '@/queries/templates'
+import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
+import type { TargetRefDraft } from './binding-draft'
+
+function makeTarget(overrides: Partial<TargetRefDraft> = {}): TargetRefDraft {
+  return {
+    kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+    projectName: '',
+    name: '',
+    ...overrides,
+  }
+}
+
+function stubQueries({
+  projects = [{ name: 'proj-a', displayName: 'Project A' }],
+  projectTemplates = [
+    {
+      name: 'ingress',
+      displayName: 'Ingress',
+      scopeRef: { scope: TemplateScope.PROJECT, scopeName: 'proj-a' },
+    },
+  ],
+  deployments = [{ name: 'web', displayName: 'Web' }],
+}: {
+  projects?: Array<{ name: string; displayName: string }>
+  projectTemplates?: Array<{
+    name: string
+    displayName: string
+    scopeRef: { scope: number; scopeName: string }
+  }>
+  deployments?: Array<{ name: string; displayName: string }>
+} = {}) {
+  ;(useListProjects as Mock).mockReturnValue({
+    data: { projects },
+    isPending: false,
+    error: null,
+  })
+  ;(useListTemplates as Mock).mockReturnValue({
+    data: projectTemplates,
+    isPending: false,
+    error: null,
+  })
+  ;(useListDeployments as Mock).mockReturnValue({
+    data: deployments,
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('TargetRefEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stubQueries()
+  })
+
+  it('renders one row per target', () => {
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({ projectName: 'proj-a', name: 'ingress' }),
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+            projectName: 'proj-a',
+            name: 'web',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('target-ref-row-0')).toBeInTheDocument()
+    expect(screen.getByTestId('target-ref-row-1')).toBeInTheDocument()
+  })
+
+  it('renders the empty-state hint when the target list is empty', () => {
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/no targets yet/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('target-ref-row-0')).not.toBeInTheDocument()
+  })
+
+  it('adds a new row when Add Target is clicked', () => {
+    const onChange = vi.fn()
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[makeTarget()]}
+        onChange={onChange}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add target/i }))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const next = onChange.mock.calls[0][0] as TargetRefDraft[]
+    expect(next).toHaveLength(2)
+    expect(next[1]).toMatchObject({
+      kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+      projectName: '',
+      name: '',
+    })
+  })
+
+  it('removes a row when Remove target is clicked', () => {
+    const onChange = vi.fn()
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({ projectName: 'proj-a', name: 'ingress' }),
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+            projectName: 'proj-a',
+            name: 'web',
+          }),
+        ]}
+        onChange={onChange}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-1')
+    fireEvent.click(within(row).getByRole('button', { name: /remove target 2/i }))
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+        projectName: 'proj-a',
+        name: 'ingress',
+      }),
+    ])
+  })
+
+  it('kind switch from PROJECT_TEMPLATE to DEPLOYMENT clears the name and re-renders picker items', async () => {
+    // Target the Radix Select with user-event so the popover opens and we can
+    // pick the "Deployment" option. The onChange handler must clear `name`
+    // since project templates and deployments share the same combobox source.
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onChange = vi.fn()
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'proj-a',
+            name: 'ingress',
+          }),
+        ]}
+        onChange={onChange}
+      />,
+    )
+
+    const row = screen.getByTestId('target-ref-row-0')
+    const kindTrigger = within(row).getByRole('combobox', {
+      name: /target 1 kind/i,
+    })
+    await user.click(kindTrigger)
+    await user.click(await screen.findByRole('option', { name: /deployment/i }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const next = onChange.mock.calls[0][0] as TargetRefDraft[]
+    expect(next[0]).toMatchObject({
+      kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+      projectName: 'proj-a',
+      name: '',
+    })
+  })
+
+  it('shows project-template items when kind=PROJECT_TEMPLATE', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'proj-a',
+            name: '',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    const nameTrigger = within(screen.getByTestId('target-ref-row-0')).getByRole(
+      'combobox',
+      { name: /target 1 name/i },
+    )
+    await user.click(nameTrigger)
+    await waitFor(() => {
+      expect(screen.getByText(/Ingress \(ingress\)/)).toBeInTheDocument()
+    })
+    // The deployment label must NOT appear while kind=PROJECT_TEMPLATE.
+    expect(screen.queryByText(/Web \(web\)/)).not.toBeInTheDocument()
+  })
+
+  it('shows deployment items when kind=DEPLOYMENT', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+            projectName: 'proj-a',
+            name: '',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    const nameTrigger = within(screen.getByTestId('target-ref-row-0')).getByRole(
+      'combobox',
+      { name: /target 1 name/i },
+    )
+    await user.click(nameTrigger)
+    await waitFor(() => {
+      expect(screen.getByText(/Web \(web\)/)).toBeInTheDocument()
+    })
+    // And the project template label must NOT appear while kind=DEPLOYMENT.
+    expect(screen.queryByText(/Ingress \(ingress\)/)).not.toBeInTheDocument()
+  })
+
+  it('changing the project clears the name', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onChange = vi.fn()
+    stubQueries({
+      projects: [
+        { name: 'proj-a', displayName: 'Project A' },
+        { name: 'proj-b', displayName: 'Project B' },
+      ],
+    })
+
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({ projectName: 'proj-a', name: 'ingress' }),
+        ]}
+        onChange={onChange}
+      />,
+    )
+
+    const row = screen.getByTestId('target-ref-row-0')
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 project/i }),
+    )
+    await user.click(await screen.findByText(/Project B \(proj-b\)/))
+
+    expect(onChange).toHaveBeenCalled()
+    const next = onChange.mock.calls[0][0] as TargetRefDraft[]
+    expect(next[0]).toMatchObject({
+      projectName: 'proj-b',
+      name: '',
+    })
+  })
+
+  it('hides the Add Target and Remove buttons when disabled', () => {
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[makeTarget({ projectName: 'proj-a', name: 'ingress' })]}
+        onChange={vi.fn()}
+        disabled
+      />,
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /add target/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /remove target 1/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
@@ -1,0 +1,260 @@
+import { useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Combobox, type ComboboxItem } from '@/components/ui/combobox'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Trash2 } from 'lucide-react'
+import {
+  TemplatePolicyBindingTargetKind,
+  type TemplatePolicyBinding,
+} from '@/queries/templatePolicyBindings'
+import type { TargetRefDraft } from './binding-draft'
+import { useListDeployments } from '@/queries/deployments'
+import { useListProjects } from '@/queries/projects'
+import { useListTemplates } from '@/queries/templates'
+import { TemplateScope, makeProjectScope } from '@/queries/templates'
+
+// Kind options exposed to the target-row select. UNSPECIFIED is intentionally
+// omitted — the backend rejects it and the UI must not offer it.
+const KIND_OPTIONS: Array<{
+  value: TemplatePolicyBindingTargetKind
+  label: string
+}> = [
+  {
+    value: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+    label: 'Project Template',
+  },
+  { value: TemplatePolicyBindingTargetKind.DEPLOYMENT, label: 'Deployment' },
+]
+
+export type TargetRefEditorProps = {
+  /** The organization these target refs live under. Required to populate the
+   * project picker. */
+  organization: string
+  targets: TargetRefDraft[]
+  onChange: (targets: TargetRefDraft[]) => void
+  disabled?: boolean
+}
+
+/**
+ * TargetRefEditor renders an editable list of binding target refs. Each row
+ * is a kind select, a project combobox (always visible), and a name combobox
+ * whose source depends on the kind: PROJECT_TEMPLATE loads project-scope
+ * templates for the selected project, DEPLOYMENT loads deployments for the
+ * selected project. The caller owns the targets state and passes an
+ * onChange callback.
+ */
+export function TargetRefEditor({
+  organization,
+  targets,
+  onChange,
+  disabled = false,
+}: TargetRefEditorProps) {
+  const handleUpdate = (index: number, patch: Partial<TargetRefDraft>) => {
+    const next = targets.map((t, i) => (i === index ? { ...t, ...patch } : t))
+    onChange(next)
+  }
+
+  const handleRemove = (index: number) => {
+    onChange(targets.filter((_, i) => i !== index))
+  }
+
+  const handleAdd = () => {
+    onChange([
+      ...targets,
+      {
+        kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+        projectName: '',
+        name: '',
+      },
+    ])
+  }
+
+  return (
+    <div className="space-y-4" data-testid="target-ref-editor">
+      {targets.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No targets yet. A binding must have at least one target.
+        </p>
+      )}
+      {targets.map((target, index) => (
+        <TargetRow
+          key={index}
+          index={index}
+          organization={organization}
+          target={target}
+          onUpdate={(patch) => handleUpdate(index, patch)}
+          onRemove={() => handleRemove(index)}
+          disabled={disabled}
+        />
+      ))}
+
+      {!disabled && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleAdd}
+          aria-label="Add target"
+        >
+          Add Target
+        </Button>
+      )}
+    </div>
+  )
+}
+
+type TargetRowProps = {
+  index: number
+  organization: string
+  target: TargetRefDraft
+  onUpdate: (patch: Partial<TargetRefDraft>) => void
+  onRemove: () => void
+  disabled: boolean
+}
+
+function TargetRow({
+  index,
+  organization,
+  target,
+  onUpdate,
+  onRemove,
+  disabled,
+}: TargetRowProps) {
+  const isDeployment = target.kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
+  const isProjectTemplate =
+    target.kind === TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE
+
+  const { data: projectsResponse } = useListProjects(organization)
+  const projectItems: ComboboxItem[] = useMemo(() => {
+    const projects = projectsResponse?.projects ?? []
+    return projects.map((p) => ({
+      value: p.name,
+      label: p.displayName ? `${p.displayName} (${p.name})` : p.name,
+    }))
+  }, [projectsResponse])
+
+  // Name picker: project-scope templates or deployments, both scoped to the
+  // selected project. Both hooks are called unconditionally — the hooks
+  // themselves guard on an empty project name via the `enabled` option, so
+  // no fetch occurs until a project is picked.
+  const projectScope = makeProjectScope(target.projectName)
+  const { data: projectTemplates = [] } = useListTemplates(projectScope)
+  const { data: deployments = [] } = useListDeployments(target.projectName)
+
+  const nameItems: ComboboxItem[] = useMemo(() => {
+    if (isProjectTemplate) {
+      return projectTemplates
+        .filter((t) => t.scopeRef?.scope === TemplateScope.PROJECT)
+        .map((t) => ({
+          value: t.name,
+          label: t.displayName ? `${t.displayName} (${t.name})` : t.name,
+        }))
+    }
+    if (isDeployment) {
+      return deployments.map((d) => ({
+        value: d.name,
+        label: d.displayName ? `${d.displayName} (${d.name})` : d.name,
+      }))
+    }
+    return []
+  }, [isProjectTemplate, isDeployment, projectTemplates, deployments])
+
+  return (
+    <div
+      data-testid={`target-ref-row-${index}`}
+      className="space-y-3 rounded-md border border-border p-4"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-sm text-muted-foreground">Target {index + 1}</span>
+        {!disabled && (
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            aria-label={`Remove target ${index + 1}`}
+            onClick={onRemove}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div>
+          <Label htmlFor={`target-kind-${index}`}>Kind</Label>
+          <Select
+            value={String(target.kind)}
+            onValueChange={(v) => {
+              const next = Number(v) as TemplatePolicyBindingTargetKind
+              // Changing the kind invalidates the selected name (PROJECT_TEMPLATE
+              // and DEPLOYMENT pull from different pickers) but keeps the
+              // project so the user does not lose that selection when toggling.
+              onUpdate({ kind: next, name: '' })
+            }}
+            disabled={disabled}
+          >
+            <SelectTrigger
+              id={`target-kind-${index}`}
+              aria-label={`Target ${index + 1} kind`}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {KIND_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={String(opt.value)}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label htmlFor={`target-project-${index}`}>Project</Label>
+          <Combobox
+            items={projectItems}
+            value={target.projectName}
+            onValueChange={(v) => {
+              if (disabled) return
+              // Changing the project invalidates the previously picked name
+              // (names are scoped per-project) so clear it.
+              onUpdate({ projectName: v, name: '' })
+            }}
+            placeholder="Select a project..."
+            searchPlaceholder="Search projects..."
+            aria-label={`Target ${index + 1} project`}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor={`target-name-${index}`}>Name</Label>
+          <Combobox
+            items={nameItems}
+            value={target.name}
+            onValueChange={(v) => {
+              if (disabled) return
+              onUpdate({ name: v })
+            }}
+            placeholder={
+              isDeployment
+                ? 'Select a deployment...'
+                : 'Select a project template...'
+            }
+            searchPlaceholder="Search..."
+            aria-label={`Target ${index + 1} name`}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Re-export so consumers can import the binding proto type via this module.
+export type { TemplatePolicyBinding }

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
@@ -10,10 +10,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Trash2 } from 'lucide-react'
-import {
-  TemplatePolicyBindingTargetKind,
-  type TemplatePolicyBinding,
-} from '@/queries/templatePolicyBindings'
+import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
 import type { TargetRefDraft } from './binding-draft'
 import { useListDeployments } from '@/queries/deployments'
 import { useListProjects } from '@/queries/projects'
@@ -128,8 +125,6 @@ function TargetRow({
   disabled,
 }: TargetRowProps) {
   const isDeployment = target.kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
-  const isProjectTemplate =
-    target.kind === TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE
 
   const { data: projectsResponse } = useListProjects(organization)
   const projectItems: ComboboxItem[] = useMemo(() => {
@@ -141,30 +136,31 @@ function TargetRow({
   }, [projectsResponse])
 
   // Name picker: project-scope templates or deployments, both scoped to the
-  // selected project. Both hooks are called unconditionally — the hooks
-  // themselves guard on an empty project name via the `enabled` option, so
+  // selected project. Both hooks are called unconditionally — they gate on a
+  // non-empty project name via their `enabled` option (useListTemplates keys
+  // on scope.scopeName, useListDeployments keys on the project argument), so
   // no fetch occurs until a project is picked.
   const projectScope = makeProjectScope(target.projectName)
   const { data: projectTemplates = [] } = useListTemplates(projectScope)
   const { data: deployments = [] } = useListDeployments(target.projectName)
 
+  // KIND_OPTIONS omits UNSPECIFIED, so kind is always DEPLOYMENT or
+  // PROJECT_TEMPLATE. Branching on a single `isDeployment` flag keeps the
+  // contract explicit and avoids an unreachable fallthrough.
   const nameItems: ComboboxItem[] = useMemo(() => {
-    if (isProjectTemplate) {
-      return projectTemplates
-        .filter((t) => t.scopeRef?.scope === TemplateScope.PROJECT)
-        .map((t) => ({
-          value: t.name,
-          label: t.displayName ? `${t.displayName} (${t.name})` : t.name,
-        }))
-    }
     if (isDeployment) {
       return deployments.map((d) => ({
         value: d.name,
         label: d.displayName ? `${d.displayName} (${d.name})` : d.name,
       }))
     }
-    return []
-  }, [isProjectTemplate, isDeployment, projectTemplates, deployments])
+    return projectTemplates
+      .filter((t) => t.scopeRef?.scope === TemplateScope.PROJECT)
+      .map((t) => ({
+        value: t.name,
+        label: t.displayName ? `${t.displayName} (${t.name})` : t.name,
+      }))
+  }, [isDeployment, projectTemplates, deployments])
 
   return (
     <div
@@ -256,5 +252,3 @@ function TargetRow({
   )
 }
 
-// Re-export so consumers can import the binding proto type via this module.
-export type { TemplatePolicyBinding }

--- a/frontend/src/components/template-policy-bindings/binding-draft.test.ts
+++ b/frontend/src/components/template-policy-bindings/binding-draft.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyPolicyKey,
+  bindingProtoToDraft,
+  draftToMutationParams,
+  draftToPolicyRef,
+  newEmptyBindingDraft,
+  parsePolicyKey,
+  policyKey,
+  targetRefDraftToProto,
+  targetRefProtoToDraft,
+  validateBindingDraft,
+} from './binding-draft'
+import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
+import { TemplateScope } from '@/queries/templates'
+
+describe('policyKey / parsePolicyKey', () => {
+  it('round-trips a composite key', () => {
+    const key = policyKey(TemplateScope.ORGANIZATION, 'test-org', 'policy-a')
+    expect(key).toBe('1/test-org/policy-a')
+    const parsed = parsePolicyKey(key)
+    expect(parsed).toEqual({
+      scope: TemplateScope.ORGANIZATION,
+      scopeName: 'test-org',
+      name: 'policy-a',
+    })
+  })
+
+  it('handles a name containing a slash', () => {
+    // parsePolicyKey joins the remainder after the first two parts so names
+    // with slashes survive the round trip.
+    const key = policyKey(TemplateScope.FOLDER, 'team', 'has/slash')
+    const parsed = parsePolicyKey(key)
+    expect(parsed.name).toBe('has/slash')
+    expect(parsed.scope).toBe(TemplateScope.FOLDER)
+    expect(parsed.scopeName).toBe('team')
+  })
+
+  it('parses an empty key into UNSPECIFIED zero values', () => {
+    const parsed = parsePolicyKey('')
+    expect(parsed.scope).toBe(TemplateScope.UNSPECIFIED)
+    expect(parsed.scopeName).toBe('')
+    expect(parsed.name).toBe('')
+  })
+})
+
+describe('validateBindingDraft', () => {
+  it('rejects a missing name', () => {
+    const draft = { ...newEmptyBindingDraft(), name: '  ' }
+    expect(validateBindingDraft(draft)).toMatch(/binding name is required/i)
+  })
+
+  it('rejects a missing policy', () => {
+    const draft = { ...newEmptyBindingDraft(), name: 'bind-a' }
+    expect(validateBindingDraft(draft)).toMatch(/policy selection is required/i)
+  })
+
+  it('rejects an empty target list', () => {
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: 'bind-a',
+      policyScope: TemplateScope.ORGANIZATION,
+      policyScopeName: 'test-org',
+      policyName: 'policy-a',
+      targetRefs: [],
+    }
+    expect(validateBindingDraft(draft)).toMatch(/must have at least one target/i)
+  })
+
+  it('rejects UNSPECIFIED kind', () => {
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: 'bind-a',
+      policyScope: TemplateScope.ORGANIZATION,
+      policyScopeName: 'test-org',
+      policyName: 'policy-a',
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.UNSPECIFIED,
+          projectName: 'proj-a',
+          name: 'ingress',
+        },
+      ],
+    }
+    expect(validateBindingDraft(draft)).toMatch(/kind is required/i)
+  })
+
+  it('rejects a missing project on a target', () => {
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: 'bind-a',
+      policyScope: TemplateScope.ORGANIZATION,
+      policyScopeName: 'test-org',
+      policyName: 'policy-a',
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: '',
+          name: 'ingress',
+        },
+      ],
+    }
+    expect(validateBindingDraft(draft)).toMatch(/project is required/i)
+  })
+
+  it('rejects duplicate (kind, projectName, name) triples', () => {
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: 'bind-a',
+      policyScope: TemplateScope.ORGANIZATION,
+      policyScopeName: 'test-org',
+      policyName: 'policy-a',
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: 'proj-a',
+          name: 'ingress',
+        },
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: 'proj-a',
+          name: 'ingress',
+        },
+      ],
+    }
+    expect(validateBindingDraft(draft)).toMatch(/duplicate/i)
+  })
+
+  it('accepts two entries that differ only in kind (per proto spec)', () => {
+    // The proto doc permits a PROJECT_TEMPLATE and a DEPLOYMENT with the same
+    // (project_name, name) pair because they name distinct resources.
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: 'bind-a',
+      policyScope: TemplateScope.ORGANIZATION,
+      policyScopeName: 'test-org',
+      policyName: 'policy-a',
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: 'proj-a',
+          name: 'shared',
+        },
+        {
+          kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+          projectName: 'proj-a',
+          name: 'shared',
+        },
+      ],
+    }
+    expect(validateBindingDraft(draft)).toBeNull()
+  })
+})
+
+describe('targetRefDraft round-trip', () => {
+  it('targetRefDraftToProto and targetRefProtoToDraft are inverses', () => {
+    const draft = {
+      kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+      projectName: 'proj-a',
+      name: 'web',
+    }
+    const proto = targetRefDraftToProto(draft)
+    expect(proto.kind).toBe(TemplatePolicyBindingTargetKind.DEPLOYMENT)
+    expect(proto.projectName).toBe('proj-a')
+    expect(proto.name).toBe('web')
+    const back = targetRefProtoToDraft(proto)
+    expect(back).toEqual(draft)
+  })
+})
+
+describe('bindingProtoToDraft', () => {
+  it('populates every field from a proto binding', () => {
+    const draft = bindingProtoToDraft({
+      name: 'bind-a',
+      displayName: 'Bind A',
+      description: 'desc',
+      policyRef: {
+        scopeRef: { scope: TemplateScope.FOLDER, scopeName: 'team' },
+        name: 'policy-a',
+      } as never,
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: 'proj-a',
+          name: 'ingress',
+        } as never,
+      ],
+    })
+    expect(draft).toMatchObject({
+      name: 'bind-a',
+      displayName: 'Bind A',
+      description: 'desc',
+      policyScope: TemplateScope.FOLDER,
+      policyScopeName: 'team',
+      policyName: 'policy-a',
+    })
+    expect(draft.targetRefs).toHaveLength(1)
+    expect(draft.targetRefs[0]).toEqual({
+      kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+      projectName: 'proj-a',
+      name: 'ingress',
+    })
+  })
+
+  it('defaults missing fields to empty / UNSPECIFIED', () => {
+    const draft = bindingProtoToDraft({})
+    expect(draft.name).toBe('')
+    expect(draft.policyScope).toBe(TemplateScope.UNSPECIFIED)
+    expect(draft.policyScopeName).toBe('')
+    expect(draft.policyName).toBe('')
+    expect(draft.targetRefs).toEqual([])
+  })
+})
+
+describe('applyPolicyKey', () => {
+  it('splits a composite policy key into the draft fields', () => {
+    const draft = newEmptyBindingDraft()
+    const next = applyPolicyKey(draft, policyKey(TemplateScope.ORGANIZATION, 'test-org', 'policy-a'))
+    expect(next.policyScope).toBe(TemplateScope.ORGANIZATION)
+    expect(next.policyScopeName).toBe('test-org')
+    expect(next.policyName).toBe('policy-a')
+    // Other fields remain untouched
+    expect(next.name).toBe(draft.name)
+    expect(next.targetRefs).toEqual(draft.targetRefs)
+  })
+})
+
+describe('draftToPolicyRef / draftToMutationParams', () => {
+  it('builds a LinkedTemplatePolicyRef from draft fields', () => {
+    const draft = {
+      ...newEmptyBindingDraft(),
+      policyScope: TemplateScope.FOLDER,
+      policyScopeName: 'team',
+      policyName: 'policy-a',
+    }
+    const ref = draftToPolicyRef(draft)
+    expect(ref.name).toBe('policy-a')
+    expect(ref.scopeRef?.scope).toBe(TemplateScope.FOLDER)
+    expect(ref.scopeRef?.scopeName).toBe('team')
+  })
+
+  it('draftToMutationParams trims whitespace on user-editable fields', () => {
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: '  bind-a  ',
+      displayName: '  Bind A  ',
+      description: '  desc  ',
+      policyScope: TemplateScope.ORGANIZATION,
+      policyScopeName: 'test-org',
+      policyName: 'policy-a',
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: 'proj-a',
+          name: 'ingress',
+        },
+      ],
+    }
+    const params = draftToMutationParams(draft)
+    expect(params.name).toBe('bind-a')
+    expect(params.displayName).toBe('Bind A')
+    expect(params.description).toBe('desc')
+    expect(params.policyRef.name).toBe('policy-a')
+    expect(params.targetRefs).toHaveLength(1)
+    expect(params.targetRefs[0].kind).toBe(
+      TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+    )
+  })
+})

--- a/frontend/src/components/template-policy-bindings/binding-draft.ts
+++ b/frontend/src/components/template-policy-bindings/binding-draft.ts
@@ -1,0 +1,220 @@
+import { create } from '@bufbuild/protobuf'
+import {
+  TemplatePolicyBindingTargetKind,
+  type TemplatePolicyBindingTargetRef,
+  type LinkedTemplatePolicyRef,
+} from '@/queries/templatePolicyBindings'
+import { TemplateScope } from '@/queries/templates'
+import {
+  TemplatePolicyBindingTargetRefSchema,
+  LinkedTemplatePolicyRefSchema,
+} from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
+import { TemplateScopeRefSchema } from '@/gen/holos/console/v1/policy_state_pb.js'
+
+/**
+ * Draft shape for a single target ref while the user is authoring a binding.
+ * Kept flatter than the proto message so inputs can be bound to strings and
+ * converted at submit time, mirroring rule-draft.ts.
+ */
+export type TargetRefDraft = {
+  kind: TemplatePolicyBindingTargetKind
+  projectName: string
+  name: string
+}
+
+/**
+ * Draft shape for a binding while the user is authoring it. `policyScope` and
+ * `policyScopeName` identify the TemplatePolicy referenced by the binding;
+ * the picker surfaces ancestor- and same-scope policies so the form submits
+ * both halves of the LinkedTemplatePolicyRef together.
+ */
+export type BindingDraft = {
+  name: string
+  displayName: string
+  description: string
+  policyScope: TemplateScope
+  policyScopeName: string
+  policyName: string
+  targetRefs: TargetRefDraft[]
+}
+
+export function newEmptyTargetRef(): TargetRefDraft {
+  return {
+    kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+    projectName: '',
+    name: '',
+  }
+}
+
+export function newEmptyBindingDraft(): BindingDraft {
+  return {
+    name: '',
+    displayName: '',
+    description: '',
+    policyScope: TemplateScope.UNSPECIFIED,
+    policyScopeName: '',
+    policyName: '',
+    targetRefs: [newEmptyTargetRef()],
+  }
+}
+
+/** Convert a target-ref draft into a proto TemplatePolicyBindingTargetRef. */
+export function targetRefDraftToProto(
+  draft: TargetRefDraft,
+): TemplatePolicyBindingTargetRef {
+  return create(TemplatePolicyBindingTargetRefSchema, {
+    kind: draft.kind,
+    name: draft.name,
+    projectName: draft.projectName,
+  })
+}
+
+/** Convert a proto TemplatePolicyBindingTargetRef back into a draft. */
+export function targetRefProtoToDraft(
+  ref: TemplatePolicyBindingTargetRef,
+): TargetRefDraft {
+  return {
+    kind: ref.kind,
+    projectName: ref.projectName ?? '',
+    name: ref.name ?? '',
+  }
+}
+
+/** Build a LinkedTemplatePolicyRef proto from a binding draft. */
+export function draftToPolicyRef(draft: BindingDraft): LinkedTemplatePolicyRef {
+  return create(LinkedTemplatePolicyRefSchema, {
+    scopeRef: create(TemplateScopeRefSchema, {
+      scope: draft.policyScope,
+      scopeName: draft.policyScopeName,
+    }),
+    name: draft.policyName,
+  })
+}
+
+/**
+ * Populate a binding draft from an existing proto binding. Used by the
+ * detail/edit route to seed the form with saved values.
+ */
+export function bindingProtoToDraft(
+  binding: {
+    name?: string
+    displayName?: string
+    description?: string
+    policyRef?: LinkedTemplatePolicyRef
+    targetRefs?: TemplatePolicyBindingTargetRef[]
+  },
+): BindingDraft {
+  const policyScope = binding.policyRef?.scopeRef?.scope ?? TemplateScope.UNSPECIFIED
+  const policyScopeName = binding.policyRef?.scopeRef?.scopeName ?? ''
+  const policyName = binding.policyRef?.name ?? ''
+  return {
+    name: binding.name ?? '',
+    displayName: binding.displayName ?? '',
+    description: binding.description ?? '',
+    policyScope,
+    policyScopeName,
+    policyName,
+    targetRefs: (binding.targetRefs ?? []).map(targetRefProtoToDraft),
+  }
+}
+
+/**
+ * validateBindingDraft returns a human-readable error string when the draft
+ * is not submittable, or null when it is valid for the client. The backend
+ * performs authoritative validation (duplicates, cross-scope reachability).
+ */
+export function validateBindingDraft(draft: BindingDraft): string | null {
+  if (!draft.name.trim()) {
+    return 'Binding name is required.'
+  }
+  if (!draft.policyName || !draft.policyScopeName) {
+    return 'Policy selection is required.'
+  }
+  if (draft.targetRefs.length === 0) {
+    return 'A binding must have at least one target.'
+  }
+  for (let i = 0; i < draft.targetRefs.length; i++) {
+    const target = draft.targetRefs[i]
+    const position = i + 1
+    if (target.kind === TemplatePolicyBindingTargetKind.UNSPECIFIED) {
+      return `Target ${position}: kind is required.`
+    }
+    if (!target.projectName) {
+      return `Target ${position}: project is required.`
+    }
+    if (!target.name) {
+      return `Target ${position}: name is required.`
+    }
+  }
+  // Reject duplicates (identical (kind, projectName, name) triples). The
+  // backend is authoritative but the UI should refuse to submit an obviously
+  // invalid draft.
+  const seen = new Set<string>()
+  for (let i = 0; i < draft.targetRefs.length; i++) {
+    const t = draft.targetRefs[i]
+    const key = `${t.kind}/${t.projectName}/${t.name}`
+    if (seen.has(key)) {
+      return `Target ${i + 1}: duplicate of another target in this binding.`
+    }
+    seen.add(key)
+  }
+  return null
+}
+
+/**
+ * Composite key used by the policy picker. A TemplatePolicy is uniquely
+ * identified by (scope, scopeName, name). Serialize into a single value so
+ * the Combobox can present it as a single option.
+ */
+export function policyKey(
+  scope: TemplateScope | number | undefined,
+  scopeName: string | undefined,
+  name: string,
+): string {
+  return `${scope ?? 0}/${scopeName ?? ''}/${name}`
+}
+
+/** Inverse of policyKey — parse a composite key back into its parts. */
+export function parsePolicyKey(key: string): {
+  scope: TemplateScope
+  scopeName: string
+  name: string
+} {
+  const parts = key.split('/')
+  return {
+    scope: (Number(parts[0]) as TemplateScope) || TemplateScope.UNSPECIFIED,
+    scopeName: parts[1] ?? '',
+    name: parts.slice(2).join('/'),
+  }
+}
+
+/**
+ * Fill in policyScope/policyScopeName/policyName on a draft from a composite
+ * policy key (used by the PolicyForm's Combobox handler).
+ */
+export function applyPolicyKey(
+  draft: BindingDraft,
+  key: string,
+): BindingDraft {
+  const { scope, scopeName, name } = parsePolicyKey(key)
+  return {
+    ...draft,
+    policyScope: scope,
+    policyScopeName: scopeName,
+    policyName: name,
+  }
+}
+
+/**
+ * Helper for the PolicyForm submit step: convert a validated draft into the
+ * set of values expected by the create/update mutation hook.
+ */
+export function draftToMutationParams(draft: BindingDraft) {
+  return {
+    name: draft.name.trim(),
+    displayName: draft.displayName.trim(),
+    description: draft.description.trim(),
+    policyRef: draftToPolicyRef(draft),
+    targetRefs: draft.targetRefs.map(targetRefDraftToProto),
+  }
+}

--- a/frontend/src/components/template-policy-bindings/binding-draft.ts
+++ b/frontend/src/components/template-policy-bindings/binding-draft.ts
@@ -206,10 +206,24 @@ export function applyPolicyKey(
 }
 
 /**
- * Helper for the PolicyForm submit step: convert a validated draft into the
+ * BindingMutationParams is the payload shape consumed by
+ * useCreateTemplatePolicyBinding and useUpdateTemplatePolicyBinding. Exported
+ * so BindingForm's onSubmit prop and consumers can reference the type
+ * directly rather than recovering it via ReturnType<typeof>.
+ */
+export type BindingMutationParams = {
+  name: string
+  displayName: string
+  description: string
+  policyRef: LinkedTemplatePolicyRef
+  targetRefs: TemplatePolicyBindingTargetRef[]
+}
+
+/**
+ * Helper for the BindingForm submit step: convert a validated draft into the
  * set of values expected by the create/update mutation hook.
  */
-export function draftToMutationParams(draft: BindingDraft) {
+export function draftToMutationParams(draft: BindingDraft): BindingMutationParams {
   return {
     name: draft.name.trim(),
     displayName: draft.displayName.trim(),

--- a/frontend/src/queries/templatePolicyBindings.ts
+++ b/frontend/src/queries/templatePolicyBindings.ts
@@ -1,0 +1,154 @@
+import { useMemo } from 'react'
+import { create } from '@bufbuild/protobuf'
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  TemplatePolicyBindingService,
+  TemplatePolicyBindingSchema,
+  TemplatePolicyBindingTargetKind,
+} from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
+import type {
+  TemplatePolicyBinding,
+  TemplatePolicyBindingTargetRef,
+  LinkedTemplatePolicyRef,
+} from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
+import type { TemplateScopeRef } from '@/gen/holos/console/v1/policy_state_pb.js'
+import { useAuth } from '@/lib/auth'
+
+// Re-export generated types/enums used by UI consumers.
+export type { TemplatePolicyBinding, TemplatePolicyBindingTargetRef, LinkedTemplatePolicyRef }
+export { TemplatePolicyBindingTargetKind }
+
+/** Query key helper for the template policy bindings list at a given scope. */
+function bindingListKey(scope: TemplateScopeRef) {
+  return ['templatePolicyBindings', 'list', scope.scope, scope.scopeName] as const
+}
+
+/** Query key helper for a single template policy binding. */
+function bindingGetKey(scope: TemplateScopeRef, name: string) {
+  return ['templatePolicyBindings', 'get', scope.scope, scope.scopeName, name] as const
+}
+
+// useListTemplatePolicyBindings fetches all bindings visible within a scope.
+// Mirrors the shape of useListTemplatePolicies in queries/templatePolicies.ts.
+export function useListTemplatePolicyBindings(scope: TemplateScopeRef) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyBindingService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: bindingListKey(scope),
+    queryFn: async () => {
+      const response = await client.listTemplatePolicyBindings({ scope })
+      return response.bindings
+    },
+    enabled: isAuthenticated && !!scope.scopeName,
+  })
+}
+
+// useGetTemplatePolicyBinding fetches a single binding by name within a scope.
+export function useGetTemplatePolicyBinding(scope: TemplateScopeRef, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyBindingService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: bindingGetKey(scope, name),
+    queryFn: async () => {
+      const response = await client.getTemplatePolicyBinding({ scope, name })
+      return response.binding
+    },
+    enabled: isAuthenticated && !!scope.scopeName && !!name,
+  })
+}
+
+// useCreateTemplatePolicyBinding creates a new binding at the given scope.
+export function useCreateTemplatePolicyBinding(scope: TemplateScopeRef) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyBindingService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      name: string
+      displayName: string
+      description: string
+      policyRef: LinkedTemplatePolicyRef
+      targetRefs: TemplatePolicyBindingTargetRef[]
+    }) =>
+      client.createTemplatePolicyBinding({
+        scope,
+        binding: create(TemplatePolicyBindingSchema, {
+          name: params.name,
+          scopeRef: scope,
+          displayName: params.displayName,
+          description: params.description,
+          policyRef: params.policyRef,
+          targetRefs: params.targetRefs,
+        }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: bindingListKey(scope) })
+    },
+  })
+}
+
+// useUpdateTemplatePolicyBinding updates an existing binding.
+export function useUpdateTemplatePolicyBinding(
+  scope: TemplateScopeRef,
+  name: string,
+) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyBindingService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      displayName?: string
+      description?: string
+      policyRef: LinkedTemplatePolicyRef
+      targetRefs: TemplatePolicyBindingTargetRef[]
+    }) =>
+      client.updateTemplatePolicyBinding({
+        scope,
+        binding: create(TemplatePolicyBindingSchema, {
+          name,
+          scopeRef: scope,
+          displayName: params.displayName ?? '',
+          description: params.description ?? '',
+          policyRef: params.policyRef,
+          targetRefs: params.targetRefs,
+        }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: bindingListKey(scope) })
+      queryClient.invalidateQueries({ queryKey: bindingGetKey(scope, name) })
+    },
+  })
+}
+
+// useDeleteTemplatePolicyBinding deletes a binding by name.
+export function useDeleteTemplatePolicyBinding(scope: TemplateScopeRef) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyBindingService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { name: string }) =>
+      client.deleteTemplatePolicyBinding({ scope, ...params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: bindingListKey(scope) })
+    },
+  })
+}

--- a/frontend/src/routes/-template-policy-bindings-routes.test.ts
+++ b/frontend/src/routes/-template-policy-bindings-routes.test.ts
@@ -1,0 +1,30 @@
+// Route tree guard for HOL-597: TemplatePolicyBindings, like TemplatePolicies,
+// must NEVER be mounted under a project-scoped path. Bindings live only at
+// folder or organization scope — the same storage-isolation guarantee as the
+// policies they reference.
+//
+// This test reads the generated route tree and asserts:
+//   1. No path matching `/projects/.+/template-policy-bindings` exists.
+//   2. The folder and org template-policy-bindings trees are present (sanity
+//      check so a stray rename doesn't let the guard pass vacuously).
+import fs from 'node:fs'
+import path from 'node:path'
+
+const routeTreePath = path.resolve(__dirname, '../routeTree.gen.ts')
+
+describe('TemplatePolicyBindings route tree', () => {
+  const source = fs.readFileSync(routeTreePath, 'utf-8')
+
+  it('does not include any project-scoped template-policy-bindings route', () => {
+    const forbidden = /\/projects\/[^'"\s]+\/template-policy-bindings/
+    expect(source).not.toMatch(forbidden)
+  })
+
+  it('includes folder-scoped template-policy-bindings route', () => {
+    expect(source).toMatch(/\/folders\/\$folderName\/template-policy-bindings/)
+  })
+
+  it('includes org-scoped template-policy-bindings route', () => {
+    expect(source).toMatch(/\/orgs\/\$orgName\/template-policy-bindings/)
+  })
+})

--- a/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
@@ -550,6 +550,14 @@ export function FolderDetailPage({
             >
               <span className="text-sm">Manage Folder Template Policies</span>
             </Link>
+            <Link
+              to="/folders/$folderName/template-policy-bindings"
+              params={{ folderName }}
+              aria-label="Folder Template Policy Bindings"
+              className="flex items-center justify-between p-3 rounded-md border border-border hover:bg-muted transition-colors"
+            >
+              <span className="text-sm">Manage Folder Template Policy Bindings</span>
+            </Link>
           </div>
 
           {/* Danger Zone */}

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/$bindingName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/$bindingName.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import {
+  useGetTemplatePolicyBinding,
+  useUpdateTemplatePolicyBinding,
+  useDeleteTemplatePolicyBinding,
+} from '@/queries/templatePolicyBindings'
+import { makeFolderScope } from '@/queries/templates'
+import { useGetFolder } from '@/queries/folders'
+import {
+  BindingForm,
+  type BindingScope,
+} from '@/components/template-policy-bindings/BindingForm'
+import { bindingProtoToDraft } from '@/components/template-policy-bindings/binding-draft'
+
+export const Route = createFileRoute(
+  '/_authenticated/folders/$folderName/template-policy-bindings/$bindingName',
+)({
+  component: FolderTemplatePolicyBindingDetailRoute,
+})
+
+function FolderTemplatePolicyBindingDetailRoute() {
+  const { folderName, bindingName } = Route.useParams()
+  return (
+    <FolderTemplatePolicyBindingDetailPage
+      folderName={folderName}
+      bindingName={bindingName}
+    />
+  )
+}
+
+export function FolderTemplatePolicyBindingDetailPage({
+  folderName: propFolderName,
+  bindingName: propBindingName,
+  forcedScopeType,
+}: {
+  folderName?: string
+  bindingName?: string
+  forcedScopeType?: BindingScope
+} = {}) {
+  let routeParams: { folderName?: string; bindingName?: string } = {}
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeParams = Route.useParams()
+  } catch {
+    routeParams = {}
+  }
+  const folderName = propFolderName ?? routeParams.folderName ?? ''
+  const bindingName = propBindingName ?? routeParams.bindingName ?? ''
+
+  const navigate = useNavigate()
+  const scope = makeFolderScope(folderName)
+  const { data: folder } = useGetFolder(folderName)
+  const orgName = folder?.organization ?? ''
+  const userRole = folder?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  const canDelete = userRole === Role.OWNER
+
+  const scopeType: BindingScope = forcedScopeType ?? 'folder'
+
+  const {
+    data: binding,
+    isPending,
+    error,
+  } = useGetTemplatePolicyBinding(scope, bindingName)
+  const updateMutation = useUpdateTemplatePolicyBinding(scope, bindingName)
+  const deleteMutation = useDeleteTemplatePolicyBinding(scope)
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const initialValues = useMemo(() => {
+    if (!binding) return undefined
+    return bindingProtoToDraft(binding)
+  }, [binding])
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                to="/orgs/$orgName/settings"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                {orgName}
+              </Link>
+              {' / '}
+              <Link
+                to="/orgs/$orgName/folders"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                Folders
+              </Link>
+              {' / '}
+              <Link
+                to="/folders/$folderName/settings"
+                params={{ folderName }}
+                className="hover:underline"
+              >
+                {folderName}
+              </Link>
+              {' / '}
+              <Link
+                to="/folders/$folderName/template-policy-bindings"
+                params={{ folderName }}
+                className="hover:underline"
+              >
+                Template Policy Bindings
+              </Link>
+              {' / '}
+              <span>{bindingName}</span>
+            </p>
+            <CardTitle className="mt-1">
+              {binding?.displayName || bindingName}
+            </CardTitle>
+          </div>
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+              aria-label="Delete binding"
+            >
+              Delete Binding
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <Separator className="mb-4" />
+          <BindingForm
+            mode="edit"
+            scopeType={scopeType}
+            scopeRef={scope}
+            organization={orgName}
+            canWrite={canWrite}
+            initialValues={initialValues}
+            lockName
+            submitLabel="Save"
+            pendingLabel="Saving..."
+            isPending={updateMutation.isPending}
+            onSubmit={async (values) => {
+              await updateMutation.mutateAsync(values)
+              toast.success('Binding saved')
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/folders/$folderName/template-policy-bindings',
+                params: { folderName },
+              })
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Template Policy Binding</DialogTitle>
+            <DialogDescription>
+              This will permanently delete the binding &quot;{bindingName}
+              &quot;. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={async () => {
+                try {
+                  await deleteMutation.mutateAsync({ name: bindingName })
+                  setDeleteOpen(false)
+                  await navigate({
+                    to: '/folders/$folderName/template-policy-bindings',
+                    params: { folderName },
+                  })
+                  toast.success('Binding deleted')
+                } catch (err) {
+                  toast.error(err instanceof Error ? err.message : String(err))
+                }
+              }}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-detail.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ folderName: 'test-folder', bindingName: 'bind-a' }),
+    }),
+    useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      to,
+      params,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/queries/templatePolicyBindings')
+  >('@/queries/templatePolicyBindings')
+  return {
+    ...actual,
+    useGetTemplatePolicyBinding: vi.fn(),
+    useUpdateTemplatePolicyBinding: vi.fn(),
+    useDeleteTemplatePolicyBinding: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/templates', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templates')>(
+    '@/queries/templates',
+  )
+  return {
+    ...actual,
+    makeFolderScope: vi
+      .fn()
+      .mockReturnValue({ scope: 2, scopeName: 'test-folder' }),
+    useListTemplates: vi.fn().mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    }),
+  }
+})
+
+vi.mock('@/queries/templatePolicies', () => ({
+  useListTemplatePolicies: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useListProjects: vi.fn().mockReturnValue({
+    data: { projects: [] },
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/queries/deployments', () => ({
+  useListDeployments: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/queries/folders', () => ({
+  useGetFolder: vi.fn(),
+}))
+
+import {
+  useGetTemplatePolicyBinding,
+  useUpdateTemplatePolicyBinding,
+  useDeleteTemplatePolicyBinding,
+  TemplatePolicyBindingTargetKind,
+} from '@/queries/templatePolicyBindings'
+import { useGetFolder } from '@/queries/folders'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { FolderTemplatePolicyBindingDetailPage } from './$bindingName'
+
+function makeBinding() {
+  return {
+    name: 'bind-a',
+    displayName: 'Folder Bind A',
+    description: 'Folder-level binding',
+    creatorEmail: 'jane@example.com',
+    policyRef: {
+      scopeRef: { scope: 2, scopeName: 'test-folder' },
+      name: 'folder-policy',
+    },
+    targetRefs: [
+      {
+        kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+        name: 'web',
+        projectName: 'proj-a',
+      },
+    ],
+  }
+}
+
+function setupMocks(userRole: Role = Role.OWNER) {
+  ;(useGetTemplatePolicyBinding as Mock).mockReturnValue({
+    data: makeBinding(),
+    isPending: false,
+    error: null,
+  })
+  ;(useUpdateTemplatePolicyBinding as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useDeleteTemplatePolicyBinding as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useGetFolder as Mock).mockReturnValue({
+    data: { name: 'test-folder', organization: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('FolderTemplatePolicyBindingDetailPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('shows the Delete Binding button for OWNER', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <FolderTemplatePolicyBindingDetailPage
+        folderName="test-folder"
+        bindingName="bind-a"
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: /delete binding/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Delete Binding button for EDITOR', () => {
+    setupMocks(Role.EDITOR)
+    render(
+      <FolderTemplatePolicyBindingDetailPage
+        folderName="test-folder"
+        bindingName="bind-a"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete binding/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  })
+
+  it('hides the Delete Binding button for VIEWER', () => {
+    setupMocks(Role.VIEWER)
+    render(
+      <FolderTemplatePolicyBindingDetailPage
+        folderName="test-folder"
+        bindingName="bind-a"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete binding/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  })
+
+  it('seeds the form with initial values from the proto binding', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <FolderTemplatePolicyBindingDetailPage
+        folderName="test-folder"
+        bindingName="bind-a"
+      />,
+    )
+    expect(screen.getByLabelText(/display name/i)).toHaveValue('Folder Bind A')
+    expect(screen.getByLabelText(/^description$/i)).toHaveValue(
+      'Folder-level binding',
+    )
+    expect(screen.getByLabelText(/name slug/i)).toBeDisabled()
+  })
+})

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-index.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ folderName: 'test-folder' }),
+    }),
+    Link: ({
+      children,
+      to,
+      params,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/queries/templatePolicyBindings')
+  >('@/queries/templatePolicyBindings')
+  return {
+    ...actual,
+    useListTemplatePolicyBindings: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/templates', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templates')>(
+    '@/queries/templates',
+  )
+  return {
+    ...actual,
+    makeFolderScope: vi
+      .fn()
+      .mockReturnValue({ scope: 2, scopeName: 'test-folder' }),
+  }
+})
+
+vi.mock('@/queries/folders', () => ({
+  useGetFolder: vi.fn(),
+}))
+
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
+import { useGetFolder } from '@/queries/folders'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { FolderTemplatePolicyBindingsIndexPage } from './index'
+
+function makeBinding(
+  name: string,
+  options: {
+    description?: string
+    creatorEmail?: string
+    targets?: number
+    policyName?: string
+  } = {},
+) {
+  return {
+    name,
+    displayName: name,
+    description: options.description ?? '',
+    creatorEmail: options.creatorEmail ?? '',
+    policyRef: options.policyName
+      ? {
+          scopeRef: { scope: 2, scopeName: 'test-folder' },
+          name: options.policyName,
+        }
+      : undefined,
+    targetRefs: Array.from({ length: options.targets ?? 0 }, (_, i) => ({
+      kind: 1,
+      name: `t-${i}`,
+      projectName: 'proj-a',
+    })),
+  }
+}
+
+function setup(
+  userRole: Role = Role.OWNER,
+  bindings: ReturnType<typeof makeBinding>[] = [],
+) {
+  ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
+    data: bindings,
+    isPending: false,
+    error: null,
+  })
+  ;(useGetFolder as Mock).mockReturnValue({
+    data: { name: 'test-folder', organization: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('FolderTemplatePolicyBindingsIndexPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders empty state when no bindings exist', () => {
+    setup(Role.OWNER, [])
+    render(<FolderTemplatePolicyBindingsIndexPage folderName="test-folder" />)
+    expect(
+      screen.getByText(/no template policy bindings yet/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders populated list with target-count and policy badges', () => {
+    setup(Role.OWNER, [
+      makeBinding('bind-a', { targets: 2, policyName: 'require-http' }),
+    ])
+    render(<FolderTemplatePolicyBindingsIndexPage folderName="test-folder" />)
+    expect(screen.getByText('bind-a')).toBeInTheDocument()
+    expect(screen.getByText(/2 targets/)).toBeInTheDocument()
+    expect(screen.getByText(/policy: require-http/)).toBeInTheDocument()
+  })
+
+  it('shows Create Binding for EDITOR (cascade covers PERMISSION_TEMPLATE_POLICIES_WRITE)', () => {
+    setup(Role.EDITOR, [])
+    render(<FolderTemplatePolicyBindingsIndexPage folderName="test-folder" />)
+    const link = screen.getByRole('link', { name: /create binding/i })
+    expect(link).toHaveAttribute(
+      'href',
+      '/folders/$folderName/template-policy-bindings/new',
+    )
+  })
+
+  it('hides Create Binding for VIEWER', () => {
+    setup(Role.VIEWER, [])
+    render(<FolderTemplatePolicyBindingsIndexPage folderName="test-folder" />)
+    expect(
+      screen.queryByRole('link', { name: /create binding/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/index.tsx
@@ -1,0 +1,174 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import { Badge } from '@/components/ui/badge'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
+import { makeFolderScope } from '@/queries/templates'
+import { useGetFolder } from '@/queries/folders'
+
+export const Route = createFileRoute(
+  '/_authenticated/folders/$folderName/template-policy-bindings/',
+)({
+  component: FolderTemplatePolicyBindingsIndexRoute,
+})
+
+function FolderTemplatePolicyBindingsIndexRoute() {
+  const { folderName } = Route.useParams()
+  return <FolderTemplatePolicyBindingsIndexPage folderName={folderName} />
+}
+
+export function FolderTemplatePolicyBindingsIndexPage({
+  folderName: propFolderName,
+}: { folderName?: string } = {}) {
+  let routeFolderName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeFolderName = Route.useParams().folderName
+  } catch {
+    routeFolderName = undefined
+  }
+  const folderName = propFolderName ?? routeFolderName ?? ''
+
+  const { data: folder } = useGetFolder(folderName)
+  const orgName = folder?.organization ?? ''
+
+  const scope = makeFolderScope(folderName)
+  const { data: bindings, isPending, error } = useListTemplatePolicyBindings(scope)
+
+  const userRole = folder?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/orgs/$orgName/settings"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              {orgName}
+            </Link>
+            {' / '}
+            <Link
+              to="/orgs/$orgName/folders"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              Folders
+            </Link>
+            {' / '}
+            <Link
+              to="/folders/$folderName/settings"
+              params={{ folderName }}
+              className="hover:underline"
+            >
+              {folderName}
+            </Link>
+            {' / Template Policy Bindings'}
+          </p>
+          <CardTitle className="mt-1">Template Policy Bindings</CardTitle>
+        </div>
+        {canWrite && (
+          <Link
+            to="/folders/$folderName/template-policy-bindings/new"
+            params={{ folderName }}
+          >
+            <Button size="sm">Create Binding</Button>
+          </Link>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Bindings attach a single TemplatePolicy to an explicit list of project
+          templates and deployments. Every target is named directly — no glob
+          patterns. Bindings live only at folder or organization scope.
+        </p>
+        <Separator />
+        {bindings && bindings.length > 0 ? (
+          <ul className="space-y-2" data-testid="bindings-list">
+            {bindings.map((binding) => (
+              <li key={binding.name}>
+                <Link
+                  to="/folders/$folderName/template-policy-bindings/$bindingName"
+                  params={{ folderName, bindingName: binding.name }}
+                  className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors border border-border"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium font-mono">
+                        {binding.name}
+                      </span>
+                      <Badge variant="outline" className="text-xs">
+                        {binding.targetRefs.length} target
+                        {binding.targetRefs.length === 1 ? '' : 's'}
+                      </Badge>
+                      {binding.policyRef?.name && (
+                        <Badge
+                          variant="outline"
+                          className="text-xs border-blue-500/30 text-blue-500"
+                        >
+                          policy: {binding.policyRef.name}
+                        </Badge>
+                      )}
+                    </div>
+                    {binding.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">
+                        {binding.description}
+                      </p>
+                    )}
+                    {binding.creatorEmail && (
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Created by {binding.creatorEmail}
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-md border border-dashed border-border p-6 text-center">
+            <p className="text-sm font-medium">
+              No template policy bindings yet.
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Bindings enumerate the explicit project templates and deployments
+              a TemplatePolicy applies to. Create a binding to attach a policy
+              to a specific target set in this folder.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/new.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/new.tsx
@@ -1,0 +1,120 @@
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplatePolicyBinding } from '@/queries/templatePolicyBindings'
+import { makeFolderScope } from '@/queries/templates'
+import { useGetFolder } from '@/queries/folders'
+import {
+  BindingForm,
+  type BindingScope,
+} from '@/components/template-policy-bindings/BindingForm'
+
+export const Route = createFileRoute(
+  '/_authenticated/folders/$folderName/template-policy-bindings/new',
+)({
+  component: CreateFolderTemplatePolicyBindingRoute,
+})
+
+function CreateFolderTemplatePolicyBindingRoute() {
+  const { folderName } = Route.useParams()
+  return <CreateFolderTemplatePolicyBindingPage folderName={folderName} />
+}
+
+export function CreateFolderTemplatePolicyBindingPage({
+  folderName: propFolderName,
+  forcedScopeType,
+}: {
+  folderName?: string
+  forcedScopeType?: BindingScope
+} = {}) {
+  let routeFolderName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeFolderName = Route.useParams().folderName
+  } catch {
+    routeFolderName = undefined
+  }
+  const folderName = propFolderName ?? routeFolderName ?? ''
+
+  const navigate = useNavigate()
+  const scope = makeFolderScope(folderName)
+  const createMutation = useCreateTemplatePolicyBinding(scope)
+  const { data: folder } = useGetFolder(folderName)
+
+  const orgName = folder?.organization ?? ''
+  const userRole = folder?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  const scopeType: BindingScope = forcedScopeType ?? 'folder'
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/orgs/$orgName/settings"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              {orgName}
+            </Link>
+            {' / '}
+            <Link
+              to="/orgs/$orgName/folders"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              Folders
+            </Link>
+            {' / '}
+            <Link
+              to="/folders/$folderName/settings"
+              params={{ folderName }}
+              className="hover:underline"
+            >
+              {folderName}
+            </Link>
+            {' / '}
+            <Link
+              to="/folders/$folderName/template-policy-bindings"
+              params={{ folderName }}
+              className="hover:underline"
+            >
+              Template Policy Bindings
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">
+            Create Template Policy Binding
+          </CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <BindingForm
+          mode="create"
+          scopeType={scopeType}
+          scopeRef={scope}
+          organization={orgName}
+          canWrite={canWrite}
+          submitLabel="Create"
+          pendingLabel="Creating..."
+          isPending={createMutation.isPending}
+          onSubmit={async (values) => {
+            await createMutation.mutateAsync(values)
+            await navigate({
+              to: '/folders/$folderName/template-policy-bindings/$bindingName',
+              params: { folderName, bindingName: values.name },
+            })
+          }}
+          onCancel={() => {
+            void navigate({
+              to: '/folders/$folderName/template-policy-bindings',
+              params: { folderName },
+            })
+          }}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
@@ -404,6 +404,15 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
                 <span className="text-sm">Manage Organization Template Policies</span>
                 <ChevronRight className="h-4 w-4 text-muted-foreground" />
               </Link>
+              <Link
+                to="/orgs/$orgName/template-policy-bindings"
+                params={{ orgName }}
+                aria-label="Organization Template Policy Bindings"
+                className="flex items-center justify-between p-3 rounded-md border border-border hover:bg-muted transition-colors"
+              >
+                <span className="text-sm">Manage Organization Template Policy Bindings</span>
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              </Link>
             </div>
 
             {/* Danger Zone */}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/$bindingName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/$bindingName.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import {
+  useGetTemplatePolicyBinding,
+  useUpdateTemplatePolicyBinding,
+  useDeleteTemplatePolicyBinding,
+} from '@/queries/templatePolicyBindings'
+import { makeOrgScope } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+import {
+  BindingForm,
+  type BindingScope,
+} from '@/components/template-policy-bindings/BindingForm'
+import { bindingProtoToDraft } from '@/components/template-policy-bindings/binding-draft'
+
+export const Route = createFileRoute(
+  '/_authenticated/orgs/$orgName/template-policy-bindings/$bindingName',
+)({
+  component: OrgTemplatePolicyBindingDetailRoute,
+})
+
+function OrgTemplatePolicyBindingDetailRoute() {
+  const { orgName, bindingName } = Route.useParams()
+  return (
+    <OrgTemplatePolicyBindingDetailPage
+      orgName={orgName}
+      bindingName={bindingName}
+    />
+  )
+}
+
+export function OrgTemplatePolicyBindingDetailPage({
+  orgName: propOrgName,
+  bindingName: propBindingName,
+  forcedScopeType,
+}: {
+  orgName?: string
+  bindingName?: string
+  forcedScopeType?: BindingScope
+} = {}) {
+  let routeParams: { orgName?: string; bindingName?: string } = {}
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeParams = Route.useParams()
+  } catch {
+    routeParams = {}
+  }
+  const orgName = propOrgName ?? routeParams.orgName ?? ''
+  const bindingName = propBindingName ?? routeParams.bindingName ?? ''
+
+  const navigate = useNavigate()
+  const scope = makeOrgScope(orgName)
+  const { data: org } = useGetOrganization(orgName)
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  // PERMISSION_TEMPLATE_POLICIES_DELETE is OWNER-only in the RBAC cascade;
+  // bindings reuse the policy permission family so the same constraint
+  // applies.
+  const canDelete = userRole === Role.OWNER
+
+  const scopeType: BindingScope = forcedScopeType ?? 'organization'
+
+  const {
+    data: binding,
+    isPending,
+    error,
+  } = useGetTemplatePolicyBinding(scope, bindingName)
+  const updateMutation = useUpdateTemplatePolicyBinding(scope, bindingName)
+  const deleteMutation = useDeleteTemplatePolicyBinding(scope)
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const initialValues = useMemo(() => {
+    if (!binding) return undefined
+    return bindingProtoToDraft(binding)
+  }, [binding])
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                to="/orgs/$orgName/settings"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                {orgName}
+              </Link>
+              {' / '}
+              <Link
+                to="/orgs/$orgName/template-policy-bindings"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                Template Policy Bindings
+              </Link>
+              {' / '}
+              <span>{bindingName}</span>
+            </p>
+            <CardTitle className="mt-1">
+              {binding?.displayName || bindingName}
+            </CardTitle>
+          </div>
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+              aria-label="Delete binding"
+            >
+              Delete Binding
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <Separator className="mb-4" />
+          <BindingForm
+            mode="edit"
+            scopeType={scopeType}
+            scopeRef={scope}
+            organization={orgName}
+            canWrite={canWrite}
+            initialValues={initialValues}
+            lockName
+            submitLabel="Save"
+            pendingLabel="Saving..."
+            isPending={updateMutation.isPending}
+            onSubmit={async (values) => {
+              await updateMutation.mutateAsync(values)
+              toast.success('Binding saved')
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/orgs/$orgName/template-policy-bindings',
+                params: { orgName },
+              })
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Template Policy Binding</DialogTitle>
+            <DialogDescription>
+              This will permanently delete the binding &quot;{bindingName}
+              &quot;. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={async () => {
+                try {
+                  await deleteMutation.mutateAsync({ name: bindingName })
+                  setDeleteOpen(false)
+                  await navigate({
+                    to: '/orgs/$orgName/template-policy-bindings',
+                    params: { orgName },
+                  })
+                  toast.success('Binding deleted')
+                } catch (err) {
+                  toast.error(err instanceof Error ? err.message : String(err))
+                }
+              }}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-detail.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org', bindingName: 'bind-a' }),
+    }),
+    useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      to,
+      params,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/queries/templatePolicyBindings')
+  >('@/queries/templatePolicyBindings')
+  return {
+    ...actual,
+    useGetTemplatePolicyBinding: vi.fn(),
+    useUpdateTemplatePolicyBinding: vi.fn(),
+    useDeleteTemplatePolicyBinding: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/templates', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templates')>(
+    '@/queries/templates',
+  )
+  return {
+    ...actual,
+    makeOrgScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-org' }),
+    useListTemplates: vi.fn().mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    }),
+  }
+})
+
+vi.mock('@/queries/templatePolicies', () => ({
+  useListTemplatePolicies: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useListProjects: vi.fn().mockReturnValue({
+    data: { projects: [] },
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/queries/deployments', () => ({
+  useListDeployments: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+import {
+  useGetTemplatePolicyBinding,
+  useUpdateTemplatePolicyBinding,
+  useDeleteTemplatePolicyBinding,
+  TemplatePolicyBindingTargetKind,
+} from '@/queries/templatePolicyBindings'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { OrgTemplatePolicyBindingDetailPage } from './$bindingName'
+
+function makeBinding() {
+  return {
+    name: 'bind-a',
+    displayName: 'Bind A',
+    description: 'Attach require-http to ingress',
+    creatorEmail: 'jane@example.com',
+    policyRef: {
+      scopeRef: { scope: 1, scopeName: 'test-org' },
+      name: 'require-http',
+    },
+    targetRefs: [
+      {
+        kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+        name: 'ingress',
+        projectName: 'proj-a',
+      },
+    ],
+  }
+}
+
+function setupMocks(
+  userRole: Role = Role.OWNER,
+  binding: ReturnType<typeof makeBinding> | undefined = makeBinding(),
+) {
+  ;(useGetTemplatePolicyBinding as Mock).mockReturnValue({
+    data: binding,
+    isPending: false,
+    error: null,
+  })
+  ;(useUpdateTemplatePolicyBinding as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useDeleteTemplatePolicyBinding as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('OrgTemplatePolicyBindingDetailPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('shows the Delete Binding button for OWNER', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplatePolicyBindingDetailPage
+        orgName="test-org"
+        bindingName="bind-a"
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: /delete binding/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Delete Binding button for EDITOR (DELETE is OWNER-only)', () => {
+    setupMocks(Role.EDITOR)
+    render(
+      <OrgTemplatePolicyBindingDetailPage
+        orgName="test-org"
+        bindingName="bind-a"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete binding/i }),
+    ).not.toBeInTheDocument()
+    // but form controls should be enabled
+    expect(screen.getByLabelText(/display name/i)).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  })
+
+  it('hides the Delete Binding button for VIEWER', () => {
+    setupMocks(Role.VIEWER)
+    render(
+      <OrgTemplatePolicyBindingDetailPage
+        orgName="test-org"
+        bindingName="bind-a"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete binding/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('seeds the form with initial values from the proto binding', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplatePolicyBindingDetailPage
+        orgName="test-org"
+        bindingName="bind-a"
+      />,
+    )
+    expect(screen.getByLabelText(/display name/i)).toHaveValue('Bind A')
+    expect(screen.getByLabelText(/^description$/i)).toHaveValue(
+      'Attach require-http to ingress',
+    )
+    // Name slug should be locked in edit mode.
+    expect(screen.getByLabelText(/name slug/i)).toBeDisabled()
+  })
+})

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-index.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org' }),
+    }),
+    Link: ({
+      children,
+      to,
+      params,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/queries/templatePolicyBindings')
+  >('@/queries/templatePolicyBindings')
+  return {
+    ...actual,
+    useListTemplatePolicyBindings: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/templates', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templates')>(
+    '@/queries/templates',
+  )
+  return {
+    ...actual,
+    makeOrgScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-org' }),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { OrgTemplatePolicyBindingsIndexPage } from './index'
+
+function makeBinding(
+  name: string,
+  options: {
+    description?: string
+    creatorEmail?: string
+    targets?: number
+    policyName?: string
+  } = {},
+) {
+  return {
+    name,
+    displayName: name,
+    description: options.description ?? '',
+    creatorEmail: options.creatorEmail ?? '',
+    policyRef: options.policyName
+      ? { scopeRef: { scope: 1, scopeName: 'test-org' }, name: options.policyName }
+      : undefined,
+    targetRefs: Array.from({ length: options.targets ?? 0 }, (_, i) => ({
+      kind: 1,
+      name: `t-${i}`,
+      projectName: 'proj-a',
+    })),
+  }
+}
+
+function setup(
+  userRole: Role = Role.OWNER,
+  bindings: ReturnType<typeof makeBinding>[] = [],
+) {
+  ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
+    data: bindings,
+    isPending: false,
+    error: null,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('OrgTemplatePolicyBindingsIndexPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders empty state when no bindings exist', () => {
+    setup(Role.OWNER, [])
+    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    expect(
+      screen.getByText(/no template policy bindings yet/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders populated list with target-count and policy badges', () => {
+    setup(Role.OWNER, [
+      makeBinding('bind-a', {
+        targets: 3,
+        policyName: 'require-http',
+        creatorEmail: 'jane@example.com',
+      }),
+      makeBinding('bind-b', { targets: 1, policyName: 'exclude-http' }),
+    ])
+    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+
+    expect(screen.getByText('bind-a')).toBeInTheDocument()
+    expect(screen.getByText('bind-b')).toBeInTheDocument()
+    expect(screen.getByText(/3 targets/)).toBeInTheDocument()
+    expect(screen.getByText(/1 target\b/)).toBeInTheDocument()
+    expect(screen.getByText(/policy: require-http/)).toBeInTheDocument()
+    expect(screen.getByText(/policy: exclude-http/)).toBeInTheDocument()
+    expect(screen.getByText(/Created by jane@example.com/)).toBeInTheDocument()
+  })
+
+  it('shows Create Binding for OWNER and EDITOR', () => {
+    setup(Role.OWNER, [])
+    const { unmount } = render(
+      <OrgTemplatePolicyBindingsIndexPage orgName="test-org" />,
+    )
+    expect(
+      screen.getByRole('link', { name: /create binding/i }),
+    ).toBeInTheDocument()
+    unmount()
+
+    setup(Role.EDITOR, [])
+    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    expect(
+      screen.getByRole('link', { name: /create binding/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides Create Binding for VIEWER', () => {
+    setup(Role.VIEWER, [])
+    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    expect(
+      screen.queryByRole('link', { name: /create binding/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('surfaces an error when the list query fails', () => {
+    ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      error: new Error('backend unreachable'),
+    })
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { name: 'test-org', userRole: Role.OWNER },
+      isPending: false,
+      error: null,
+    })
+    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    expect(screen.getByText('backend unreachable')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/index.tsx
@@ -1,0 +1,151 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import { Badge } from '@/components/ui/badge'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
+import { makeOrgScope } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+
+export const Route = createFileRoute(
+  '/_authenticated/orgs/$orgName/template-policy-bindings/',
+)({
+  component: OrgTemplatePolicyBindingsIndexRoute,
+})
+
+function OrgTemplatePolicyBindingsIndexRoute() {
+  const { orgName } = Route.useParams()
+  return <OrgTemplatePolicyBindingsIndexPage orgName={orgName} />
+}
+
+export function OrgTemplatePolicyBindingsIndexPage({
+  orgName: propOrgName,
+}: { orgName?: string } = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const scope = makeOrgScope(orgName)
+  const { data: bindings, isPending, error } = useListTemplatePolicyBindings(scope)
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  // PERMISSION_TEMPLATE_POLICIES_WRITE cascades to editors too (bindings reuse
+  // the policy permission family — see HOL-595).
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            {orgName} / Template Policy Bindings
+          </p>
+          <CardTitle className="mt-1">Template Policy Bindings</CardTitle>
+        </div>
+        {canWrite && (
+          <Link
+            to="/orgs/$orgName/template-policy-bindings/new"
+            params={{ orgName }}
+          >
+            <Button size="sm">Create Binding</Button>
+          </Link>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Bindings attach a single TemplatePolicy to an explicit list of project
+          templates and deployments. Every target is named directly — no glob
+          patterns. Bindings live only at folder or organization scope.
+        </p>
+        <Separator />
+        {bindings && bindings.length > 0 ? (
+          <ul className="space-y-2" data-testid="bindings-list">
+            {bindings.map((binding) => (
+              <li key={binding.name}>
+                <Link
+                  to="/orgs/$orgName/template-policy-bindings/$bindingName"
+                  params={{ orgName, bindingName: binding.name }}
+                  className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors border border-border"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium font-mono">
+                        {binding.name}
+                      </span>
+                      <Badge variant="outline" className="text-xs">
+                        {binding.targetRefs.length} target
+                        {binding.targetRefs.length === 1 ? '' : 's'}
+                      </Badge>
+                      {binding.policyRef?.name && (
+                        <Badge
+                          variant="outline"
+                          className="text-xs border-blue-500/30 text-blue-500"
+                        >
+                          policy: {binding.policyRef.name}
+                        </Badge>
+                      )}
+                    </div>
+                    {binding.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">
+                        {binding.description}
+                      </p>
+                    )}
+                    {binding.creatorEmail && (
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Created by {binding.creatorEmail}
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-md border border-dashed border-border p-6 text-center">
+            <p className="text-sm font-medium">
+              No template policy bindings yet.
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Bindings enumerate the explicit project templates and deployments
+              a TemplatePolicy applies to. Create a binding to attach a policy
+              to a specific target set in this organization.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/new.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/new.tsx
@@ -1,0 +1,103 @@
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplatePolicyBinding } from '@/queries/templatePolicyBindings'
+import { makeOrgScope } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+import {
+  BindingForm,
+  type BindingScope,
+} from '@/components/template-policy-bindings/BindingForm'
+
+export const Route = createFileRoute(
+  '/_authenticated/orgs/$orgName/template-policy-bindings/new',
+)({
+  component: CreateOrgTemplatePolicyBindingRoute,
+})
+
+function CreateOrgTemplatePolicyBindingRoute() {
+  const { orgName } = Route.useParams()
+  return <CreateOrgTemplatePolicyBindingPage orgName={orgName} />
+}
+
+export function CreateOrgTemplatePolicyBindingPage({
+  orgName: propOrgName,
+  forcedScopeType,
+}: {
+  orgName?: string
+  forcedScopeType?: BindingScope
+} = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const navigate = useNavigate()
+  const scope = makeOrgScope(orgName)
+  const createMutation = useCreateTemplatePolicyBinding(scope)
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  const scopeType: BindingScope = forcedScopeType ?? 'organization'
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/orgs/$orgName/settings"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              {orgName}
+            </Link>
+            {' / '}
+            <Link
+              to="/orgs/$orgName/template-policy-bindings"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              Template Policy Bindings
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">
+            Create Template Policy Binding
+          </CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <BindingForm
+          mode="create"
+          scopeType={scopeType}
+          scopeRef={scope}
+          organization={orgName}
+          canWrite={canWrite}
+          submitLabel="Create"
+          pendingLabel="Creating..."
+          isPending={createMutation.isPending}
+          onSubmit={async (values) => {
+            await createMutation.mutateAsync(values)
+            await navigate({
+              to: '/orgs/$orgName/template-policy-bindings/$bindingName',
+              params: { orgName, bindingName: values.name },
+            })
+          }}
+          onCancel={() => {
+            void navigate({
+              to: '/orgs/$orgName/template-policy-bindings',
+              params: { orgName },
+            })
+          }}
+        />
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds the admin-facing UI for creating, listing, editing, and deleting `TemplatePolicyBinding` resources under both organization and folder scopes — the non-glob successor to `TemplatePolicyRule.Target` introduced by HOL-590 / ADR 029.
- New query hook module `frontend/src/queries/templatePolicyBindings.ts` exposes `useListTemplatePolicyBindings`, `useGetTemplatePolicyBinding`, `useCreateTemplatePolicyBinding`, `useUpdateTemplatePolicyBinding`, `useDeleteTemplatePolicyBinding`, wrapping the generated `TemplatePolicyBindingServiceClient` with list-query invalidation on mutation.
- New shared components under `frontend/src/components/template-policy-bindings/`:
  - `BindingForm.tsx` — create/edit form with fields for name, displayName, description, a policy picker (`useListTemplatePolicies(scope)`), and a target-refs list. Enforces the same folder/org scope guard as `PolicyForm`.
  - `TargetRefEditor.tsx` — editable list of target refs with per-row Kind select, project Combobox, and a name Combobox sourced from `useListTemplates` (for `PROJECT_TEMPLATE`) or `useListDeployments` (for `DEPLOYMENT`).
  - `binding-draft.ts` — draft model and proto conversion helpers, matching the `rule-draft.ts` pattern.
- New TanStack Router routes under both `_authenticated/orgs/$orgName/template-policy-bindings/` and `_authenticated/folders/$folderName/template-policy-bindings/` (index, new, `$bindingName` detail), linked from the matching settings pages.
- 33 new Vitest + React Testing Library tests with `vi.mock()` applied to the query hooks (no real RPC). Includes a route-tree guard pinning that bindings never mount under `/projects` paths, mirroring the existing `template-policies` guard.

Existing glob inputs on the TemplatePolicy editor remain — their removal lands in HOL-598.

Fixes HOL-597

## Test plan

- [x] `cd frontend && npm test` passes (1094 tests, 73 files)
- [x] `cd frontend && npm run build` passes
- [x] `npm run lint` reports no new findings in `template-policy-bindings` files
- [ ] Manual smoke: create/edit/delete bindings at org and folder scope; confirm RBAC gates for OWNER/EDITOR/VIEWER

Generated with [Claude Code](https://claude.com/claude-code)