### PR TITLE
feat(deployments): resolve gatewayNamespace from org annotation (HOL-644)

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -453,11 +453,20 @@ func (s *Server) Serve(ctx context.Context) error {
 		// itself cancels the reflector to avoid leaking LIST/WATCH retry
 		// goroutines and logs a warning.
 		deploymentStatusCache := statuscache.New(ctx, k8sClientset)
+		// HOL-644: bridge the deployments handler to the organization
+		// gateway-namespace annotation so PlatformInput.gatewayNamespace
+		// reflects the platform engineer's configured value (set via the
+		// Organization service in HOL-643) rather than the historical
+		// hard-coded "istio-ingress". Reuses the existing projectResolver
+		// (a *projects.ProjectGrantResolver) for the project→org lookup;
+		// the annotation read goes through orgsK8s.
+		gatewayResolver := organizations.NewGatewayNamespaceResolver(orgsK8s, projectResolver)
 		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templates.NewProjectScopedResolver(templatesK8s), &deployments.CueRenderer{}, deploymentsApplier).
 			WithAncestorWalker(projectFolderResolver).
 			WithAncestorTemplateProvider(ancestorTemplateResolver).
 			WithStatusCache(deploymentStatusCache).
-			WithPolicyDriftChecker(deploymentDriftAdapter)
+			WithPolicyDriftChecker(deploymentDriftAdapter).
+			WithOrganizationGatewayResolver(gatewayResolver)
 		deploymentsPath, deploymentsHTTPHandler := consolev1connect.NewDeploymentServiceHandler(deploymentsHandler, protectedInterceptors)
 		mux.Handle(deploymentsPath, deploymentsHTTPHandler)
 	} else {

--- a/console/deployments/buildplatforminput_test.go
+++ b/console/deployments/buildplatforminput_test.go
@@ -1,0 +1,384 @@
+// Tests for buildPlatformInput's gateway-namespace resolution path
+// (HOL-526 phase 3 / HOL-644). The legacy implementation hard-coded
+// PlatformInput.GatewayNamespace = DefaultGatewayNamespace ("istio-ingress")
+// which broke any user template that explicitly set the same field to a
+// site-specific value (e.g. "ci-private-apps-gateway"): CUE's unification
+// rules treat string : "istio-ingress" & string : "ci-private-apps-gateway"
+// as a conflict and refuse to evaluate. These tests pin the new behavior:
+//
+//   - With no OrganizationGatewayResolver wired, the handler still emits
+//     DefaultGatewayNamespace (legacy behavior, preserves existing test
+//     wiring that does not bother to construct an org NS).
+//   - With a resolver that returns "" (annotation absent), the handler
+//     emits DefaultGatewayNamespace.
+//   - With a resolver that returns a non-empty value, the handler emits
+//     that value verbatim — and unification with a template setting the
+//     same value succeeds (the bug-reproduction scenario).
+//   - With a resolver that errors, the handler logs and falls back to
+//     DefaultGatewayNamespace (a transient lookup failure must never break
+//     a render).
+
+package deployments
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/organizations"
+	"github.com/holos-run/holos-console/console/projects"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/rpc"
+)
+
+// stubGatewayResolver is a hand-rolled OrganizationGatewayResolver for the
+// table-driven tests. The fake K8s client + real resolver path is exercised
+// in TestBuildPlatformInput_GatewayNamespace_K8sResolverIntegration so this
+// stub keeps the unit tests focused on Handler semantics.
+type stubGatewayResolver struct {
+	value     string
+	err       error
+	called    int
+	calledFor string
+}
+
+func (s *stubGatewayResolver) GetGatewayNamespace(_ context.Context, project string) (string, error) {
+	s.called++
+	s.calledFor = project
+	return s.value, s.err
+}
+
+// newHandlerWithGateway wires a Handler with the minimum stubs needed to
+// exercise buildPlatformInput's gateway resolution path. The renderer,
+// applier, and other collaborators are not invoked by buildPlatformInput
+// itself, so trivial stubs are sufficient.
+func newHandlerWithGateway(gw OrganizationGatewayResolver) *Handler {
+	fakeClient := fake.NewClientset()
+	k8s := NewK8sClient(fakeClient, testResolver())
+	h := NewHandler(k8s, &stubProjectResolver{}, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{})
+	if gw != nil {
+		h = h.WithOrganizationGatewayResolver(gw)
+	}
+	return h
+}
+
+func TestBuildPlatformInput_GatewayNamespace(t *testing.T) {
+	cases := []struct {
+		name     string
+		resolver OrganizationGatewayResolver
+		want     string
+		// wantCallFor asserts that the resolver was invoked with the
+		// expected project name. Empty means "do not check".
+		wantCallFor string
+	}{
+		{
+			// Legacy test wiring: no resolver configured. Behavior must
+			// be unchanged from the pre-HOL-644 hard-coded default so
+			// the dozens of existing handler tests keep passing without
+			// being touched.
+			name:     "nil resolver falls back to DefaultGatewayNamespace",
+			resolver: nil,
+			want:     DefaultGatewayNamespace,
+		},
+		{
+			// Org has no annotation set: resolver returns "". The
+			// handler must apply DefaultGatewayNamespace — a legitimate
+			// "use the default" signal, not an error.
+			name:     "empty resolver value falls back to DefaultGatewayNamespace",
+			resolver: &stubGatewayResolver{value: ""},
+			want:     DefaultGatewayNamespace,
+		},
+		{
+			// HOL-526 bug-fix path: org's gateway-namespace
+			// annotation is set to a site-specific value. The handler
+			// must inject that value so a template that pins the same
+			// value unifies cleanly instead of conflicting with the
+			// historical "istio-ingress" injection.
+			name:        "configured resolver value is propagated verbatim",
+			resolver:    &stubGatewayResolver{value: "ci-private-apps-gateway"},
+			want:        "ci-private-apps-gateway",
+			wantCallFor: "my-project",
+		},
+		{
+			// Transient resolver failure (e.g. org NS not yet
+			// created, transient K8s API error): the handler must NOT
+			// fail the build — it logs at WARN and falls back to the
+			// historical default so callers get a render error from
+			// CUE only when the template itself conflicts, not from
+			// the gateway lookup.
+			name:        "resolver error falls back to DefaultGatewayNamespace",
+			resolver:    &stubGatewayResolver{err: errors.New("k8s api unavailable")},
+			want:        DefaultGatewayNamespace,
+			wantCallFor: "my-project",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHandlerWithGateway(tc.resolver)
+			pi := h.buildPlatformInput(context.Background(), "my-project", "prj-my-project", &rpc.Claims{Sub: "u1", Email: "test@example.com"})
+			if pi.GatewayNamespace != tc.want {
+				t.Errorf("GatewayNamespace = %q, want %q", pi.GatewayNamespace, tc.want)
+			}
+			if tc.wantCallFor != "" {
+				stub, ok := tc.resolver.(*stubGatewayResolver)
+				if !ok {
+					t.Fatalf("wantCallFor set but resolver is not a *stubGatewayResolver")
+				}
+				if stub.called != 1 {
+					t.Errorf("resolver call count = %d, want 1", stub.called)
+				}
+				if stub.calledFor != tc.wantCallFor {
+					t.Errorf("resolver called for %q, want %q", stub.calledFor, tc.wantCallFor)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildPlatformInput_GatewayNamespace_PropagatesToRenderer is the
+// integration boundary check: the resolved value must actually land in the
+// PlatformInput passed to the Renderer, not just be set on a local
+// variable. This guards against future refactors that compute the value
+// correctly but forget to thread it through to inputs.Platform.
+func TestBuildPlatformInput_GatewayNamespace_PropagatesToRenderer(t *testing.T) {
+	stub := &stubGatewayResolver{value: "edge-gateway"}
+	h := newHandlerWithGateway(stub)
+	pi := h.buildPlatformInput(context.Background(), "my-project", "prj-my-project", &rpc.Claims{Sub: "u1"})
+	if pi.GatewayNamespace != "edge-gateway" {
+		t.Fatalf("PlatformInput.GatewayNamespace = %q, want %q", pi.GatewayNamespace, "edge-gateway")
+	}
+	// Sanity: the other fields the renderer relies on must also be set —
+	// a regression here would be confusing because the gateway field
+	// would still pass while the broader contract was broken.
+	if pi.Project != "my-project" {
+		t.Errorf("Project = %q, want %q", pi.Project, "my-project")
+	}
+	if pi.Namespace != "prj-my-project" {
+		t.Errorf("Namespace = %q, want %q", pi.Namespace, "prj-my-project")
+	}
+}
+
+// TestBuildPlatformInput_GatewayNamespace_K8sResolverIntegration drives the
+// real organizations.GatewayNamespaceResolver against a fake K8s client to
+// catch wiring drift between the deployments interface and the
+// organizations adapter implementation. A pure-stub test would let a future
+// rename of the projects.ProjectGrantResolver method (GetProjectOrganization)
+// silently break production wiring without failing CI.
+func TestBuildPlatformInput_GatewayNamespace_K8sResolverIntegration(t *testing.T) {
+	const orgName = "acme"
+	const projectName = "my-project"
+
+	// orgNs builds an organization namespace for the integration tests.
+	// The label set mirrors what organizations.K8sClient.CreateOrganization
+	// produces in production so GetOrganization's label assertions pass.
+	orgNs := func(annotations map[string]string) *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "holos-org-" + orgName,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+					v1alpha2.LabelOrganization: orgName,
+				},
+				Annotations: annotations,
+			},
+		}
+	}
+	// projectNs mirrors the production project namespace shape: the
+	// LabelOrganization value lets projects.GetProjectOrg derive the org
+	// name without walking ancestry.
+	projectNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-" + projectName,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      projectName,
+				v1alpha2.LabelOrganization: orgName,
+			},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name:        "annotation absent yields DefaultGatewayNamespace",
+			annotations: nil,
+			want:        DefaultGatewayNamespace,
+		},
+		{
+			name:        "annotation empty yields DefaultGatewayNamespace",
+			annotations: map[string]string{v1alpha2.AnnotationGatewayNamespace: ""},
+			want:        DefaultGatewayNamespace,
+		},
+		{
+			name:        "annotation set to ci-private-apps-gateway is propagated (HOL-526 fix)",
+			annotations: map[string]string{v1alpha2.AnnotationGatewayNamespace: "ci-private-apps-gateway"},
+			want:        "ci-private-apps-gateway",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientset(orgNs(tc.annotations), projectNs)
+			// Use the same prefix layout as testResolver() in k8s_test.go
+			// (NamespacePrefix="holos-", OrganizationPrefix="org-",
+			// ProjectPrefix="prj-") so OrgNamespace + ProjectNamespace
+			// match the holos-org-<name> / holos-prj-<name> objects above.
+			r := &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+			orgsK8s := organizations.NewK8sClient(fakeClient, r)
+			projectsK8s := projects.NewK8sClient(fakeClient, r)
+			projectGrants := projects.NewProjectGrantResolver(projectsK8s)
+			gw := organizations.NewGatewayNamespaceResolver(orgsK8s, projectGrants)
+
+			h := NewHandler(NewK8sClient(fakeClient, r), &stubProjectResolver{}, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).
+				WithOrganizationGatewayResolver(gw)
+
+			pi := h.buildPlatformInput(context.Background(), projectName, "holos-prj-"+projectName, &rpc.Claims{Sub: "u1"})
+			if pi.GatewayNamespace != tc.want {
+				t.Errorf("GatewayNamespace = %q, want %q", pi.GatewayNamespace, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildPlatformInput_GatewayNamespace_TemplateUnifies pins the actual
+// HOL-526 bug fix: with the org annotation set to "ci-private-apps-gateway"
+// and the deployment template setting platform.gatewayNamespace to the same
+// value, the render must succeed (no CUE unification conflict) and the
+// resulting resource must carry that value. Pre-HOL-644, the handler
+// injected the hard-coded "istio-ingress" while the template injected
+// "ci-private-apps-gateway", causing CUE to fail with a string conflict
+// and the deployment to be rejected.
+func TestBuildPlatformInput_GatewayNamespace_TemplateUnifies(t *testing.T) {
+	const orgName = "acme"
+	const projectName = "my-project"
+	const gw = "ci-private-apps-gateway"
+
+	orgNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-" + orgName,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				v1alpha2.LabelOrganization: orgName,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationGatewayNamespace: gw,
+			},
+		},
+	}
+	projectNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-" + projectName,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelProject:      projectName,
+				v1alpha2.LabelOrganization: orgName,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientset(orgNamespace, projectNamespace)
+	r := &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+	orgsK8s := organizations.NewK8sClient(fakeClient, r)
+	projectsK8s := projects.NewK8sClient(fakeClient, r)
+	gwResolver := organizations.NewGatewayNamespaceResolver(orgsK8s, projects.NewProjectGrantResolver(projectsK8s))
+
+	h := NewHandler(NewK8sClient(fakeClient, r), &stubProjectResolver{}, &stubSettingsResolver{settings: enabledSettings()}, &stubTemplateResolver{cm: fakeTemplate("default")}, &stubRenderer{}, &stubApplier{}).
+		WithOrganizationGatewayResolver(gwResolver)
+
+	pi := h.buildPlatformInput(context.Background(), projectName, "holos-prj-"+projectName, &rpc.Claims{
+		Sub:           "u1",
+		Email:         "test@example.com",
+		EmailVerified: true,
+	})
+	if pi.GatewayNamespace != gw {
+		t.Fatalf("GatewayNamespace = %q, want %q", pi.GatewayNamespace, gw)
+	}
+
+	// Drive the real CueRenderer with a template that pins the same
+	// gateway namespace value the org has configured. Pre-HOL-644 this
+	// would fail with a CUE unification conflict because the handler
+	// injected "istio-ingress" while the template injected
+	// "ci-private-apps-gateway". With the fix in place, both inputs agree
+	// and the render succeeds.
+	renderer := &CueRenderer{}
+	resources, err := renderFlat(renderer, context.Background(), gatewayNamespacePinningTemplate(gw), pi, v1alpha2.ProjectInput{
+		Name:  "web-app",
+		Image: "nginx",
+		Tag:   "1.25",
+		Port:  8080,
+	})
+	if err != nil {
+		t.Fatalf("expected render to succeed when template and org agree on gatewayNamespace=%q, got error: %v", gw, err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	got := resources[0].GetAnnotations()["test.holos.run/gateway-namespace"]
+	if got != gw {
+		t.Errorf("rendered gateway-namespace annotation = %q, want %q", got, gw)
+	}
+}
+
+// gatewayNamespacePinningTemplate returns a CUE template that pins
+// platform.gatewayNamespace to the supplied value. This is the shape of
+// template that triggered the HOL-526 conflict before the fix: it asserts
+// a concrete value at the same path the backend was injecting, and CUE
+// rejects the unification when the values disagree.
+func gatewayNamespacePinningTemplate(want string) string {
+	return `
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+platform: {
+	project:          string
+	namespace:        string
+	gatewayNamespace: "` + want + `"
+	organization:     string
+	claims: {
+		iss:            string
+		sub:            string
+		exp:            int
+		iat:            int
+		email:          string
+		email_verified: bool
+	}
+}
+
+projectResources: {
+	namespacedResources: (platform.namespace): {
+		ServiceAccount: (input.name): {
+			apiVersion: "v1"
+			kind:       "ServiceAccount"
+			metadata: {
+				name:      input.name
+				namespace: platform.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+					"app.kubernetes.io/name":       input.name
+				}
+				annotations: {
+					"test.holos.run/gateway-namespace": platform.gatewayNamespace
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+}

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -119,6 +119,20 @@ type ResourceApplier interface {
 	DiscoverNamespaces(ctx context.Context, project, deploymentName string) ([]string, error)
 }
 
+// OrganizationGatewayResolver resolves the configured ingress-gateway
+// namespace for the organization that owns a given project. Implementations
+// read the org namespace's gateway-namespace annotation
+// (v1alpha2.AnnotationGatewayNamespace, set via the Organization service in
+// HOL-643). Returning an empty string means the org has no override and the
+// caller should fall back to DefaultGatewayNamespace.
+//
+// The handler treats a non-nil error as a soft failure: it logs and falls
+// back to DefaultGatewayNamespace so a transient lookup failure (or a missing
+// org namespace in legacy test fixtures) cannot break renders.
+type OrganizationGatewayResolver interface {
+	GetGatewayNamespace(ctx context.Context, project string) (string, error)
+}
+
 // Handler implements the DeploymentService.
 type Handler struct {
 	consolev1connect.UnimplementedDeploymentServiceHandler
@@ -133,6 +147,7 @@ type Handler struct {
 	ancestorTemplateProvider AncestorTemplateProvider
 	statusCache              statuscache.Cache
 	policyDriftChecker       PolicyDriftChecker
+	gatewayResolver          OrganizationGatewayResolver
 }
 
 // PolicyDriftChecker exposes the minimal surface a deployment needs from the
@@ -183,6 +198,19 @@ func (h *Handler) WithAncestorWalker(aw AncestorWalker) *Handler {
 // the full ancestor chain (org + folders) at render time.
 func (h *Handler) WithAncestorTemplateProvider(atp AncestorTemplateProvider) *Handler {
 	h.ancestorTemplateProvider = atp
+	return h
+}
+
+// WithOrganizationGatewayResolver configures the handler with a resolver
+// that returns the ingress-gateway namespace configured on the project's
+// owning organization (see v1alpha2.AnnotationGatewayNamespace, persisted by
+// the Organization service in HOL-643). When set, buildPlatformInput
+// consults the resolver and falls back to DefaultGatewayNamespace only when
+// the annotation is absent (or the lookup fails). When unset, behavior is
+// unchanged from the legacy hard-coded default — a nil resolver keeps
+// existing test wiring working without modification.
+func (h *Handler) WithOrganizationGatewayResolver(r OrganizationGatewayResolver) *Handler {
+	h.gatewayResolver = r
 	return h
 }
 
@@ -1532,15 +1560,56 @@ func defaultPort(port int) int {
 	return port
 }
 
+// resolveGatewayNamespace returns the gateway namespace to inject into
+// PlatformInput for the given project. It consults the configured
+// OrganizationGatewayResolver (HOL-644) and falls back to
+// DefaultGatewayNamespace when no resolver is wired, when the resolver
+// errors, or when the org has no override annotation. Errors are logged at
+// WARN — they MUST NOT fail the render, since a transient lookup miss
+// should degrade to the historical hard-coded default rather than reject a
+// deployment.
+func (h *Handler) resolveGatewayNamespace(ctx context.Context, project string) string {
+	if h.gatewayResolver == nil {
+		return DefaultGatewayNamespace
+	}
+	gwNs, err := h.gatewayResolver.GetGatewayNamespace(ctx, project)
+	if err != nil {
+		slog.WarnContext(ctx, "could not resolve org gateway namespace, falling back to default",
+			slog.String("project", project),
+			slog.String("default", DefaultGatewayNamespace),
+			slog.Any("error", err),
+		)
+		return DefaultGatewayNamespace
+	}
+	if gwNs == "" {
+		return DefaultGatewayNamespace
+	}
+	return gwNs
+}
+
 // buildPlatformInput constructs a v1alpha2.PlatformInput from handler context.
 // When an AncestorWalker is configured, Folders is populated with the ordered
 // list of folder names in the ancestor chain (org → folders → project) so CUE
 // templates can reference platform.folders.
+//
+// GatewayNamespace resolution (HOL-526 phase 3, HOL-644):
+//
+//   - When an OrganizationGatewayResolver is configured AND it returns a
+//     non-empty value with no error, that value is injected. This lets a
+//     platform engineer pin gateway-namespace to a cluster-specific value
+//     (e.g. "ci-private-apps-gateway") via the org settings UI without
+//     forcing every template author to set platform.gatewayNamespace
+//     explicitly — and, critically, lets a template author who DOES set it
+//     unify cleanly with the backend value (no CUE conflict on string :
+//     "X" & string : "Y").
+//   - When the resolver is nil, errors, or returns empty, the value falls
+//     back to DefaultGatewayNamespace ("istio-ingress") so legacy clusters
+//     and unconfigured test wiring keep working unchanged.
 func (h *Handler) buildPlatformInput(ctx context.Context, project, namespace string, claims *rpc.Claims) v1alpha2.PlatformInput {
 	pi := v1alpha2.PlatformInput{
 		Project:          project,
 		Namespace:        namespace,
-		GatewayNamespace: DefaultGatewayNamespace,
+		GatewayNamespace: h.resolveGatewayNamespace(ctx, project),
 	}
 	if claims != nil {
 		pi.Claims = v1alpha2.Claims{

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -1478,8 +1478,16 @@ func TestCueRenderer_GatewayNamespace(t *testing.T) {
 	})
 
 	t.Run("default gatewayNamespace istio-ingress is applied by Go", func(t *testing.T) {
-		// The Go handler defaults GatewayNamespace to "istio-ingress" before
-		// calling the renderer. This test verifies the default renders correctly.
+		// HOL-644: The default DefaultGatewayNamespace ("istio-ingress") is
+		// only applied by the Go handler when the org has no
+		// gateway-namespace annotation set. This test verifies the renderer
+		// continues to propagate that fallback value into the template
+		// unchanged when buildPlatformInput injects it (the resolver is
+		// unconfigured or the annotation is empty). When the org sets
+		// AnnotationGatewayNamespace to a custom value, the handler injects
+		// that value instead — see the
+		// TestHandler_BuildPlatformInput_GatewayNamespace_OrgConfigured
+		// scenario in handler_test.go.
 		system := v1alpha2.PlatformInput{
 			Project:          "my-project",
 			Namespace:        namespace,

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -1485,9 +1485,11 @@ func TestCueRenderer_GatewayNamespace(t *testing.T) {
 		// unchanged when buildPlatformInput injects it (the resolver is
 		// unconfigured or the annotation is empty). When the org sets
 		// AnnotationGatewayNamespace to a custom value, the handler injects
-		// that value instead — see the
-		// TestHandler_BuildPlatformInput_GatewayNamespace_OrgConfigured
-		// scenario in handler_test.go.
+		// that value instead — see
+		// TestBuildPlatformInput_GatewayNamespace_TemplateUnifies (and the
+		// "configured resolver value is propagated verbatim" subtest of
+		// TestBuildPlatformInput_GatewayNamespace) in
+		// buildplatforminput_test.go.
 		system := v1alpha2.PlatformInput{
 			Project:          "my-project",
 			Namespace:        namespace,

--- a/console/organizations/resolver.go
+++ b/console/organizations/resolver.go
@@ -43,3 +43,60 @@ func (r *OrgGrantResolver) GetOrgDefaultGrants(ctx context.Context, org string) 
 	defaultRoles, _ := GetDefaultShareRoles(ns)
 	return defaultUsers, defaultRoles, nil
 }
+
+// ProjectOrgResolver maps a user-facing project name to the user-facing
+// organization name that owns it. It deliberately mirrors
+// settings.ProjectOrgResolver so the existing project→org mapping can be
+// reused without dragging the projects package into a cyclic import here.
+type ProjectOrgResolver interface {
+	GetProjectOrganization(ctx context.Context, project string) (string, error)
+}
+
+// GatewayNamespaceResolver looks up the configured ingress-gateway
+// namespace for the organization that owns a given project. It implements
+// the deployments.OrganizationGatewayResolver interface so the deployments
+// handler can inject the platform engineer's configured value (set via the
+// Organization service in HOL-643) into PlatformInput.gatewayNamespace —
+// removing the historical hard-coded "istio-ingress" injection that
+// conflicted with template authors who explicitly pinned a different value
+// (HOL-526).
+//
+// Resolution path: project → org name (via ProjectOrgResolver) → org
+// namespace (via K8sClient.GetOrganization) → gateway-namespace annotation
+// (via GetGatewayNamespace). Returns an empty string when the annotation is
+// absent so the caller can apply its own fallback (deployments.Handler
+// falls back to DefaultGatewayNamespace).
+type GatewayNamespaceResolver struct {
+	k8s         *K8sClient
+	projectOrgs ProjectOrgResolver
+}
+
+// NewGatewayNamespaceResolver constructs a GatewayNamespaceResolver. The
+// projectOrgs resolver is required: without it, we cannot map a project to
+// its owning organization and no annotation lookup is possible.
+func NewGatewayNamespaceResolver(k8s *K8sClient, projectOrgs ProjectOrgResolver) *GatewayNamespaceResolver {
+	return &GatewayNamespaceResolver{k8s: k8s, projectOrgs: projectOrgs}
+}
+
+// GetGatewayNamespace returns the value of the gateway-namespace annotation
+// on the organization namespace that owns the given project, or "" when the
+// annotation is unset. Returns an error only when the project→org lookup or
+// the org-namespace fetch fails; the deployments handler treats such errors
+// as soft failures and falls back to DefaultGatewayNamespace.
+func (r *GatewayNamespaceResolver) GetGatewayNamespace(ctx context.Context, project string) (string, error) {
+	if r.projectOrgs == nil {
+		return "", nil
+	}
+	org, err := r.projectOrgs.GetProjectOrganization(ctx, project)
+	if err != nil {
+		return "", err
+	}
+	if org == "" {
+		return "", nil
+	}
+	ns, err := r.k8s.GetOrganization(ctx, org)
+	if err != nil {
+		return "", err
+	}
+	return GetGatewayNamespace(ns), nil
+}

--- a/console/organizations/resolver_test.go
+++ b/console/organizations/resolver_test.go
@@ -1,0 +1,134 @@
+package organizations
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+// stubProjectOrgResolver is a hand-rolled ProjectOrgResolver. The real
+// implementation lives in console/projects (ProjectGrantResolver) and is
+// exercised end-to-end in console/deployments tests; here we focus on
+// GatewayNamespaceResolver's branching logic in isolation so a regression
+// in the org annotation read does not get masked by a failure in the
+// project→org step.
+type stubProjectOrgResolver struct {
+	org string
+	err error
+}
+
+func (s *stubProjectOrgResolver) GetProjectOrganization(_ context.Context, _ string) (string, error) {
+	return s.org, s.err
+}
+
+func TestGatewayNamespaceResolver_GetGatewayNamespace(t *testing.T) {
+	const orgName = "acme"
+
+	makeOrgNs := func(annotations map[string]string) *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "holos-org-" + orgName,
+				Labels: map[string]string{
+					v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+					v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+					v1alpha2.LabelOrganization: orgName,
+				},
+				Annotations: annotations,
+			},
+		}
+	}
+
+	t.Run("returns annotation value when set", func(t *testing.T) {
+		client := fake.NewClientset(makeOrgNs(map[string]string{
+			v1alpha2.AnnotationGatewayNamespace: "ci-private-apps-gateway",
+		}))
+		k8s := NewK8sClient(client, testResolver())
+		r := NewGatewayNamespaceResolver(k8s, &stubProjectOrgResolver{org: orgName})
+		got, err := r.GetGatewayNamespace(context.Background(), "any-project")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "ci-private-apps-gateway" {
+			t.Errorf("got %q, want %q", got, "ci-private-apps-gateway")
+		}
+	})
+
+	t.Run("returns empty when annotation absent", func(t *testing.T) {
+		client := fake.NewClientset(makeOrgNs(nil))
+		k8s := NewK8sClient(client, testResolver())
+		r := NewGatewayNamespaceResolver(k8s, &stubProjectOrgResolver{org: orgName})
+		got, err := r.GetGatewayNamespace(context.Background(), "any-project")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty string", got)
+		}
+	})
+
+	t.Run("returns empty when project has no organization", func(t *testing.T) {
+		// A project with no LabelOrganization yields "" from
+		// GetProjectOrganization. The resolver must short-circuit
+		// rather than calling GetOrganization with an empty name
+		// (which would error out and trigger the soft-fail fallback,
+		// hiding the real cause).
+		client := fake.NewClientset(makeOrgNs(nil))
+		k8s := NewK8sClient(client, testResolver())
+		r := NewGatewayNamespaceResolver(k8s, &stubProjectOrgResolver{org: ""})
+		got, err := r.GetGatewayNamespace(context.Background(), "orphan-project")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty string", got)
+		}
+	})
+
+	t.Run("returns project-org-resolver error", func(t *testing.T) {
+		client := fake.NewClientset()
+		k8s := NewK8sClient(client, testResolver())
+		r := NewGatewayNamespaceResolver(k8s, &stubProjectOrgResolver{err: errors.New("boom")})
+		_, err := r.GetGatewayNamespace(context.Background(), "any-project")
+		if err == nil {
+			t.Fatal("expected error from project-org resolver, got nil")
+		}
+	})
+
+	t.Run("returns k8s lookup error when org namespace missing", func(t *testing.T) {
+		// The fake client has no org namespace, so GetOrganization
+		// surfaces a NotFound. The resolver must propagate the error
+		// (not swallow it to "") so the deployments handler logs the
+		// real cause when it falls back to DefaultGatewayNamespace.
+		client := fake.NewClientset()
+		k8s := NewK8sClient(client, testResolver())
+		r := NewGatewayNamespaceResolver(k8s, &stubProjectOrgResolver{org: orgName})
+		_, err := r.GetGatewayNamespace(context.Background(), "any-project")
+		if err == nil {
+			t.Fatal("expected error from missing org namespace, got nil")
+		}
+	})
+
+	t.Run("nil project-org resolver yields empty without error", func(t *testing.T) {
+		// Defensive guard: a misconfigured wire-up that forgets to
+		// pass a ProjectOrgResolver must degrade gracefully rather
+		// than NPE. The deployments handler treats "" as "use the
+		// default" so this preserves legacy behavior in the
+		// pathological case.
+		client := fake.NewClientset(makeOrgNs(nil))
+		k8s := NewK8sClient(client, testResolver())
+		r := NewGatewayNamespaceResolver(k8s, nil)
+		got, err := r.GetGatewayNamespace(context.Background(), "any-project")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty string", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Replace the hard-coded `DefaultGatewayNamespace` ("istio-ingress") injection in `buildPlatformInput` with a lookup of the authoring org's `console.holos.run/gateway-namespace` annotation. Falls back to "istio-ingress" only when the annotation is absent (or the resolver is unwired / errors).
- Add `OrganizationGatewayResolver` interface + `WithOrganizationGatewayResolver` option on `deployments.Handler`, and implement it as `organizations.GatewayNamespaceResolver` (project → org name → org NS → annotation).
- Wire the resolver through production in `console/console.go` so platform-engineer-configured values from HOL-643 actually flow into renders.
- This is the phase that ships the HOL-526 bug fix end-to-end: a template that pins `platform.gatewayNamespace: "ci-private-apps-gateway"` to match the org-configured value now renders without a CUE unification conflict.

Tests are table-driven Go tests with the fake K8s client (per AGENTS.md). They cover:
- `nil` resolver, empty value, configured value, resolver error (handler-level branches).
- The real `organizations.GatewayNamespaceResolver` driven against a fake K8s client + real `projects.ProjectGrantResolver` (catches wiring drift).
- The end-to-end bug-reproduction scenario through the real `CueRenderer`.
- Six branches in the new resolver (annotation set/absent, project orphaned, project-org error, missing org NS, defensive nil-projectOrgs guard).

E2E was not run locally — change is purely backend Go (no UI routes, components, or auth lib touched), so per the E2E relevance table this falls in the "NO" bucket. Relying on CI E2E if it runs.

Fixes HOL-644

## Test plan

- [x] `go test ./console/deployments/ ./console/organizations/ -count=1` passes
- [x] `go test ./... -count=1` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files
- [x] `make lint` shows no new findings (pre-existing issues unrelated to this PR)
- [ ] CI green
- [ ] Smoke: a deployment template that pins `platform.gatewayNamespace: "ci-private-apps-gateway"` against an org with that same annotation renders without a CUE conflict (this is asserted by `TestBuildPlatformInput_GatewayNamespace_TemplateUnifies`)

Generated with [Claude Code](https://claude.com/claude-code)