### PR TITLE
docs(agents): restyle Guardrails list to match holos-console-docs tone (HOL-637)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,6 @@ opening a PR.
 
 ## Guardrails
 
-- **Demo docs routing** — Demo setup materials and CUE example snippets belong
-  in
-  [`holos-run/holos-console-docs/demo/`](https://github.com/holos-run/holos-console-docs/tree/main/demo),
-  **not** in this repo. Demo-related issues must include concrete examples and
-  operator guidance. Smoke-test instructions must include `kubectl` commands
-  for the resources required to observe the feature in the demo environment.
-  Forward pointers:
-  [demo README](https://github.com/holos-run/holos-console-docs/blob/main/demo/README.md)
-  and
-  [smoke tests](https://github.com/holos-run/holos-console-docs/tree/main/demo/smoke-tests).
+- [Demo Docs Routing](https://github.com/holos-run/holos-console-docs/tree/main/demo) — Demo setup materials and CUE example snippets belong in `holos-run/holos-console-docs/demo/`, **not** in this repo; demo-related issues must include concrete examples and operator guidance.
+- [Smoke Test Contract](https://github.com/holos-run/holos-console-docs/tree/main/demo/smoke-tests) — Smoke-test instructions must use `kubectl` commands for the resources required to observe the feature in the demo environment.
+- [Demo README](https://github.com/holos-run/holos-console-docs/blob/main/demo/README.md) — Forward pointer to the demo setup order, prerequisites, and per-template walkthroughs.


### PR DESCRIPTION
## Summary

- Split the single multi-paragraph Demo Docs Routing bullet in `AGENTS.md` into three one-line entries (Demo Docs Routing, Smoke Test Contract, Demo README), each following the linked-title + em-dash summary style used by `holos-console-docs/AGENTS.md`.
- No content was dropped: routing rule, `kubectl` smoke-test contract, and the forward pointer to the demo README are all preserved, just reformatted.

This PR is paired with https://github.com/holos-run/holos-console-docs/pull/8, which adds a `## Demo Environment` section to `holos-console-docs/AGENTS.md` pointing back to this guardrail as the source of truth.

Fixes HOL-637

## Verification performed

- Link-audit script (`/tmp/check-links.py`) parsed every Markdown link in the five files touched by HOL-634/HOL-635/HOL-636 plus the two AGENTS.md files and resolved each one (including cross-repo GitHub URLs mapped to the local clone of the sibling repo). 0 broken links, 0 bad anchors.
- Scanned `holos-console/` for duplicate demo or smoke-test content: none exists (docs are repo-global — `docs/migrations/...`, `README.md`, `CONTRIBUTING.md` — none touch the demo environment).
- Scanned `holos-console-docs/docs/agents/` for any accidental `guardrail-demo-*.md` duplicate of the routing guardrail: none exists. Single source of truth remains `holos-console/AGENTS.md#guardrails`.

## Removed content

Nothing load-bearing removed. The previous bullet contained a parenthetical prose paragraph; the same facts now appear as three separate bullets with the same links and the same obligations (routing, kubectl contract, forward pointer).

## Test plan

- [x] Visual review of rendered `AGENTS.md` on the branch — three linked bullets, consistent tone with `holos-console-docs/AGENTS.md`.
- [x] All Markdown links resolve via `/tmp/check-links.py`.
- [ ] CI: Unit Tests, Lint, E2E Tests — docs-only change; expect all green (no Go/UI/proto files touched).

Generated with [Claude Code](https://claude.com/claude-code)