### PR TITLE
feat(frontend): use org gatewayNamespace in template preview defaults (HOL-646)

### DIFF
--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
@@ -120,6 +120,32 @@ export function CueTemplateEditor({
   const [activeTab, setActiveTab] = useState('editor')
   const [cuePlatformInput, setCuePlatformInput] = useState(() => prettyPrintJson(defaultPlatformInput))
   const [cueInput, setCueInput] = useState(() => prettyPrintJson(defaultProjectInput))
+
+  // The defaults can change after first render when async data (such as the
+  // authoring org's gatewayNamespace, HOL-646) finishes loading. Re-sync the
+  // textarea state to the new default value only if the user has not edited
+  // it — track the last applied default in a ref and compare with current
+  // state to detect that case.
+  const lastPlatformDefaultRef = useRef(prettyPrintJson(defaultPlatformInput))
+  const lastProjectDefaultRef = useRef(prettyPrintJson(defaultProjectInput))
+  useEffect(() => {
+    const next = prettyPrintJson(defaultPlatformInput)
+    if (next !== lastPlatformDefaultRef.current) {
+      setCuePlatformInput((current) =>
+        current === lastPlatformDefaultRef.current ? next : current,
+      )
+      lastPlatformDefaultRef.current = next
+    }
+  }, [defaultPlatformInput])
+  useEffect(() => {
+    const next = prettyPrintJson(defaultProjectInput)
+    if (next !== lastProjectDefaultRef.current) {
+      setCueInput((current) =>
+        current === lastProjectDefaultRef.current ? next : current,
+      )
+      lastProjectDefaultRef.current = next
+    }
+  }, [defaultProjectInput])
 
   const debouncedCueInput = useDebouncedValue(cueInput, 500)
   const debouncedCuePlatformInput = useDebouncedValue(cuePlatformInput, 500)

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -26,6 +26,7 @@ import {
   makeFolderScope,
 } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
+import { useGetOrganization } from '@/queries/organizations'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateReleases } from '@/components/template-releases'
 import { PlatformTemplateEnabledToggle } from '@/components/platform-template-enabled-toggle'
@@ -65,6 +66,11 @@ export function FolderTemplateDetailPage({
 
   const { data: folder } = useGetFolder(folderName)
   const orgName = folder?.organization ?? ''
+  // The authoring org's gatewayNamespace (HOL-526) is mirrored into the
+  // platform-input preview default so the preview matches what the backend
+  // will inject at render time. Folder templates inherit this from the
+  // folder's parent organization.
+  const { data: org } = useGetOrganization(orgName)
 
   const scope = makeFolderScope(folderName)
   const { data: template, isPending, error } = useGetTemplate(scope, templateName)
@@ -89,7 +95,9 @@ export function FolderTemplateDetailPage({
   const userRole = folder?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER
 
-  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
+  // Falls back to "istio-ingress" when the org has not configured one.
+  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
+  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "${gatewayNamespace}"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   const handleSave = async () => {

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -70,7 +70,7 @@ export function FolderTemplateDetailPage({
   // platform-input preview default so the preview matches what the backend
   // will inject at render time. Folder templates inherit this from the
   // folder's parent organization.
-  const { data: org } = useGetOrganization(orgName)
+  const { data: org, isPending: orgPending, error: orgError } = useGetOrganization(orgName)
 
   const scope = makeFolderScope(folderName)
   const { data: template, isPending, error } = useGetTemplate(scope, templateName)
@@ -95,9 +95,18 @@ export function FolderTemplateDetailPage({
   const userRole = folder?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER
 
-  // Falls back to "istio-ingress" when the org has not configured one.
-  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
-  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "${gatewayNamespace}"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
+  // Fall back to "istio-ingress" only after the org query has successfully
+  // resolved with no value configured. While the org load is pending or
+  // errored (e.g. a folder EDITOR may not have org-read permission), omit
+  // the field entirely so the preview never advertises a value that may be
+  // incorrect — the backend (HOL-644) still injects the org's actual value
+  // at render time.
+  const orgLoaded = orgName.length > 0 && !orgPending && !orgError
+  const gatewayNamespace = orgLoaded ? (org?.gatewayNamespace || 'istio-ingress') : ''
+  const gatewayNamespaceLine = gatewayNamespace
+    ? `  gatewayNamespace: "${gatewayNamespace}"\n`
+    : ''
+  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n${gatewayNamespaceLine}  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   const handleSave = async () => {

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/-detail.test.tsx
@@ -34,6 +34,10 @@ vi.mock('@/queries/folders', () => ({
   useGetFolder: vi.fn(),
 }))
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: vi.fn((value: unknown) => value),
 }))
@@ -52,6 +56,7 @@ import {
   useRenderTemplate,
 } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
+import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { FolderTemplateDetailPage } from './$templateName'
 
@@ -95,6 +100,11 @@ function setupMocks(
   })
   ;(useGetFolder as Mock).mockReturnValue({
     data: { name: 'test-folder', organization: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', gatewayNamespace: '' },
     isPending: false,
     error: null,
   })
@@ -468,6 +478,11 @@ describe('FolderTemplateDetailPage', () => {
       isPending: false,
       error: null,
     })
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { name: 'test-org', gatewayNamespace: '' },
+      isPending: false,
+      error: null,
+    })
     render(
       <FolderTemplateDetailPage
         folderName="test-folder"
@@ -505,6 +520,11 @@ describe('FolderTemplateDetailPage', () => {
     })
     ;(useGetFolder as Mock).mockReturnValue({
       data: { name: 'test-folder', organization: 'test-org', userRole: Role.OWNER },
+      isPending: false,
+      error: null,
+    })
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { name: 'test-org', gatewayNamespace: '' },
       isPending: false,
       error: null,
     })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
@@ -54,7 +54,7 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
 
   const scope = makeOrgScope(orgName)
   const { data: template, isPending, error } = useGetTemplate(scope, templateName)
-  const { data: org } = useGetOrganization(orgName)
+  const { data: org, isPending: orgPending, error: orgError } = useGetOrganization(orgName)
   const updateMutation = useUpdateTemplate(scope, templateName)
   const cloneMutation = useCloneTemplate(scope)
 
@@ -77,9 +77,17 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
 
   // Use the authoring org's configured gateway namespace (HOL-526) so the
   // preview default matches what the backend injects at render time. Fall
-  // back to "istio-ingress" when the org has not configured one.
-  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
-  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "${gatewayNamespace}"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
+  // back to "istio-ingress" only after the org query has successfully
+  // resolved with no value configured. While the org load is pending or
+  // errored (e.g. user lacks org-read permission), omit the field entirely
+  // so the preview never advertises a value that may be incorrect — the
+  // backend (HOL-644) still injects the org's actual value at render time.
+  const orgLoaded = !orgPending && !orgError
+  const gatewayNamespace = orgLoaded ? (org?.gatewayNamespace || 'istio-ingress') : ''
+  const gatewayNamespaceLine = gatewayNamespace
+    ? `  gatewayNamespace: "${gatewayNamespace}"\n`
+    : ''
+  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n${gatewayNamespaceLine}  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   const handleSave = async () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/$templateName.tsx
@@ -75,7 +75,11 @@ export function OrgTemplateDetailPage({ orgName: propOrgName, templateName: prop
   const userRole = org?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER
 
-  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
+  // Use the authoring org's configured gateway namespace (HOL-526) so the
+  // preview default matches what the backend injects at render time. Fall
+  // back to "istio-ingress" when the org has not configured one.
+  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
+  const defaultPlatformInput = `platform: {\n  project:          "example-project"\n  namespace:        "prj-example-project"\n  gatewayNamespace: "${gatewayNamespace}"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   const handleSave = async () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-$templateName.test.tsx
@@ -87,4 +87,35 @@ describe('OrgTemplateDetailPage', () => {
     const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
     expect(platformInput.value).toContain('gatewayNamespace: "istio-ingress"')
   })
+
+  // HOL-646 review round 1: org-query failure (e.g. user can read the
+  // template via a folder/project grant but cannot read the parent org)
+  // must NOT silently substitute the platform default. Omit the field
+  // entirely so the preview does not advertise a value that may differ
+  // from what the backend actually injects at render time.
+  it('Platform Input omits gatewayNamespace when org query is pending', async () => {
+    ;(useGetTemplate as Mock).mockReturnValue({ data: mockTemplate, isPending: false, error: null })
+    ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
+    ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'clone' }), isPending: false })
+    ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: true, error: null })
+    ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+    const user = userEvent.setup()
+    render(<OrgTemplateDetailPage orgName="test-org" templateName="platform-base" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).not.toContain('gatewayNamespace')
+  })
+
+  it('Platform Input omits gatewayNamespace when org query errors', async () => {
+    ;(useGetTemplate as Mock).mockReturnValue({ data: mockTemplate, isPending: false, error: null })
+    ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
+    ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'clone' }), isPending: false })
+    ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: false, error: new Error('forbidden') })
+    ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
+    const user = userEvent.setup()
+    render(<OrgTemplateDetailPage orgName="test-org" templateName="platform-base" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).not.toContain('gatewayNamespace')
+  })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/org-templates/-$templateName.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org', templateName: 'platform-base' }),
+    }),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+vi.mock('@/queries/templates', () => ({
+  useGetTemplate: vi.fn(),
+  useUpdateTemplate: vi.fn(),
+  useCloneTemplate: vi.fn(),
+  useRenderTemplate: vi.fn(),
+  useListReleases: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  useCreateRelease: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  makeOrgScope: vi.fn().mockReturnValue({ scope: 1, scopeName: 'test-org' }),
+}))
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// Identity debounce so tests do not have to manage timers.
+vi.mock('@/hooks/use-debounced-value', () => ({
+  useDebouncedValue: vi.fn((value: unknown) => value),
+}))
+
+import { useGetTemplate, useUpdateTemplate, useCloneTemplate, useRenderTemplate } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { OrgTemplateDetailPage } from './$templateName'
+
+const mockTemplate = {
+  name: 'platform-base',
+  displayName: 'Platform Base',
+  description: 'Base platform template',
+  cueTemplate: '// cue template',
+  enabled: true,
+}
+
+function setupMocks(userRole = Role.OWNER, orgGatewayNamespace = '') {
+  ;(useGetTemplate as Mock).mockReturnValue({ data: mockTemplate, isPending: false, error: null })
+  ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
+  ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'clone' }), isPending: false })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole, gatewayNamespace: orgGatewayNamespace },
+    isPending: false,
+    error: null,
+  })
+  ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: 'apiVersion: v1\n', renderedJson: '' }, error: null, isFetching: false })
+}
+
+describe('OrgTemplateDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // HOL-646: the Platform Input preview default mirrors the authoring org's
+  // configured gatewayNamespace so the preview matches what the backend
+  // injects at render time. Falls back to "istio-ingress" when unset.
+  it('Platform Input uses org gatewayNamespace when configured', async () => {
+    setupMocks(Role.OWNER, 'custom-gateway-ns')
+    const user = userEvent.setup()
+    render(<OrgTemplateDetailPage orgName="test-org" templateName="platform-base" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).toContain('gatewayNamespace: "custom-gateway-ns"')
+    expect(platformInput.value).not.toContain('gatewayNamespace: "istio-ingress"')
+  })
+
+  it('Platform Input falls back to istio-ingress when org gatewayNamespace is empty', async () => {
+    setupMocks(Role.OWNER, '')
+    const user = userEvent.setup()
+    render(<OrgTemplateDetailPage orgName="test-org" templateName="platform-base" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).toContain('gatewayNamespace: "istio-ingress"')
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -25,6 +25,7 @@ import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useListLinkableTemplates, useCheckUpdates, useGetProjectTemplatePolicyState, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { LinkifiedText } from '@/components/linkified-text'
 import { UpgradeDialog } from '@/components/template-updates'
@@ -54,6 +55,11 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const scope = makeProjectScope(projectName)
   const { data: template, isPending, error } = useGetTemplate(scope, templateName)
   const { data: project } = useGetProject(projectName)
+  // The authoring org's gatewayNamespace (HOL-526) is mirrored into the
+  // platform-input preview default so the preview matches what the backend
+  // will inject at render time. The project's parent organization is the
+  // source of truth for this setting.
+  const { data: org } = useGetOrganization(project?.organization ?? '')
   const { data: linkableTemplates = [], isPending: linkablePending } = useListLinkableTemplates(scope)
   const updateMutation = useUpdateTemplate(scope, templateName)
   const deleteMutation = useDeleteTemplate(scope)
@@ -96,7 +102,9 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const canDelete = userRole === Role.OWNER
   const canEditLinks = userRole === Role.OWNER
 
-  const defaultPlatformInput = `platform: {\n  project:          "${projectName}"\n  namespace:        "holos-prj-${projectName}"\n  gatewayNamespace: "istio-ingress"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
+  // Falls back to "istio-ingress" when the org has not configured one.
+  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
+  const defaultPlatformInput = `platform: {\n  project:          "${projectName}"\n  namespace:        "holos-prj-${projectName}"\n  gatewayNamespace: "${gatewayNamespace}"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   // handleReconcile triggers an UpdateTemplate with the template's current

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -59,7 +59,7 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   // platform-input preview default so the preview matches what the backend
   // will inject at render time. The project's parent organization is the
   // source of truth for this setting.
-  const { data: org } = useGetOrganization(project?.organization ?? '')
+  const { data: org, isPending: orgPending, error: orgError } = useGetOrganization(project?.organization ?? '')
   const { data: linkableTemplates = [], isPending: linkablePending } = useListLinkableTemplates(scope)
   const updateMutation = useUpdateTemplate(scope, templateName)
   const deleteMutation = useDeleteTemplate(scope)
@@ -102,9 +102,18 @@ export function DeploymentTemplateDetailPage({ projectName: propProjectName, tem
   const canDelete = userRole === Role.OWNER
   const canEditLinks = userRole === Role.OWNER
 
-  // Falls back to "istio-ingress" when the org has not configured one.
-  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
-  const defaultPlatformInput = `platform: {\n  project:          "${projectName}"\n  namespace:        "holos-prj-${projectName}"\n  gatewayNamespace: "${gatewayNamespace}"\n  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
+  // Fall back to "istio-ingress" only after the org query has successfully
+  // resolved with no value configured. While the org load is pending or
+  // errored (e.g. a project EDITOR may not have org-read permission), omit
+  // the field entirely so the preview never advertises a value that may be
+  // incorrect — the backend (HOL-644) still injects the org's actual value
+  // at render time.
+  const orgLoaded = (project?.organization ?? '').length > 0 && !orgPending && !orgError
+  const gatewayNamespace = orgLoaded ? (org?.gatewayNamespace || 'istio-ingress') : ''
+  const gatewayNamespaceLine = gatewayNamespace
+    ? `  gatewayNamespace: "${gatewayNamespace}"\n`
+    : ''
+  const defaultPlatformInput = `platform: {\n  project:          "${projectName}"\n  namespace:        "holos-prj-${projectName}"\n${gatewayNamespaceLine}  claims: {\n    iss:            "https://login.example.com"\n    sub:            "user-abc123"\n    iat:            1743868800\n    exp:            1743872400\n    email:          "developer@example.com"\n    email_verified: true\n  }\n}`
   const defaultProjectInput = `input: {\n  name:  "example"\n  image: "nginx"\n  tag:   "latest"\n  port:  8080\n}`
 
   // handleReconcile triggers an UpdateTemplate with the template's current

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -42,6 +42,10 @@ vi.mock('@/queries/projects', () => ({
   useGetProject: vi.fn(),
 }))
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 // Mock the debounce hook so tests don't have to manage timers by default.
@@ -52,6 +56,7 @@ vi.mock('@/hooks/use-debounced-value', () => ({
 
 import { useGetTemplate, useUpdateTemplate, useDeleteTemplate, useCloneTemplate, useRenderTemplate, useListLinkableTemplates, useCheckUpdates, useGetProjectTemplatePolicyState } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { DeploymentTemplateDetailPage } from './$templateName'
@@ -65,13 +70,14 @@ const mockTemplate = {
   linkedTemplates: [] as Array<{ name: string; scope: number; scopeName: string }>,
 }
 
-function setupMocks(userRole = Role.OWNER, templateOverrides?: Partial<typeof mockTemplate>, renderYaml = '') {
+function setupMocks(userRole = Role.OWNER, templateOverrides?: Partial<typeof mockTemplate>, renderYaml = '', orgGatewayNamespace?: string) {
   const template = { ...mockTemplate, ...templateOverrides }
   ;(useGetTemplate as Mock).mockReturnValue({ data: template, isPending: false, error: null })
   ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
   ;(useDeleteTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
   ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'new-template' }), isPending: false })
-  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole }, isLoading: false })
+  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole, organization: 'test-org' }, isLoading: false })
+  ;(useGetOrganization as Mock).mockReturnValue({ data: { name: 'test-org', gatewayNamespace: orgGatewayNamespace ?? '' }, isPending: false, error: null })
   ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: renderYaml, renderedJson: '' }, error: null, isFetching: false })
 }
 
@@ -173,6 +179,7 @@ describe('DeploymentTemplateDetailPage', () => {
     ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     ;(useDeleteTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null, reset: vi.fn() })
     ;(useGetProject as Mock).mockReturnValue({ data: undefined, isLoading: true })
+    ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
     ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
     render(<DeploymentTemplateDetailPage />)
     const skeletons = document.querySelectorAll('[data-slot="skeleton"]')
@@ -183,7 +190,8 @@ describe('DeploymentTemplateDetailPage', () => {
     ;(useGetTemplate as Mock).mockReturnValue({ data: undefined, isPending: false, error: new Error('not found') })
     ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     ;(useDeleteTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null, reset: vi.fn() })
-    ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
+    ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER, organization: 'test-org' }, isLoading: false })
+    ;(useGetOrganization as Mock).mockReturnValue({ data: { name: 'test-org', gatewayNamespace: '' }, isPending: false, error: null })
     ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
     render(<DeploymentTemplateDetailPage />)
     expect(screen.getByText('not found')).toBeInTheDocument()
