### PR TITLE
feat(cli): migrate TemplatePolicyRule.Target globs to bindings (HOL-599)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,9 +208,9 @@ See [docs/dev-token-endpoint.md](docs/dev-token-endpoint.md) for the full API re
 
 ## Migrations
 
-Operator-facing migration runbooks live in [docs/migrations/](../docs/migrations/). Each `holos-console migrate <subcommand>` shipped with a runbook under that path; re-read the matching file before running a migration in production.
+Operator-facing migration runbooks live in [docs/migrations/](docs/migrations/). Each `holos-console migrate <subcommand>` shipped with a runbook under that path; re-read the matching file before running a migration in production.
 
-- [`docs/migrations/hol-590-template-policy-bindings.md`](../docs/migrations/hol-590-template-policy-bindings.md) — translate legacy `TemplatePolicyRule.Target` globs into `TemplatePolicyBinding` objects before HOL-600 removes the glob evaluation path.
+- [`docs/migrations/hol-590-template-policy-bindings.md`](docs/migrations/hol-590-template-policy-bindings.md) — translate legacy `TemplatePolicyRule.Target` globs into `TemplatePolicyBinding` objects before HOL-600 removes the glob evaluation path.
 
 ## Annotation Keys for External Links
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,12 @@ curl -s --cacert "$(mkcert -CAROOT)/rootCA.pem" \
 
 See [docs/dev-token-endpoint.md](docs/dev-token-endpoint.md) for the full API reference.
 
+## Migrations
+
+Operator-facing migration runbooks live in [docs/migrations/](../docs/migrations/). Each `holos-console migrate <subcommand>` shipped with a runbook under that path; re-read the matching file before running a migration in production.
+
+- [`docs/migrations/hol-590-template-policy-bindings.md`](../docs/migrations/hol-590-template-policy-bindings.md) — translate legacy `TemplatePolicyRule.Target` globs into `TemplatePolicyBinding` objects before HOL-600 removes the glob evaluation path.
+
 ## Annotation Keys for External Links
 
 When working in `console/deployments/` or `console/links/`, refer to

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -106,6 +106,12 @@ func Command() *cobra.Command {
 	cmd.Flags().BoolVar(&logHealthChecks, "log-health-checks", false, "Log /healthz and /readyz requests (suppressed by default)")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 
+	// Subcommands. Migration commands run against the same cluster the
+	// server would otherwise serve; they reuse the namespace-prefix flags
+	// above so a cluster configured with non-default prefixes is walked
+	// correctly without re-declaring them on every subcommand.
+	cmd.AddCommand(newMigrateCommand())
+
 	return cmd
 }
 

--- a/cli/migrate_template_policy_targets.go
+++ b/cli/migrate_template_policy_targets.go
@@ -241,6 +241,14 @@ func MigrateTemplatePolicyTargets(ctx context.Context, opts MigrateTemplatePolic
 	// fail-open contract on a single per-namespace list error (log and
 	// continue) that matches the K8sClient.ListPoliciesInNamespace shape
 	// used at runtime.
+	//
+	// Every count that the summary line reports — BindingsCreated,
+	// PoliciesUpdated, Conflicts, Skipped — is tallied here during
+	// planning, BEFORE any mutation runs. That way the dry-run preview
+	// matches what --apply would produce, which is what an operator
+	// looks for when deciding whether to re-run with --apply. The
+	// apply loop below only mutates the cluster; it never touches the
+	// counters.
 	result := &MigrationResult{}
 	for _, ns := range classified.policyBearing {
 		cms, err := listPoliciesInNamespace(ctx, opts.Client, ns.Name)
@@ -261,6 +269,23 @@ func MigrateTemplatePolicyTargets(ctx context.Context, opts MigrateTemplatePolic
 				continue
 			}
 			result.Plans = append(result.Plans, plan)
+			switch {
+			case plan.BindingExists && !plan.BindingTargetsMatch:
+				// An existing binding with a different target
+				// set — or a non-binding ConfigMap that
+				// collided on the synthesized name — is a
+				// conflict that only an operator can resolve.
+				// The apply loop leaves both the policy and
+				// the offending object untouched.
+				result.Conflicts++
+			default:
+				if !plan.BindingExists && !plan.EmptyTargets {
+					result.BindingsCreated++
+				}
+				if plan.ClearPolicyTargets {
+					result.PoliciesUpdated++
+				}
+			}
 		}
 	}
 
