### PR TITLE
docs(readme): expand README with project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ exposes ConnectRPC services. The built UI is embedded into the Go binary via
 
 See `AGENTS.md` for project conventions and the `Makefile` for common tasks:
 
-- `make test` runs the full test suite
+- `make test` runs Go and UI unit tests (`test-go` and `test-ui`)
 - `make generate` regenerates code when proto or schema files change
-- `make test-e2e` runs end-to-end tests against a local k3d cluster
+- `make test-e2e` runs Playwright end-to-end tests; the Playwright config
+  starts the Go backend and Vite dev server automatically

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Holos Console
+
+A Go HTTPS server with a React frontend that serves a web console UI and
+exposes ConnectRPC services. The built UI is embedded into the Go binary via
+`go:embed`.
+
+## Development
+
+See `AGENTS.md` for project conventions and the `Makefile` for common tasks:
+
+- `make test` runs the full test suite
+- `make generate` regenerates code when proto or schema files change
+- `make test-e2e` runs end-to-end tests against a local k3d cluster


### PR DESCRIPTION
## Summary
- Expand the minimal README with a short project overview and a pointer to common `make` targets and `AGENTS.md`.

Refs HOL-638

## Test plan
- [x] README renders correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)