@@ -280,6 +288,28 @@ describe('DeploymentTemplateDetailPage', () => {
     expect(platformInput.value).toContain('test-project')
     expect(platformInput.value).toContain('claims')
     expect(platformInput.value).toContain('email')
+  })
+
+  // HOL-646: the Platform Input preview default mirrors the authoring org's
+  // configured gatewayNamespace so the preview matches what the backend
+  // injects at render time. Falls back to "istio-ingress" when unset.
+  it('Platform Input uses org gatewayNamespace when configured', async () => {
+    setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n', 'custom-gateway-ns')
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage projectName="test-project" templateName="web-app" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).toContain('gatewayNamespace: "custom-gateway-ns"')
+    expect(platformInput.value).not.toContain('gatewayNamespace: "istio-ingress"')
+  })
+
+  it('Platform Input falls back to istio-ingress when org gatewayNamespace is empty', async () => {
+    setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n', '')
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage projectName="test-project" templateName="web-app" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).toContain('gatewayNamespace: "istio-ingress"')
   })
 
   it('Project Input textarea contains name, image, tag, and port', async () => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx
@@ -312,6 +312,32 @@ describe('DeploymentTemplateDetailPage', () => {
     expect(platformInput.value).toContain('gatewayNamespace: "istio-ingress"')
   })
 
+  // HOL-646 review round 1: a project EDITOR may have project-read but
+  // not org-read permission. In that case useGetOrganization returns an
+  // error or stays pending. We must NOT silently substitute "istio-ingress"
+  // — the backend (HOL-644) still injects the org's actually-configured
+  // gateway namespace at render time, so a fabricated default would
+  // mislead. Omit the field entirely instead.
+  it('Platform Input omits gatewayNamespace when org query is pending', async () => {
+    setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n')
+    ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: true, error: null })
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage projectName="test-project" templateName="web-app" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).not.toContain('gatewayNamespace')
+  })
+
+  it('Platform Input omits gatewayNamespace when org query errors', async () => {
+    setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n')
+    ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: false, error: new Error('forbidden') })
+    const user = userEvent.setup()
+    render(<DeploymentTemplateDetailPage projectName="test-project" templateName="web-app" />)
+    await user.click(screen.getByRole('tab', { name: /preview/i }))
+    const platformInput = screen.getByRole('textbox', { name: /platform input/i }) as HTMLTextAreaElement
+    expect(platformInput.value).not.toContain('gatewayNamespace')
+  })
+
   it('Project Input textarea contains name, image, tag, and port', async () => {
     setupMocks(Role.OWNER, undefined, 'apiVersion: v1\n')
     const user = userEvent.setup()

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-linking-regression.test.tsx
@@ -64,6 +64,10 @@ vi.mock('@/queries/projects', () => ({
   useGetProject: vi.fn(),
 }))
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: vi.fn((value: unknown) => value),
 }))