@@ -279,13 +304,6 @@ func MigrateTemplatePolicyTargets(ctx context.Context, opts MigrateTemplatePolic
 	// existing binding is detected and re-used next time.
 	for _, plan := range result.Plans {
 		if plan.BindingExists && !plan.BindingTargetsMatch {
-			// Existing binding with different target set — an
-			// operator must decide whether to delete the binding
-			// or keep the policy globs. We leave everything
-			// untouched in that case, including the policy's
-			// Target globs, so the next dry-run reproduces the
-			// same conflict until the operator intervenes.
-			result.Conflicts++
 			continue
 		}
 		if !plan.BindingExists && !plan.EmptyTargets {
@@ -293,14 +311,12 @@ func MigrateTemplatePolicyTargets(ctx context.Context, opts MigrateTemplatePolic
 				return result, fmt.Errorf("creating binding %q in %q: %w",
 					plan.BindingName, plan.PolicyNamespace, err)
 			}
-			result.BindingsCreated++
 		}
 		if plan.ClearPolicyTargets {
 			if err := clearPolicyTargets(ctx, opts.Client, plan); err != nil {
 				return result, fmt.Errorf("clearing targets on policy %q in %q: %w",
 					plan.PolicyName, plan.PolicyNamespace, err)
 			}
-			result.PoliciesUpdated++
 		}
 	}
 

--- a/cli/migrate_template_policy_targets.go
+++ b/cli/migrate_template_policy_targets.go
@@ -1,0 +1,1052 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/secrets"
+	"github.com/holos-run/holos-console/console/templatepolicies"
+	"github.com/holos-run/holos-console/console/templatepolicybindings"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// migrateBindingNameSuffix is appended to the policy name to derive the
+// TemplatePolicyBinding name produced by the migration. Keeping the suffix
+// deterministic is what makes the migration idempotent: re-running the
+// command finds the existing binding by name and leaves it alone.
+const migrateBindingNameSuffix = "-migrated"
+
+// newMigrateCommand returns the `holos-console migrate` parent command
+// grouping every migration subcommand in the tree.
+func newMigrateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Run in-place migrations against TemplatePolicy and related resources",
+		Long: "migrate groups one-shot migration commands that translate older " +
+			"TemplatePolicy storage shapes into the shapes expected by the " +
+			"current console. Each subcommand is idempotent and defaults to " +
+			"--dry-run; pass --apply to mutate cluster state.",
+	}
+	cmd.AddCommand(newMigrateTemplatePolicyTargetsCommand())
+	return cmd
+}
+
+// newMigrateTemplatePolicyTargetsCommand returns the `migrate
+// template-policy-targets` subcommand. The subcommand translates populated
+// TemplatePolicyRule.Target globs into TemplatePolicyBinding objects as a
+// prerequisite for HOL-600 (removal of the legacy glob evaluation path).
+func newMigrateTemplatePolicyTargetsCommand() *cobra.Command {
+	var apply bool
+	cmd := &cobra.Command{
+		Use:   "template-policy-targets",
+		Short: "Translate TemplatePolicyRule.Target globs into TemplatePolicyBindings",
+		Long: "template-policy-targets iterates every TemplatePolicy in the " +
+			"cluster, enumerates the concrete render targets that each rule's " +
+			"globs currently match (projects, project-scope templates, and " +
+			"deployments), and creates a TemplatePolicyBinding per policy " +
+			"with the union of those targets. After a binding lands, the " +
+			"policy's rule-level Target globs are cleared on the next Update " +
+			"so HOL-600 can remove the legacy evaluation path without " +
+			"surprise.\n\n" +
+			"The command is idempotent: re-running it produces no new bindings " +
+			"when the target sets have not changed, and a policy whose Target " +
+			"globs are already empty is skipped entirely.\n\n" +
+			"--dry-run is the default. Pass --apply to write bindings and " +
+			"clear the Target fields on the originating policies.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := secrets.NewClientset()
+			if err != nil {
+				return fmt.Errorf("building kubernetes client: %w", err)
+			}
+			if client == nil {
+				return fmt.Errorf("no kubernetes config available; set KUBECONFIG or run inside the cluster")
+			}
+			r := newResolverFromFlags()
+			opts := MigrateTemplatePolicyTargetsOptions{
+				Client:   client,
+				Resolver: r,
+				Apply:    apply,
+				Out:      cmd.OutOrStdout(),
+			}
+			res, err := MigrateTemplatePolicyTargets(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+			printMigrationSummary(cmd.OutOrStdout(), res, apply)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "Apply changes (default dry-run prints the plan without mutating state)")
+	return cmd
+}
+
+// newResolverFromFlags builds a namespace resolver from the root command's
+// global prefix flags. The migration command runs inside the same process
+// the server uses at runtime, so the flags are already parsed into the
+// package-level variables by the time this helper is invoked.
+func newResolverFromFlags() *resolver.Resolver {
+	return &resolver.Resolver{
+		NamespacePrefix:    namespacePrefix,
+		OrganizationPrefix: organizationPrefix,
+		FolderPrefix:       folderPrefix,
+		ProjectPrefix:      projectPrefix,
+	}
+}
+
+// MigrateTemplatePolicyTargetsOptions wires the migrator to its Kubernetes
+// client and output sink. The struct is exported so the table-driven tests in
+// this package can construct the same contract without duplicating cobra flag
+// plumbing.
+type MigrateTemplatePolicyTargetsOptions struct {
+	// Client is the Kubernetes client used to list namespaces, ConfigMaps,
+	// and to write bindings / updated policies. Required.
+	Client kubernetes.Interface
+	// Resolver translates between user-facing names and Kubernetes
+	// namespace names. Required.
+	Resolver *resolver.Resolver
+	// Apply controls whether the migrator mutates cluster state. When
+	// false (the default), the migrator computes the plan and prints it
+	// but leaves the cluster untouched.
+	Apply bool
+	// Out is the sink for the plan/summary text. Required.
+	Out io.Writer
+}
+
+// PolicyMigrationPlan describes what the migrator intends to do for a single
+// TemplatePolicy. The migrator produces one plan per policy with non-empty
+// Target globs; policies whose Target globs are already empty are skipped
+// before a plan is generated.
+type PolicyMigrationPlan struct {
+	// PolicyNamespace is the folder or organization namespace that owns
+	// the policy ConfigMap.
+	PolicyNamespace string
+	// PolicyName is the policy ConfigMap's metadata.name.
+	PolicyName string
+	// BindingName is the deterministic name the migrator will use when
+	// creating (or verifying) the TemplatePolicyBinding that replaces
+	// this policy's Target globs. Re-running the migrator finds the
+	// same binding by this name — that is how idempotency is enforced.
+	BindingName string
+	// Scope is the TemplateScope derived from PolicyNamespace. Used to
+	// write the policy_ref on the binding and to route subsequent
+	// UpdatePolicy / CreateBinding calls through the correct K8s
+	// namespace.
+	Scope consolev1.TemplateScope
+	// ScopeName is the folder or organization slug derived from
+	// PolicyNamespace.
+	ScopeName string
+	// TargetRefs is the de-duplicated union of every render target
+	// selected by any rule's Target globs on this policy. The migrator
+	// creates a binding with this exact list.
+	TargetRefs []*consolev1.TemplatePolicyBindingTargetRef
+	// BindingExists records whether a TemplatePolicyBinding by BindingName
+	// already exists when the plan is built. Idempotency branches off
+	// this flag: an existing binding with the same targets is left alone,
+	// an existing binding with different targets is reported as a
+	// conflict (and the migrator refuses to touch it).
+	BindingExists bool
+	// BindingTargetsMatch is set when BindingExists is true and the
+	// existing binding's target_refs (set semantics) equal TargetRefs.
+	// When true the migrator considers the binding side already migrated
+	// and only proceeds with clearing the policy's Target fields.
+	BindingTargetsMatch bool
+	// ClearPolicyTargets is true when the policy still carries a non-
+	// empty Target on at least one rule. When false the policy is
+	// already cleared and the migrator skips the UpdatePolicy call.
+	ClearPolicyTargets bool
+	// Notes accumulates per-plan warnings or informational messages
+	// (e.g. conflict notices) so the printed summary can surface them
+	// without forcing every caller to re-derive them.
+	Notes []string
+}
+
+// MigrationResult aggregates the per-policy outcomes of a migration run.
+// Exported fields are zero-valued on fresh clusters (no policies to
+// migrate), which is the canonical "empty" shape the idempotency tests
+// assert against.
+type MigrationResult struct {
+	// Plans lists one entry per policy with non-empty Target globs. The
+	// order reflects the namespace list / per-namespace policy list order
+	// at the time of execution and is therefore not guaranteed stable
+	// across runs.
+	Plans []*PolicyMigrationPlan
+	// BindingsCreated counts the bindings the migrator wrote during this
+	// run. Always 0 for a dry-run.
+	BindingsCreated int
+	// PoliciesUpdated counts the policies whose Target globs the
+	// migrator cleared during this run. Always 0 for a dry-run.
+	PoliciesUpdated int
+	// Conflicts counts plans that were skipped because an existing
+	// binding by the same name carried different target_refs than the
+	// migrator would have written. A non-zero value indicates operator
+	// intervention is required before the migration can complete.
+	Conflicts int
+	// Skipped counts policies whose Target globs are already empty and
+	// therefore do not require migration. Always reported so an operator
+	// can see the migrator ran to completion and found no work.
+	Skipped int
+}
+
+// MigrateTemplatePolicyTargets is the package-level entry point tests and the
+// cobra subcommand share. It discovers every policy-bearing namespace in the
+// cluster, builds a PolicyMigrationPlan per policy with non-empty Target
+// globs, and (when Apply is true) writes the bindings and clears the Target
+// fields.
+func MigrateTemplatePolicyTargets(ctx context.Context, opts MigrateTemplatePolicyTargetsOptions) (*MigrationResult, error) {
+	if opts.Client == nil {
+		return nil, fmt.Errorf("kubernetes client is required")
+	}
+	if opts.Resolver == nil {
+		return nil, fmt.Errorf("namespace resolver is required")
+	}
+	if opts.Out == nil {
+		return nil, fmt.Errorf("output writer is required")
+	}
+
+	// Index every managed namespace up front so we can classify and walk
+	// without making per-policy round-trips to the K8s API. The selector
+	// keeps the list narrowly scoped to namespaces the console owns;
+	// unmanaged namespaces never appear in the traversal.
+	namespaces, err := listManagedNamespaces(ctx, opts.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	classified := classifyNamespaces(opts.Resolver, namespaces)
+
+	// Walk the owning namespace for each policy; the helper handles the
+	// fail-open contract on a single per-namespace list error (log and
+	// continue) that matches the K8sClient.ListPoliciesInNamespace shape
+	// used at runtime.
+	result := &MigrationResult{}
+	for _, ns := range classified.policyBearing {
+		cms, err := listPoliciesInNamespace(ctx, opts.Client, ns.Name)
+		if err != nil {
+			// A transient list failure must not mask bindings we
+			// already wrote in prior iterations; surface it to the
+			// caller so the operator can retry.
+			return result, fmt.Errorf("listing policies in %q: %w", ns.Name, err)
+		}
+		for i := range cms {
+			cm := &cms[i]
+			plan, planErr := buildPolicyPlan(ctx, opts.Client, opts.Resolver, classified, ns, cm)
+			if planErr != nil {
+				return result, planErr
+			}
+			if plan == nil {
+				result.Skipped++
+				continue
+			}
+			result.Plans = append(result.Plans, plan)
+		}
+	}
+
+	// Print the plan before any mutation so operators see exactly what
+	// the migrator intends to do. A dry-run stops here.
+	printMigrationPlan(opts.Out, result.Plans)
+
+	if !opts.Apply {
+		return result, nil
+	}
+
+	// Apply phase: each plan is executed atomically per policy — binding
+	// first, then clear. A binding-create failure leaves the policy
+	// untouched so the next run retries cleanly; a policy-update failure
+	// after a successful binding-create is retryable too because the
+	// existing binding is detected and re-used next time.
+	for _, plan := range result.Plans {
+		if len(plan.Notes) > 0 && plan.BindingExists && !plan.BindingTargetsMatch {
+			result.Conflicts++
+			continue
+		}
+		if !plan.BindingExists {
+			if err := createBindingFromPlan(ctx, opts.Client, plan); err != nil {
+				return result, fmt.Errorf("creating binding %q in %q: %w",
+					plan.BindingName, plan.PolicyNamespace, err)
+			}
+			result.BindingsCreated++
+		}
+		if plan.ClearPolicyTargets {
+			if err := clearPolicyTargets(ctx, opts.Client, plan); err != nil {
+				return result, fmt.Errorf("clearing targets on policy %q in %q: %w",
+					plan.PolicyName, plan.PolicyNamespace, err)
+			}
+			result.PoliciesUpdated++
+		}
+	}
+
+	return result, nil
+}
+
+// listManagedNamespaces fetches every namespace carrying the
+// managed-by=console.holos.run label. The migrator never reads unmanaged
+// namespaces — an operator with a hand-authored ConfigMap in an unrelated
+// namespace should not have their data surfaced by a migration command.
+func listManagedNamespaces(ctx context.Context, client kubernetes.Interface) ([]corev1.Namespace, error) {
+	labelSelector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue
+	list, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing managed namespaces: %w", err)
+	}
+	return list.Items, nil
+}
+
+// classifiedNamespaces partitions managed namespaces by their resource-type
+// label so the migrator can cheaply answer "which projects descend from this
+// folder?" without re-listing the cluster per policy.
+type classifiedNamespaces struct {
+	byName       map[string]*corev1.Namespace
+	organization map[string]*corev1.Namespace // scopeName -> namespace
+	folder       map[string]*corev1.Namespace // scopeName -> namespace
+	project      map[string]*corev1.Namespace // project slug -> namespace
+	// policyBearing is the ordered union of organization + folder
+	// namespaces — the two kinds that can own a TemplatePolicy. Order
+	// is deterministic (organizations first, then folders, each in
+	// alphabetical namespace-name order) so the plan is reproducible
+	// enough for operators to diff between dry-run and apply.
+	policyBearing []*corev1.Namespace
+}
+
+// classifyNamespaces splits a managed-namespace listing by resource-type
+// label. Namespaces whose prefix does not resolve to one of the three
+// expected kinds are ignored — they may be render-state ConfigMaps'
+// companion namespaces or other managed resources that do not participate
+// in template-policy migration.
+func classifyNamespaces(r *resolver.Resolver, namespaces []corev1.Namespace) *classifiedNamespaces {
+	c := &classifiedNamespaces{
+		byName:       make(map[string]*corev1.Namespace, len(namespaces)),
+		organization: make(map[string]*corev1.Namespace),
+		folder:       make(map[string]*corev1.Namespace),
+		project:      make(map[string]*corev1.Namespace),
+	}
+	for i := range namespaces {
+		ns := &namespaces[i]
+		c.byName[ns.Name] = ns
+		kind, name, err := r.ResourceTypeFromNamespace(ns.Name)
+		if err != nil {
+			continue
+		}
+		switch kind {
+		case v1alpha2.ResourceTypeOrganization:
+			c.organization[name] = ns
+		case v1alpha2.ResourceTypeFolder:
+			c.folder[name] = ns
+		case v1alpha2.ResourceTypeProject:
+			c.project[name] = ns
+		}
+	}
+	// Deterministic order: organizations sorted by namespace name,
+	// folders next sorted by namespace name. The actual per-policy
+	// order within each namespace is driven by the K8s list response
+	// and is therefore not under our control, but cross-namespace order
+	// is.
+	orgNames := make([]string, 0, len(c.organization))
+	for name := range c.organization {
+		orgNames = append(orgNames, name)
+	}
+	sort.Strings(orgNames)
+	folderNames := make([]string, 0, len(c.folder))
+	for name := range c.folder {
+		folderNames = append(folderNames, name)
+	}
+	sort.Strings(folderNames)
+	for _, name := range orgNames {
+		c.policyBearing = append(c.policyBearing, c.organization[name])
+	}
+	for _, name := range folderNames {
+		c.policyBearing = append(c.policyBearing, c.folder[name])
+	}
+	return c
+}
+
+// listPoliciesInNamespace lists TemplatePolicy ConfigMaps in the given
+// namespace. The label selector mirrors
+// templatepolicies.K8sClient.listPoliciesInNamespace so the migrator reads
+// the same objects the runtime handler would.
+func listPoliciesInNamespace(ctx context.Context, client kubernetes.Interface, ns string) ([]corev1.ConfigMap, error) {
+	labelSelector := v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeTemplatePolicy
+	list, err := client.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// buildPolicyPlan produces a PolicyMigrationPlan for a single policy, or
+// returns (nil, nil) when the policy has no non-empty Target globs and
+// therefore does not need migration. Any K8s error encountered while
+// enumerating candidate render targets propagates — a partial plan is
+// worse than no plan because the apply phase would under-bind.
+func buildPolicyPlan(
+	ctx context.Context,
+	client kubernetes.Interface,
+	r *resolver.Resolver,
+	nsIndex *classifiedNamespaces,
+	scopeNs *corev1.Namespace,
+	policy *corev1.ConfigMap,
+) (*PolicyMigrationPlan, error) {
+	rawRules := policy.Annotations[v1alpha2.AnnotationTemplatePolicyRules]
+	rules, err := templatepolicies.UnmarshalRules(rawRules)
+	if err != nil {
+		return nil, fmt.Errorf("parsing rules on policy %q in %q: %w",
+			policy.Name, policy.Namespace, err)
+	}
+	if !policyHasNonEmptyTargets(rules) {
+		return nil, nil
+	}
+
+	scope, scopeName, err := templateScopeFromNamespace(r, scopeNs.Name)
+	if err != nil {
+		return nil, fmt.Errorf("classifying scope for %q: %w", scopeNs.Name, err)
+	}
+
+	// Enumerate the candidate projects reachable from this policy's
+	// owning scope. For an organization scope every managed project
+	// labeled with the org qualifies; for a folder scope only the
+	// projects whose ancestor chain passes through this folder
+	// qualify. The helper resolves ancestry via the parent label —
+	// the same seam the runtime walker uses at render time.
+	projects, err := descendantProjects(nsIndex, scopeNs)
+	if err != nil {
+		return nil, fmt.Errorf("enumerating descendant projects for %q: %w", scopeNs.Name, err)
+	}
+
+	// Collect the render targets per rule. A rule with an empty
+	// project_pattern matches every descendant project (the resolver
+	// treats "" as "*"), and a rule with an empty deployment_pattern
+	// selects BOTH the project-scope templates and deployments within
+	// each matching project — the same semantics ruleAppliesTo
+	// encodes.
+	targetSet := newTargetRefSet()
+	for _, rule := range rules {
+		if rule == nil || rule.GetTarget() == nil {
+			continue
+		}
+		projectPattern := rule.GetTarget().GetProjectPattern()
+		deploymentPattern := rule.GetTarget().GetDeploymentPattern()
+		if projectPattern == "" && deploymentPattern == "" {
+			continue
+		}
+		for _, projNs := range projects {
+			projectSlug, projErr := r.ProjectFromNamespace(projNs.Name)
+			if projErr != nil {
+				// Non-project namespace in the project index is
+				// a classification bug; skip defensively rather
+				// than crash the whole migration.
+				continue
+			}
+			if !patternMatches(projectPattern, projectSlug) {
+				continue
+			}
+			if deploymentPattern == "" {
+				// Empty deployment pattern selects both the
+				// project-scope templates and the deployments
+				// in the project — the renderer's unified
+				// semantic.
+				tmpls, tErr := listProjectTemplates(ctx, client, projNs.Name)
+				if tErr != nil {
+					return nil, fmt.Errorf("listing project templates in %q: %w", projNs.Name, tErr)
+				}
+				for _, tmpl := range tmpls {
+					targetSet.Add(&consolev1.TemplatePolicyBindingTargetRef{
+						Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+						Name:        tmpl.Name,
+						ProjectName: projectSlug,
+					})
+				}
+				deployments, dErr := listProjectDeployments(ctx, client, projNs.Name)
+				if dErr != nil {
+					return nil, fmt.Errorf("listing deployments in %q: %w", projNs.Name, dErr)
+				}
+				for _, dep := range deployments {
+					targetSet.Add(&consolev1.TemplatePolicyBindingTargetRef{
+						Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+						Name:        dep.Name,
+						ProjectName: projectSlug,
+					})
+				}
+				continue
+			}
+			deployments, dErr := listProjectDeployments(ctx, client, projNs.Name)
+			if dErr != nil {
+				return nil, fmt.Errorf("listing deployments in %q: %w", projNs.Name, dErr)
+			}
+			for _, dep := range deployments {
+				if !patternMatches(deploymentPattern, dep.Name) {
+					continue
+				}
+				targetSet.Add(&consolev1.TemplatePolicyBindingTargetRef{
+					Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+					Name:        dep.Name,
+					ProjectName: projectSlug,
+				})
+			}
+		}
+	}
+
+	bindingName := policy.Name + migrateBindingNameSuffix
+	plan := &PolicyMigrationPlan{
+		PolicyNamespace:    policy.Namespace,
+		PolicyName:         policy.Name,
+		BindingName:        bindingName,
+		Scope:              scope,
+		ScopeName:          scopeName,
+		TargetRefs:         targetSet.Sorted(),
+		ClearPolicyTargets: true,
+	}
+
+	// Inspect any pre-existing binding by BindingName. A matching set
+	// means the binding side is already migrated and only the
+	// policy-side clear still needs to run; a differing set is a
+	// conflict an operator must resolve.
+	existing, err := client.CoreV1().ConfigMaps(policy.Namespace).Get(ctx, bindingName, metav1.GetOptions{})
+	if err == nil {
+		plan.BindingExists = true
+		existingRefs, parseErr := templatepolicybindings.UnmarshalTargetRefs(existing.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs])
+		if parseErr != nil {
+			plan.Notes = append(plan.Notes,
+				fmt.Sprintf("existing binding %q has unparseable target_refs: %v", bindingName, parseErr))
+		} else if targetSetsEqual(existingRefs, plan.TargetRefs) {
+			plan.BindingTargetsMatch = true
+		} else {
+			plan.Notes = append(plan.Notes,
+				fmt.Sprintf("existing binding %q has different target_refs; leaving untouched", bindingName))
+		}
+	} else if !k8serrors.IsNotFound(err) {
+		return nil, fmt.Errorf("checking for existing binding %q in %q: %w",
+			bindingName, policy.Namespace, err)
+	}
+
+	return plan, nil
+}
+
+// policyHasNonEmptyTargets reports whether any rule on the policy still
+// carries a Target glob that the migrator needs to translate. A policy
+// whose rules are all cleared is already migrated and the migrator skips it
+// entirely — the canonical idempotency short-circuit.
+func policyHasNonEmptyTargets(rules []*consolev1.TemplatePolicyRule) bool {
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+		t := rule.GetTarget()
+		if t == nil {
+			continue
+		}
+		if t.GetProjectPattern() != "" || t.GetDeploymentPattern() != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// templateScopeFromNamespace derives the TemplateScope + scope slug from a
+// policy-owning namespace. Only organization and folder namespaces reach
+// here; the classification helper already filtered project and unknown
+// kinds out of the policy-bearing slice.
+func templateScopeFromNamespace(r *resolver.Resolver, ns string) (consolev1.TemplateScope, string, error) {
+	kind, name, err := r.ResourceTypeFromNamespace(ns)
+	if err != nil {
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED, "", err
+	}
+	switch kind {
+	case v1alpha2.ResourceTypeOrganization:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION, name, nil
+	case v1alpha2.ResourceTypeFolder:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER, name, nil
+	default:
+		return consolev1.TemplateScope_TEMPLATE_SCOPE_UNSPECIFIED, "",
+			fmt.Errorf("namespace %q is not a policy-bearing scope (got %q)", ns, kind)
+	}
+}
+
+// descendantProjects returns every managed project namespace whose ancestor
+// chain passes through scopeNs. The walk uses the parent label index built
+// in classifyNamespaces so the helper never touches the K8s API — all the
+// metadata it needs is already in memory.
+func descendantProjects(nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace) ([]*corev1.Namespace, error) {
+	wantNs := scopeNs.Name
+	out := make([]*corev1.Namespace, 0)
+	for _, projNs := range nsIndex.project {
+		if ancestorChainContains(nsIndex, projNs, wantNs) {
+			out = append(out, projNs)
+		}
+	}
+	// Stable ordering keeps the printed plan reproducible across runs.
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// ancestorChainContains walks the parent label from startNs up the
+// hierarchy, returning true when wantNs appears on the chain. The walk is
+// bounded by the number of known namespaces so a mis-labeled parent chain
+// cannot cause an infinite loop at migration time.
+func ancestorChainContains(nsIndex *classifiedNamespaces, startNs *corev1.Namespace, wantNs string) bool {
+	current := startNs
+	for depth := 0; depth < len(nsIndex.byName)+1; depth++ {
+		if current == nil {
+			return false
+		}
+		if current.Name == wantNs {
+			return true
+		}
+		parent := current.Labels[v1alpha2.AnnotationParent]
+		if parent == "" {
+			return false
+		}
+		next, ok := nsIndex.byName[parent]
+		if !ok {
+			return false
+		}
+		current = next
+	}
+	return false
+}
+
+// listProjectTemplates returns every managed project-scope Template ConfigMap
+// in the project namespace. Selector semantics mirror
+// K8sResourceTopology.ListProjectTemplates so the migrator reads the same
+// objects the HOL-570 guardrail uses.
+func listProjectTemplates(ctx context.Context, client kubernetes.Interface, projectNs string) ([]corev1.ConfigMap, error) {
+	selector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeTemplate + "," +
+		v1alpha2.LabelTemplateScope + "=" + v1alpha2.TemplateScopeProject
+	list, err := client.CoreV1().ConfigMaps(projectNs).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// listProjectDeployments returns every managed Deployment ConfigMap in the
+// project namespace. Selector semantics mirror
+// K8sResourceTopology.ListProjectDeployments so the migrator reads the same
+// objects the HOL-570 guardrail uses.
+func listProjectDeployments(ctx context.Context, client kubernetes.Interface, projectNs string) ([]corev1.ConfigMap, error) {
+	selector := v1alpha2.LabelManagedBy + "=" + v1alpha2.ManagedByValue + "," +
+		v1alpha2.LabelResourceType + "=" + v1alpha2.ResourceTypeDeployment
+	list, err := client.CoreV1().ConfigMaps(projectNs).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// patternMatches wraps path.Match with the same "empty pattern means *"
+// treatment folderResolver uses at render time. Matching semantics are kept
+// in lock-step so the migration enumerates exactly the set the runtime
+// currently activates — an operator who dry-runs today sees the same
+// targets the resolver selected yesterday.
+func patternMatches(pattern, subject string) bool {
+	if pattern == "" {
+		pattern = "*"
+	}
+	ok, err := path.Match(pattern, subject)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// targetRefSet is a deterministic, de-duplicating collector for
+// (kind, projectName, name) triples. The sorted output is what the
+// migrator writes to the binding's annotation and compares against the
+// existing binding for idempotency.
+type targetRefSet struct {
+	byKey map[string]*consolev1.TemplatePolicyBindingTargetRef
+}
+
+func newTargetRefSet() *targetRefSet {
+	return &targetRefSet{byKey: map[string]*consolev1.TemplatePolicyBindingTargetRef{}}
+}
+
+// Add inserts a target ref into the set if it is not already present. The
+// key is the "kind|projectName|name" triple — exactly the shape the binding
+// handler rejects duplicates on, so the migration never produces a binding
+// the handler would reject.
+func (s *targetRefSet) Add(ref *consolev1.TemplatePolicyBindingTargetRef) {
+	if ref == nil {
+		return
+	}
+	k := targetRefKey(ref)
+	if _, ok := s.byKey[k]; ok {
+		return
+	}
+	s.byKey[k] = ref
+}
+
+// Sorted returns the set's contents sorted by the composite key. The
+// deterministic order is what lets the idempotency check in
+// targetSetsEqual use slice equality instead of hashing.
+func (s *targetRefSet) Sorted() []*consolev1.TemplatePolicyBindingTargetRef {
+	out := make([]*consolev1.TemplatePolicyBindingTargetRef, 0, len(s.byKey))
+	keys := make([]string, 0, len(s.byKey))
+	for k := range s.byKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		out = append(out, s.byKey[k])
+	}
+	return out
+}
+
+// targetRefKey produces the composite key used by the set and by
+// targetSetsEqual. Keeping a single key function eliminates the risk of
+// an idempotency-check/Add-key divergence that would resurrect a binding
+// the migrator thought it had already written.
+func targetRefKey(ref *consolev1.TemplatePolicyBindingTargetRef) string {
+	return bindingTargetKindString(ref.GetKind()) + "|" + ref.GetProjectName() + "|" + ref.GetName()
+}
+
+// targetSetsEqual reports whether two target-ref lists are equal under set
+// semantics. The migrator uses this to decide whether an existing binding
+// matches the plan it would write; a mismatch is a conflict an operator
+// must resolve.
+func targetSetsEqual(a, b []*consolev1.TemplatePolicyBindingTargetRef) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	want := make(map[string]struct{}, len(a))
+	for _, ref := range a {
+		want[targetRefKey(ref)] = struct{}{}
+	}
+	for _, ref := range b {
+		if _, ok := want[targetRefKey(ref)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// bindingTargetKindString mirrors templatepolicybindings.targetKindToString.
+// The migration command cannot import the unexported helper, but the
+// annotation contract it protects is identical — both encode PROJECT_TEMPLATE
+// as "project-template" and DEPLOYMENT as "deployment".
+func bindingTargetKindString(k consolev1.TemplatePolicyBindingTargetKind) string {
+	switch k {
+	case consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE:
+		return "project-template"
+	case consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT:
+		return "deployment"
+	default:
+		return ""
+	}
+}
+
+// templateScopeAnnotationValue is the scope label the binding's annotation
+// carries. Matches templatepolicybindings.scopeLabelValue one-for-one so
+// the runtime resolver decodes what the migrator writes.
+func templateScopeAnnotationValue(scope consolev1.TemplateScope) string {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return v1alpha2.TemplateScopeOrganization
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return v1alpha2.TemplateScopeFolder
+	default:
+		return ""
+	}
+}
+
+// createBindingFromPlan writes the TemplatePolicyBinding ConfigMap the plan
+// describes. The wire shape duplicates templatepolicybindings.CreateBinding's
+// annotation layout so the runtime handler reads exactly what the migration
+// wrote — there is no separate binding-handler code path for migrated
+// bindings.
+func createBindingFromPlan(ctx context.Context, client kubernetes.Interface, plan *PolicyMigrationPlan) error {
+	policyRef := &consolev1.LinkedTemplatePolicyRef{
+		ScopeRef: &consolev1.TemplateScopeRef{
+			Scope:     plan.Scope,
+			ScopeName: plan.ScopeName,
+		},
+		Name: plan.PolicyName,
+	}
+	policyJSON, err := marshalBindingPolicyRef(policyRef)
+	if err != nil {
+		return err
+	}
+	targetsJSON, err := marshalBindingTargetRefs(plan.TargetRefs)
+	if err != nil {
+		return err
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      plan.BindingName,
+			Namespace: plan.PolicyNamespace,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplatePolicyBinding,
+				v1alpha2.LabelTemplateScope: templateScopeAnnotationValue(plan.Scope),
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName:                     plan.PolicyName + " (migrated targets)",
+				v1alpha2.AnnotationDescription:                     "Auto-generated by holos-console migrate template-policy-targets (HOL-599). Supersedes the legacy TemplatePolicyRule.Target globs on " + plan.PolicyName + ".",
+				v1alpha2.AnnotationCreatorEmail:                    "holos-console-migrate",
+				v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  string(policyJSON),
+				v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: string(targetsJSON),
+			},
+		},
+	}
+	_, err = client.CoreV1().ConfigMaps(plan.PolicyNamespace).Create(ctx, cm, metav1.CreateOptions{})
+	return err
+}
+
+// storedPolicyRefWire mirrors templatepolicybindings.storedPolicyRef so the
+// migration package can round-trip the same JSON the runtime handler
+// expects without introducing a cross-package dependency cycle.
+type storedPolicyRefWire struct {
+	Scope     string `json:"scope"`
+	ScopeName string `json:"scopeName"`
+	Name      string `json:"name"`
+}
+
+// storedTargetRefWire mirrors templatepolicybindings.storedTargetRef for the
+// same reason storedPolicyRefWire mirrors its counterpart.
+type storedTargetRefWire struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	ProjectName string `json:"projectName"`
+}
+
+func marshalBindingPolicyRef(ref *consolev1.LinkedTemplatePolicyRef) ([]byte, error) {
+	sr := storedPolicyRefWire{}
+	if ref != nil {
+		if s := ref.GetScopeRef(); s != nil {
+			sr.Scope = templateScopeAnnotationValue(s.GetScope())
+			sr.ScopeName = s.GetScopeName()
+		}
+		sr.Name = ref.GetName()
+	}
+	b, err := json.Marshal(sr)
+	if err != nil {
+		return nil, fmt.Errorf("serializing binding policy_ref: %w", err)
+	}
+	return b, nil
+}
+
+func marshalBindingTargetRefs(refs []*consolev1.TemplatePolicyBindingTargetRef) ([]byte, error) {
+	out := make([]storedTargetRefWire, 0, len(refs))
+	for _, r := range refs {
+		if r == nil {
+			continue
+		}
+		out = append(out, storedTargetRefWire{
+			Kind:        bindingTargetKindString(r.GetKind()),
+			Name:        r.GetName(),
+			ProjectName: r.GetProjectName(),
+		})
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("serializing binding target_refs: %w", err)
+	}
+	return b, nil
+}
+
+// clearPolicyTargets updates the policy's rule annotation so every rule
+// carries empty project_pattern and deployment_pattern strings. The rest of
+// the rule — Kind, Template, VersionConstraint — is preserved verbatim.
+// Clearing happens in-place so HOL-600 can delete the legacy evaluation
+// path with a single follow-up release.
+func clearPolicyTargets(ctx context.Context, client kubernetes.Interface, plan *PolicyMigrationPlan) error {
+	cm, err := client.CoreV1().ConfigMaps(plan.PolicyNamespace).Get(ctx, plan.PolicyName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting policy for update: %w", err)
+	}
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyRules]
+	rules, err := templatepolicies.UnmarshalRules(raw)
+	if err != nil {
+		return fmt.Errorf("parsing rules for update: %w", err)
+	}
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+		rule.Target = &consolev1.TemplatePolicyTarget{}
+	}
+	clearedJSON, err := marshalClearedRules(rules)
+	if err != nil {
+		return err
+	}
+	cm.Annotations[v1alpha2.AnnotationTemplatePolicyRules] = string(clearedJSON)
+	_, err = client.CoreV1().ConfigMaps(plan.PolicyNamespace).Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+// ruleWire mirrors the on-disk JSON shape stored by
+// templatepolicies.marshalRules. The migrator must write back the exact
+// same fields the runtime handler reads — re-using the unexported helper
+// would introduce an import cycle, so the wire struct is duplicated here
+// with the same `json:` tags.
+type ruleWire struct {
+	Kind     string          `json:"kind"`
+	Template templateRefWire `json:"template"`
+	Target   targetWire      `json:"target"`
+}
+
+type templateRefWire struct {
+	Scope             string `json:"scope"`
+	ScopeName         string `json:"scope_name"`
+	Name              string `json:"name"`
+	VersionConstraint string `json:"version_constraint,omitempty"`
+}
+
+type targetWire struct {
+	ProjectPattern    string `json:"project_pattern"`
+	DeploymentPattern string `json:"deployment_pattern,omitempty"`
+}
+
+// marshalClearedRules serializes the in-memory rules with both Target
+// globs set to the empty string. The function intentionally does NOT call
+// out into templatepolicies.marshalRules — that helper is unexported, and
+// duplicating the wire struct keeps the migrator independent from
+// templatepolicies' internal refactors.
+func marshalClearedRules(rules []*consolev1.TemplatePolicyRule) ([]byte, error) {
+	out := make([]ruleWire, 0, len(rules))
+	for _, r := range rules {
+		if r == nil {
+			continue
+		}
+		wire := ruleWire{Kind: ruleKindWire(r.GetKind())}
+		if tmpl := r.GetTemplate(); tmpl != nil {
+			wire.Template = templateRefWire{
+				Scope:             templateScopeWire(tmpl.GetScope()),
+				ScopeName:         tmpl.GetScopeName(),
+				Name:              tmpl.GetName(),
+				VersionConstraint: tmpl.GetVersionConstraint(),
+			}
+		}
+		// Target fields deliberately left zero — this is the whole
+		// point of the migration: post-apply the policy carries no
+		// meaningful Target data so HOL-600 can delete the
+		// evaluation path.
+		out = append(out, wire)
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("serializing cleared template policy rules: %w", err)
+	}
+	return b, nil
+}
+
+// ruleKindWire duplicates templatepolicies.kindToString's encoding for the
+// reasons explained on ruleWire. UNSPECIFIED maps to the empty string,
+// which the runtime unmarshal also accepts as UNSPECIFIED.
+func ruleKindWire(k consolev1.TemplatePolicyKind) string {
+	switch k {
+	case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE:
+		return "require"
+	case consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE:
+		return "exclude"
+	default:
+		return ""
+	}
+}
+
+// templateScopeWire duplicates templatepolicies.templateScopeLabel's encoding
+// for the reasons explained on ruleWire.
+func templateScopeWire(scope consolev1.TemplateScope) string {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return v1alpha2.TemplateScopeOrganization
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return v1alpha2.TemplateScopeFolder
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_PROJECT:
+		return v1alpha2.TemplateScopeProject
+	default:
+		return ""
+	}
+}
+
+// printMigrationPlan writes a human-readable plan to w. Operators diff the
+// dry-run output against the --apply output to confirm nothing changed
+// between the two runs — the migrator renders the same text in both modes.
+// The write errors are intentionally discarded — the migrator is a CLI
+// subcommand and its output sink is stdout / a test bytes.Buffer; a write
+// failure on either is unrecoverable and not worth bubbling up over the
+// mutation-result return.
+func printMigrationPlan(w io.Writer, plans []*PolicyMigrationPlan) {
+	if len(plans) == 0 {
+		_, _ = fmt.Fprintln(w, "No TemplatePolicy objects carry non-empty Target globs; nothing to migrate.")
+		return
+	}
+	_, _ = fmt.Fprintf(w, "Planning migration for %d policy/policies:\n", len(plans))
+	for _, plan := range plans {
+		_, _ = fmt.Fprintf(w, "\npolicy %s/%s -> binding %s/%s (scope=%s, scope_name=%s)\n",
+			plan.PolicyNamespace, plan.PolicyName,
+			plan.PolicyNamespace, plan.BindingName,
+			scopeDisplay(plan.Scope), plan.ScopeName,
+		)
+		if len(plan.TargetRefs) == 0 {
+			_, _ = fmt.Fprintln(w, "  targets: <none> (globs matched no render targets)")
+		} else {
+			_, _ = fmt.Fprintln(w, "  targets:")
+			for _, ref := range plan.TargetRefs {
+				_, _ = fmt.Fprintf(w, "    - kind=%s project=%s name=%s\n",
+					bindingTargetKindString(ref.GetKind()), ref.GetProjectName(), ref.GetName())
+			}
+		}
+		switch {
+		case plan.BindingExists && plan.BindingTargetsMatch:
+			_, _ = fmt.Fprintln(w, "  status: binding already exists with matching targets; will clear policy Target globs only")
+		case plan.BindingExists && !plan.BindingTargetsMatch:
+			_, _ = fmt.Fprintln(w, "  status: CONFLICT — existing binding has different targets; no changes will be made")
+		default:
+			_, _ = fmt.Fprintln(w, "  status: will create new binding and clear policy Target globs")
+		}
+		for _, note := range plan.Notes {
+			_, _ = fmt.Fprintf(w, "  note: %s\n", note)
+		}
+	}
+}
+
+// printMigrationSummary prints a final tally so operators can confirm the
+// run finished. The wording distinguishes dry-run from apply so a skimming
+// reader cannot confuse a preview with a completed mutation. Write errors
+// are discarded for the same reason as in printMigrationPlan.
+func printMigrationSummary(w io.Writer, res *MigrationResult, apply bool) {
+	if res == nil {
+		return
+	}
+	verb := "would create"
+	policyVerb := "would clear targets on"
+	if apply {
+		verb = "created"
+		policyVerb = "cleared targets on"
+	}
+	_, _ = fmt.Fprintf(w, "\nSummary: %d %s bindings; %s %d policies; %d skipped (already migrated); %d conflicts.\n",
+		res.BindingsCreated, verb, policyVerb, res.PoliciesUpdated, res.Skipped, res.Conflicts)
+	if !apply {
+		_, _ = fmt.Fprintln(w, "Re-run with --apply to mutate the cluster.")
+	}
+}
+
+// scopeDisplay returns a short, operator-friendly label for a TemplateScope.
+// Used only in the printed plan.
+func scopeDisplay(scope consolev1.TemplateScope) string {
+	switch scope {
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_ORGANIZATION:
+		return "organization"
+	case consolev1.TemplateScope_TEMPLATE_SCOPE_FOLDER:
+		return "folder"
+	default:
+		return strings.ToLower(scope.String())
+	}
+}

--- a/cli/migrate_template_policy_targets.go
+++ b/cli/migrate_template_policy_targets.go
@@ -29,6 +29,14 @@ import (
 // command finds the existing binding by name and leaves it alone.
 const migrateBindingNameSuffix = "-migrated"
 
+// maxK8sNameLength is the Kubernetes DNS-label limit for ConfigMap
+// metadata.name. A policy whose name, once the "-migrated" suffix is
+// appended, would exceed this limit cannot be turned into a binding by
+// the deterministic naming scheme. The migrator surfaces such policies
+// during planning as a conflict so dry-run output makes the problem
+// visible before --apply fails mid-run.
+const maxK8sNameLength = 63
+
 // newMigrateCommand returns the `holos-console migrate` parent command
 // grouping every migration subcommand in the tree.
 func newMigrateCommand() *cobra.Command {
@@ -451,7 +459,7 @@ func buildPolicyPlan(
 	// projects whose ancestor chain passes through this folder
 	// qualify. The helper resolves ancestry via the parent label —
 	// the same seam the runtime walker uses at render time.
-	projects, err := descendantProjects(nsIndex, scopeNs)
+	projects, err := descendantProjects(r, nsIndex, scopeNs)
 	if err != nil {
 		return nil, fmt.Errorf("enumerating descendant projects for %q: %w", scopeNs.Name, err)
 	}
@@ -545,6 +553,23 @@ func buildPolicyPlan(
 		plan.Notes = append(plan.Notes,
 			"glob patterns matched no live project templates or deployments; skipping binding creation (an empty target_refs list is rejected by the binding handler) while still clearing the policy Target globs")
 	}
+	// Preflight the synthesized binding name against the K8s DNS-label
+	// limit. A policy name long enough to push the "-migrated" suffix
+	// past 63 characters cannot be expressed as a ConfigMap, and the
+	// error would only surface mid-apply — the operator sees a clean
+	// dry-run then a broken run. Surface it during planning so the
+	// dry-run output matches what --apply will actually do.
+	if len(bindingName) > maxK8sNameLength {
+		plan.Notes = append(plan.Notes,
+			fmt.Sprintf("synthesized binding name %q is %d characters, exceeds Kubernetes DNS-label limit %d; rename the policy before running the migration or create the binding manually",
+				bindingName, len(bindingName), maxK8sNameLength))
+		// Route through the conflict branch so neither the binding
+		// nor the policy mutation happens. BindingExists=true with
+		// BindingTargetsMatch=false is the plan's "skip everything,
+		// operator must act" shape.
+		plan.BindingExists = true
+		return plan, nil
+	}
 
 	// Inspect any pre-existing binding by BindingName. A matching set
 	// means the binding side is already migrated and only the
@@ -596,6 +621,13 @@ func buildPolicyPlan(
 // carries a Target glob that the migrator needs to translate. A policy
 // whose rules are all cleared is already migrated and the migrator skips it
 // entirely — the canonical idempotency short-circuit.
+//
+// "Cleared" means either the Target is literally empty (project_pattern=""
+// and deployment_pattern="") or the migrator's placeholder shape
+// (project_pattern="*" and deployment_pattern=""). Both forms are
+// treated as "no migration work left" so a second run of this command is
+// a no-op regardless of whether an earlier version wrote an empty string
+// or this version's placeholder.
 func policyHasNonEmptyTargets(rules []*consolev1.TemplatePolicyRule) bool {
 	for _, rule := range rules {
 		if rule == nil {
@@ -605,9 +637,14 @@ func policyHasNonEmptyTargets(rules []*consolev1.TemplatePolicyRule) bool {
 		if t == nil {
 			continue
 		}
-		if t.GetProjectPattern() != "" || t.GetDeploymentPattern() != "" {
+		if t.GetDeploymentPattern() != "" {
 			return true
 		}
+		pp := t.GetProjectPattern()
+		if pp == "" || pp == clearedProjectPatternPlaceholder {
+			continue
+		}
+		return true
 	}
 	return false
 }
@@ -637,26 +674,44 @@ func templateScopeFromNamespace(r *resolver.Resolver, ns string) (consolev1.Temp
 // in classifyNamespaces so the helper never touches the K8s API — all the
 // metadata it needs is already in memory.
 //
+// The candidate set is narrowed by the policy scope's owning organization
+// label (via `orgForScopeNamespace`) so a malformed project chain in an
+// unrelated organization cannot fail the migration for a policy that
+// could never match that project anyway. This mirrors
+// `K8sResourceTopology.ListProjectsUnderScope` (HOL-570), which also
+// pre-filters by the org label before walking ancestors — keeping the
+// blast radius of ancestry errors narrow is the whole point of that
+// filter, and the migration preserves the same contract.
+//
 // Projects carrying a non-nil DeletionTimestamp are skipped to mirror
-// K8sResourceTopology.ListProjectsUnderScope (HOL-570): the runtime
-// topology treats a terminating namespace as already unreachable, so the
-// migration must not bind targets in namespaces that will never activate
-// under the legacy glob path the binding is replacing.
+// the same topology helper: the runtime treats a terminating namespace as
+// already unreachable, so the migration must not bind targets in
+// namespaces that will never activate under the legacy glob path the
+// binding is replacing.
 //
 // Ancestry walk failures (missing parent label, missing parent namespace,
-// cycle, depth exceeded) propagate to the caller. Silently dropping an
-// unreachable project would be a data-loss path: the migrator would skip
-// targets that legitimately match the policy's globs, clear the policy's
-// Target fields, and leave the project permanently uncovered once
-// HOL-600 removes the legacy evaluation. Failing loudly forces the
-// operator to fix the ancestry before the migration runs, which matches
-// the fail-closed behavior `K8sResourceTopology.ListProjectsUnderScope`
-// uses at render time.
-func descendantProjects(nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace) ([]*corev1.Namespace, error) {
+// cycle, depth exceeded) encountered on an in-org candidate project
+// propagate to the caller. Silently dropping an unreachable project would
+// be a data-loss path: the migrator would skip targets that legitimately
+// match the policy's globs, clear the policy's Target fields, and leave
+// the project permanently uncovered once HOL-600 removes the legacy
+// evaluation. Failing loudly forces the operator to fix the ancestry
+// before the migration runs.
+func descendantProjects(r *resolver.Resolver, nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace) ([]*corev1.Namespace, error) {
 	wantNs := scopeNs.Name
+	orgLabel := orgForScopeNamespace(r, scopeNs)
 	out := make([]*corev1.Namespace, 0)
 	for _, projNs := range nsIndex.project {
 		if projNs.DeletionTimestamp != nil {
+			continue
+		}
+		// Pre-filter by organization label so a malformed parent
+		// chain in a different org cannot fail this walk. When the
+		// scope namespace itself carries no org label (legacy
+		// fixtures, tests that set up a bare fixture without the
+		// org label) fall through to the ancestry check without a
+		// pre-filter — correctness first, speed second.
+		if orgLabel != "" && projNs.Labels[v1alpha2.LabelOrganization] != orgLabel {
 			continue
 		}
 		contained, err := ancestorChainContains(nsIndex, projNs, wantNs)
@@ -670,6 +725,37 @@ func descendantProjects(nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace
 	// Stable ordering keeps the printed plan reproducible across runs.
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
+}
+
+// orgForScopeNamespace returns the organization slug that owns the
+// policy's scope namespace, used as a pre-filter on the descendant
+// project walk.
+//
+//   - Organization scope: the slug derives directly from the namespace
+//     prefix, classified via the resolver. The organization namespace
+//     carries no LabelOrganization by convention, so a label lookup
+//     would miss it.
+//   - Folder scope: read LabelOrganization from the folder namespace; if
+//     the label is missing, return "" and fall through to the
+//     unfiltered walk (matches the runtime topology fallback).
+//   - Any other case (unclassified namespace): return "" so the caller
+//     defaults to the unfiltered walk.
+func orgForScopeNamespace(r *resolver.Resolver, scopeNs *corev1.Namespace) string {
+	if scopeNs == nil {
+		return ""
+	}
+	kind, name, err := r.ResourceTypeFromNamespace(scopeNs.Name)
+	if err != nil {
+		return ""
+	}
+	switch kind {
+	case v1alpha2.ResourceTypeOrganization:
+		return name
+	case v1alpha2.ResourceTypeFolder:
+		return scopeNs.Labels[v1alpha2.LabelOrganization]
+	default:
+		return ""
+	}
 }
 
 // ancestorChainContains walks the parent label from startNs up the
@@ -1012,8 +1098,27 @@ type targetWire struct {
 	DeploymentPattern string `json:"deployment_pattern,omitempty"`
 }
 
-// marshalClearedRules serializes the in-memory rules with both Target
-// globs set to the empty string. The function intentionally does NOT call
+// clearedProjectPatternPlaceholder is the stand-in project_pattern written
+// on every rule when the migration clears a policy's Target globs. The
+// runtime validator (templatepolicies.validatePolicyRules, pre-HOL-600)
+// still rejects empty project_pattern strings, so a migration that wrote
+// project_pattern="" would leave affected policies effectively read-only
+// through the UI/API until HOL-600 deletes the validator. Using the
+// universal glob "*" satisfies the validator without changing the
+// semantic meaning: a binding that covers the render target overrides
+// the glob (HOL-596 resolver contract), and for targets with no
+// covering binding the "*" glob is an accurate statement that the
+// policy applies everywhere — which is also what HOL-600 will
+// implicitly assume when it removes the glob path entirely.
+//
+// Tests that assert the glob fields are cleared check for either ""
+// or "*" and ignore deployment_pattern (which stays empty — the
+// validator does not require it).
+const clearedProjectPatternPlaceholder = "*"
+
+// marshalClearedRules serializes the in-memory rules with
+// project_pattern set to the placeholder constant and deployment_pattern
+// set to the empty string. The function intentionally does NOT call
 // out into templatepolicies.marshalRules — that helper is unexported, and
 // duplicating the wire struct keeps the migrator independent from
 // templatepolicies' internal refactors.
@@ -1032,10 +1137,12 @@ func marshalClearedRules(rules []*consolev1.TemplatePolicyRule) ([]byte, error) 
 				VersionConstraint: tmpl.GetVersionConstraint(),
 			}
 		}
-		// Target fields deliberately left zero — this is the whole
-		// point of the migration: post-apply the policy carries no
-		// meaningful Target data so HOL-600 can delete the
-		// evaluation path.
+		// project_pattern is set to the universal-match placeholder so
+		// the existing validator accepts subsequent UpdatePolicy
+		// calls from the UI during the HOL-599 → HOL-600 transition
+		// window. deployment_pattern stays empty — the validator
+		// does not require it.
+		wire.Target = targetWire{ProjectPattern: clearedProjectPatternPlaceholder}
 		out = append(out, wire)
 	}
 	b, err := json.Marshal(out)

--- a/cli/migrate_template_policy_targets.go
+++ b/cli/migrate_template_policy_targets.go
@@ -619,15 +619,15 @@ func buildPolicyPlan(
 
 // policyHasNonEmptyTargets reports whether any rule on the policy still
 // carries a Target glob that the migrator needs to translate. A policy
-// whose rules are all cleared is already migrated and the migrator skips it
-// entirely — the canonical idempotency short-circuit.
+// whose rules are all cleared (both project_pattern and
+// deployment_pattern are the empty string) is already migrated and the
+// migrator skips it entirely — the canonical idempotency short-circuit.
 //
-// "Cleared" means either the Target is literally empty (project_pattern=""
-// and deployment_pattern="") or the migrator's placeholder shape
-// (project_pattern="*" and deployment_pattern=""). Both forms are
-// treated as "no migration work left" so a second run of this command is
-// a no-op regardless of whether an earlier version wrote an empty string
-// or this version's placeholder.
+// A rule with project_pattern="*" (a legitimate legacy pre-migration
+// glob) is NOT treated as cleared: the `"*"` token is what an operator
+// would write to target every project, and the migrator must translate
+// it into an explicit binding rather than mistaking it for the post-
+// migration shape.
 func policyHasNonEmptyTargets(rules []*consolev1.TemplatePolicyRule) bool {
 	for _, rule := range rules {
 		if rule == nil {
@@ -637,14 +637,9 @@ func policyHasNonEmptyTargets(rules []*consolev1.TemplatePolicyRule) bool {
 		if t == nil {
 			continue
 		}
-		if t.GetDeploymentPattern() != "" {
+		if t.GetProjectPattern() != "" || t.GetDeploymentPattern() != "" {
 			return true
 		}
-		pp := t.GetProjectPattern()
-		if pp == "" || pp == clearedProjectPatternPlaceholder {
-			continue
-		}
-		return true
 	}
 	return false
 }
@@ -1098,30 +1093,33 @@ type targetWire struct {
 	DeploymentPattern string `json:"deployment_pattern,omitempty"`
 }
 
-// clearedProjectPatternPlaceholder is the stand-in project_pattern written
-// on every rule when the migration clears a policy's Target globs. The
-// runtime validator (templatepolicies.validatePolicyRules, pre-HOL-600)
-// still rejects empty project_pattern strings, so a migration that wrote
-// project_pattern="" would leave affected policies effectively read-only
-// through the UI/API until HOL-600 deletes the validator. Using the
-// universal glob "*" satisfies the validator without changing the
-// semantic meaning: a binding that covers the render target overrides
-// the glob (HOL-596 resolver contract), and for targets with no
-// covering binding the "*" glob is an accurate statement that the
-// policy applies everywhere — which is also what HOL-600 will
-// implicitly assume when it removes the glob path entirely.
+// marshalClearedRules serializes the in-memory rules with BOTH Target
+// globs set to the empty string — the shape the AC requires. The function
+// intentionally does NOT call out into templatepolicies.marshalRules —
+// that helper is unexported, and duplicating the wire struct keeps the
+// migrator independent from templatepolicies' internal refactors.
 //
-// Tests that assert the glob fields are cleared check for either ""
-// or "*" and ignore deployment_pattern (which stays empty — the
-// validator does not require it).
-const clearedProjectPatternPlaceholder = "*"
-
-// marshalClearedRules serializes the in-memory rules with
-// project_pattern set to the placeholder constant and deployment_pattern
-// set to the empty string. The function intentionally does NOT call
-// out into templatepolicies.marshalRules — that helper is unexported, and
-// duplicating the wire struct keeps the migrator independent from
-// templatepolicies' internal refactors.
+// A `project_pattern: ""` placeholder is chosen over `"*"` for two
+// reasons. First, a literal `"*"` would still be evaluated by the pre-
+// HOL-600 resolver for render targets the binding does NOT cover (new
+// projects, new deployments), broadening the policy's effective set
+// during the transition window — the HOL-596 resolver only bypasses the
+// glob for the specific render targets named by a matching binding, not
+// for every target that shares the policy. Second, `"*"` is a legitimate
+// pre-migration glob value, so a placeholder that picks the same token
+// would make the idempotency classifier unable to tell a legacy wildcard
+// rule apart from a migrator-cleared rule, silently skipping migration
+// of policies that actually still need one.
+//
+// The empty-string form does mean the current
+// templatepolicies.validatePolicyRules rejects UI/API updates of
+// migrated policies until HOL-600 removes the validator. That window is
+// already in effect today because HOL-598 removed the UI inputs that
+// could supply a non-empty project_pattern — i.e., the UI cannot update
+// any TemplatePolicy right now regardless of whether the migration has
+// run. HOL-600 is the paired patch that removes the validator, at which
+// point all policies become UI-updatable again. The runbook calls this
+// out explicitly.
 func marshalClearedRules(rules []*consolev1.TemplatePolicyRule) ([]byte, error) {
 	out := make([]ruleWire, 0, len(rules))
 	for _, r := range rules {
@@ -1137,12 +1135,10 @@ func marshalClearedRules(rules []*consolev1.TemplatePolicyRule) ([]byte, error) 
 				VersionConstraint: tmpl.GetVersionConstraint(),
 			}
 		}
-		// project_pattern is set to the universal-match placeholder so
-		// the existing validator accepts subsequent UpdatePolicy
-		// calls from the UI during the HOL-599 → HOL-600 transition
-		// window. deployment_pattern stays empty — the validator
-		// does not require it.
-		wire.Target = targetWire{ProjectPattern: clearedProjectPatternPlaceholder}
+		// Target fields deliberately left zero — this is the whole
+		// point of the migration. Post-apply the policy carries no
+		// meaningful Target data so HOL-600 can delete the
+		// evaluation path without surprise.
 		out = append(out, wire)
 	}
 	b, err := json.Marshal(out)

--- a/cli/migrate_template_policy_targets.go
+++ b/cli/migrate_template_policy_targets.go
@@ -534,18 +534,39 @@ func buildPolicyPlan(
 	// means the binding side is already migrated and only the
 	// policy-side clear still needs to run; a differing set is a
 	// conflict an operator must resolve.
+	//
+	// Organization and folder namespaces also host Template and
+	// TemplatePolicy ConfigMaps, so we must verify the resource-type
+	// label before treating the matched object as a binding. Without
+	// that check a Template named "<policy>-migrated" (or any other
+	// ConfigMap that happened to share the synthesized binding name)
+	// would make the migrator report a permanent conflict that no
+	// operator action on the binding side could resolve.
 	existing, err := client.CoreV1().ConfigMaps(policy.Namespace).Get(ctx, bindingName, metav1.GetOptions{})
 	if err == nil {
-		plan.BindingExists = true
-		existingRefs, parseErr := templatepolicybindings.UnmarshalTargetRefs(existing.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs])
-		if parseErr != nil {
+		if existing.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeTemplatePolicyBinding {
 			plan.Notes = append(plan.Notes,
-				fmt.Sprintf("existing binding %q has unparseable target_refs: %v", bindingName, parseErr))
-		} else if targetSetsEqual(existingRefs, plan.TargetRefs) {
-			plan.BindingTargetsMatch = true
+				fmt.Sprintf("ConfigMap %q exists in %q but is not a TemplatePolicyBinding (resource-type=%q); binding cannot be written without colliding — resolve by hand before re-running",
+					bindingName, policy.Namespace, existing.Labels[v1alpha2.LabelResourceType]))
+			// Record the blocker as a conflict-shaped plan so the
+			// apply loop skips both the binding create and the
+			// policy clear. BindingExists=true combined with
+			// BindingTargetsMatch=false routes through the
+			// conflict branch, leaving the policy untouched until
+			// an operator removes the offending ConfigMap.
+			plan.BindingExists = true
 		} else {
-			plan.Notes = append(plan.Notes,
-				fmt.Sprintf("existing binding %q has different target_refs; leaving untouched", bindingName))
+			plan.BindingExists = true
+			existingRefs, parseErr := templatepolicybindings.UnmarshalTargetRefs(existing.Annotations[v1alpha2.AnnotationTemplatePolicyBindingTargetRefs])
+			if parseErr != nil {
+				plan.Notes = append(plan.Notes,
+					fmt.Sprintf("existing binding %q has unparseable target_refs: %v", bindingName, parseErr))
+			} else if targetSetsEqual(existingRefs, plan.TargetRefs) {
+				plan.BindingTargetsMatch = true
+			} else {
+				plan.Notes = append(plan.Notes,
+					fmt.Sprintf("existing binding %q has different target_refs; leaving untouched", bindingName))
+			}
 		}
 	} else if !k8serrors.IsNotFound(err) {
 		return nil, fmt.Errorf("checking for existing binding %q in %q: %w",
@@ -605,6 +626,16 @@ func templateScopeFromNamespace(r *resolver.Resolver, ns string) (consolev1.Temp
 // topology treats a terminating namespace as already unreachable, so the
 // migration must not bind targets in namespaces that will never activate
 // under the legacy glob path the binding is replacing.
+//
+// Ancestry walk failures (missing parent label, missing parent namespace,
+// cycle, depth exceeded) propagate to the caller. Silently dropping an
+// unreachable project would be a data-loss path: the migrator would skip
+// targets that legitimately match the policy's globs, clear the policy's
+// Target fields, and leave the project permanently uncovered once
+// HOL-600 removes the legacy evaluation. Failing loudly forces the
+// operator to fix the ancestry before the migration runs, which matches
+// the fail-closed behavior `K8sResourceTopology.ListProjectsUnderScope`
+// uses at render time.
 func descendantProjects(nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace) ([]*corev1.Namespace, error) {
 	wantNs := scopeNs.Name
 	out := make([]*corev1.Namespace, 0)
@@ -612,7 +643,11 @@ func descendantProjects(nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace
 		if projNs.DeletionTimestamp != nil {
 			continue
 		}
-		if ancestorChainContains(nsIndex, projNs, wantNs) {
+		contained, err := ancestorChainContains(nsIndex, projNs, wantNs)
+		if err != nil {
+			return nil, fmt.Errorf("walking ancestors of %q: %w", projNs.Name, err)
+		}
+		if contained {
 			out = append(out, projNs)
 		}
 	}
@@ -625,26 +660,44 @@ func descendantProjects(nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace
 // hierarchy, returning true when wantNs appears on the chain. The walk is
 // bounded by the number of known namespaces so a mis-labeled parent chain
 // cannot cause an infinite loop at migration time.
-func ancestorChainContains(nsIndex *classifiedNamespaces, startNs *corev1.Namespace, wantNs string) bool {
+//
+// An organization namespace is a legitimate terminal: reaching it without
+// finding wantNs means wantNs is not on the chain, and the walker returns
+// (false, nil). Every other "cannot continue" situation — a non-
+// organization namespace with no parent label, a parent label that points
+// at a namespace not in the managed index, or a cycle — is an ancestry
+// error propagated to the caller so the migration fails loudly rather
+// than silently dropping a project.
+func ancestorChainContains(nsIndex *classifiedNamespaces, startNs *corev1.Namespace, wantNs string) (bool, error) {
+	if startNs == nil {
+		return false, fmt.Errorf("nil start namespace")
+	}
 	current := startNs
+	visited := make(map[string]struct{}, len(nsIndex.byName))
 	for depth := 0; depth < len(nsIndex.byName)+1; depth++ {
-		if current == nil {
-			return false
-		}
 		if current.Name == wantNs {
-			return true
+			return true, nil
+		}
+		if _, seen := visited[current.Name]; seen {
+			return false, fmt.Errorf("cycle detected at %q (starting from %q)", current.Name, startNs.Name)
+		}
+		visited[current.Name] = struct{}{}
+		// Reaching an organization namespace means the chain is
+		// complete; wantNs is definitively not on it.
+		if current.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeOrganization {
+			return false, nil
 		}
 		parent := current.Labels[v1alpha2.AnnotationParent]
 		if parent == "" {
-			return false
+			return false, fmt.Errorf("namespace %q is missing required parent annotation %q", current.Name, v1alpha2.AnnotationParent)
 		}
 		next, ok := nsIndex.byName[parent]
 		if !ok {
-			return false
+			return false, fmt.Errorf("parent namespace %q of %q is not in the managed index", parent, current.Name)
 		}
 		current = next
 	}
-	return false
+	return false, fmt.Errorf("namespace hierarchy depth exceeded limit starting from %q", startNs.Name)
 }
 
 // listProjectTemplates returns every managed project-scope Template ConfigMap

--- a/cli/migrate_template_policy_targets.go
+++ b/cli/migrate_template_policy_targets.go
@@ -168,6 +168,15 @@ type PolicyMigrationPlan struct {
 	// empty Target on at least one rule. When false the policy is
 	// already cleared and the migrator skips the UpdatePolicy call.
 	ClearPolicyTargets bool
+	// EmptyTargets is true when the rule globs currently match no
+	// render targets in the cluster. The migrator skips binding
+	// creation in that case (the binding handler rejects an empty
+	// target_refs list, so writing one would produce an
+	// uneditable artifact) but still clears the policy's Target
+	// globs so HOL-600 can remove the evaluation path safely — the
+	// globs matched nothing under the legacy path either, so clearing
+	// them is semantics-preserving.
+	EmptyTargets bool
 	// Notes accumulates per-plan warnings or informational messages
 	// (e.g. conflict notices) so the printed summary can surface them
 	// without forcing every caller to re-derive them.
@@ -269,11 +278,17 @@ func MigrateTemplatePolicyTargets(ctx context.Context, opts MigrateTemplatePolic
 	// after a successful binding-create is retryable too because the
 	// existing binding is detected and re-used next time.
 	for _, plan := range result.Plans {
-		if len(plan.Notes) > 0 && plan.BindingExists && !plan.BindingTargetsMatch {
+		if plan.BindingExists && !plan.BindingTargetsMatch {
+			// Existing binding with different target set — an
+			// operator must decide whether to delete the binding
+			// or keep the policy globs. We leave everything
+			// untouched in that case, including the policy's
+			// Target globs, so the next dry-run reproduces the
+			// same conflict until the operator intervenes.
 			result.Conflicts++
 			continue
 		}
-		if !plan.BindingExists {
+		if !plan.BindingExists && !plan.EmptyTargets {
 			if err := createBindingFromPlan(ctx, opts.Client, plan); err != nil {
 				return result, fmt.Errorf("creating binding %q in %q: %w",
 					plan.BindingName, plan.PolicyNamespace, err)
@@ -499,14 +514,20 @@ func buildPolicyPlan(
 	}
 
 	bindingName := policy.Name + migrateBindingNameSuffix
+	resolvedTargets := targetSet.Sorted()
 	plan := &PolicyMigrationPlan{
 		PolicyNamespace:    policy.Namespace,
 		PolicyName:         policy.Name,
 		BindingName:        bindingName,
 		Scope:              scope,
 		ScopeName:          scopeName,
-		TargetRefs:         targetSet.Sorted(),
+		TargetRefs:         resolvedTargets,
 		ClearPolicyTargets: true,
+		EmptyTargets:       len(resolvedTargets) == 0,
+	}
+	if plan.EmptyTargets {
+		plan.Notes = append(plan.Notes,
+			"glob patterns matched no live project templates or deployments; skipping binding creation (an empty target_refs list is rejected by the binding handler) while still clearing the policy Target globs")
 	}
 
 	// Inspect any pre-existing binding by BindingName. A matching set
@@ -578,10 +599,19 @@ func templateScopeFromNamespace(r *resolver.Resolver, ns string) (consolev1.Temp
 // chain passes through scopeNs. The walk uses the parent label index built
 // in classifyNamespaces so the helper never touches the K8s API — all the
 // metadata it needs is already in memory.
+//
+// Projects carrying a non-nil DeletionTimestamp are skipped to mirror
+// K8sResourceTopology.ListProjectsUnderScope (HOL-570): the runtime
+// topology treats a terminating namespace as already unreachable, so the
+// migration must not bind targets in namespaces that will never activate
+// under the legacy glob path the binding is replacing.
 func descendantProjects(nsIndex *classifiedNamespaces, scopeNs *corev1.Namespace) ([]*corev1.Namespace, error) {
 	wantNs := scopeNs.Name
 	out := make([]*corev1.Namespace, 0)
 	for _, projNs := range nsIndex.project {
+		if projNs.DeletionTimestamp != nil {
+			continue
+		}
 		if ancestorChainContains(nsIndex, projNs, wantNs) {
 			out = append(out, projNs)
 		}
@@ -1008,6 +1038,8 @@ func printMigrationPlan(w io.Writer, plans []*PolicyMigrationPlan) {
 			_, _ = fmt.Fprintln(w, "  status: binding already exists with matching targets; will clear policy Target globs only")
 		case plan.BindingExists && !plan.BindingTargetsMatch:
 			_, _ = fmt.Fprintln(w, "  status: CONFLICT — existing binding has different targets; no changes will be made")
+		case plan.EmptyTargets:
+			_, _ = fmt.Fprintln(w, "  status: globs matched no live render targets; will clear policy Target globs only (no binding is written because the binding handler rejects an empty target_refs list)")
 		default:
 			_, _ = fmt.Fprintln(w, "  status: will create new binding and clear policy Target globs")
 		}

--- a/cli/migrate_template_policy_targets_test.go
+++ b/cli/migrate_template_policy_targets_test.go
@@ -214,6 +214,11 @@ func withDeployment(ns, name string) fixtureOption {
 // label is missing. This is an ancestry-error fixture: the migrator must
 // refuse to enumerate descendants for policies that could be affected by
 // the broken chain rather than silently dropping the project.
+//
+// The project carries an LabelOrganization so the org pre-filter on
+// descendantProjects does not silently skip it — the point of this
+// fixture is to land on the ancestry-walk code path with a malformed
+// parent chain.
 func withProjectNamespaceOrphan(name string) fixtureOption {
 	return func(b *fixtureBuilder) {
 		b.objects = append(b.objects, &corev1.Namespace{
@@ -222,6 +227,7 @@ func withProjectNamespaceOrphan(name string) fixtureOption {
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
 					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+					v1alpha2.LabelOrganization: "acme",
 					// No AnnotationParent — this is the
 					// orphan we are testing against.
 				},
@@ -242,6 +248,29 @@ func withCollidingConfigMap(ns, name, resourceType string) fixtureOption {
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
 					v1alpha2.LabelResourceType: resourceType,
+				},
+			},
+		})
+	}
+}
+
+// withCrossOrgOrphanProject adds a project namespace that is labeled as
+// belonging to `org` but has no parent annotation. Used to exercise the
+// org-scoped pre-filter on descendantProjects: a broken project in a
+// *different* organization from the policy under migration must not
+// fail the walk.
+func withCrossOrgOrphanProject(name, org string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: b.r.ProjectNamespace(name),
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+					v1alpha2.LabelOrganization: org,
+					// No AnnotationParent — deliberately
+					// broken to exercise the cross-org
+					// isolation guarantee.
 				},
 			},
 		})
@@ -795,6 +824,77 @@ func TestMigrateTemplatePolicyTargets(t *testing.T) {
 			},
 		},
 		{
+			// Codex round-4 review HOL-599: the descendant walk
+			// must narrow candidates by the policy scope's owning
+			// organization label so a malformed project chain in
+			// a *different* org cannot fail a migration for
+			// unrelated policies. Runtime topology does this (HOL-
+			// 570) and the migrator must match its contract.
+			name: "malformed project in another organization does not block migration of this org's policy",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withOrgNamespace("contoso"),
+				withProjectNamespace("lilies", "acme"),
+				// Broken project in the *other* org — label
+				// identifies it as contoso's, no parent.
+				withCrossOrgOrphanProject("strays", "contoso"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 1,
+				policiesUpdated: 1,
+				wantPlans:       1,
+				wantTargets: map[string][]wantTarget{
+					r.OrgNamespace("acme") + "/audit" + migrateBindingNameSuffix: {
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "lilies"},
+					},
+				},
+			},
+		},
+		{
+			// Codex round-4 review HOL-599: a policy name long
+			// enough to push the "-migrated" suffix past the K8s
+			// DNS-label limit (63 chars) must be flagged during
+			// planning rather than failing mid-apply. Surface it
+			// as a conflict so dry-run output matches what apply
+			// would do.
+			name: "policy name whose migrated binding would exceed 63 chars is a conflict",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				// 55-char policy name + "-migrated" (9 chars)
+				// = 64 chars, one over the limit.
+				withPolicy(r.OrgNamespace("acme"), "audit-this-policy-has-a-really-long-descriptive-name-xx", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated:     0,
+				policiesUpdated:     0,
+				conflicts:           1,
+				wantPlans:           1,
+				wantPolicyUnchanged: [][2]string{{r.OrgNamespace("acme"), "audit-this-policy-has-a-really-long-descriptive-name-xx"}},
+			},
+		},
+		{
 			// Codex round-1 review HOL-599: a namespace with a
 			// non-nil DeletionTimestamp is being reclaimed, so
 			// K8sResourceTopology.ListProjectsUnderScope excludes
@@ -959,7 +1059,15 @@ func assertClusterState(t *testing.T, client *fake.Clientset, want assertions) {
 			continue
 		}
 		for i, rule := range rules {
-			if rule.Target.ProjectPattern != "" || rule.Target.DeploymentPattern != "" {
+			// A cleared target is either the empty struct or the
+			// migrator's placeholder shape (project_pattern="*",
+			// deployment_pattern=""). Anything else still carries
+			// a real glob and the migration failed to translate
+			// it.
+			pp := rule.Target.ProjectPattern
+			dp := rule.Target.DeploymentPattern
+			cleared := dp == "" && (pp == "" || pp == clearedProjectPatternPlaceholder)
+			if !cleared {
 				t.Errorf("policy %s/%s rule[%d]: Target still populated (%+v)", ns, name, i, rule.Target)
 			}
 		}

--- a/cli/migrate_template_policy_targets_test.go
+++ b/cli/migrate_template_policy_targets_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -209,6 +210,44 @@ func withDeployment(ns, name string) fixtureOption {
 	}
 }
 
+// withProjectNamespaceOrphan adds a managed project namespace whose parent
+// label is missing. This is an ancestry-error fixture: the migrator must
+// refuse to enumerate descendants for policies that could be affected by
+// the broken chain rather than silently dropping the project.
+func withProjectNamespaceOrphan(name string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: b.r.ProjectNamespace(name),
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+					// No AnnotationParent — this is the
+					// orphan we are testing against.
+				},
+			},
+		})
+	}
+}
+
+// withCollidingConfigMap adds a ConfigMap in ns whose name matches what
+// the migrator synthesizes for a binding but whose resource-type label
+// identifies it as something else (e.g. a leftover Template).
+func withCollidingConfigMap(ns, name, resourceType string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: resourceType,
+				},
+			},
+		})
+	}
+}
+
 // withTerminatingProjectNamespace adds a managed project namespace whose
 // metadata.deletionTimestamp is non-nil — i.e. the namespace is in the
 // process of being deleted. The migrator must skip such namespaces to
@@ -342,6 +381,13 @@ func TestMigrateTemplatePolicyTargets(t *testing.T) {
 		// twoRuns triggers a second apply pass with the same fixture
 		// after the first pass mutates it. Used by the idempotency row.
 		twoRuns bool
+		// wantError asserts the first pass returns an error; use
+		// errorMatch to pin the error message substring. When set, no
+		// assertions run against the (nil) MigrationResult, but the
+		// cluster-state assertions on `first` still run so tests can
+		// confirm nothing was mutated before the error surfaced.
+		wantError  bool
+		errorMatch string
 		// first describes the first-pass expectations. Every scenario
 		// has exactly one first-pass assertion. Idempotent scenarios
 		// add a second.
@@ -673,6 +719,77 @@ func TestMigrateTemplatePolicyTargets(t *testing.T) {
 			},
 		},
 		{
+			// Codex round-2 review HOL-599: a ConfigMap named
+			// "<policy>-migrated" that is NOT a
+			// TemplatePolicyBinding (e.g. a leftover Template by
+			// the same name) must not be confused for a pre-
+			// existing binding. Without the resource-type check
+			// the migrator would report a permanent conflict that
+			// no binding-side operator action could resolve.
+			name: "non-binding ConfigMap with the same name as the target binding is a conflict",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+				withCollidingConfigMap(
+					r.OrgNamespace("acme"),
+					"audit"+migrateBindingNameSuffix,
+					v1alpha2.ResourceTypeTemplate,
+				),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated:     0,
+				policiesUpdated:     0,
+				conflicts:           1,
+				wantPlans:           1,
+				wantPolicyUnchanged: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+		{
+			// Codex round-2 review HOL-599: a project namespace
+			// whose parent label references a namespace not in
+			// the managed index is an ancestry error. Silently
+			// dropping the project would let the migrator clear
+			// policy Target globs while skipping legitimate
+			// bindings — a permanent coverage-loss path once
+			// HOL-600 lands. Fail loudly so the operator fixes
+			// ancestry before the migration proceeds.
+			name: "broken parent label fails loudly instead of dropping the project",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withProjectNamespaceOrphan("roses"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withDeployment(r.ProjectNamespace("roses"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run:        runArgs{apply: true},
+			wantError:  true,
+			errorMatch: "parent annotation",
+			first: assertions{
+				// No assertions run when wantError is true.
+				wantPolicyUnchanged: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+		{
 			// Codex round-1 review HOL-599: a namespace with a
 			// non-nil DeletionTimestamp is being reclaimed, so
 			// K8sResourceTopology.ListProjectsUnderScope excludes
@@ -731,6 +848,19 @@ func TestMigrateTemplatePolicyTargets(t *testing.T) {
 				Out:      &buf,
 			}
 			res, err := MigrateTemplatePolicyTargets(context.Background(), opts)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("migrate succeeded; wanted error matching %q", tt.errorMatch)
+				}
+				if tt.errorMatch != "" && !strings.Contains(err.Error(), tt.errorMatch) {
+					t.Fatalf("migrate error = %q, want substring %q", err.Error(), tt.errorMatch)
+				}
+				// Cluster-state assertions still apply: an
+				// error must not have left partial mutations
+				// behind.
+				assertClusterState(t, client, tt.first)
+				return
+			}
 			if err != nil {
 				t.Fatalf("migrate failed: %v", err)
 			}

--- a/cli/migrate_template_policy_targets_test.go
+++ b/cli/migrate_template_policy_targets_test.go
@@ -480,6 +480,11 @@ func TestMigrateTemplatePolicyTargets(t *testing.T) {
 			},
 		},
 		{
+			// Dry-run semantics: the summary counters reflect the
+			// planned work (what --apply WOULD do), matching the
+			// "would create N bindings" wording printed to stdout.
+			// Cluster-state assertions below confirm no actual
+			// mutation happened in dry-run mode.
 			name: "dry-run plans but does not mutate",
 			options: []fixtureOption{
 				withOrgNamespace("acme"),
@@ -497,8 +502,8 @@ func TestMigrateTemplatePolicyTargets(t *testing.T) {
 			},
 			run: runArgs{apply: false},
 			first: assertions{
-				bindingsCreated:     0,
-				policiesUpdated:     0,
+				bindingsCreated:     1,
+				policiesUpdated:     1,
 				wantPlans:           1,
 				wantNoBindingIn:     [][2]string{{r.OrgNamespace("acme"), "audit" + migrateBindingNameSuffix}},
 				wantPolicyUnchanged: [][2]string{{r.OrgNamespace("acme"), "audit"}},

--- a/cli/migrate_template_policy_targets_test.go
+++ b/cli/migrate_template_policy_targets_test.go
@@ -209,6 +209,33 @@ func withDeployment(ns, name string) fixtureOption {
 	}
 }
 
+// withTerminatingProjectNamespace adds a managed project namespace whose
+// metadata.deletionTimestamp is non-nil — i.e. the namespace is in the
+// process of being deleted. The migrator must skip such namespaces to
+// mirror K8sResourceTopology.ListProjectsUnderScope (HOL-570).
+func withTerminatingProjectNamespace(name, parent string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		now := metav1.Now()
+		b.objects = append(b.objects, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              b.r.ProjectNamespace(name),
+				DeletionTimestamp: &now,
+				// Kubernetes requires a finalizer when
+				// DeletionTimestamp is set; the fake client
+				// does not enforce this, but a real cluster
+				// would.
+				Finalizers: []string{"kubernetes"},
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+					v1alpha2.AnnotationParent:  parentNamespace(b.r, parent),
+					v1alpha2.LabelOrganization: rootOrgFromParent(parent),
+				},
+			},
+		})
+	}
+}
+
 // withBinding adds a pre-existing TemplatePolicyBinding ConfigMap. Used by
 // the idempotency test to simulate "the migration already ran once".
 func withBinding(ns, name, policyRefJSON, targetRefsJSON string) fixtureOption {
@@ -612,6 +639,78 @@ func TestMigrateTemplatePolicyTargets(t *testing.T) {
 					},
 				},
 				wantPolicyCleared: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+		{
+			// Codex round-1 review HOL-599: a policy whose globs
+			// match no live render targets must not produce a
+			// binding with target_refs=[] (the binding handler
+			// rejects empty lists and the resulting artifact would
+			// be uneditable). The migrator still clears the policy
+			// globs because they matched nothing under the legacy
+			// path either — clearing is semantics-preserving.
+			name: "globs matching no targets skip binding creation but still clear policy",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "nonexistent", DeploymentPattern: "nothing"},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated:   0,
+				policiesUpdated:   1,
+				wantPlans:         1,
+				wantPolicyCleared: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+				wantNoBindingIn:   [][2]string{{r.OrgNamespace("acme"), "audit" + migrateBindingNameSuffix}},
+			},
+		},
+		{
+			// Codex round-1 review HOL-599: a namespace with a
+			// non-nil DeletionTimestamp is being reclaimed, so
+			// K8sResourceTopology.ListProjectsUnderScope excludes
+			// it. The migrator must match the topology contract so
+			// it does not bind targets the legacy glob evaluation
+			// path would never have activated.
+			name: "terminating project namespaces are excluded from target enumeration",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withTerminatingProjectNamespace("roses", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				// The terminating project still has a live
+				// deployment ConfigMap — the migrator must
+				// skip the whole project because the runtime
+				// topology does, not cherry-pick its
+				// deployments.
+				withDeployment(r.ProjectNamespace("roses"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 1,
+				policiesUpdated: 1,
+				wantPlans:       1,
+				wantTargets: map[string][]wantTarget{
+					r.OrgNamespace("acme") + "/audit" + migrateBindingNameSuffix: {
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "lilies"},
+					},
+				},
 			},
 		},
 	}

--- a/cli/migrate_template_policy_targets_test.go
+++ b/cli/migrate_template_policy_targets_test.go
@@ -1,0 +1,823 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// testResolver returns the canonical default-prefix resolver the tests use.
+// Keeping the construction in a helper lets the tests read like the
+// production wire-up the CLI subcommand builds from flag values.
+func testResolver() *resolver.Resolver {
+	return &resolver.Resolver{
+		NamespacePrefix:    "holos-",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
+}
+
+// testRule mirrors the JSON wire shape stored under
+// AnnotationTemplatePolicyRules. The field names match the on-disk shape
+// exactly so tests can fabricate fixtures without importing the unexported
+// helpers in console/templatepolicies.
+type testRule struct {
+	Kind     string           `json:"kind"`
+	Template testRuleTemplate `json:"template"`
+	Target   testRuleTarget   `json:"target"`
+}
+
+type testRuleTemplate struct {
+	Scope             string `json:"scope"`
+	ScopeName         string `json:"scope_name"`
+	Name              string `json:"name"`
+	VersionConstraint string `json:"version_constraint,omitempty"`
+}
+
+type testRuleTarget struct {
+	ProjectPattern    string `json:"project_pattern"`
+	DeploymentPattern string `json:"deployment_pattern,omitempty"`
+}
+
+// fixtureOption mutates a fake-clientset fixture. Each test case declares
+// the options it needs (namespaces, policies, deployments, templates,
+// pre-existing bindings) so the table stays a compact data description of
+// the scenario rather than a prose run-book.
+type fixtureOption func(*fixtureBuilder)
+
+// fixtureBuilder accumulates objects and is flushed to a fake.Clientset at
+// the start of each subtest.
+type fixtureBuilder struct {
+	objects []runtime.Object
+	r       *resolver.Resolver
+	t       *testing.T
+}
+
+func newFixtureBuilder(t *testing.T) *fixtureBuilder {
+	return &fixtureBuilder{r: testResolver(), t: t}
+}
+
+func (b *fixtureBuilder) build() *fake.Clientset {
+	return fake.NewClientset(b.objects...)
+}
+
+// withOrgNamespace adds a managed organization namespace.
+func withOrgNamespace(name string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: b.r.OrgNamespace(name),
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				},
+			},
+		})
+	}
+}
+
+// withFolderNamespace adds a managed folder namespace whose parent label
+// points at parent's namespace.
+func withFolderNamespace(name, parent string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: b.r.FolderNamespace(name),
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+					v1alpha2.AnnotationParent:  parentNamespace(b.r, parent),
+					v1alpha2.LabelOrganization: rootOrgFromParent(parent),
+				},
+			},
+		})
+	}
+}
+
+// withProjectNamespace adds a managed project namespace whose parent label
+// points at parent's namespace.
+func withProjectNamespace(name, parent string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: b.r.ProjectNamespace(name),
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+					v1alpha2.AnnotationParent:  parentNamespace(b.r, parent),
+					v1alpha2.LabelOrganization: rootOrgFromParent(parent),
+				},
+			},
+		})
+	}
+}
+
+// parentNamespace resolves a parent reference by best-effort name lookup:
+// a name matching a known organization slug becomes the org namespace; any
+// other non-empty value becomes the folder namespace. The tests use
+// distinct slugs across kinds so the ambiguity never arises in practice.
+func parentNamespace(r *resolver.Resolver, parent string) string {
+	switch parent {
+	case "":
+		return ""
+	case "acme", "contoso", "globex":
+		return r.OrgNamespace(parent)
+	default:
+		return r.FolderNamespace(parent)
+	}
+}
+
+// rootOrgFromParent returns the organization slug associated with a parent
+// reference. Used to label folder and project namespaces so the migrator's
+// classification reflects production shape.
+func rootOrgFromParent(parent string) string {
+	switch parent {
+	case "acme", "contoso", "globex":
+		return parent
+	default:
+		return "acme"
+	}
+}
+
+// withPolicy adds a TemplatePolicy ConfigMap in ns with the given rules.
+func withPolicy(ns, name string, rules []testRule) fixtureOption {
+	return func(b *fixtureBuilder) {
+		raw, err := json.Marshal(rules)
+		if err != nil {
+			b.t.Fatalf("marshal rules: %v", err)
+		}
+		b.objects = append(b.objects, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+				},
+				Annotations: map[string]string{
+					v1alpha2.AnnotationTemplatePolicyRules: string(raw),
+				},
+			},
+		})
+	}
+}
+
+// withProjectTemplate adds a project-scope Template ConfigMap. The migrator
+// consumes these when a rule's deployment_pattern is empty.
+func withProjectTemplate(ns, name string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
+				},
+			},
+		})
+	}
+}
+
+// withDeployment adds a Deployment ConfigMap. The migrator consumes these
+// when a rule's deployment_pattern matches.
+func withDeployment(ns, name string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeDeployment,
+				},
+			},
+		})
+	}
+}
+
+// withBinding adds a pre-existing TemplatePolicyBinding ConfigMap. Used by
+// the idempotency test to simulate "the migration already ran once".
+func withBinding(ns, name, policyRefJSON, targetRefsJSON string) fixtureOption {
+	return func(b *fixtureBuilder) {
+		b.objects = append(b.objects, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicyBinding,
+				},
+				Annotations: map[string]string{
+					v1alpha2.AnnotationTemplatePolicyBindingPolicyRef:  policyRefJSON,
+					v1alpha2.AnnotationTemplatePolicyBindingTargetRefs: targetRefsJSON,
+				},
+			},
+		})
+	}
+}
+
+// wantTarget is a compact shape for asserting which render targets the
+// migrator selected. Test tables declare it in an order-insensitive slice
+// and the assertion helper normalizes both sides before comparing.
+type wantTarget struct {
+	Kind    consolev1.TemplatePolicyBindingTargetKind
+	Name    string
+	Project string
+}
+
+// sortTargets yields a stable order the assertion can compare byte-for-
+// byte, eliminating flakiness caused by map iteration on either side.
+func sortTargets(in []wantTarget) []wantTarget {
+	out := append([]wantTarget(nil), in...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Project != out[j].Project {
+			return out[i].Project < out[j].Project
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// extractTargets reduces a plan's TargetRefs to the comparable wantTarget
+// shape. Keeps the assertion decoupled from proto internals.
+func extractTargets(refs []*consolev1.TemplatePolicyBindingTargetRef) []wantTarget {
+	out := make([]wantTarget, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, wantTarget{Kind: r.GetKind(), Name: r.GetName(), Project: r.GetProjectName()})
+	}
+	return out
+}
+
+// runArgs selects the mode MigrateTemplatePolicyTargets runs in.
+type runArgs struct {
+	apply bool
+}
+
+// assertions is the expectation block for a single migration pass. Hoisted
+// to package scope so the helper functions below can take a value receiver
+// instead of passing 5+ discrete parameters around.
+type assertions struct {
+	bindingsCreated int
+	policiesUpdated int
+	skipped         int
+	conflicts       int
+	wantPlans       int
+	wantTargets     map[string][]wantTarget // binding full path -> expected targets
+	// wantNoBindingIn lists (namespace, name) pairs we must not find
+	// after the run. Used by the dry-run row to assert zero mutations.
+	wantNoBindingIn [][2]string
+	// wantPolicyCleared lists (namespace, name) pairs whose Target globs
+	// must be empty after the run. Used to pin the "clear after
+	// migration" AC.
+	wantPolicyCleared [][2]string
+	// wantPolicyUnchanged lists (namespace, name) pairs whose Target
+	// globs must still be non-empty after the run (dry-run and conflict
+	// rows).
+	wantPolicyUnchanged [][2]string
+}
+
+// TestMigrateTemplatePolicyTargets is the single table-driven test that
+// exercises every acceptance-criterion scenario from HOL-599:
+//
+//   - Empty cluster → no bindings written.
+//   - Policy with one deployment_pattern matching two deployments across
+//     two projects → one binding with two target_refs.
+//   - Idempotency: a second run finds an existing binding with matching
+//     targets and writes nothing new.
+//
+// A handful of additional rows cover the behavioral edges the main scenarios
+// do not exercise (empty deployment_pattern selecting both kinds, dry-run
+// mutating nothing, conflict detection).
+func TestMigrateTemplatePolicyTargets(t *testing.T) {
+	r := testResolver()
+
+	tests := []struct {
+		name    string
+		options []fixtureOption
+		run     runArgs
+		// twoRuns triggers a second apply pass with the same fixture
+		// after the first pass mutates it. Used by the idempotency row.
+		twoRuns bool
+		// first describes the first-pass expectations. Every scenario
+		// has exactly one first-pass assertion. Idempotent scenarios
+		// add a second.
+		first assertions
+		// second describes the expected state after a second apply
+		// pass, when twoRuns is true. Both passes operate on the same
+		// fake client.
+		second assertions
+	}{
+		{
+			name:    "empty cluster writes no bindings",
+			options: nil,
+			run:     runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 0,
+				policiesUpdated: 0,
+				skipped:         0,
+				conflicts:       0,
+				wantPlans:       0,
+			},
+		},
+		{
+			name: "policy with one deployment_pattern matching two deployments across two projects",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withProjectNamespace("roses", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withDeployment(r.ProjectNamespace("roses"), "api"),
+				// A deployment that should NOT match by name.
+				withDeployment(r.ProjectNamespace("lilies"), "worker"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 1,
+				policiesUpdated: 1,
+				wantPlans:       1,
+				wantTargets: map[string][]wantTarget{
+					r.OrgNamespace("acme") + "/audit" + migrateBindingNameSuffix: {
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "lilies"},
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "roses"},
+					},
+				},
+				wantPolicyCleared: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+		{
+			name: "idempotency: second run skips policies already cleared",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run:     runArgs{apply: true},
+			twoRuns: true,
+			first: assertions{
+				bindingsCreated: 1,
+				policiesUpdated: 1,
+				wantPlans:       1,
+				wantTargets: map[string][]wantTarget{
+					r.OrgNamespace("acme") + "/audit" + migrateBindingNameSuffix: {
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "lilies"},
+					},
+				},
+				wantPolicyCleared: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+			second: assertions{
+				bindingsCreated: 0,
+				policiesUpdated: 0,
+				skipped:         1,
+				wantPlans:       0,
+			},
+		},
+		{
+			name: "dry-run plans but does not mutate",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run: runArgs{apply: false},
+			first: assertions{
+				bindingsCreated:     0,
+				policiesUpdated:     0,
+				wantPlans:           1,
+				wantNoBindingIn:     [][2]string{{r.OrgNamespace("acme"), "audit" + migrateBindingNameSuffix}},
+				wantPolicyUnchanged: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+		{
+			name: "empty deployment_pattern matches both project templates and deployments",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withProjectTemplate(r.ProjectNamespace("lilies"), "stack"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "lilies", DeploymentPattern: ""},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 1,
+				policiesUpdated: 1,
+				wantPlans:       1,
+				wantTargets: map[string][]wantTarget{
+					r.OrgNamespace("acme") + "/audit" + migrateBindingNameSuffix: {
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "lilies"},
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE, Name: "stack", Project: "lilies"},
+					},
+				},
+			},
+		},
+		{
+			name: "folder scope only selects descendant projects",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withFolderNamespace("eng", "acme"),
+				withProjectNamespace("lilies", "eng"),
+				withProjectNamespace("orchids", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withDeployment(r.ProjectNamespace("orchids"), "api"),
+				withPolicy(r.FolderNamespace("eng"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeFolder, ScopeName: "eng", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 1,
+				policiesUpdated: 1,
+				wantPlans:       1,
+				wantTargets: map[string][]wantTarget{
+					r.FolderNamespace("eng") + "/audit" + migrateBindingNameSuffix: {
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "lilies"},
+					},
+				},
+			},
+		},
+		{
+			name: "policy with already-empty targets is skipped",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "", DeploymentPattern: ""},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 0,
+				policiesUpdated: 0,
+				skipped:         1,
+				wantPlans:       0,
+			},
+		},
+		{
+			name: "existing binding with matching targets is left in place, policy still cleared",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+				withBinding(
+					r.OrgNamespace("acme"),
+					"audit"+migrateBindingNameSuffix,
+					`{"scope":"organization","scopeName":"acme","name":"audit"}`,
+					`[{"kind":"deployment","name":"api","projectName":"lilies"}]`,
+				),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated:   0,
+				policiesUpdated:   1,
+				wantPlans:         1,
+				wantPolicyCleared: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+		{
+			name: "existing binding with different targets is a conflict",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+				}),
+				withBinding(
+					r.OrgNamespace("acme"),
+					"audit"+migrateBindingNameSuffix,
+					`{"scope":"organization","scopeName":"acme","name":"audit"}`,
+					`[{"kind":"deployment","name":"worker","projectName":"lilies"}]`,
+				),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated:     0,
+				policiesUpdated:     0,
+				conflicts:           1,
+				wantPlans:           1,
+				wantPolicyUnchanged: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+		{
+			name: "two rules with disjoint targets produce a single binding with the union",
+			options: []fixtureOption{
+				withOrgNamespace("acme"),
+				withProjectNamespace("lilies", "acme"),
+				withDeployment(r.ProjectNamespace("lilies"), "api"),
+				withDeployment(r.ProjectNamespace("lilies"), "worker"),
+				withPolicy(r.OrgNamespace("acme"), "audit", []testRule{
+					{
+						Kind: "require",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "audit-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "api"},
+					},
+					{
+						Kind: "exclude",
+						Template: testRuleTemplate{
+							Scope: v1alpha2.TemplateScopeOrganization, ScopeName: "acme", Name: "legacy-policy",
+						},
+						Target: testRuleTarget{ProjectPattern: "*", DeploymentPattern: "worker"},
+					},
+				}),
+			},
+			run: runArgs{apply: true},
+			first: assertions{
+				bindingsCreated: 1,
+				policiesUpdated: 1,
+				wantPlans:       1,
+				wantTargets: map[string][]wantTarget{
+					r.OrgNamespace("acme") + "/audit" + migrateBindingNameSuffix: {
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "api", Project: "lilies"},
+						{Kind: consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT, Name: "worker", Project: "lilies"},
+					},
+				},
+				wantPolicyCleared: [][2]string{{r.OrgNamespace("acme"), "audit"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newFixtureBuilder(t)
+			for _, opt := range tt.options {
+				opt(b)
+			}
+			client := b.build()
+
+			var buf bytes.Buffer
+			opts := MigrateTemplatePolicyTargetsOptions{
+				Client:   client,
+				Resolver: r,
+				Apply:    tt.run.apply,
+				Out:      &buf,
+			}
+			res, err := MigrateTemplatePolicyTargets(context.Background(), opts)
+			if err != nil {
+				t.Fatalf("migrate failed: %v", err)
+			}
+			assertResult(t, "first pass", res, tt.first)
+			assertClusterState(t, client, tt.first)
+
+			if !tt.twoRuns {
+				return
+			}
+			res2, err := MigrateTemplatePolicyTargets(context.Background(), opts)
+			if err != nil {
+				t.Fatalf("second migrate failed: %v", err)
+			}
+			assertResult(t, "second pass", res2, tt.second)
+			assertClusterState(t, client, tt.second)
+		})
+	}
+}
+
+// assertResult compares a MigrationResult against the expected counts and
+// per-binding targets the row declared.
+func assertResult(t *testing.T, label string, got *MigrationResult, want assertions) {
+	t.Helper()
+	if got.BindingsCreated != want.bindingsCreated {
+		t.Errorf("%s: BindingsCreated = %d, want %d", label, got.BindingsCreated, want.bindingsCreated)
+	}
+	if got.PoliciesUpdated != want.policiesUpdated {
+		t.Errorf("%s: PoliciesUpdated = %d, want %d", label, got.PoliciesUpdated, want.policiesUpdated)
+	}
+	if got.Skipped != want.skipped {
+		t.Errorf("%s: Skipped = %d, want %d", label, got.Skipped, want.skipped)
+	}
+	if got.Conflicts != want.conflicts {
+		t.Errorf("%s: Conflicts = %d, want %d", label, got.Conflicts, want.conflicts)
+	}
+	if len(got.Plans) != want.wantPlans {
+		t.Errorf("%s: len(Plans) = %d, want %d", label, len(got.Plans), want.wantPlans)
+	}
+	for fullName, wantRefs := range want.wantTargets {
+		plan := findPlanByFullName(got.Plans, fullName)
+		if plan == nil {
+			t.Errorf("%s: expected plan %q not found", label, fullName)
+			continue
+		}
+		gotRefs := sortTargets(extractTargets(plan.TargetRefs))
+		wantSorted := sortTargets(wantRefs)
+		if len(gotRefs) != len(wantSorted) {
+			t.Errorf("%s: plan %q target count = %d, want %d (got=%v want=%v)",
+				label, fullName, len(gotRefs), len(wantSorted), gotRefs, wantSorted)
+			continue
+		}
+		for i := range gotRefs {
+			if gotRefs[i] != wantSorted[i] {
+				t.Errorf("%s: plan %q target[%d] = %+v, want %+v", label, fullName, i, gotRefs[i], wantSorted[i])
+			}
+		}
+	}
+}
+
+// findPlanByFullName locates a plan by "namespace/bindingName". Returns nil
+// if no plan matches — the caller turns the nil into a test failure.
+func findPlanByFullName(plans []*PolicyMigrationPlan, fullName string) *PolicyMigrationPlan {
+	for _, plan := range plans {
+		if plan.PolicyNamespace+"/"+plan.BindingName == fullName {
+			return plan
+		}
+	}
+	return nil
+}
+
+// assertClusterState verifies the mutations declared by wantPolicyCleared,
+// wantPolicyUnchanged, and wantNoBindingIn match what is actually on the
+// fake cluster after the run.
+func assertClusterState(t *testing.T, client *fake.Clientset, want assertions) {
+	t.Helper()
+	ctx := context.Background()
+	for _, pair := range want.wantPolicyCleared {
+		ns, name := pair[0], pair[1]
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("policy %s/%s: get failed: %v", ns, name, err)
+			continue
+		}
+		raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyRules]
+		if raw == "" {
+			continue
+		}
+		var rules []testRule
+		if err := json.Unmarshal([]byte(raw), &rules); err != nil {
+			t.Errorf("policy %s/%s: unmarshal failed: %v", ns, name, err)
+			continue
+		}
+		for i, rule := range rules {
+			if rule.Target.ProjectPattern != "" || rule.Target.DeploymentPattern != "" {
+				t.Errorf("policy %s/%s rule[%d]: Target still populated (%+v)", ns, name, i, rule.Target)
+			}
+		}
+	}
+	for _, pair := range want.wantPolicyUnchanged {
+		ns, name := pair[0], pair[1]
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("policy %s/%s: get failed: %v", ns, name, err)
+			continue
+		}
+		raw := cm.Annotations[v1alpha2.AnnotationTemplatePolicyRules]
+		if raw == "" {
+			t.Errorf("policy %s/%s: expected unchanged rules but annotation is empty", ns, name)
+			continue
+		}
+		var rules []testRule
+		if err := json.Unmarshal([]byte(raw), &rules); err != nil {
+			t.Errorf("policy %s/%s: unmarshal failed: %v", ns, name, err)
+			continue
+		}
+		populated := false
+		for _, rule := range rules {
+			if rule.Target.ProjectPattern != "" || rule.Target.DeploymentPattern != "" {
+				populated = true
+				break
+			}
+		}
+		if !populated {
+			t.Errorf("policy %s/%s: Target globs unexpectedly cleared", ns, name)
+		}
+	}
+	for _, pair := range want.wantNoBindingIn {
+		ns, name := pair[0], pair[1]
+		_, err := client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			t.Errorf("binding %s/%s: unexpectedly present after dry-run", ns, name)
+		}
+	}
+}
+
+// TestMigrateTemplatePolicyTargetsRejectsMissingDeps guards the small defensive
+// checks in the entry point: callers that wire the migrator without a
+// client, a resolver, or an output writer must be told explicitly rather
+// than seeing a nil-deref in the middle of a partial run.
+func TestMigrateTemplatePolicyTargetsRejectsMissingDeps(t *testing.T) {
+	r := testResolver()
+	var buf bytes.Buffer
+	cases := []struct {
+		name string
+		opts MigrateTemplatePolicyTargetsOptions
+	}{
+		{
+			name: "missing client",
+			opts: MigrateTemplatePolicyTargetsOptions{Resolver: r, Out: &buf},
+		},
+		{
+			name: "missing resolver",
+			opts: MigrateTemplatePolicyTargetsOptions{Client: fake.NewClientset(), Out: &buf},
+		},
+		{
+			name: "missing out writer",
+			opts: MigrateTemplatePolicyTargetsOptions{Client: fake.NewClientset(), Resolver: r},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := MigrateTemplatePolicyTargets(context.Background(), tt.opts)
+			if err == nil {
+				t.Fatal("expected error for missing dependency; got nil")
+			}
+		})
+	}
+}
+
+// TestMigrateCommandRegistered confirms `migrate template-policy-targets`
+// is wired into the root cobra tree. A subcommand that is not registered
+// is invisible to operators, so the regression test pins the registration
+// separately from the migrator's internal behavior.
+func TestMigrateCommandRegistered(t *testing.T) {
+	cmd := Command()
+	migrate, _, err := cmd.Find([]string{"migrate"})
+	if err != nil || migrate == nil {
+		t.Fatalf("migrate subcommand not registered: %v", err)
+	}
+	sub, _, err := cmd.Find([]string{"migrate", "template-policy-targets"})
+	if err != nil || sub == nil {
+		t.Fatalf("migrate template-policy-targets subcommand not registered: %v", err)
+	}
+	if flag := sub.Flags().Lookup("apply"); flag == nil {
+		t.Fatal("--apply flag not declared on migrate template-policy-targets")
+	} else if flag.DefValue != "false" {
+		t.Fatalf("--apply default = %q, want %q", flag.DefValue, "false")
+	}
+}

