### PR TITLE
docs(testing): import testing guardrails from holos-console-docs (HOL-651)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Agent context map for the `holos-console` code repo. For architecture, testing,
+Agent context map for the `holos-console` code repo. For architecture,
 UI conventions, and the full catalog of cross-cutting guardrails, see the
 companion
 [AGENTS.md in holos-console-docs](https://github.com/holos-run/holos-console-docs/blob/main/AGENTS.md).
@@ -8,6 +8,13 @@ companion
 This code is not yet released. Do not preserve backwards compatibility when
 making changes. Review `CONTRIBUTING.md` for commit message requirements before
 opening a PR.
+
+## Testing
+
+- [Test Strategy](docs/agents/test-strategy.md) — Prefer unit tests; reserve E2E for OIDC login and real K8s round-trips.
+- [Testing Patterns](docs/agents/testing-patterns.md) — Go table-driven tests, Vitest + RTL for UI, Playwright for E2E, multi-persona helpers.
+- [Testing Guide](docs/testing.md) — Full decision-rule table and ConnectRPC mock worked example.
+- [E2E Testing](docs/e2e-testing.md) — Tight iteration loop, port overrides, multi-persona helpers, and which tests need Kubernetes.
 
 ## Guardrails
 

--- a/docs/agents/test-strategy.md
+++ b/docs/agents/test-strategy.md
@@ -1,0 +1,13 @@
+# Test Strategy
+
+**Prefer unit tests over E2E tests.** Rendering, interaction, navigation logic, and ConnectRPC data shaping all belong in unit tests using mocked query hooks. Reserve E2E tests for:
+
+- The OIDC login flow (requires a real Dex server)
+- Full-stack CRUD round-trips that verify server-side behavior (requires a real Kubernetes cluster)
+
+When a behavior can be verified with a unit test, write a unit test. Do not add an E2E test for the same behavior.
+
+## Related
+
+- [Testing Patterns](testing-patterns.md) — Specific patterns for Go, UI, and E2E tests
+- [Contributing — Testing](../../CONTRIBUTING.md#testing) — Test make targets and single test invocations

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -1,0 +1,27 @@
+# Testing Patterns
+
+Specific test frameworks and conventions for each layer.
+
+See `docs/testing.md` for the complete decision rule, the ConnectRPC mock pattern with a worked example, file-naming conventions for route-directory test files, and a table of all existing test files.
+
+## Go Tests
+
+Standard `*_test.go` files with table-driven tests. Uses `k8s.io/client-go/kubernetes/fake` for K8s operations. CLI integration tests use `testscript` in `console/testscript_test.go`.
+
+## UI Unit Tests
+
+Vitest + React Testing Library + jsdom. Mock query hooks (`@/queries/*`) with `vi.mock()` and `vi.fn()`. Route-directory test files must be prefixed with `-` (e.g. `-about.test.tsx`) so TanStack Router's generator ignores them. Run with `make test-ui`.
+
+## E2E Tests
+
+Playwright in `frontend/e2e/`. `make test-e2e` orchestrates the full stack (builds Go binary, starts Go backend on :8443 and Vite on :5173). For tight iteration, start servers once and run targeted tests — see `docs/e2e-testing.md` for the full workflow including K8s-backed tests.
+
+## Multi-Persona E2E Helpers
+
+`frontend/e2e/helpers.ts` exports `getPersonaToken()`, `switchPersona()`, `loginAsPersona()`, and `apiGrantOrgAccess()` for tests that verify RBAC behavior across different roles. These helpers use the dev token endpoint (`POST /api/dev/token`) to obtain tokens and inject them into sessionStorage. See `docs/e2e-testing.md` for usage patterns.
+
+## Related
+
+- [Test Strategy](test-strategy.md) — When to use unit tests vs E2E
+- [Contributing — Dev Tools and Persona Switching](../../CONTRIBUTING.md#dev-tools-and-persona-switching) — Test personas and dev token endpoint
+- [Contributing — Testing](../../CONTRIBUTING.md#testing) — How to run individual tests

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,143 @@
+# E2E Testing
+
+Playwright E2E tests live in `frontend/e2e/`. Tests are run via `make test-e2e`.
+
+## Tight Iteration Loop
+
+Playwright reuses running servers when `reuseExistingServer` is true (the default outside CI). Start servers once, then iterate on specific tests without restarting.
+
+### Step 1 — Start servers
+
+For tests that do **not** need Kubernetes (auth, sidebar navigation):
+
+```bash
+make build
+make run &   # Go backend on :8443
+make dev &   # Vite dev server on :5173
+```
+
+For tests that **do** need Kubernetes (orgs, projects, secrets):
+
+```bash
+make build
+KUBECONFIG=$(k3d kubeconfig get workload) make run &
+make dev &
+```
+
+> **Note:** Only one server can bind a port at a time. If `make run` fails with "address already in use", kill the existing process first:
+> ```bash
+> pkill -f holos-console
+> ```
+
+### Step 2 — Run a specific test
+
+With servers running, Playwright reuses them and runs only the targeted tests:
+
+```bash
+cd frontend
+
+# Run a single test by name pattern (chromium only, no retries):
+npx playwright test --grep "should create secret with sharing" --project=chromium --reporter=list
+
+# Run a whole spec file:
+npx playwright test e2e/auth.spec.ts --project=chromium --reporter=list
+
+# Run all tests as CI would:
+make test-e2e
+```
+
+### Step 3 — Iterate
+
+Edit the test or component, then re-run the same command. The servers stay running between runs.
+
+When done:
+
+```bash
+pkill -f holos-console
+pkill -f vite
+```
+
+## Port Overrides
+
+`playwright.config.ts` reads `HOLOS_BACKEND_PORT` (default `8443`) and `HOLOS_VITE_PORT` (default `5173`). This allows running a second backend on a non-default port without stopping the main server:
+
+```bash
+# Start a K8s-backed backend on 8444 (main server stays on 8443):
+KUBECONFIG=$(k3d kubeconfig get workload) ./bin/holos-console \
+  --enable-insecure-dex --cert certs/tls.crt --key certs/tls.key --listen :8444 &
+
+# Run tests against it (Playwright starts Vite on 5174, proxying to 8444):
+cd frontend && HOLOS_BACKEND_PORT=8444 HOLOS_VITE_PORT=5174 \
+  npx playwright test --grep "should create secret" --project=chromium
+
+# Caveat: OIDC redirect URIs are hardcoded for :5173 in the Go server,
+# so login flows break on :5174. Use the standard ports when possible.
+```
+
+## CI
+
+The CI e2e job installs k3s so the full service stack (orgs, projects, secrets) is available. The `KUBECONFIG` is set in `$GITHUB_ENV` and inherited by the Go binary when Playwright starts it.
+
+Tests that require Kubernetes time out in CI without k3s because `OrganizationService` and `ProjectService` are not registered when no kubeconfig is available.
+
+## Multi-Persona Tests
+
+E2E tests can authenticate as different test personas to verify RBAC behavior. The helpers in `frontend/e2e/helpers.ts` use the dev token endpoint (`POST /api/dev/token`) to obtain signed OIDC tokens and inject them into `sessionStorage`.
+
+### Available Helpers
+
+| Helper | Purpose |
+|--------|---------|
+| `getPersonaToken(page, email)` | Fetch a signed ID token for a persona |
+| `switchPersona(page, email)` | Inject a persona's token and reload |
+| `loginAsPersona(page, email)` | Auto-login as admin, then switch to persona |
+| `apiGrantOrgAccess(page, org, email, role)` | Grant a persona a role on an org |
+
+### Email Constants
+
+```ts
+import {
+  ADMIN_EMAIL,              // admin@localhost
+  PLATFORM_ENGINEER_EMAIL,  // platform@localhost
+  PRODUCT_ENGINEER_EMAIL,   // product@localhost
+  SRE_EMAIL,                // sre@localhost
+} from './helpers'
+```
+
+### Example: Test RBAC across personas
+
+```ts
+test('editor cannot delete org', async ({ page }) => {
+  // Login as admin (owner) and create an org
+  await loginAsPersona(page, ADMIN_EMAIL)
+  await apiCreateOrg(page, 'test-org')
+  await apiGrantOrgAccess(page, 'test-org', PRODUCT_ENGINEER_EMAIL, 2) // EDITOR
+
+  // Switch to product engineer (editor role)
+  await switchPersona(page, PRODUCT_ENGINEER_EMAIL)
+
+  // Verify the editor cannot delete the org
+  // ... assertion logic ...
+
+  // Cleanup as admin
+  await switchPersona(page, ADMIN_EMAIL)
+  await apiDeleteOrg(page, 'test-org')
+})
+```
+
+### Notes
+
+- The dev token endpoint is available whenever `--enable-insecure-dex` is set (always in E2E).
+- `loginAsPersona()` first completes the auto-login flow (authenticating as admin), then switches to the requested persona if it is not admin.
+- `switchPersona()` can be called mid-test to change identities without restarting the browser.
+- The `multi-persona.spec.ts` test file demonstrates token acquisition, persona switching, and RBAC grant verification patterns.
+
+## Which Tests Need Kubernetes
+
+| Test file | Tests | Needs K8s? |
+|-----------|-------|-----------|
+| `e2e/auth.spec.ts` | All | No |
+| `e2e/multi-persona.spec.ts` | Token endpoint tests (first 5) | No |
+| `e2e/multi-persona.spec.ts` | RBAC grant tests | Yes |
+| `e2e/secrets.spec.ts` | sidebar navigation (first 2) | No |
+| `e2e/secrets.spec.ts` | create/update/list secrets, add key | Yes |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,180 @@
+# Testing Guide
+
+## Decision Rule: Unit Tests First
+
+**Prefer unit tests. Use E2E only when a real server or Kubernetes cluster is necessary.**
+
+| Behaviour to test | Use |
+|---|---|
+| Component renders correct DOM given props or state | Unit test |
+| Interaction changes displayed state (sort, toggle, filter) | Unit test |
+| Navigation logic triggered by user action (picker selects org, nav items change) | Unit test |
+| ConnectRPC data shapes up in the UI (list, grid, badges) | Unit test with mocked query hooks |
+| Full OIDC login/redirect flow | E2E (`auth.spec.ts`) |
+| Secret CRUD round-trip against a real Kubernetes API server | E2E (`secrets.spec.ts`) |
+| Picker selection triggers a real route navigation | E2E (`navigation.spec.ts`) |
+
+**Why:** E2E tests are slow (30 s server startup, serial execution, 2 retries in CI), brittle (selector churn, timing), and require a full cluster for most pages. Unit tests with mocked RPC data give the same rendering confidence in milliseconds with no infrastructure.
+
+## Running Tests
+
+```bash
+make test-ui    # Fast: Vitest unit tests, no cluster required (< 5 s)
+make test-e2e   # Slow: Playwright E2E, needs Go backend + K8s cluster
+```
+
+### Running individual tests
+
+```bash
+# Unit: by file or test name
+cd frontend && npm test -- SecretPage
+cd frontend && npm test -- -t "renders table with Name"
+
+# E2E: by test name
+cd frontend && npx playwright test --grep "full login flow"
+```
+
+## Mocking ConnectRPC Query Hooks
+
+The query hooks in `frontend/src/queries/` wrap ConnectRPC clients.  Unit tests
+mock these modules directly with `vi.mock`, following the same pattern already
+used for `useAuth`, `useOrg`, and `useVersion`.
+
+### Pattern
+
+```typescript
+// At the top of the test file, before any imports
+vi.mock('@/queries/secrets', () => ({
+  useListSecrets: vi.fn(),
+  useCreateSecret: vi.fn(),
+  useDeleteSecret: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ useAuth: vi.fn() }))
+
+import type { Mock } from 'vitest'
+import { useListSecrets, useCreateSecret, useDeleteSecret } from '@/queries/secrets'
+import { useAuth } from '@/lib/auth'
+import { SecretsListPage } from './index'
+
+// In each test (or a shared helper):
+;(useListSecrets as Mock).mockReturnValue({
+  data: [
+    { name: 'my-secret', description: 'Desc', accessible: true, userGrants: [], roleGrants: [] },
+  ],
+  isLoading: false,
+  error: null,
+})
+;(useCreateSecret as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false, reset: vi.fn() })
+;(useDeleteSecret as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false, reset: vi.fn(), error: null })
+;(useAuth as Mock).mockReturnValue({
+  isAuthenticated: true,
+  isLoading: false,
+  user: { profile: { email: 'test@example.com' } },
+})
+```
+
+### Mocking Route Parameters
+
+Page components that call `Route.useParams()` need the router mock to provide a
+`useParams` implementation.  Override `createFileRoute` so that the exported
+`Route` object has a callable `useParams`:
+
+```typescript
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({ useParams: () => ({ projectName: 'test-project' }) }),
+    Link: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+    useNavigate: () => vi.fn(),
+  }
+})
+```
+
+`vi.mock` calls are hoisted to the top of the file by Vitest, so the mock is
+active before the module-under-test is imported.
+
+### Mutation Return Values
+
+Mock mutations return objects that match `useMutation`'s shape:
+
+```typescript
+;(useSomeMutation as Mock).mockReturnValue({
+  mutateAsync: vi.fn().mockResolvedValue({ /* response shape */ }),
+  isPending: false,
+  reset: vi.fn(),
+  error: null,
+})
+```
+
+For testing pending/error states, override `isPending: true` or `error: new Error('...')`.
+
+### Worked Example: SecretsListPage
+
+See `frontend/src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx`
+for a complete example covering:
+
+- Table column headers rendered
+- Secret name links rendered
+- Sharing summary badge
+- Sort toggle (ascending → descending → ascending)
+- Empty state
+- Loading skeleton when auth is loading
+- Error state when fetch fails
+
+## File Naming Convention
+
+Test files inside `frontend/src/routes/` must be prefixed with `-` so TanStack
+Router's file-based routing ignores them:
+
+```
+src/routes/_authenticated/-about.test.tsx        ✓
+src/routes/_authenticated/about.test.tsx         ✗  (causes a route tree warning)
+```
+
+Test files in `src/components/` and `src/lib/` can use any name.
+
+## Existing Test Files
+
+| File | What it covers |
+|---|---|
+| `src/components/app-sidebar.test.tsx` | Sidebar rendering: footer links, version, project/org pickers, nav items |
+| `src/components/view-mode-toggle.test.tsx` | Data/Resource and Claims/Raw toggle buttons |
+| `src/components/secret-data-grid.test.tsx` | Key-value grid: add/remove rows, trailing newline, copy toast |
+| `src/components/sharing-panel.test.tsx` | Grant display, edit mode, save, cancel, nbf/exp |
+| `src/components/raw-view.test.tsx` | JSON pretty-print, field filtering, copy |
+| `src/components/secret-data-editor.test.tsx` | Editor add/remove key |
+| `src/components/secret-data-viewer.test.tsx` | Viewer reveal/hide/copy |
+| `src/components/cue-template-editor.test.tsx` | CUE editor: textarea, onChange, readOnly, save button, preview tab (platform input, project input, rendered YAML), render error, render status indicator |
+| `src/components/env-var-editor.test.tsx` | Env var editor: add/remove rows, literal value, secretKeyRef, configMapKeyRef, name/key select population |
+| `src/components/linkified-text.test.tsx` | LinkifiedText: plain text, single/multiple URLs, mid-sentence URL, empty/undefined, link styling |
+| `src/routes/_authenticated/-about.test.tsx` | About page: Server Version card, license card |
+| `src/routes/_authenticated/-profile.test.tsx` | Profile page: token claims, raw JSON view |
+| `src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx` | Secrets list page: table, sorting, error/loading |
+| `src/routes/_authenticated/projects/$projectName/secrets/-$name.test.tsx` | Secret detail page: display, edit, delete |
+| `src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx` | Project settings page: display name, description, sharing, default secret sharing, delete |
+| `src/routes/_authenticated/projects/$projectName/settings/-settings-deployments.test.tsx` | Project settings — Features section: deployments toggle, RBAC (owner/editor/viewer) |
+| `src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx` | Deployment templates list: template names, create/delete buttons, RBAC, empty/error state |
+| `src/routes/_authenticated/projects/$projectName/templates/-$templateName.test.tsx` | Deployment template detail: CUE editor, save/delete, RBAC, skeleton, error state |
+| `src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx` | Create template page: form fields (display name, slug, description, CUE), slug auto-derivation, validation, cancel link |
+| `src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx` | Deployments list: names, image/tag, status badges, create/delete, RBAC, empty/error state |
+| `src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx` | Deployment detail: image/tag, replicas, conditions, logs, re-deploy/delete, RBAC, tab layout (Status/Logs/Template), URL-driven tab selection, API Access section (curl + grpcurl examples) |
+| `src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx` | Create deployment page: form fields (display name, slug, description, template, image, tag, command, args, env vars, port), Combobox template selector, defaults pre-fill (name/description from CUE defaults), RBAC |
+| `src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx` | Org settings page: display name, description, sharing, default sharing, delete |
+| `src/routes/_authenticated/orgs/$orgName/settings/-org-templates.test.tsx` | Platform templates list and detail: names, descriptions, mandatory badge, RBAC (owner/viewer), skeleton, error state |
+| `src/routes/_authenticated/projects/-$projectName.test.tsx` | ProjectLayout: sets selected project from URL param |
+| `src/routes/_authenticated/orgs/$orgName/projects/-index.test.tsx` | Org projects page: list, navigate to project |
+| `src/routes/-_authenticated.test.tsx` | Auth layout: silent renewal, OIDC redirect |
+| `src/lib/isOwner.test.ts` | RBAC owner check logic |
+| `src/lib/org-context.test.tsx` | Org context: persistence, reset, filtering |
+| `src/lib/project-context.test.tsx` | Project context: persistence, reset, filtering |
+| `src/lib/-query-client.test.ts` | QueryClient retry logic: suppresses Unauthenticated errors, retries other errors up to 3 times |
+| `src/lib/slug.test.ts` | Slug generation from display names |
+| `src/lib/transport.test.ts` | Token storage and transport setup |
+| `src/hooks/-use-debounced-value.test.ts` | useDebouncedValue: initial value, delay behavior, timer reset on rapid changes, default delay |
+| `src/queries/-organizations.test.ts` | Organization query hooks: get, update, sharing, default sharing, delete |
+| `src/queries/-projects.test.ts` | useListProjects and useCreateProject hooks |
+| `src/components/create-org-dialog.test.tsx` | Create organization dialog: validation, submission |
+| `src/components/create-project-dialog.test.tsx` | Create project dialog: validation, submission |
+| `src/index.test.ts` | App entry point smoke test |


### PR DESCRIPTION
## Summary

- Copy the canonical testing guardrails out of the `holos-console-docs` repo and into `holos-console` so agents working in this worktree find the unit-first rule without a cross-repo hop.
- New files: `docs/agents/test-strategy.md`, `docs/agents/testing-patterns.md`, `docs/testing.md`, `docs/e2e-testing.md`.
- `AGENTS.md` gets a top-level `## Testing` section indexing the four files. The intro sentence drops the word "testing" from the forward-pointer to `holos-console-docs/AGENTS.md` (architecture, UI conventions, and cross-cutting guardrails still forward-point). The `## Guardrails` demo-docs entries are untouched.
- Broken relative links inside the imported files were rewritten: `build-commands.md` and `authentication.md` now point at `CONTRIBUTING.md#testing` and `CONTRIBUTING.md#dev-tools-and-persona-switching`; the `frontend-patterns.md` line was dropped (not part of the testing story and no in-repo equivalent).

Fixes HOL-651

## Test plan

- [x] `make test-go` — 77 Go packages, all green.
- [x] `make test-ui` — 77 suites, 1144 tests, all green.
- [ ] Spot-check that `AGENTS.md` renders on GitHub with all four testing links resolving (reviewer: click each link in the PR diff view).
- [ ] Confirm `grep -r holos-console-docs` inside this repo only surfaces demo/smoke-test / architecture references, never testing — `grep` already run locally, but repeat post-merge as a sanity check.

Local E2E was not run (no k3d cluster available in this worktree). Not relevant per the docs-only E2E-relevance decision table — this phase touches only `docs/**` and `AGENTS.md`. Relying on the CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)