@@ -80,6 +84,7 @@ import {
   useListLinkableTemplates,
 } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateTemplatePage } from './new'
 import { DeploymentTemplateDetailPage } from './$templateName'
@@ -125,8 +130,13 @@ function setupCreateMocks(userRole = Role.OWNER) {
     isError: false,
   })
   ;(useGetProject as Mock).mockReturnValue({
-    data: { name: 'test-project', userRole },
+    data: { name: 'test-project', userRole, organization: 'test-org' },
     isLoading: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', gatewayNamespace: '' },
+    isPending: false,
+    error: null,
   })
 }
 
@@ -136,7 +146,8 @@ function setupDetailMocks(userRole = Role.OWNER, templateOverrides?: Partial<typ
   ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
   ;(useDeleteTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
   ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'new-template' }), isPending: false })
-  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole }, isLoading: false })
+  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole, organization: 'test-org' }, isLoading: false })
+  ;(useGetOrganization as Mock).mockReturnValue({ data: { name: 'test-org', gatewayNamespace: '' }, isPending: false, error: null })
   ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -38,6 +38,10 @@ vi.mock('@/queries/projects', () => ({
   useGetProject: vi.fn(),
 }))
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: vi.fn((value: unknown) => value),
 }))
@@ -46,6 +50,7 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateTemplatePage } from './new'
 
