### PR TITLE
feat(frontend): add gateway namespace inline-edit row to org settings

### DIFF
--- a/frontend/src/queries/organizations.ts
+++ b/frontend/src/queries/organizations.ts
@@ -62,8 +62,13 @@ export function useUpdateOrganization() {
   const client = useMemo(() => createClient(OrganizationService, transport), [transport])
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (params: { name: string; displayName?: string; description?: string; defaultFolder?: string }) =>
-      client.updateOrganization(params),
+    mutationFn: (params: {
+      name: string
+      displayName?: string
+      description?: string
+      defaultFolder?: string
+      gatewayNamespace?: string
+    }) => client.updateOrganization(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['connect-query'] })
     },

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx
@@ -63,6 +63,7 @@ const mockOrg = {
   defaultUserGrants: [{ principal: 'bob@example.com', role: 1 }],
   defaultRoleGrants: [{ principal: 'engineering', role: 2 }],
   defaultFolder: 'default',
+  gatewayNamespace: 'custom-gateway',
   userRole: 3, // OWNER
 }
 
@@ -228,6 +229,101 @@ describe('OrgSettingsPage', () => {
       expect(screen.getByText('A test organization')).toBeInTheDocument()
       const mutateAsync = (useUpdateOrganization as Mock).mock.results[0].value.mutateAsync
       expect(mutateAsync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Gateway Namespace inline edit', () => {
+    it('renders the current gatewayNamespace from the mocked org', () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      expect(screen.getByText('custom-gateway')).toBeInTheDocument()
+    })
+
+    it('renders an empty-state hint when gatewayNamespace is unset', () => {
+      setupMocks({ gatewayNamespace: '' })
+      render(<OrgSettingsPage />)
+      // Empty-state copy should mention the istio-ingress default.
+      expect(screen.getByText(/not set/i)).toBeInTheDocument()
+      expect(screen.getByText(/istio-ingress/i)).toBeInTheDocument()
+    })
+
+    it('clicking pencil switches to input with current value', () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      const editButtons = screen.getAllByRole('button', { name: /edit gateway namespace/i })
+      fireEvent.click(editButtons[0])
+      const input = screen.getByRole('textbox', { name: /gateway namespace/i })
+      expect(input).toBeInTheDocument()
+      expect((input as HTMLInputElement).value).toBe('custom-gateway')
+    })
+
+    it('saving calls useUpdateOrganization with new gatewayNamespace', async () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      const editButtons = screen.getAllByRole('button', { name: /edit gateway namespace/i })
+      fireEvent.click(editButtons[0])
+      const input = screen.getByRole('textbox', { name: /gateway namespace/i })
+      fireEvent.change(input, { target: { value: 'platform-gateway' } })
+      fireEvent.click(screen.getByRole('button', { name: /save gateway namespace/i }))
+      const mutateAsync = (useUpdateOrganization as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          name: 'test-org',
+          gatewayNamespace: 'platform-gateway',
+        })
+      })
+    })
+
+    it('saving an empty value calls useUpdateOrganization with gatewayNamespace: ""', async () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      const editButtons = screen.getAllByRole('button', { name: /edit gateway namespace/i })
+      fireEvent.click(editButtons[0])
+      const input = screen.getByRole('textbox', { name: /gateway namespace/i })
+      fireEvent.change(input, { target: { value: '' } })
+      fireEvent.click(screen.getByRole('button', { name: /save gateway namespace/i }))
+      const mutateAsync = (useUpdateOrganization as Mock).mock.results[0].value.mutateAsync
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          name: 'test-org',
+          gatewayNamespace: '',
+        })
+      })
+    })
+
+    it('cancel restores previous value without calling useUpdateOrganization', () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      const editButtons = screen.getAllByRole('button', { name: /edit gateway namespace/i })
+      fireEvent.click(editButtons[0])
+      const input = screen.getByRole('textbox', { name: /gateway namespace/i })
+      fireEvent.change(input, { target: { value: 'changed-gateway' } })
+      fireEvent.click(screen.getByRole('button', { name: /cancel gateway namespace/i }))
+      expect(screen.getByText('custom-gateway')).toBeInTheDocument()
+      const mutateAsync = (useUpdateOrganization as Mock).mock.results[0].value.mutateAsync
+      expect(mutateAsync).not.toHaveBeenCalled()
+    })
+
+    it('shows a DNS-1123 validation hint while editing an invalid value', () => {
+      setupMocks()
+      render(<OrgSettingsPage />)
+      const editButtons = screen.getAllByRole('button', { name: /edit gateway namespace/i })
+      fireEvent.click(editButtons[0])
+      const input = screen.getByRole('textbox', { name: /gateway namespace/i })
+      fireEvent.change(input, { target: { value: 'INVALID_NS' } })
+      // A small client-side hint should appear; server-side still authoritative.
+      expect(screen.getByText(/dns-1123/i)).toBeInTheDocument()
+    })
+
+    it('renders read-only (no edit pencil) for non-owners', () => {
+      setupMocks({ userRole: 1 }) // VIEWER
+      render(<OrgSettingsPage />)
+      // The current value still renders.
+      expect(screen.getByText('custom-gateway')).toBeInTheDocument()
+      // But there is no edit affordance for non-owners.
+      expect(
+        screen.queryByRole('button', { name: /edit gateway namespace/i }),
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
@@ -74,6 +74,10 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
   const [editingDescription, setEditingDescription] = useState(false)
   const [draftDescription, setDraftDescription] = useState('')
 
+  // Gateway Namespace inline edit
+  const [editingGatewayNamespace, setEditingGatewayNamespace] = useState(false)
+  const [draftGatewayNamespace, setDraftGatewayNamespace] = useState('')
+
   // Delete dialog
   const [deleteOpen, setDeleteOpen] = useState(false)
 
@@ -103,6 +107,16 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
     try {
       await updateOrganization.mutateAsync({ name: orgName, description: draftDescription })
       setEditingDescription(false)
+      toast.success('Saved')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const handleSaveGatewayNamespace = async () => {
+    try {
+      await updateOrganization.mutateAsync({ name: orgName, gatewayNamespace: draftGatewayNamespace })
+      setEditingGatewayNamespace(false)
       toast.success('Saved')
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
@@ -162,10 +176,16 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
   const defaultUserGrants = (org?.defaultUserGrants ?? []) as Grant[]
   const defaultRoleGrants = (org?.defaultRoleGrants ?? []) as Grant[]
   const defaultFolder = org?.defaultFolder ?? ''
+  const gatewayNamespace = org?.gatewayNamespace ?? ''
   const folderItems = (folders ?? []).map((f) => ({
     value: f.name,
     label: f.displayName || f.name,
   }))
+
+  // DNS-1123 label: 1–63 chars, lowercase alphanumeric or '-', start and end with alphanumeric.
+  // The server is authoritative; this is a small client-side hint only.
+  const draftGatewayNamespaceIsValid =
+    draftGatewayNamespace === '' || /^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$/.test(draftGatewayNamespace)
 
   return (
     <Card>
@@ -309,6 +329,68 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
                     >
                       <Pencil className="h-4 w-4" />
                     </Button>
+                  </>
+                )}
+              </div>
+
+              {/* Gateway Namespace */}
+              <div className="flex items-start gap-2">
+                <span className="w-32 text-sm text-muted-foreground shrink-0 pt-2">Gateway Namespace</span>
+                {editingGatewayNamespace ? (
+                  <div className="flex-1 flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <Input
+                        autoFocus
+                        aria-label="gateway namespace"
+                        value={draftGatewayNamespace}
+                        onChange={(e) => setDraftGatewayNamespace(e.target.value)}
+                        className="flex-1"
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && draftGatewayNamespaceIsValid) handleSaveGatewayNamespace()
+                        }}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="save gateway namespace"
+                        onClick={handleSaveGatewayNamespace}
+                        disabled={updateOrganization.isPending || !draftGatewayNamespaceIsValid}
+                      >
+                        <Check className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="cancel gateway namespace"
+                        onClick={() => setEditingGatewayNamespace(false)}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    {!draftGatewayNamespaceIsValid && (
+                      <span className="text-xs text-destructive">
+                        Must be a DNS-1123 label: lowercase letters, digits, or '-'; 1–63 chars; start and end with alphanumeric.
+                      </span>
+                    )}
+                    <span className="text-xs text-muted-foreground">
+                      Leave empty to clear and fall back to the platform default (istio-ingress).
+                    </span>
+                  </div>
+                ) : (
+                  <>
+                    <span className={`flex-1 text-sm ${gatewayNamespace ? 'font-mono' : 'text-muted-foreground'} pt-2`}>
+                      {gatewayNamespace || 'Not set — defaults to istio-ingress'}
+                    </span>
+                    {isOwner && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="edit gateway namespace"
+                        onClick={() => { setDraftGatewayNamespace(gatewayNamespace); setEditingGatewayNamespace(true) }}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    )}
                   </>
                 )}
               </div>


### PR DESCRIPTION
## Summary

- Adds a "Gateway Namespace" inline-edit row to the org settings General section, mirroring the existing Display Name / Description rows (pencil / Check / X with sonner toasts).
- Empty value renders the hint "Not set — defaults to istio-ingress"; saving an empty string clears the org's `gateway_namespace` annotation and falls back to the platform default.
- Pencil affordance is gated on `isOwner` per the AC; viewers and editors see the value read-only.
- Surfaces a small client-side DNS-1123 validation hint while editing; the server in HOL-643 remains authoritative.
- Extends `useUpdateOrganization`'s mutation params type with `gatewayNamespace?: string`; Connect-Query forwards it as the proto's `gateway_namespace` field generated in HOL-642.
- Vitest coverage: 8 new cases (read current value, empty-state hint copy, edit prefill, save with new value, save empty to clear, cancel restores prior, DNS-1123 hint, read-only for non-owners).

Phase 4 of 6 of HOL-526 (parent: gateway namespace as a per-org annotation).

Fixes HOL-645

## Test plan

- [x] `npx vitest run` (frontend): 76 files / 1136 tests pass.
- [x] `npx tsc -b` (frontend): clean.
- [x] `make test` (Go): all packages green.
- [x] `npm run lint`: 0 new errors/warnings introduced in changed files (pre-existing issues unchanged).
- [ ] Manual smoke (deferred to HOL-647): edit gateway namespace as Owner, verify annotation written; verify Viewer sees no pencil; verify empty value clears annotation.

> Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)