### PR TITLE
feat(frontend): remove glob inputs, link bindings from Policy detail

### DIFF
--- a/frontend/src/components/template-policies/PolicyBindingsSection.tsx
+++ b/frontend/src/components/template-policies/PolicyBindingsSection.tsx
@@ -1,0 +1,132 @@
+import { Link } from '@tanstack/react-router'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import type { TemplatePolicyBinding } from '@/queries/templatePolicyBindings'
+
+/**
+ * PolicyBindingsSection surfaces the TemplatePolicyBindings that attach the
+ * current policy to specific render targets.
+ *
+ * Per HOL-598, attachment is expressed exclusively through TemplatePolicyBinding
+ * (the glob Target fields on each rule were removed from the editor). The
+ * section calls `useListTemplatePolicyBindings(scope)` at the policy's own
+ * scope and filters client-side by `policyRef.name === policyName`. Each row
+ * links to the binding detail page so admins can jump from a policy to the
+ * bindings that reference it.
+ */
+export type PolicyBindingsSectionProps =
+  | {
+      scopeType: 'organization'
+      orgName: string
+      policyName: string
+      bindings: TemplatePolicyBinding[]
+      isPending: boolean
+      error: Error | null
+    }
+  | {
+      scopeType: 'folder'
+      folderName: string
+      policyName: string
+      bindings: TemplatePolicyBinding[]
+      isPending: boolean
+      error: Error | null
+    }
+
+export function PolicyBindingsSection(props: PolicyBindingsSectionProps) {
+  const { policyName, bindings, isPending, error } = props
+
+  const matched = bindings.filter(
+    (b) => b.policyRef?.name === policyName,
+  )
+
+  return (
+    <section className="space-y-3" aria-labelledby="policy-bindings-heading">
+      <div>
+        <h3
+          id="policy-bindings-heading"
+          className="text-base font-semibold"
+        >
+          Bindings
+        </h3>
+        <p className="text-xs text-muted-foreground mt-1">
+          TemplatePolicyBindings attach this policy to specific project
+          templates and deployments. Create a binding to apply the policy.
+        </p>
+      </div>
+
+      {isPending ? (
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+      ) : error ? (
+        <Alert variant="destructive" data-testid="policy-bindings-error">
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      ) : matched.length === 0 ? (
+        <div
+          data-testid="policy-bindings-empty"
+          className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground"
+        >
+          No bindings reference this policy yet. Create a binding from the
+          Template Policy Bindings page to attach it to specific targets.
+        </div>
+      ) : (
+        <ul className="space-y-2" data-testid="policy-bindings-list">
+          {matched.map((binding) => (
+            <li key={binding.name}>
+              {props.scopeType === 'organization' ? (
+                <Link
+                  to="/orgs/$orgName/template-policy-bindings/$bindingName"
+                  params={{
+                    orgName: props.orgName,
+                    bindingName: binding.name,
+                  }}
+                  className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors border border-border"
+                >
+                  <BindingRow binding={binding} />
+                </Link>
+              ) : (
+                <Link
+                  to="/folders/$folderName/template-policy-bindings/$bindingName"
+                  params={{
+                    folderName: props.folderName,
+                    bindingName: binding.name,
+                  }}
+                  className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors border border-border"
+                >
+                  <BindingRow binding={binding} />
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+function BindingRow({ binding }: { binding: TemplatePolicyBinding }) {
+  const targetCount = binding.targetRefs?.length ?? 0
+  return (
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-sm font-medium font-mono">{binding.name}</span>
+        <Badge variant="outline" className="text-xs">
+          {targetCount} target{targetCount === 1 ? '' : 's'}
+        </Badge>
+      </div>
+      {binding.displayName && binding.displayName !== binding.name && (
+        <p className="text-xs text-muted-foreground truncate mt-0.5">
+          {binding.displayName}
+        </p>
+      )}
+      {binding.description && (
+        <p className="text-xs text-muted-foreground truncate mt-0.5">
+          {binding.description}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/template-policies/PolicyForm.tsx
+++ b/frontend/src/components/template-policies/PolicyForm.tsx
@@ -139,9 +139,9 @@ export function PolicyForm({
   return (
     <div className="space-y-4">
       <div className="rounded-md border border-border p-3 text-sm text-muted-foreground">
-        Template policies apply to BOTH project templates and deployments. Rules use glob
-        patterns against project and deployment names. To require a template on every
-        project template and deployment, leave both patterns as <code>*</code>.
+        Template policies apply to both project templates and deployments. A policy is only
+        enforced where a TemplatePolicyBinding attaches it to specific render targets — see
+        the Bindings section on the policy detail page.
       </div>
 
       <div>

--- a/frontend/src/components/template-policies/RuleEditor.test.tsx
+++ b/frontend/src/components/template-policies/RuleEditor.test.tsx
@@ -9,17 +9,6 @@ import {
   EXCLUDE_RULE_DESCRIPTION,
 } from '@/components/platform-template-copy'
 
-// RED (HOL-588): The verbose REQUIRE/EXCLUDE copy previously rendered inside
-// each `<SelectItem>` and overflowed the popover. The tooltip on a button
-// trigger next to the Kind `<Label>` is now the single surface for that copy.
-// These tests pin:
-//
-//   1. Kind <SelectItem> rows render only the short `REQUIRE` / `EXCLUDE`
-//      label and do not carry any fragment of the long rule descriptions.
-//   2. A focusable `<button>` sits next to the Kind label with
-//      `aria-label="Explain REQUIRE and EXCLUDE"`, and its tooltip surfaces
-//      text from both REQUIRE_RULE_DESCRIPTION and EXCLUDE_RULE_DESCRIPTION.
-//
 // Polyfills for jsdom — Radix Select / Tooltip use pointer capture APIs that
 // are absent in jsdom and must exist for `userEvent` interactions to dispatch
 // cleanly. We also polyfill scrollIntoView (already installed globally by
@@ -39,8 +28,6 @@ function makeRule(overrides: Partial<RuleDraft> = {}): RuleDraft {
     kind: TemplatePolicyKind.REQUIRE,
     templateKey: '',
     versionConstraint: '',
-    projectPattern: '*',
-    deploymentPattern: '*',
     ...overrides,
   }
 }
@@ -114,5 +101,58 @@ describe('RuleEditor — Kind help tooltip (HOL-588)', () => {
     const tooltip = await screen.findByRole('tooltip')
     expect(tooltip).toHaveTextContent(REQUIRE_RULE_DESCRIPTION)
     expect(tooltip).toHaveTextContent(EXCLUDE_RULE_DESCRIPTION)
+  })
+})
+
+// HOL-598: Attachment is now expressed exclusively via TemplatePolicyBinding
+// rows. The glob pattern inputs on each rule have been removed so admins stop
+// authoring opaque globs. These tests pin the new contract: the RuleEditor
+// MUST NOT render a "Project pattern" or "Deployment pattern" input, and any
+// `projectPattern`/`deploymentPattern` field carried on a pre-existing rule is
+// ignored at render time.
+describe('RuleEditor — glob target inputs removed (HOL-598)', () => {
+  it('does not render Project pattern or Deployment pattern inputs', () => {
+    render(
+      <RuleEditor
+        rules={[makeRule()]}
+        onChange={vi.fn()}
+        linkableTemplates={[]}
+      />,
+    )
+
+    const row = screen.getByTestId('rule-editor-row-0')
+    expect(within(row).queryByLabelText(/project pattern/i)).toBeNull()
+    expect(within(row).queryByLabelText(/deployment pattern/i)).toBeNull()
+    expect(within(row).queryByText(/project pattern/i)).toBeNull()
+    expect(within(row).queryByText(/deployment pattern/i)).toBeNull()
+  })
+
+  it('does not emit a projectPattern/deploymentPattern when adding a new rule', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onChange = vi.fn<(rules: RuleDraft[]) => void>()
+
+    render(
+      <RuleEditor
+        rules={[]}
+        onChange={onChange}
+        linkableTemplates={[]}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /add rule/i }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const emitted = onChange.mock.calls[0][0]
+    expect(emitted).toHaveLength(1)
+    const draft = emitted[0] as Partial<RuleDraft> & {
+      projectPattern?: string
+      deploymentPattern?: string
+    }
+    // The RuleDraft shape is pruned; the add-rule handler must not introduce
+    // either glob field on the new draft.
+    expect(draft.projectPattern).toBeUndefined()
+    expect(draft.deploymentPattern).toBeUndefined()
   })
 })

--- a/frontend/src/components/template-policies/RuleEditor.tsx
+++ b/frontend/src/components/template-policies/RuleEditor.tsx
@@ -22,7 +22,7 @@ import { Trash2, Info, AlertTriangle } from 'lucide-react'
 import { TemplatePolicyKind } from '@/queries/templatePolicies'
 import { TemplateScope, linkableKey } from '@/queries/templates'
 import type { LinkableTemplate } from '@/queries/templates'
-import type { RuleDraft } from '@/components/template-policies/rule-draft'
+import { newEmptyRule, type RuleDraft } from '@/components/template-policies/rule-draft'
 import {
   REQUIRE_RULE_DESCRIPTION,
   EXCLUDE_RULE_DESCRIPTION,
@@ -81,13 +81,9 @@ export function RuleEditor({
   }
 
   const handleAdd = () => {
-    onChange([...rules, {
-      kind: TemplatePolicyKind.REQUIRE,
-      templateKey: '',
-      versionConstraint: '',
-      projectPattern: '*',
-      deploymentPattern: '*',
-    }])
+    // HOL-598: the draft no longer carries glob pattern fields; attachment is
+    // expressed exclusively via TemplatePolicyBinding.
+    onChange([...rules, newEmptyRule()])
   }
 
   return (
@@ -201,61 +197,14 @@ export function RuleEditor({
                   Semver range. Leave empty to always use the latest release.
                 </p>
               </div>
-
-              <div>
-                <Label htmlFor={`rule-project-pattern-${index}`} className="flex items-center gap-1">
-                  Project pattern
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-3.5 w-3.5 text-muted-foreground cursor-default" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>
-                          Glob pattern matched against both ProjectTemplate names (per-project)
-                          and the project name. Use <code>*</code> to match every project.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </Label>
-                <Input
-                  id={`rule-project-pattern-${index}`}
-                  aria-label={`Rule ${index + 1} project pattern`}
-                  placeholder="*"
-                  value={rule.projectPattern}
-                  onChange={(e) => handleUpdate(index, { projectPattern: e.target.value })}
-                  disabled={disabled}
-                />
-              </div>
-
-              <div>
-                <Label htmlFor={`rule-deployment-pattern-${index}`} className="flex items-center gap-1">
-                  Deployment pattern
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-3.5 w-3.5 text-muted-foreground cursor-default" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>
-                          Glob pattern matched against Deployment names within the matched
-                          projects. Use <code>*</code> to match every deployment, or leave empty
-                          to apply at project-level only.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </Label>
-                <Input
-                  id={`rule-deployment-pattern-${index}`}
-                  aria-label={`Rule ${index + 1} deployment pattern`}
-                  placeholder="*"
-                  value={rule.deploymentPattern}
-                  onChange={(e) => handleUpdate(index, { deploymentPattern: e.target.value })}
-                  disabled={disabled}
-                />
-              </div>
+              {/*
+               * HOL-598: the former "Project pattern" and "Deployment pattern"
+               * text inputs lived here. They authored opaque glob patterns on
+               * the rule's Target. Attachment is now expressed exclusively via
+               * TemplatePolicyBinding (see the Bindings section on the Policy
+               * detail page), so the inputs were removed. Newly created and
+               * edited rules submit with `target` unset.
+               */}
             </div>
 
             {isExclude && (

--- a/frontend/src/components/template-policies/rule-draft.test.ts
+++ b/frontend/src/components/template-policies/rule-draft.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import {
+  newEmptyRule,
+  ruleDraftToProto,
+  ruleProtoToDraft,
+  validateRuleDraft,
+  type RuleDraft,
+} from './rule-draft'
+import { TemplatePolicyKind } from '@/queries/templatePolicies'
+import { TemplateScope, linkableKey } from '@/queries/templates'
+
+// HOL-598: The rule draft is no longer a vehicle for glob Target authoring.
+// Attachment is expressed exclusively via TemplatePolicyBinding. These tests
+// pin the new contract: `newEmptyRule()` does not carry glob fields,
+// `ruleDraftToProto` emits a rule with `target` unset, `ruleProtoToDraft`
+// discards any legacy populated Target, and `validateRuleDraft` no longer
+// gates on glob patterns.
+describe('rule-draft (HOL-598)', () => {
+  describe('newEmptyRule', () => {
+    it('returns a draft with no glob pattern fields', () => {
+      const draft = newEmptyRule()
+      expect(draft).toEqual({
+        kind: TemplatePolicyKind.REQUIRE,
+        templateKey: '',
+        versionConstraint: '',
+      })
+      const extra = draft as Partial<RuleDraft> & {
+        projectPattern?: string
+        deploymentPattern?: string
+      }
+      expect(extra.projectPattern).toBeUndefined()
+      expect(extra.deploymentPattern).toBeUndefined()
+    })
+  })
+
+  describe('ruleDraftToProto', () => {
+    it('emits a proto rule with target unset', () => {
+      const draft: RuleDraft = {
+        kind: TemplatePolicyKind.REQUIRE,
+        templateKey: linkableKey(TemplateScope.ORGANIZATION, 'acme', 'httproute'),
+        versionConstraint: '^1.0.0',
+      }
+      const proto = ruleDraftToProto(draft)
+      expect(proto.kind).toBe(TemplatePolicyKind.REQUIRE)
+      expect(proto.template?.name).toBe('httproute')
+      expect(proto.template?.scopeName).toBe('acme')
+      expect(proto.template?.versionConstraint).toBe('^1.0.0')
+      // AC: target must be unset (or explicitly empty) on every new/edited rule.
+      expect(proto.target).toBeUndefined()
+    })
+
+    it('emits target unset even if a legacy projectPattern field is set on the draft', () => {
+      // Defensively accept legacy in-memory drafts that might still carry old
+      // fields and verify they are stripped at the proto conversion boundary.
+      const legacyDraft = {
+        kind: TemplatePolicyKind.EXCLUDE,
+        templateKey: linkableKey(TemplateScope.FOLDER, 'team-a', 'gateway'),
+        versionConstraint: '',
+        projectPattern: '*',
+        deploymentPattern: '*',
+      } as RuleDraft
+      const proto = ruleDraftToProto(legacyDraft)
+      expect(proto.target).toBeUndefined()
+    })
+  })
+
+  describe('ruleProtoToDraft', () => {
+    it('produces a draft with no glob pattern fields even when the proto Target was populated', () => {
+      // Cast through `unknown` so the test stays readable without hand-rolling
+      // the `$typeName` brand fields required by protobuf-es Message types.
+      const draft = ruleProtoToDraft({
+        kind: TemplatePolicyKind.REQUIRE,
+        template: {
+          scope: TemplateScope.ORGANIZATION,
+          scopeName: 'acme',
+          name: 'httproute',
+          versionConstraint: '',
+        },
+        target: {
+          projectPattern: 'legacy-*',
+          deploymentPattern: 'prod-*',
+        },
+      } as unknown as Parameters<typeof ruleProtoToDraft>[0])
+      expect(draft).toEqual({
+        kind: TemplatePolicyKind.REQUIRE,
+        templateKey: linkableKey(TemplateScope.ORGANIZATION, 'acme', 'httproute'),
+        versionConstraint: '',
+      })
+      const extra = draft as Partial<RuleDraft> & {
+        projectPattern?: string
+        deploymentPattern?: string
+      }
+      expect(extra.projectPattern).toBeUndefined()
+      expect(extra.deploymentPattern).toBeUndefined()
+    })
+  })
+
+  describe('validateRuleDraft', () => {
+    it('requires a template selection', () => {
+      const draft = newEmptyRule()
+      expect(validateRuleDraft(draft)).toMatch(/template/i)
+    })
+
+    it('passes when a template is selected and no glob fields exist', () => {
+      const draft: RuleDraft = {
+        kind: TemplatePolicyKind.REQUIRE,
+        templateKey: linkableKey(TemplateScope.ORGANIZATION, 'acme', 'httproute'),
+        versionConstraint: '',
+      }
+      expect(validateRuleDraft(draft)).toBeNull()
+    })
+  })
+})

--- a/frontend/src/components/template-policies/rule-draft.ts
+++ b/frontend/src/components/template-policies/rule-draft.ts
@@ -6,10 +6,7 @@ import {
   linkableKey,
   parseLinkableKey,
 } from '@/queries/templates'
-import {
-  TemplatePolicyRuleSchema,
-  TemplatePolicyTargetSchema,
-} from '@/gen/holos/console/v1/template_policies_pb.js'
+import { TemplatePolicyRuleSchema } from '@/gen/holos/console/v1/template_policies_pb.js'
 import { LinkedTemplateRefSchema } from '@/gen/holos/console/v1/policy_state_pb.js'
 
 /**
@@ -17,13 +14,16 @@ import { LinkedTemplateRefSchema } from '@/gen/holos/console/v1/policy_state_pb.
  * intentionally flatter than the proto TemplatePolicyRule message so inputs
  * can be bound to strings, and only gets converted into proto messages when
  * the form is submitted.
+ *
+ * HOL-598: the `projectPattern` and `deploymentPattern` glob fields were
+ * removed from the UI. Attachment is now expressed exclusively via
+ * TemplatePolicyBinding. The draft therefore no longer carries glob fields,
+ * and `ruleDraftToProto` emits a rule with `target` unset.
  */
 export type RuleDraft = {
   kind: TemplatePolicyKind
   templateKey: string // composite key built by linkableKey(...)
   versionConstraint: string
-  projectPattern: string
-  deploymentPattern: string
 }
 
 export function newEmptyRule(): RuleDraft {
@@ -31,12 +31,14 @@ export function newEmptyRule(): RuleDraft {
     kind: TemplatePolicyKind.REQUIRE,
     templateKey: '',
     versionConstraint: '',
-    projectPattern: '*',
-    deploymentPattern: '*',
   }
 }
 
-/** Convert a draft into a proto rule message suitable for submission. */
+/**
+ * Convert a draft into a proto rule message suitable for submission. The
+ * resulting rule has `target` unset — HOL-598 routes all attachment through
+ * TemplatePolicyBinding.
+ */
 export function ruleDraftToProto(draft: RuleDraft): TemplatePolicyRule {
   const { scope, scopeName, name } = parseLinkableKey(draft.templateKey)
   return create(TemplatePolicyRuleSchema, {
@@ -47,14 +49,16 @@ export function ruleDraftToProto(draft: RuleDraft): TemplatePolicyRule {
       name,
       versionConstraint: draft.versionConstraint,
     }),
-    target: create(TemplatePolicyTargetSchema, {
-      projectPattern: draft.projectPattern,
-      deploymentPattern: draft.deploymentPattern,
-    }),
+    // target is intentionally omitted. HOL-598 removed UI authoring of the
+    // glob Target fields; bindings now carry attachment exclusively.
   })
 }
 
-/** Convert a proto rule back into a draft for the editor. */
+/**
+ * Convert a proto rule back into a draft for the editor. Any legacy `target`
+ * field present on the server-side message is discarded — the editor cannot
+ * author globs, so the draft does not surface them.
+ */
 export function ruleProtoToDraft(rule: TemplatePolicyRule): RuleDraft {
   const tmpl = rule.template
   return {
@@ -63,33 +67,19 @@ export function ruleProtoToDraft(rule: TemplatePolicyRule): RuleDraft {
       ? linkableKey(tmpl.scope, tmpl.scopeName, tmpl.name)
       : '',
     versionConstraint: tmpl?.versionConstraint ?? '',
-    projectPattern: rule.target?.projectPattern ?? '',
-    deploymentPattern: rule.target?.deploymentPattern ?? '',
   }
 }
 
 /**
  * validateRuleDraft returns a human-readable error string when the draft is
  * not submittable, or null when it is valid for the client. The backend
- * performs authoritative validation (e.g. glob compilation, EXCLUDE-vs-linked
- * checks).
+ * performs authoritative validation (e.g. EXCLUDE-vs-linked checks). With
+ * HOL-598 the only client-side requirement is a selected template — glob
+ * patterns no longer exist in the draft.
  */
 export function validateRuleDraft(draft: RuleDraft): string | null {
   if (!draft.templateKey) {
     return 'Template selection is required.'
-  }
-  if (!draft.projectPattern) {
-    return 'Project pattern is required (use "*" to match every project).'
-  }
-  // filepath.Match uses "\" as an escape character. Detect unpaired escapes
-  // early so the user sees feedback before the backend round-trip.
-  const patterns = [draft.projectPattern, draft.deploymentPattern]
-  for (const p of patterns) {
-    if (!p) continue
-    // Reject bare backslash at end of string or unmatched brackets as common
-    // mistakes. Backend remains authoritative.
-    if (/\\$/.test(p)) return 'Invalid glob pattern: trailing backslash.'
-    if (/\[[^\]]*$/.test(p)) return 'Invalid glob pattern: unmatched "[".'
   }
   return null
 }

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policies/$policyName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policies/$policyName.tsx
@@ -22,11 +22,13 @@ import {
 } from '@/queries/templatePolicies'
 import { makeFolderScope } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import {
   PolicyForm,
   type PolicyScope,
 } from '@/components/template-policies/PolicyForm'
 import { ruleProtoToDraft } from '@/components/template-policies/rule-draft'
+import { PolicyBindingsSection } from '@/components/template-policies/PolicyBindingsSection'
 
 export const Route = createFileRoute(
   '/_authenticated/folders/$folderName/template-policies/$policyName',
@@ -80,6 +82,10 @@ export function FolderTemplatePolicyDetailPage({
   } = useGetTemplatePolicy(scope, policyName)
   const updateMutation = useUpdateTemplatePolicy(scope, policyName)
   const deleteMutation = useDeleteTemplatePolicy(scope)
+  // HOL-598: list folder-scope bindings and filter to those referencing this
+  // policy by name. Folder-scope bindings live in the same namespace as the
+  // folder-scope policy itself; binding detail links target the folder route.
+  const bindingsQuery = useListTemplatePolicyBindings(scope)
 
   const [deleteOpen, setDeleteOpen] = useState(false)
 
@@ -184,6 +190,15 @@ export function FolderTemplatePolicyDetailPage({
                 params: { folderName },
               })
             }}
+          />
+          <Separator className="my-6" />
+          <PolicyBindingsSection
+            scopeType="folder"
+            folderName={folderName}
+            policyName={policyName}
+            bindings={bindingsQuery.data ?? []}
+            isPending={bindingsQuery.isPending}
+            error={bindingsQuery.error}
           />
         </CardContent>
       </Card>

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policies/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policies/-detail.test.tsx
@@ -57,12 +57,23 @@ vi.mock('@/queries/folders', () => ({
   useGetFolder: vi.fn(),
 }))
 
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/queries/templatePolicyBindings')
+  >('@/queries/templatePolicyBindings')
+  return {
+    ...actual,
+    useListTemplatePolicyBindings: vi.fn(),
+  }
+})
+
 import {
   useGetTemplatePolicy,
   useUpdateTemplatePolicy,
   useDeleteTemplatePolicy,
   TemplatePolicyKind,
 } from '@/queries/templatePolicies'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import { useGetFolder } from '@/queries/folders'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { FolderTemplatePolicyDetailPage } from './$policyName'
@@ -91,6 +102,13 @@ function makeMockPolicy() {
 function setupMocks(
   userRole: Role = Role.OWNER,
   policy: ReturnType<typeof makeMockPolicy> | undefined = makeMockPolicy(),
+  bindings: Array<{
+    name: string
+    displayName?: string
+    description?: string
+    policyRef?: { name: string; scopeRef?: { scope: number; scopeName: string } }
+    targetRefs?: Array<{ kind?: number; name: string; projectName?: string }>
+  }> = [],
 ) {
   ;(useGetTemplatePolicy as Mock).mockReturnValue({
     data: policy,
@@ -107,6 +125,11 @@ function setupMocks(
   })
   ;(useGetFolder as Mock).mockReturnValue({
     data: { name: 'test-folder', organization: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
+    data: bindings,
     isPending: false,
     error: null,
   })
@@ -158,5 +181,79 @@ describe('FolderTemplatePolicyDetailPage', () => {
     expect(screen.queryByRole('button', { name: /delete policy/i })).not.toBeInTheDocument()
     expect(screen.getByLabelText(/display name/i)).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  })
+
+  // HOL-598: folder-scope policies must surface matching folder-scope bindings
+  // via useListTemplatePolicyBindings(folderScope) + client-side name filter.
+  describe('Bindings section (HOL-598)', () => {
+    it('renders a Bindings heading and an empty-state message when no bindings reference the policy', () => {
+      setupMocks(Role.OWNER, makeMockPolicy(), [])
+      render(
+        <FolderTemplatePolicyDetailPage folderName="test-folder" policyName="policy-a" />,
+      )
+      expect(
+        screen.getByRole('heading', { name: /^bindings$/i }),
+      ).toBeInTheDocument()
+      expect(screen.getByTestId('policy-bindings-empty')).toBeInTheDocument()
+    })
+
+    it('lists only bindings whose policyRef.name matches this policy', () => {
+      const bindings = [
+        {
+          name: 'binding-for-policy-a',
+          displayName: 'Binding for policy-a',
+          policyRef: {
+            name: 'policy-a',
+            scopeRef: { scope: 2, scopeName: 'test-folder' },
+          },
+          targetRefs: [{ kind: 1, name: 'project-template', projectName: 'frontend' }],
+        },
+        {
+          name: 'binding-for-other',
+          policyRef: {
+            name: 'other-policy',
+            scopeRef: { scope: 2, scopeName: 'test-folder' },
+          },
+          targetRefs: [],
+        },
+      ]
+      setupMocks(Role.OWNER, makeMockPolicy(), bindings)
+      render(
+        <FolderTemplatePolicyDetailPage folderName="test-folder" policyName="policy-a" />,
+      )
+
+      const list = screen.getByTestId('policy-bindings-list')
+      expect(list).toBeInTheDocument()
+      expect(list).toHaveTextContent('binding-for-policy-a')
+      expect(list).not.toHaveTextContent('binding-for-other')
+    })
+
+    it('links each row to the folder binding detail route', () => {
+      const bindings = [
+        {
+          name: 'binding-for-policy-a',
+          policyRef: {
+            name: 'policy-a',
+            scopeRef: { scope: 2, scopeName: 'test-folder' },
+          },
+          targetRefs: [] as Array<{ kind?: number; name: string; projectName?: string }>,
+        },
+      ]
+      setupMocks(Role.OWNER, makeMockPolicy(), bindings)
+      render(
+        <FolderTemplatePolicyDetailPage folderName="test-folder" policyName="policy-a" />,
+      )
+
+      const link = screen.getByRole('link', { name: /binding-for-policy-a/i })
+      expect(link).toHaveAttribute(
+        'href',
+        '/folders/$folderName/template-policy-bindings/$bindingName',
+      )
+      const params = JSON.parse(link.getAttribute('data-params') ?? '{}')
+      expect(params).toEqual({
+        folderName: 'test-folder',
+        bindingName: 'binding-for-policy-a',
+      })
+    })
   })
 })

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policies/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policies/-new.test.tsx
@@ -122,17 +122,18 @@ describe('CreateFolderTemplatePolicyPage', () => {
     expect(screen.getByText(/create template policy/i)).toBeInTheDocument()
   })
 
-  it('explains the `*` pattern convention and dual project/deployment scope', () => {
+  // HOL-598: the form header no longer documents glob patterns. It now
+  // redirects admins to TemplatePolicyBinding for attachment.
+  it('explains that attachment is expressed via TemplatePolicyBinding', () => {
     render(<CreateFolderTemplatePolicyPage folderName="test-folder" />)
-    // Form copy must explicitly cover the mandatory-flag removal guidance.
-    expect(
-      screen.getByText(
-        /leave both patterns as/i,
-      ),
-    ).toBeInTheDocument()
     expect(
       screen.getByText(/apply to both project templates and deployments/i),
     ).toBeInTheDocument()
+    expect(
+      screen.getByText(/templatepolicybinding/i),
+    ).toBeInTheDocument()
+    // The old `*`-pattern copy is gone with the glob inputs.
+    expect(screen.queryByText(/leave both patterns as/i)).toBeNull()
   })
 
   it('rejects submission when the policy has no name', async () => {
@@ -162,27 +163,16 @@ describe('CreateFolderTemplatePolicyPage', () => {
     expect(mutateAsync).not.toHaveBeenCalled()
   })
 
-  it('rejects glob patterns with trailing backslash with an inline error', async () => {
-    const mutateAsync = vi.fn().mockResolvedValue({ name: '' })
-    setupMocks(mutateAsync)
+  // HOL-598: The "Project pattern" and "Deployment pattern" inputs were
+  // removed from the rule editor. This test replaces the old
+  // trailing-backslash check by pinning that neither label exists anymore.
+  it('does not render glob pattern inputs on each rule', () => {
+    setupMocks()
     render(<CreateFolderTemplatePolicyPage folderName="test-folder" />)
 
-    fireEvent.change(screen.getByLabelText(/display name/i), {
-      target: { value: 'Bad Pattern' },
-    })
-    // Simulate a selected template so the next validator fires.
     const firstRow = screen.getByTestId('rule-editor-row-0')
-    const pattern = within(firstRow).getByLabelText(/project pattern/i)
-    fireEvent.change(pattern, { target: { value: 'foo\\' } })
-
-    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
-    await waitFor(() => {
-      // Template selection is still required, so that error fires first.
-      expect(
-        screen.getByText(/template selection is required|trailing backslash/i),
-      ).toBeInTheDocument()
-    })
-    expect(mutateAsync).not.toHaveBeenCalled()
+    expect(within(firstRow).queryByLabelText(/project pattern/i)).toBeNull()
+    expect(within(firstRow).queryByLabelText(/deployment pattern/i)).toBeNull()
   })
 
   it('disables the Create button for VIEWER role', () => {
@@ -253,6 +243,43 @@ describe('CreateFolderTemplatePolicyPage', () => {
       expect.objectContaining({ scope: 2, scopeName: 'test-folder' }),
       expect.objectContaining({ includeSelfScope: true }),
     )
+  })
+
+  // HOL-598: the submit payload must carry rules with no `target` field. The
+  // proto converter (rule-draft.ts:ruleDraftToProto) omits Target entirely;
+  // this test exercises the full PolicyForm -> mutation path.
+  it('submits rules without a Target field', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({ name: 'require-folder-gateway' })
+    setupMocks(mutateAsync)
+    render(<CreateFolderTemplatePolicyPage folderName="test-folder" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'Require FolderGateway' },
+    })
+    // Select the folder-scope template from the Combobox. The options use
+    // the generated linkable key as value; fire the change directly on the
+    // hidden input the Combobox wraps to avoid pointer-event gymnastics.
+    const firstRow = screen.getByTestId('rule-editor-row-0')
+    const trigger = within(firstRow).getByRole('combobox', {
+      name: /rule 1 template/i,
+    })
+    fireEvent.click(trigger)
+    // Pick the folder-scope template by its rendered label.
+    const folderOption = await screen.findByText(
+      /folder \/ test-folder \/ folder-gateway/,
+    )
+    fireEvent.click(folderOption)
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(1)
+    })
+    const payload = mutateAsync.mock.calls[0][0] as {
+      rules: Array<{ target?: unknown }>
+    }
+    expect(payload.rules).toHaveLength(1)
+    expect(payload.rules[0].target).toBeUndefined()
   })
 
   it('shows both same-scope and ancestor templates in the rule template picker', async () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/$policyName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/$policyName.tsx
@@ -22,11 +22,13 @@ import {
 } from '@/queries/templatePolicies'
 import { makeOrgScope } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import {
   PolicyForm,
   type PolicyScope,
 } from '@/components/template-policies/PolicyForm'
 import { ruleProtoToDraft } from '@/components/template-policies/rule-draft'
+import { PolicyBindingsSection } from '@/components/template-policies/PolicyBindingsSection'
 
 export const Route = createFileRoute(
   '/_authenticated/orgs/$orgName/template-policies/$policyName',
@@ -77,6 +79,10 @@ export function OrgTemplatePolicyDetailPage({
   } = useGetTemplatePolicy(scope, policyName)
   const updateMutation = useUpdateTemplatePolicy(scope, policyName)
   const deleteMutation = useDeleteTemplatePolicy(scope)
+  // HOL-598: surface TemplatePolicyBindings that reference this policy. The
+  // list RPC returns every binding at the org scope; the section filters to
+  // ones whose `policyRef.name` matches the current policy.
+  const bindingsQuery = useListTemplatePolicyBindings(scope)
 
   const [deleteOpen, setDeleteOpen] = useState(false)
 
@@ -169,6 +175,15 @@ export function OrgTemplatePolicyDetailPage({
                 params: { orgName },
               })
             }}
+          />
+          <Separator className="my-6" />
+          <PolicyBindingsSection
+            scopeType="organization"
+            orgName={orgName}
+            policyName={policyName}
+            bindings={bindingsQuery.data ?? []}
+            isPending={bindingsQuery.isPending}
+            error={bindingsQuery.error}
           />
         </CardContent>
       </Card>

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-detail.test.tsx
@@ -57,12 +57,23 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/queries/templatePolicyBindings')
+  >('@/queries/templatePolicyBindings')
+  return {
+    ...actual,
+    useListTemplatePolicyBindings: vi.fn(),
+  }
+})
+
 import {
   useGetTemplatePolicy,
   useUpdateTemplatePolicy,
   useDeleteTemplatePolicy,
   TemplatePolicyKind,
 } from '@/queries/templatePolicies'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { OrgTemplatePolicyDetailPage } from './$policyName'
@@ -91,6 +102,13 @@ function makeMockPolicy() {
 function setupMocks(
   userRole: Role = Role.OWNER,
   policy: ReturnType<typeof makeMockPolicy> | undefined = makeMockPolicy(),
+  bindings: Array<{
+    name: string
+    displayName?: string
+    description?: string
+    policyRef?: { name: string; scopeRef?: { scope: number; scopeName: string } }
+    targetRefs?: Array<{ kind?: number; name: string; projectName?: string }>
+  }> = [],
 ) {
   ;(useGetTemplatePolicy as Mock).mockReturnValue({
     data: policy,
@@ -107,6 +125,11 @@ function setupMocks(
   })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
+    data: bindings,
     isPending: false,
     error: null,
   })
@@ -139,5 +162,82 @@ describe('OrgTemplatePolicyDetailPage', () => {
     expect(screen.queryByRole('button', { name: /delete policy/i })).not.toBeInTheDocument()
     expect(screen.getByLabelText(/display name/i)).not.toBeDisabled()
     expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  })
+
+  // HOL-598: the Policy detail page must surface the bindings that attach
+  // this policy to specific render targets. The section is implemented via
+  // useListTemplatePolicyBindings(scope) + client-side filter on
+  // policyRef.name === policyName.
+  describe('Bindings section (HOL-598)', () => {
+    it('renders a Bindings heading and an empty-state message when no bindings reference the policy', () => {
+      setupMocks(Role.OWNER, makeMockPolicy(), [])
+      render(<OrgTemplatePolicyDetailPage orgName="test-org" policyName="policy-a" />)
+      expect(
+        screen.getByRole('heading', { name: /^bindings$/i }),
+      ).toBeInTheDocument()
+      expect(screen.getByTestId('policy-bindings-empty')).toBeInTheDocument()
+    })
+
+    it('lists only bindings whose policyRef.name matches this policy', () => {
+      const bindings = [
+        {
+          name: 'binding-for-policy-a',
+          displayName: 'Binding for policy-a',
+          description: 'attaches policy-a to api deployments',
+          policyRef: {
+            name: 'policy-a',
+            scopeRef: { scope: 1, scopeName: 'test-org' },
+          },
+          targetRefs: [
+            { kind: 2, name: 'api', projectName: 'frontend' },
+            { kind: 2, name: 'worker', projectName: 'frontend' },
+          ],
+        },
+        {
+          name: 'binding-for-policy-b',
+          displayName: 'Unrelated binding',
+          policyRef: {
+            name: 'policy-b',
+            scopeRef: { scope: 1, scopeName: 'test-org' },
+          },
+          targetRefs: [{ kind: 2, name: 'api', projectName: 'frontend' }],
+        },
+      ]
+      setupMocks(Role.OWNER, makeMockPolicy(), bindings)
+      render(<OrgTemplatePolicyDetailPage orgName="test-org" policyName="policy-a" />)
+
+      const list = screen.getByTestId('policy-bindings-list')
+      expect(list).toBeInTheDocument()
+      expect(list).toHaveTextContent('binding-for-policy-a')
+      expect(list).not.toHaveTextContent('binding-for-policy-b')
+    })
+
+    it('links each row to the binding detail route', () => {
+      const bindings = [
+        {
+          name: 'binding-for-policy-a',
+          policyRef: {
+            name: 'policy-a',
+            scopeRef: { scope: 1, scopeName: 'test-org' },
+          },
+          targetRefs: [] as Array<{ kind?: number; name: string; projectName?: string }>,
+        },
+      ]
+      setupMocks(Role.OWNER, makeMockPolicy(), bindings)
+      render(<OrgTemplatePolicyDetailPage orgName="test-org" policyName="policy-a" />)
+
+      const link = screen.getByRole('link', { name: /binding-for-policy-a/i })
+      // The Link mock at the top of this file exposes the `to` template as
+      // href, so we can assert the route shape without running the router.
+      expect(link).toHaveAttribute(
+        'href',
+        '/orgs/$orgName/template-policy-bindings/$bindingName',
+      )
+      const params = JSON.parse(link.getAttribute('data-params') ?? '{}')
+      expect(params).toEqual({
+        orgName: 'test-org',
+        bindingName: 'binding-for-policy-a',
+      })
+    })
   })
 })


### PR DESCRIPTION
## Summary
- RuleEditor no longer renders the `project_pattern` / `deployment_pattern` glob inputs; add-rule emits drafts with no glob fields.
- `rule-draft.ts` drops `projectPattern`/`deploymentPattern` from `RuleDraft`; `ruleDraftToProto` submits every rule with `target` unset and `ruleProtoToDraft` discards any legacy populated Target.
- Policy detail pages (org + folder) gain a "Bindings" section (new `PolicyBindingsSection`) that lists every `TemplatePolicyBinding` at the policy's scope whose `policyRef.name` matches, via `useListTemplatePolicyBindings(scope)` + a client-side filter. Each row links to the binding detail route.
- PolicyForm header copy updated to point at `TemplatePolicyBinding` for attachment.
- Tests: `RuleEditor.test`, new `rule-draft.test`, org + folder detail tests, and `-new.test` pin the new contract with `vi.mock()` on the query hooks.

Pre-existing populated Target fields continue to evaluate via the resolver (HOL-596) until HOL-599 migrates them into bindings and HOL-600 removes the legacy path.

Fixes HOL-598

## Test plan
- [x] `cd frontend && npm test` (1128 passing)
- [x] `cd frontend && npm run build`
- [x] `make test-go`
- [ ] Manual smoke: open a Policy detail page and confirm the Rule rows no longer show pattern inputs and the Bindings section lists matching bindings.

Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)