@@ -67,8 +72,13 @@ function setupMocks(
     isError: !!renderError,
   })
   ;(useGetProject as Mock).mockReturnValue({
-    data: { name: 'test-project', userRole },
+    data: { name: 'test-project', userRole, organization: 'test-org' },
     isLoading: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', gatewayNamespace: '' },
+    isPending: false,
+    error: null,
   })
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-version-selector.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-version-selector.test.tsx
@@ -78,6 +78,10 @@ vi.mock('@/queries/projects', () => ({
   useGetProject: vi.fn(),
 }))
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: vi.fn((value: unknown) => value),
 }))
@@ -94,6 +98,7 @@ import {
   useListLinkableTemplates,
 } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateTemplatePage } from './new'
 import { DeploymentTemplateDetailPage } from './$templateName'
@@ -163,8 +168,13 @@ function setupCreateMocks(userRole = Role.OWNER) {
     isError: false,
   })
   ;(useGetProject as Mock).mockReturnValue({
-    data: { name: 'test-project', userRole },
+    data: { name: 'test-project', userRole, organization: 'test-org' },
     isLoading: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', gatewayNamespace: '' },
+    isPending: false,
+    error: null,
   })
 }
 
@@ -174,7 +184,8 @@ function setupDetailMocks(userRole = Role.OWNER, templateOverrides?: Partial<typ
   ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
   ;(useDeleteTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
   ;(useCloneTemplate as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ name: 'new-template' }), isPending: false })
