### PR TITLE
chore(agents): add AGENTS.md with demo docs routing guardrail (HOL-634)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Agent context map for the `holos-console` code repo. For architecture, testing,
+UI conventions, and the full catalog of cross-cutting guardrails, see the
+companion
+[AGENTS.md in holos-console-docs](https://github.com/holos-run/holos-console-docs/blob/main/AGENTS.md).
+
+This code is not yet released. Do not preserve backwards compatibility when
+making changes. Review `CONTRIBUTING.md` for commit message requirements before
+opening a PR.
+
+## Guardrails
+
+- **Demo docs routing** — Demo setup materials and CUE example snippets belong
+  in
+  [`holos-run/holos-console-docs/demo/`](https://github.com/holos-run/holos-console-docs/tree/main/demo),
+  **not** in this repo. Demo-related issues must include concrete examples and
+  operator guidance. Smoke-test instructions must include `kubectl` commands
+  for the resources required to observe the feature in the demo environment.
+  Forward pointers:
+  [demo README](https://github.com/holos-run/holos-console-docs/blob/main/demo/README.md)
+  and
+  [smoke tests](https://github.com/holos-run/holos-console-docs/tree/main/demo/smoke-tests).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+Working with Claude Code or another coding agent? Start with [AGENTS.md](AGENTS.md) for the repo-local guardrails and a pointer to the shared agent context in `holos-console-docs`.
+
 ## Prerequisites
 
 - Go 1.25.0 or later


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` at the repo root as the agent context map for the `holos-console` code repo, linking out to the companion `AGENTS.md` in `holos-console-docs` for architecture, testing, UI conventions, and the shared guardrail catalog.
- Declare a single **Demo docs routing** guardrail: demo setup materials and CUE example snippets belong in `holos-run/holos-console-docs/demo/` (not in this repo); demo-related issues must include concrete examples and operator guidance; smoke-test instructions must include `kubectl` commands for the resources needed to observe the feature in the demo environment.
- Forward-reference the demo `README.md` and `smoke-tests/` directory that HOL-635 and HOL-636 will populate.
- Add a one-line pointer in `CONTRIBUTING.md` near the top so contributors discover `AGENTS.md`.

Fixes HOL-634

## Test plan
- [ ] Render `AGENTS.md` on GitHub and confirm all outbound links resolve (the `demo/` paths are forward-pointers and may 404 until HOL-635/HOL-636 land — that is expected).
- [ ] Render `CONTRIBUTING.md` on GitHub and confirm the new `AGENTS.md` pointer at the top renders.
- [ ] No code files touched, so no `make test` run is required; confirm the CI docs/lint checks pass.

Generated with [Claude Code](https://claude.com/claude-code)