### PR TITLE
chore(gatewayns): cleanup, docs, and smoke-test for HOL-526

### DIFF
--- a/api/v1alpha2/input.go
+++ b/api/v1alpha2/input.go
@@ -48,7 +48,15 @@ type PlatformInput struct {
 	Project string `json:"project"          yaml:"project"          cue:"project"`
 	// Namespace is the Kubernetes namespace for the project, resolved by the backend.
 	Namespace string `json:"namespace"        yaml:"namespace"        cue:"namespace"`
-	// GatewayNamespace is the namespace of the ingress gateway (default: "istio-ingress").
+	// GatewayNamespace is the namespace of the ingress gateway. The backend
+	// resolves it from the owning organization's
+	// `console.holos.run/gateway-namespace` annotation (set via the Settings UI
+	// and the OrganizationService, see HOL-526). When the annotation is unset
+	// or the lookup fails, the renderer falls back to the historical default
+	// "istio-ingress" so legacy clusters keep working unchanged. Template
+	// authors who pin platform.gatewayNamespace to a literal MUST use the same
+	// value the org is configured with — CUE unifies string : "X" & string :
+	// "Y" as a conflict.
 	GatewayNamespace string `json:"gatewayNamespace" yaml:"gatewayNamespace" cue:"gatewayNamespace"`
 	// Organization is the root organization name.
 	Organization string `json:"organization"     yaml:"organization"     cue:"organization"`

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -379,7 +379,15 @@
 	// Namespace is the Kubernetes namespace for the project, resolved by the backend.
 	namespace: string  @go(Namespace)
 
-	// GatewayNamespace is the namespace of the ingress gateway (default: "istio-ingress").
+	// GatewayNamespace is the namespace of the ingress gateway. The backend
+	// resolves it from the owning organization's
+	// `console.holos.run/gateway-namespace` annotation (set via the Settings UI
+	// and the OrganizationService, see HOL-526). When the annotation is unset
+	// or the lookup fails, the renderer falls back to the historical default
+	// "istio-ingress" so legacy clusters keep working unchanged. Template
+	// authors who pin platform.gatewayNamespace to a literal MUST use the same
+	// value the org is configured with — CUE unifies string : "X" & string :
+	// "Y" as a conflict.
 	gatewayNamespace: string  @go(GatewayNamespace)
 
 	// Organization is the root organization name.

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -56,7 +56,14 @@ type TemplateResolver interface {
 	GetTemplate(ctx context.Context, project, name string) (*corev1.ConfigMap, error)
 }
 
-// DefaultGatewayNamespace is the default namespace for the ingress gateway.
+// DefaultGatewayNamespace is the fallback namespace for the ingress gateway,
+// injected into PlatformInput.GatewayNamespace when no resolver is wired,
+// when the OrganizationGatewayResolver returns an error, or when the owning
+// org has no `console.holos.run/gateway-namespace` annotation set (HOL-526
+// makes this configurable per-organization via the Settings UI; HOL-644
+// wires the resolver). It is intentionally NOT the only supported value —
+// platform engineers pin a cluster-specific gateway namespace (e.g.
+// "ci-private-apps-gateway") via the org annotation.
 const DefaultGatewayNamespace = "istio-ingress"
 
 // Renderer evaluates CUE templates with deployment parameters.

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
@@ -217,7 +217,10 @@ describe('CreateFolderTemplatePage', () => {
 
       const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
       expect(cueEditor.value).toContain('HTTPRoute')
-      expect(cueEditor.value).toContain('istio-ingress')
+      // The example now uses platform.gatewayNamespace (org-configurable)
+      // rather than hard-coding "istio-ingress" — see HOL-526.
+      expect(cueEditor.value).toContain('platform.gatewayNamespace')
+      expect(cueEditor.value).not.toContain('"istio-ingress"')
     })
   })
 

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/new.tsx
@@ -14,17 +14,23 @@ import { useCreateTemplate, makeFolderScope } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
 
 // EXAMPLE_FOLDER_PLATFORM_TEMPLATE is the example folder-level platform template CUE content.