-  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole }, isLoading: false })
+  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole, organization: 'test-org' }, isLoading: false })
+  ;(useGetOrganization as Mock).mockReturnValue({ data: { name: 'test-org', gatewayNamespace: '' }, isPending: false, error: null })
   ;(useRenderTemplate as Mock).mockReturnValue({ data: { renderedYaml: '', renderedJson: '' }, error: null, isFetching: false })
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -243,7 +243,7 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   // The authoring org's gatewayNamespace (HOL-526) is mirrored into the
   // platform-input preview default so the preview matches what the backend
   // will inject at render time.
-  const { data: org } = useGetOrganization(project?.organization ?? '')
+  const { data: org, isPending: orgPending, error: orgError } = useGetOrganization(project?.organization ?? '')
   const { data: linkableTemplates = [], isPending: linkablePending } = useListLinkableTemplates(scope)
 
   const userRole = project?.userRole ?? Role.VIEWER
@@ -266,13 +266,21 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
     (t) => t.scopeRef?.scope === TemplateScope.FOLDER,
   )
 
-  // Falls back to "istio-ingress" when the org has not configured one.
-  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
+  // Fall back to "istio-ingress" only after the org query has successfully
+  // resolved with no value configured. While the org load is pending or
+  // errored (e.g. a project EDITOR may not have org-read permission), omit
+  // the field entirely so the preview never advertises a value that may be
+  // incorrect — the backend (HOL-644) still injects the org's actual value
+  // at render time.
+  const orgLoaded = (project?.organization ?? '').length > 0 && !orgPending && !orgError
+  const gatewayNamespace = orgLoaded ? (org?.gatewayNamespace || 'istio-ingress') : ''
+  const gatewayNamespaceLine = gatewayNamespace
+    ? `\tgatewayNamespace: "${gatewayNamespace}"\n`
+    : ''
   const previewCuePlatformInput = `platform: {
 \tproject:          "${projectName}"
 \tnamespace:        "holos-prj-${projectName}"
-\tgatewayNamespace: "${gatewayNamespace}"
-\tclaims: {
+${gatewayNamespaceLine}\tclaims: {
 \t\tiss:            "https://login.example.com"
 \t\tsub:            "user-abc123"
 \t\tiat:            1743868800

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -14,6 +14,7 @@ import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates, makeProjectScope, TemplateScope, linkableKey, parseLinkableKey } from '@/queries/templates'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 
 const DEFAULT_CUE_TEMPLATE = `// Use generated type definitions from api/v1alpha2 (prepended by renderer).