--- a/cli/migrate_template_policy_targets_test.go
+++ b/cli/migrate_template_policy_targets_test.go
@@ -1059,15 +1059,13 @@ func assertClusterState(t *testing.T, client *fake.Clientset, want assertions) {
 			continue
 		}
 		for i, rule := range rules {
-			// A cleared target is either the empty struct or the
-			// migrator's placeholder shape (project_pattern="*",
-			// deployment_pattern=""). Anything else still carries
-			// a real glob and the migration failed to translate
-			// it.
-			pp := rule.Target.ProjectPattern
-			dp := rule.Target.DeploymentPattern
-			cleared := dp == "" && (pp == "" || pp == clearedProjectPatternPlaceholder)
-			if !cleared {
+			// Both globs must be the empty string after the
+			// migration. A literal "*" is NOT acceptable — it
+			// would be indistinguishable from a legitimate
+			// pre-migration wildcard rule and would also keep
+			// the legacy resolver path active for uncovered
+			// render targets.
+			if rule.Target.ProjectPattern != "" || rule.Target.DeploymentPattern != "" {
 				t.Errorf("policy %s/%s rule[%d]: Target still populated (%+v)", ns, name, i, rule.Target)
 			}
 		}

--- a/docs/migrations/hol-590-template-policy-bindings.md
+++ b/docs/migrations/hol-590-template-policy-bindings.md
@@ -1,0 +1,103 @@
+# Migration: TemplatePolicyRule.Target globs -> TemplatePolicyBindings
+
+This runbook covers the one-shot cluster migration added in HOL-599. Run it once per environment before rolling out HOL-600, which removes the legacy `TemplatePolicyRule.Target.{project_pattern, deployment_pattern}` evaluation path.
+
+## Background
+
+Prior to HOL-590, `TemplatePolicy` selected its render targets via two glob fields on every rule:
+
+- `target.project_pattern` — matched against the project slug.
+- `target.deployment_pattern` — matched against the deployment name; when empty, the rule matched both project-scope templates and deployments.
+
+HOL-590 replaced that selector with an explicit `TemplatePolicyBinding` resource: a named attachment from a single `TemplatePolicy` to a concrete list of `(kind, project_name, name)` render targets. The resolver (HOL-596) already evaluates bindings alongside the legacy globs; this migration translates any currently-populated glob into an equivalent binding, then clears the glob fields on the policy so HOL-600 can delete the evaluation path safely.
+
+## When to run
+
+Run this migration exactly once per environment, **after** the binding handler, resolver, and UI have landed (HOL-592..598) and **before** HOL-600 is merged.
+
+A cluster where every `TemplatePolicy` has empty `Target` fields does not need this migration. The command is still safe to run against such a cluster — it reports `0 plans, N skipped` and exits clean.
+
+## Command
+
+```
+holos-console migrate template-policy-targets [--apply]
+```
+
+Defaults:
+
+- `--dry-run` is implied. The command prints the plan it would execute and exits without mutating the cluster. Re-run with `--apply` to mutate.
+- The namespace-prefix flags (`--namespace-prefix`, `--organization-prefix`, `--folder-prefix`, `--project-prefix`) are inherited from the root `holos-console` command. If your deployment uses non-default prefixes, pass them on the command line.
+
+Kubernetes credentials are discovered the same way the server discovers them: in-cluster first, then `KUBECONFIG`. The command fails fast with `no kubernetes config available` if neither is configured.
+
+### Dry-run
+
+```
+holos-console migrate template-policy-targets
+```
+
+Emits one block per policy with non-empty `Target` globs:
+
+```
+policy holos-org-acme/audit -> binding holos-org-acme/audit-migrated (scope=organization, scope_name=acme)
+  targets:
+    - kind=deployment project=lilies name=api
+    - kind=deployment project=roses name=api
+  status: will create new binding and clear policy Target globs
+
+Summary: 0 would create bindings; would clear targets on 0 policies; 0 skipped (already migrated); 0 conflicts.
+Re-run with --apply to mutate the cluster.
+```
+
+### Apply
+
+```
+holos-console migrate template-policy-targets --apply
+```
+
+Re-runs the same enumeration, then:
+
+1. Creates each missing `TemplatePolicyBinding` with the computed target set.
+2. Clears the `target.project_pattern` and `target.deployment_pattern` fields on every rule in the originating policy (all other rule fields are preserved verbatim).
+
+The final summary line distinguishes dry-run from apply:
+
+```
+Summary: 3 created bindings; cleared targets on 3 policies; 1 skipped (already migrated); 0 conflicts.
+```
+
+## What the command does, in detail
+
+1. Lists every namespace carrying the `app.kubernetes.io/managed-by=console.holos.run` label.
+2. Classifies each namespace as organization, folder, or project using the same prefix scheme the runtime resolver uses.
+3. For each organization and folder namespace, lists `TemplatePolicy` ConfigMaps (`console.holos.run/resource-type=template-policy`).
+4. Skips any policy whose rules already have empty `Target` globs — such a policy is either newly authored under HOL-598's UI or has already been migrated on a previous run.
+5. For each remaining policy, enumerates the descendant project namespaces (by walking the `console.holos.run/parent` label chain), then for each rule with a non-empty `Target`:
+   - Matches `project_pattern` against each descendant project slug.
+   - When `deployment_pattern` is empty, selects every project-scope template and every deployment in the matched projects.
+   - When `deployment_pattern` is non-empty, selects only deployments whose name matches the pattern in the matched projects.
+6. Deduplicates the collected `(kind, project_name, name)` triples into a sorted target list.
+7. Looks up any existing binding named `<policy-name>-migrated` in the policy's namespace:
+   - If the binding already exists with the same target set, leaves it alone (and only clears the policy's `Target` fields on `--apply`).
+   - If the binding exists with a different target set, records a `CONFLICT` in the plan and leaves the policy untouched.
+   - If no binding exists, creates one on `--apply`.
+8. On `--apply`, creates the binding first, then clears the policy's `Target` fields.
+
+## Idempotency
+
+Re-running the command is always safe:
+
+- A policy whose `Target` fields are already empty is skipped entirely. The command reports it under `N skipped (already migrated)`.
+- A binding with the deterministic name `<policy-name>-migrated` that already carries the expected target set is re-used. The command does not attempt to recreate it and does not attempt to mutate it.
+- A partial run that created the binding but failed before clearing the policy retries cleanly: the next invocation finds the binding, verifies the target set matches, and proceeds directly to clearing the policy.
+
+## Operator actions after a conflict
+
+A `CONFLICT` row means an existing binding has the expected name but different target refs. The command refuses to overwrite the binding so an operator can inspect it and decide how to proceed:
+
+- If the existing binding is correct, rename or delete the policy's `Target` fields by hand and re-run this migration — the policy will then be classified as "already migrated" and skipped.
+- If the existing binding is wrong, delete it and re-run with `--apply` to have the migrator recreate it.
+
+## Semantic caveat
+
+Pre-HOL-590 rule-level `Target` globs could select a narrower set per rule than the policy as a whole. The binding model is per-policy: a single binding covers all of its bound policy's rules for every target it names. If a policy has multiple rules with disjoint `Target` globs, the migration produces one binding with the union of all matched targets. Post-migration every rule applies to every target named on that union — which may broaden some rules relative to their pre-migration glob. In practice platform engineers author policy rules to cover the same target set, so this broadening is uncommon; if your cluster has exotic per-rule targets, review the printed plan before running `--apply` and split the policy into multiple narrower policies beforehand.

--- a/docs/migrations/hol-590-template-policy-bindings.md
+++ b/docs/migrations/hol-590-template-policy-bindings.md
@@ -117,11 +117,14 @@ Typical recovery steps:
 
 The synthesized binding name is always `<policy-name>-migrated`. A policy whose name is longer than 54 characters produces a binding name over the 63-character Kubernetes DNS-label limit; the migrator flags such policies as a conflict during planning so the dry-run output makes the problem visible before an `--apply` run. Rename the policy (or create the binding by hand) and re-run the migration.
 
-## Cleared target shape
+## Cleared target shape and the HOL-598 → HOL-600 transition window
 
-On `--apply` the migrator rewrites every rule's `target` to the placeholder shape `{project_pattern: "*", deployment_pattern: ""}` rather than the empty struct. The reason is practical: the pre-HOL-600 `TemplatePolicy` validator still requires a non-empty `project_pattern`, so a policy cleared to `{}` would be read-only through the UI/API until HOL-600 lands and removes the validator. The `"*"` placeholder satisfies the validator, and the resolver honors the binding (HOL-596) as the authoritative selector for covered render targets. When HOL-600 lands and the legacy evaluation path goes away, the placeholder is inert.
+On `--apply` the migrator rewrites every rule's `target` to the empty struct `{project_pattern: "", deployment_pattern: ""}` — the shape the ticket's AC specifies. That shape has two important interactions with the transition window between HOL-598 (UI glob-input removal, already merged) and HOL-600 (validator + legacy-evaluation-path removal, follows this PR):
 
-Re-running the migration after the cleared state is a no-op: the idempotency short-circuit treats both `project_pattern=""` and `project_pattern="*"` (with empty `deployment_pattern`) as "already migrated" and skips the policy entirely.
+1. The pre-HOL-600 `TemplatePolicy` validator still rejects a rule with `project_pattern=""` on UI/API updates. That means a migrated policy cannot be updated through the UI or the `UpdateTemplatePolicy` RPC until HOL-600 lands. This is NOT a regression introduced by the migration: HOL-598 already removed the UI inputs that could supply a non-empty `project_pattern`, so the UI cannot update ANY policy during the transition window regardless of whether the migration has run. HOL-600 is the paired patch that removes the validator and restores UI updatability.
+2. Using any non-empty placeholder (e.g. `"*"`) would have two bad consequences during the same window. First, the pre-HOL-600 resolver only bypasses a rule's glob for render targets a matching binding specifically covers — a `"*"` placeholder would therefore broaden the policy's effective set to every render target not named by the binding (new projects, new deployments). Second, `"*"` is a legitimate pre-migration wildcard, so the idempotency classifier would be unable to tell a legacy wildcard rule apart from a migrator-cleared rule, silently skipping policies that actually still need translation.
+
+Re-running the migration is still a no-op: a policy whose rules are all literally empty is classified as "already migrated" and skipped.
 
 ## Semantic caveat
 

--- a/docs/migrations/hol-590-template-policy-bindings.md
+++ b/docs/migrations/hol-590-template-policy-bindings.md
@@ -76,12 +76,14 @@ Summary: 3 created bindings; cleared targets on 3 policies; 1 skipped (already m
    - Matches `project_pattern` against each descendant project slug.
    - When `deployment_pattern` is empty, selects every project-scope template and every deployment in the matched projects.
    - When `deployment_pattern` is non-empty, selects only deployments whose name matches the pattern in the matched projects.
-6. Deduplicates the collected `(kind, project_name, name)` triples into a sorted target list.
-7. Looks up any existing binding named `<policy-name>-migrated` in the policy's namespace:
+6. Skips project namespaces carrying a non-nil `metadata.deletionTimestamp` so the migrator's descendant set matches the runtime topology's (HOL-570). Binding targets that live in terminating namespaces would never have activated under the legacy glob evaluation path.
+7. Deduplicates the collected `(kind, project_name, name)` triples into a sorted target list.
+8. If the target list is empty (the globs currently match no live render targets), skips binding creation — the binding handler rejects an empty `target_refs` list and writing one would leave an uneditable ConfigMap artifact. The policy's `Target` fields are still cleared on `--apply` because the globs matched nothing under the legacy path either, so clearing is semantics-preserving.
+9. Looks up any existing binding named `<policy-name>-migrated` in the policy's namespace:
    - If the binding already exists with the same target set, leaves it alone (and only clears the policy's `Target` fields on `--apply`).
    - If the binding exists with a different target set, records a `CONFLICT` in the plan and leaves the policy untouched.
-   - If no binding exists, creates one on `--apply`.
-8. On `--apply`, creates the binding first, then clears the policy's `Target` fields.
+   - If no binding exists (and the target list is non-empty), creates one on `--apply`.
+10. On `--apply`, creates the binding first (when needed), then clears the policy's `Target` fields.
 
 ## Idempotency
 
@@ -90,6 +92,7 @@ Re-running the command is always safe:
 - A policy whose `Target` fields are already empty is skipped entirely. The command reports it under `N skipped (already migrated)`.
 - A binding with the deterministic name `<policy-name>-migrated` that already carries the expected target set is re-used. The command does not attempt to recreate it and does not attempt to mutate it.
 - A partial run that created the binding but failed before clearing the policy retries cleanly: the next invocation finds the binding, verifies the target set matches, and proceeds directly to clearing the policy.
+- A policy whose globs match no live render targets is cleared without producing a binding. A subsequent run sees the cleared Target fields and classifies the policy as already migrated.
 
 ## Operator actions after a conflict
 

--- a/docs/migrations/hol-590-template-policy-bindings.md
+++ b/docs/migrations/hol-590-template-policy-bindings.md
@@ -101,6 +101,18 @@ A `CONFLICT` row means an existing binding has the expected name but different t
 - If the existing binding is correct, rename or delete the policy's `Target` fields by hand and re-run this migration — the policy will then be classified as "already migrated" and skipped.
 - If the existing binding is wrong, delete it and re-run with `--apply` to have the migrator recreate it.
 
+A conflict row can also indicate a **name collision with a non-binding ConfigMap** (for example a leftover Template named `<policy>-migrated`). The plan note identifies this case explicitly and names the colliding `resource-type`. Delete or rename the offending ConfigMap and re-run the migration; the migrator does not overwrite objects it did not create.
+
+## Operator actions after an ancestry error
+
+The command fails fast when a managed project namespace's parent chain is broken — missing `console.holos.run/parent` label, a parent that is not in the managed namespace index, or a cycle. Fixing the error before the migration runs is required because silently dropping the project from the descendant set would allow the migrator to clear policy `Target` globs while skipping legitimate bindings, which would permanently remove policy coverage once HOL-600 lands.
+
+Typical recovery steps:
+
+- Inspect the failing namespace reported in the error message (`walking ancestors of "holos-prj-<slug>"`).
+- Restore the missing or cyclic `console.holos.run/parent` label so the chain terminates at the owning organization namespace.
+- Re-run the migration — the migrator re-walks the chain and proceeds once the ancestry is consistent.
+
 ## Semantic caveat
 
 Pre-HOL-590 rule-level `Target` globs could select a narrower set per rule than the policy as a whole. The binding model is per-policy: a single binding covers all of its bound policy's rules for every target it names. If a policy has multiple rules with disjoint `Target` globs, the migration produces one binding with the union of all matched targets. Post-migration every rule applies to every target named on that union — which may broaden some rules relative to their pre-migration glob. In practice platform engineers author policy rules to cover the same target set, so this broadening is uncommon; if your cluster has exotic per-rule targets, review the printed plan before running `--apply` and split the policy into multiple narrower policies beforehand.

--- a/docs/migrations/hol-590-template-policy-bindings.md
+++ b/docs/migrations/hol-590-template-policy-bindings.md
@@ -113,6 +113,16 @@ Typical recovery steps:
 - Restore the missing or cyclic `console.holos.run/parent` label so the chain terminates at the owning organization namespace.
 - Re-run the migration — the migrator re-walks the chain and proceeds once the ancestry is consistent.
 
+## Policy name length caveat
+
+The synthesized binding name is always `<policy-name>-migrated`. A policy whose name is longer than 54 characters produces a binding name over the 63-character Kubernetes DNS-label limit; the migrator flags such policies as a conflict during planning so the dry-run output makes the problem visible before an `--apply` run. Rename the policy (or create the binding by hand) and re-run the migration.
+
+## Cleared target shape
+
+On `--apply` the migrator rewrites every rule's `target` to the placeholder shape `{project_pattern: "*", deployment_pattern: ""}` rather than the empty struct. The reason is practical: the pre-HOL-600 `TemplatePolicy` validator still requires a non-empty `project_pattern`, so a policy cleared to `{}` would be read-only through the UI/API until HOL-600 lands and removes the validator. The `"*"` placeholder satisfies the validator, and the resolver honors the binding (HOL-596) as the authoritative selector for covered render targets. When HOL-600 lands and the legacy evaluation path goes away, the placeholder is inert.
+
+Re-running the migration after the cleared state is a no-op: the idempotency short-circuit treats both `project_pattern=""` and `project_pattern="*"` (with empty `deployment_pattern`) as "already migrated" and skips the policy entirely.
+
 ## Semantic caveat
 
 Pre-HOL-590 rule-level `Target` globs could select a narrower set per rule than the policy as a whole. The binding model is per-policy: a single binding covers all of its bound policy's rules for every target it names. If a policy has multiple rules with disjoint `Target` globs, the migration produces one binding with the union of all matched targets. Post-migration every rule applies to every target named on that union — which may broaden some rules relative to their pre-migration glob. In practice platform engineers author policy rules to cover the same target set, so this broadening is uncommon; if your cluster has exotic per-rule targets, review the printed plan before running `--apply` and split the policy into multiple narrower policies beforehand.


### PR DESCRIPTION
## Summary
- Adds `holos-console migrate template-policy-targets` (default `--dry-run`, mutates on `--apply`) that translates legacy `TemplatePolicyRule.Target.{project_pattern, deployment_pattern}` globs into explicit `TemplatePolicyBinding` objects and clears the originating `Target` fields in place.
- Migration is idempotent: policies whose Target globs are already empty are skipped; bindings with matching target sets are re-used; bindings with differing target sets are reported as `CONFLICT` and left untouched for operator triage.
- Table-driven tests use `k8s.io/client-go/kubernetes/fake` to pin every AC scenario (empty cluster, one deployment_pattern matching two deployments across two projects, idempotent second run) plus the behavioral edges (empty deployment_pattern selecting both project templates and deployments, folder-scope descendant selection, dry-run immutability, conflict detection, multi-rule union).
- Operator runbook at `docs/migrations/hol-590-template-policy-bindings.md` documents dry-run, apply, idempotency, and the rule-to-binding semantic caveat. `CONTRIBUTING.md` links to the runbook from a new `## Migrations` section.

Fixes HOL-599

## Test plan
- [ ] `make lint && make test` pass locally.
- [ ] `go test ./cli/...` — all 14 subtests pass.
- [ ] `holos-console migrate --help` and `holos-console migrate template-policy-targets --help` render the new subcommand documentation.
- [ ] Smoke check the runbook against a local cluster with a policy carrying non-empty Target globs: dry-run prints the plan, `--apply` creates the binding and clears the Target, re-run reports "already migrated".

Generated with [Claude Code](https://claude.com/claude-code)