### PR TITLE
feat(organizations): persist gateway_namespace annotation via OrganizationService

### DIFF
--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -11,6 +11,7 @@ import (
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/rbac"
@@ -570,7 +571,19 @@ func (h *Handler) UpdateOrganization(
 		}
 	}
 
-	if _, err := h.k8s.UpdateOrganization(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description); err != nil {
+	// Validate gateway_namespace before forwarding to k8s. Empty string is
+	// accepted as "clear the annotation"; non-empty values must conform to
+	// the Kubernetes DNS-1123 label rule (the same rule k8s applies to
+	// namespace names).
+	if req.Msg.GatewayNamespace != nil && *req.Msg.GatewayNamespace != "" {
+		if errs := validation.IsDNS1123Label(*req.Msg.GatewayNamespace); len(errs) > 0 {
+			return nil, connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("gateway_namespace %q is not a valid DNS-1123 label: %s",
+					*req.Msg.GatewayNamespace, strings.Join(errs, "; ")))
+		}
+	}
+
+	if _, err := h.k8s.UpdateOrganization(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, req.Msg.GatewayNamespace); err != nil {
 		return nil, mapK8sError(err)
 	}
 
@@ -919,6 +932,7 @@ func buildOrganization(k8s *K8sClient, ns interface{ GetName() string }, shareUs
 			org.Description = annotations[v1alpha2.AnnotationDescription]
 			org.CreatorEmail = annotations[v1alpha2.AnnotationCreatorEmail]
 			org.DefaultFolder = annotations[v1alpha2.AnnotationDefaultFolder]
+			org.GatewayNamespace = annotations[v1alpha2.AnnotationGatewayNamespace]
 		}
 		// Populate default sharing grants and creation timestamp from typed namespace
 		if nsTyped, ok := ns.(*corev1.Namespace); ok {

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -1214,6 +1214,187 @@ func TestUpdateOrganization_UpdateDefaultFolder_EmptyValue(t *testing.T) {
 	assertInvalidArgument(t, err)
 }
 
+// ---- UpdateOrganization gateway_namespace tests ----
+
+// gatewayNamespaceFromK8s reads the gateway-namespace annotation directly from
+// the fake clientset bypassing the handler. Used by the UpdateOrganization
+// gateway_namespace tests to assert the persisted annotation state.
+func gatewayNamespaceFromK8s(t *testing.T, h *Handler, org string) (string, bool) {
+	t.Helper()
+	ns, err := h.k8s.client.CoreV1().Namespaces().Get(context.Background(),
+		h.k8s.resolver.OrgNamespace(org), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get namespace: %v", err)
+	}
+	v, ok := ns.Annotations[v1alpha2.AnnotationGatewayNamespace]
+	return v, ok
+}
+
+func TestUpdateOrganization_GatewayNamespace_RoundTrip(t *testing.T) {
+	// Editor-permission table that walks set, preserve (nil), clear, and
+	// invalid-DNS-label paths through the handler so the proto field, the
+	// k8s annotation, and the buildOrganization read-back all stay in sync.
+	tests := []struct {
+		name             string
+		initial          string  // initial annotation value, "" means not set
+		input            *string // value sent in the update request
+		wantValue        string  // expected annotation after update
+		wantSet          bool    // whether the annotation should be present
+		wantInvalidArg   bool    // whether the call should return InvalidArgument
+		wantOrgFieldGet  bool    // whether to also assert via GetOrganization RPC
+		wantOrgFieldWant string
+	}{
+		{
+			name:             "set when absent",
+			initial:          "",
+			input:            ptr("gw-system"),
+			wantValue:        "gw-system",
+			wantSet:          true,
+			wantOrgFieldGet:  true,
+			wantOrgFieldWant: "gw-system",
+		},
+		{
+			name:             "preserve with nil",
+			initial:          "existing-gw",
+			input:            nil,
+			wantValue:        "existing-gw",
+			wantSet:          true,
+			wantOrgFieldGet:  true,
+			wantOrgFieldWant: "existing-gw",
+		},
+		{
+			name:             "clear with empty string",
+			initial:          "existing-gw",
+			input:            ptr(""),
+			wantValue:        "",
+			wantSet:          false,
+			wantOrgFieldGet:  true,
+			wantOrgFieldWant: "",
+		},
+		{
+			name:           "invalid DNS-1123 label rejected",
+			initial:        "existing-gw",
+			input:          ptr("Invalid_Name"),
+			wantValue:      "existing-gw", // unchanged
+			wantSet:        true,
+			wantInvalidArg: true,
+		},
+		{
+			name:           "invalid DNS-1123 label with dots rejected",
+			initial:        "",
+			input:          ptr("gw.example.com"),
+			wantValue:      "",
+			wantSet:        false,
+			wantInvalidArg: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := orgNS("acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+			if tc.initial != "" {
+				ns.Annotations[v1alpha2.AnnotationGatewayNamespace] = tc.initial
+			}
+			handler := newTestHandler(ns)
+			ctx := contextWithClaims("alice@example.com")
+
+			_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+				Name:             "acme",
+				GatewayNamespace: tc.input,
+			}))
+			if tc.wantInvalidArg {
+				assertInvalidArgument(t, err)
+			} else if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			got, ok := gatewayNamespaceFromK8s(t, handler, "acme")
+			if ok != tc.wantSet {
+				t.Errorf("annotation present=%t, want %t", ok, tc.wantSet)
+			}
+			if got != tc.wantValue {
+				t.Errorf("annotation value=%q, want %q", got, tc.wantValue)
+			}
+
+			if tc.wantOrgFieldGet {
+				resp, err := handler.GetOrganization(ctx, connect.NewRequest(&consolev1.GetOrganizationRequest{Name: "acme"}))
+				if err != nil {
+					t.Fatalf("GetOrganization: %v", err)
+				}
+				if resp.Msg.Organization.GatewayNamespace != tc.wantOrgFieldWant {
+					t.Errorf("Organization.GatewayNamespace=%q, want %q",
+						resp.Msg.Organization.GatewayNamespace, tc.wantOrgFieldWant)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateOrganization_GatewayNamespace_PreservesOtherAnnotations(t *testing.T) {
+	// Setting gateway_namespace must not perturb display_name or description.
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+	ns.Annotations[v1alpha2.AnnotationDisplayName] = "ACME Corp"
+	ns.Annotations[v1alpha2.AnnotationDescription] = "the test org"
+	handler := newTestHandler(ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+		Name:             "acme",
+		GatewayNamespace: ptr("gw-system"),
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	updated, err := handler.k8s.client.CoreV1().Namespaces().Get(context.Background(),
+		"holos-org-acme", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get namespace: %v", err)
+	}
+	if updated.Annotations[v1alpha2.AnnotationDisplayName] != "ACME Corp" {
+		t.Errorf("display name perturbed: %q", updated.Annotations[v1alpha2.AnnotationDisplayName])
+	}
+	if updated.Annotations[v1alpha2.AnnotationDescription] != "the test org" {
+		t.Errorf("description perturbed: %q", updated.Annotations[v1alpha2.AnnotationDescription])
+	}
+	if updated.Annotations[v1alpha2.AnnotationGatewayNamespace] != "gw-system" {
+		t.Errorf("gateway-namespace=%q, want %q",
+			updated.Annotations[v1alpha2.AnnotationGatewayNamespace], "gw-system")
+	}
+}
+
+func TestListOrganizations_PopulatesGatewayNamespace(t *testing.T) {
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	ns.Annotations[v1alpha2.AnnotationGatewayNamespace] = "gw-system"
+	handler := newTestHandler(ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	resp, err := handler.ListOrganizations(ctx, connect.NewRequest(&consolev1.ListOrganizationsRequest{}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resp.Msg.Organizations) != 1 {
+		t.Fatalf("expected 1 org, got %d", len(resp.Msg.Organizations))
+	}
+	if resp.Msg.Organizations[0].GatewayNamespace != "gw-system" {
+		t.Errorf("Organization.GatewayNamespace=%q, want %q",
+			resp.Msg.Organizations[0].GatewayNamespace, "gw-system")
+	}
+}
+
+func TestUpdateOrganization_GatewayNamespace_ViewerDenies(t *testing.T) {
+	// Viewers are blocked from any UpdateOrganization mutation; gateway_namespace
+	// rides on the same PERMISSION_ORGANIZATIONS_WRITE check (no new permission).
+	ns := orgNS("acme", `[{"principal":"alice@example.com","role":"viewer"}]`)
+	handler := newTestHandler(ns)
+	ctx := contextWithClaims("alice@example.com")
+
+	_, err := handler.UpdateOrganization(ctx, connect.NewRequest(&consolev1.UpdateOrganizationRequest{
+		Name:             "acme",
+		GatewayNamespace: ptr("gw-system"),
+	}))
+	assertPermissionDenied(t, err)
+}
+
 // ---- PopulateDefaults tests ----
 
 // mockTemplateSeeder implements TemplateSeeder for tests.

--- a/console/organizations/k8s.go
+++ b/console/organizations/k8s.go
@@ -122,9 +122,10 @@ func (c *K8sClient) CreateOrganization(ctx context.Context, name, displayName, d
 	return c.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 }
 
-// UpdateOrganization updates the description and display name annotations on an organization namespace.
-// Nil pointers preserve existing values.
-func (c *K8sClient) UpdateOrganization(ctx context.Context, name string, displayName, description *string) (*corev1.Namespace, error) {
+// UpdateOrganization updates the description, display name, and gateway
+// namespace annotations on an organization namespace. Nil pointers preserve
+// existing values; empty strings clear the corresponding annotation.
+func (c *K8sClient) UpdateOrganization(ctx context.Context, name string, displayName, description, gatewayNamespace *string) (*corev1.Namespace, error) {
 	slog.DebugContext(ctx, "updating organization in kubernetes",
 		slog.String("name", name),
 	)
@@ -147,6 +148,13 @@ func (c *K8sClient) UpdateOrganization(ctx context.Context, name string, display
 			delete(ns.Annotations, v1alpha2.AnnotationDescription)
 		} else {
 			ns.Annotations[v1alpha2.AnnotationDescription] = *description
+		}
+	}
+	if gatewayNamespace != nil {
+		if *gatewayNamespace == "" {
+			delete(ns.Annotations, v1alpha2.AnnotationGatewayNamespace)
+		} else {
+			ns.Annotations[v1alpha2.AnnotationGatewayNamespace] = *gatewayNamespace
 		}
 	}
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
@@ -187,6 +195,34 @@ func GetDefaultFolder(ns *corev1.Namespace) string {
 		return ""
 	}
 	return ns.Annotations[v1alpha2.AnnotationDefaultFolder]
+}
+
+// GetGatewayNamespace reads the gateway-namespace annotation from an org
+// namespace. Returns empty string if not set.
+func GetGatewayNamespace(ns *corev1.Namespace) string {
+	if ns.Annotations == nil {
+		return ""
+	}
+	return ns.Annotations[v1alpha2.AnnotationGatewayNamespace]
+}
+
+// SetGatewayNamespace writes (or clears) the gateway-namespace annotation on
+// the org namespace. An empty value deletes the annotation.
+func (c *K8sClient) SetGatewayNamespace(ctx context.Context, name, value string) error {
+	ns, err := c.GetOrganization(ctx, name)
+	if err != nil {
+		return err
+	}
+	if ns.Annotations == nil {
+		ns.Annotations = make(map[string]string)
+	}
+	if value == "" {
+		delete(ns.Annotations, v1alpha2.AnnotationGatewayNamespace)
+	} else {
+		ns.Annotations[v1alpha2.AnnotationGatewayNamespace] = value
+	}
+	_, err = c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+	return err
 }
 
 // UpdateOrganizationSharing updates the sharing annotations on an organization namespace.

--- a/console/organizations/k8s_test.go
+++ b/console/organizations/k8s_test.go
@@ -19,6 +19,13 @@ func testResolver() *resolver.Resolver {
 	return &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 }
 
+// ptr returns a pointer to v. Used by table-driven tests that exercise the
+// optional-field semantics of UpdateOrganization (nil = preserve, "" = clear,
+// non-empty = set).
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestListOrganizations_ReturnsOnlyOrgNamespaces(t *testing.T) {
 	orgNS := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -259,7 +266,7 @@ func TestUpdateOrganization_UpdatesAnnotations(t *testing.T) {
 
 	displayName := "Updated Name"
 	desc := "Updated desc"
-	result, err := k8s.UpdateOrganization(context.Background(), "acme", &displayName, &desc)
+	result, err := k8s.UpdateOrganization(context.Background(), "acme", &displayName, &desc, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -275,6 +282,154 @@ func TestUpdateOrganization_UpdatesAnnotations(t *testing.T) {
 	}
 }
 
+func TestUpdateOrganization_GatewayNamespaceSetClearPreserve(t *testing.T) {
+	// Round-trip the gateway-namespace annotation via UpdateOrganization.
+	// Covers: set when absent, clear (empty string), and preserve (nil pointer).
+	tests := []struct {
+		name              string
+		initial           string // initial annotation value, "" means no annotation
+		input             *string
+		wantValue         string
+		wantAnnotationSet bool
+	}{
+		{
+			name:              "set when absent",
+			initial:           "",
+			input:             ptr("gw-system"),
+			wantValue:         "gw-system",
+			wantAnnotationSet: true,
+		},
+		{
+			name:              "overwrite existing",
+			initial:           "old-gw",
+			input:             ptr("new-gw"),
+			wantValue:         "new-gw",
+			wantAnnotationSet: true,
+		},
+		{
+			name:              "clear with empty string",
+			initial:           "gw-system",
+			input:             ptr(""),
+			wantValue:         "",
+			wantAnnotationSet: false,
+		},
+		{
+			name:              "preserve with nil",
+			initial:           "gw-system",
+			input:             nil,
+			wantValue:         "gw-system",
+			wantAnnotationSet: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			annotations := map[string]string{}
+			if tc.initial != "" {
+				annotations[v1alpha2.AnnotationGatewayNamespace] = tc.initial
+			}
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "holos-org-acme",
+					Labels: map[string]string{
+						v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+						resolver.ResourceTypeLabel: resolver.ResourceTypeOrganization,
+					},
+					Annotations: annotations,
+				},
+			}
+			fakeClient := fake.NewClientset(ns)
+			k8s := NewK8sClient(fakeClient, testResolver())
+
+			result, err := k8s.UpdateOrganization(context.Background(), "acme", nil, nil, tc.input)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			got, ok := result.Annotations[v1alpha2.AnnotationGatewayNamespace]
+			if ok != tc.wantAnnotationSet {
+				t.Errorf("annotation present=%t, want %t", ok, tc.wantAnnotationSet)
+			}
+			if got != tc.wantValue {
+				t.Errorf("annotation value=%q, want %q", got, tc.wantValue)
+			}
+			if helper := GetGatewayNamespace(result); helper != tc.wantValue {
+				t.Errorf("GetGatewayNamespace=%q, want %q", helper, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestGetGatewayNamespace_ReturnsEmptyWhenAbsent(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "holos-org-acme"},
+	}
+	if got := GetGatewayNamespace(ns); got != "" {
+		t.Errorf("expected empty string when annotation absent, got %q", got)
+	}
+}
+
+func TestGetGatewayNamespace_ReadsAnnotation(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-acme",
+			Annotations: map[string]string{
+				v1alpha2.AnnotationGatewayNamespace: "gw-system",
+			},
+		},
+	}
+	if got := GetGatewayNamespace(ns); got != "gw-system" {
+		t.Errorf("expected 'gw-system', got %q", got)
+	}
+}
+
+func TestSetGatewayNamespace_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name              string
+		initial           string
+		write             string
+		wantValue         string
+		wantAnnotationSet bool
+	}{
+		{name: "write when absent", initial: "", write: "gw-system", wantValue: "gw-system", wantAnnotationSet: true},
+		{name: "overwrite existing", initial: "old", write: "new", wantValue: "new", wantAnnotationSet: true},
+		{name: "clear with empty", initial: "old", write: "", wantValue: "", wantAnnotationSet: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			annotations := map[string]string{}
+			if tc.initial != "" {
+				annotations[v1alpha2.AnnotationGatewayNamespace] = tc.initial
+			}
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "holos-org-acme",
+					Labels: map[string]string{
+						v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+						resolver.ResourceTypeLabel: resolver.ResourceTypeOrganization,
+					},
+					Annotations: annotations,
+				},
+			}
+			fakeClient := fake.NewClientset(ns)
+			k8s := NewK8sClient(fakeClient, testResolver())
+
+			if err := k8s.SetGatewayNamespace(context.Background(), "acme", tc.write); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			updated, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-org-acme", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("expected namespace, got %v", err)
+			}
+			got, ok := updated.Annotations[v1alpha2.AnnotationGatewayNamespace]
+			if ok != tc.wantAnnotationSet {
+				t.Errorf("annotation present=%t, want %t", ok, tc.wantAnnotationSet)
+			}
+			if got != tc.wantValue {
+				t.Errorf("annotation value=%q, want %q", got, tc.wantValue)
+			}
+		})
+	}
+}
+
 func TestUpdateOrganization_RejectsUnmanaged(t *testing.T) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -285,7 +440,7 @@ func TestUpdateOrganization_RejectsUnmanaged(t *testing.T) {
 	k8s := NewK8sClient(fakeClient, testResolver())
 
 	desc := "test"
-	_, err := k8s.UpdateOrganization(context.Background(), "fake", nil, &desc)
+	_, err := k8s.UpdateOrganization(context.Background(), "fake", nil, &desc, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
## Summary

- Extend `K8sClient.UpdateOrganization` with a `gatewayNamespace *string` parameter using nil-preserve / empty-clear / non-empty-set semantics matching `displayName`/`description`.
- Add `GetGatewayNamespace(ns)` and `K8sClient.SetGatewayNamespace(ctx, name, value)` helpers, mirroring the default-folder pattern.
- Wire `req.Msg.GatewayNamespace` through `Handler.UpdateOrganization`; validate non-empty values with `validation.IsDNS1123Label` and return `connect.CodeInvalidArgument` on failure. RBAC reuses `PERMISSION_ORGANIZATIONS_WRITE`.
- Populate `org.GatewayNamespace` in `buildOrganization` so `GetOrganization`, `ListOrganizations`, `UpdateOrganizationSharing`, and the raw counterparts surface the field.
- Phase 2 of HOL-526 (after HOL-642 proto + annotation constant). Renderer wiring is still deferred to HOL-644.

Fixes HOL-643

## Test plan

- [x] `go test ./console/organizations/...` (k8s + handler tables green)
- [x] `go test -v -run 'GatewayNamespace|TestSetGatewayNamespace|TestGetGatewayNamespace' ./console/organizations/...` (new tests pass)
- [x] `make test` (full Go + UI suite green: 76 test files / 1128 UI tests)
- [x] `make vet`
- [x] `make generate` (no diff outside `console/dist` build artifacts)

> Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check. Pure backend RPC change with no frontend or route changes — E2E relevance is low for this phase.

Generated with [Claude Code](https://claude.com/claude-code)