@@ -239,6 +240,10 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
   const scope = makeProjectScope(projectName)
   const createMutation = useCreateTemplate(scope)
   const { data: project } = useGetProject(projectName)
+  // The authoring org's gatewayNamespace (HOL-526) is mirrored into the
+  // platform-input preview default so the preview matches what the backend
+  // will inject at render time.
+  const { data: org } = useGetOrganization(project?.organization ?? '')
   const { data: linkableTemplates = [], isPending: linkablePending } = useListLinkableTemplates(scope)
 
   const userRole = project?.userRole ?? Role.VIEWER
@@ -261,10 +266,12 @@ export function CreateTemplatePage({ projectName: propProjectName }: { projectNa
     (t) => t.scopeRef?.scope === TemplateScope.FOLDER,
   )
 
+  // Falls back to "istio-ingress" when the org has not configured one.
+  const gatewayNamespace = org?.gatewayNamespace || 'istio-ingress'
   const previewCuePlatformInput = `platform: {
 \tproject:          "${projectName}"
 \tnamespace:        "holos-prj-${projectName}"
-\tgatewayNamespace: "istio-ingress"
+\tgatewayNamespace: "${gatewayNamespace}"
 \tclaims: {
 \t\tiss:            "https://login.example.com"
 \t\tsub:            "user-abc123"


### PR DESCRIPTION
## Summary

- Read the authoring org with `useGetOrganization` on each template editing surface and thread its `gatewayNamespace` into the `defaultPlatformInput` template literal, falling back to `"istio-ingress"` when unset.
- Surfaces touched: org-templates edit, project-templates edit, folder-templates detail, project-templates new.
- Fix latent one-shot `useState` initialization in `cue-template-editor` so the textarea re-syncs to a freshly resolved default only when the user hasn't typed yet (tracked via `useRef`).

This restores the "preview matches what the backend renders" contract that HOL-644 established server-side: an org configured with `gateway-system` now sees the preview Platform Input emit `gatewayNamespace: "gateway-system"` instead of always `istio-ingress`.

Fixes HOL-646

## Test plan

- [x] `npx vitest run` — 1140 tests pass (77 files)
- [x] `npx tsc -b` — clean
- [x] New Vitest case asserts `gatewayNamespace: "custom-gateway-ns"` appears in the org-templates Preview tab when the org has a configured value
- [x] Companion case asserts the fallback to `"istio-ingress"` when the org's value is empty
- [x] project-templates test gains the same two assertions
- [x] folder-templates, project-templates-new, linking-regression, version-selector tests updated to mock `useGetOrganization` so the new query call doesn't crash the renderer

> Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)