-// It provides an HTTPRoute into the istio-ingress namespace using platformResources.
-const EXAMPLE_FOLDER_PLATFORM_TEMPLATE = `// Folder-level platform template — HTTPRoute for istio-ingress gateway.
-// Applied to projects within this folder hierarchy.
+// It provides an HTTPRoute into the org-configured ingress-gateway namespace
+// (platform.gatewayNamespace, set per-org via Settings; falls back to
+// "istio-ingress" when unset). Authors who need a literal pin should use the
+// same value the org is configured with — see HOL-526.
+const EXAMPLE_FOLDER_PLATFORM_TEMPLATE = `// Folder-level platform template — HTTPRoute for the org-configured ingress gateway.
+// Applied to projects within this folder hierarchy. The HTTPRoute lands in
+// platform.gatewayNamespace, which the backend resolves from the org's
+// console.holos.run/gateway-namespace annotation. Configure it on the org's
+// Settings page (see HOL-526).
 platformResources: {
-    namespacedResources: ("istio-ingress"): {
+    namespacedResources: (platform.gatewayNamespace): {
         HTTPRoute: (input.name): {
             apiVersion: "gateway.networking.k8s.io/v1"
             kind:       "HTTPRoute"
             metadata: {
                 name:      input.name
-                namespace: "istio-ingress"
+                namespace: platform.gatewayNamespace
                 labels: {
                     "app.kubernetes.io/managed-by": "console.holos.run"
                     "app.kubernetes.io/name":       input.name
@@ -97,7 +103,7 @@ export function CreateFolderTemplatePage({ folderName: propFolderName }: { folde
     setName('httproute-ingress')
     setDisplayName('HTTPRoute Ingress')
     setDescription(
-      'Provides an HTTPRoute for the istio-ingress gateway, routing traffic to project services.',
+      'Provides an HTTPRoute for the org-configured ingress gateway, routing traffic to project services.',
     )
     setCueTemplate(EXAMPLE_FOLDER_PLATFORM_TEMPLATE)
   }
@@ -211,8 +217,8 @@ export function CreateFolderTemplatePage({ folderName: propFolderName }: { folde
                     <TooltipContent>
                       <p>
                         Platform templates are unified with project deployment templates at render
-                        time via CUE. This example provides an HTTPRoute for the istio-ingress
-                        gateway.
+                        time via CUE. This example provides an HTTPRoute for the org-configured
+                        ingress gateway (platform.gatewayNamespace).
                       </p>
                     </TooltipContent>
                   </Tooltip>


### PR DESCRIPTION
## Summary

Phase 6 (final) of HOL-526 — sweeps stale comments and example-template literals that contradict the now-shipped per-org gateway-namespace configuration, regenerates the CUE schema doc, and links to the companion smoke-test PR in the docs repo.

- Rewrites `PlatformInput.GatewayNamespace`'s doc comment in `api/v1alpha2/input.go` to describe the annotation-resolved path (`console.holos.run/gateway-namespace`, set via the Settings UI / OrganizationService) and warn template authors that pinning a literal must match the org-configured value or CUE rejects the unification. The schema_gen.cue regeneration carries the same comment forward.
- Rewrites `DefaultGatewayNamespace`'s doc comment in `console/deployments/handler.go` to clarify it is the fallback (not the permanent default) when the resolver is nil, errors, or the annotation is absent — and references HOL-526 / HOL-644.
- Updates the Create-Folder-Template "Load Example" CUE in `frontend/src/routes/_authenticated/folders/$folderName/templates/new.tsx` to use `(platform.gatewayNamespace)` for both the `namespacedResources` key and the HTTPRoute `metadata.namespace`. The associated assertion in `-new.test.tsx` now confirms the example uses `platform.gatewayNamespace` and explicitly does NOT contain a `"istio-ingress"` literal.
- Tooltip and description copy in the same page swap "for the istio-ingress gateway" for "for the org-configured ingress gateway (`platform.gatewayNamespace`)".

Out of scope (intentionally kept):
- The operator-visible empty-state copy in `orgs/$orgName/settings/index.tsx` ("Not set — defaults to istio-ingress") keeps the literal — it IS the literal fallback users see on the Settings row, and documenting it is the row's job.
- Test fixtures (`*_test.go`, `*.test.tsx`) and contextual examples (`k8s.go` comment about HTTPRoutes commonly landing in istio-ingress) are accepted by the AC's exclusion list (b) and (c).

Smoke-test note (per AGENTS.md, demo materials live in the sibling docs repo): authored as a separate PR — holos-run/holos-console-docs#13.

Fixes HOL-647

## Test plan

- [x] `make generate` regenerates `api/v1alpha2/schema_gen.cue` cleanly with the new comment.
- [x] `make test` — Go tests + frontend (1144 passing).
- [x] `make lint` — same 27 pre-existing issues as `origin/main`; no new findings introduced.
- [ ] CI green.
- [ ] Code review (round 1) clean or all findings fixed in-PR.

Generated with [Claude Code](https://claude.com/claude-code)