### PR TITLE
test(multi-persona): split spec — token-endpoint to Go, persona display to Vitest (HOL-656)

### DIFF
--- a/console/oidc/token_exchange_test.go
+++ b/console/oidc/token_exchange_test.go
@@ -9,8 +9,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/holos-run/holos-console/console/oidc"
 )
 
@@ -32,25 +35,75 @@ func newDexState(t *testing.T) *oidc.DexState {
 	return state
 }
 
-func TestHandleTokenExchange_Success(t *testing.T) {
-	state := newDexState(t)
+// postTokenExchange invokes the handler with a JSON-encoded body and returns
+// the recorder so the test can assert on status, headers, and body.
+func postTokenExchange(t *testing.T, state *oidc.DexState, body string) *httptest.ResponseRecorder {
+	t.Helper()
 	handler := oidc.HandleTokenExchange(state)
-
-	body := `{"email":"platform@localhost"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
-
 	handler(rr, req)
+	return rr
+}
+
+// decodeTokenResponse decodes a successful token-exchange response body.
+func decodeTokenResponse(t *testing.T, rr *httptest.ResponseRecorder) oidc.TokenExchangeResponse {
+	t.Helper()
+	var resp oidc.TokenExchangeResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return resp
+}
+
+// verifiedClaims parses an id_token JWS against the Dex signing public key
+// and returns the decoded claims. Fails the test if the signature does not
+// verify.
+func verifiedClaims(t *testing.T, state *oidc.DexState, idToken string) map[string]any {
+	t.Helper()
+
+	keys, err := state.Storage.GetKeys(context.Background())
+	if err != nil {
+		t.Fatalf("state.Storage.GetKeys: %v", err)
+	}
+	if keys.SigningKeyPub == nil {
+		t.Fatal("no signing public key available in Dex storage")
+	}
+
+	// Accept whatever algorithm Dex is configured with; in practice the
+	// embedded Dex uses RS256 but we don't want to hard-code it here.
+	alg := jose.SignatureAlgorithm(keys.SigningKeyPub.Algorithm)
+	if alg == "" {
+		alg = jose.RS256
+	}
+	parsed, err := jose.ParseSigned(idToken, []jose.SignatureAlgorithm{alg})
+	if err != nil {
+		t.Fatalf("jose.ParseSigned: %v", err)
+	}
+
+	payload, err := parsed.Verify(keys.SigningKeyPub)
+	if err != nil {
+		t.Fatalf("signature verification failed: %v", err)
+	}
+
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+	return claims
+}
+
+func TestHandleTokenExchange_Success(t *testing.T) {
+	state := newDexState(t)
+
+	rr := postTokenExchange(t, state, `{"email":"platform@localhost"}`)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
-	var resp oidc.TokenExchangeResponse
-	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
+	resp := decodeTokenResponse(t, rr)
 
 	if resp.IDToken == "" {
 		t.Error("id_token is empty")
@@ -63,6 +116,227 @@ func TestHandleTokenExchange_Success(t *testing.T) {
 	}
 	if resp.ExpiresIn <= 0 {
 		t.Errorf("expires_in = %d, want > 0", resp.ExpiresIn)
+	}
+}
+
+// TestHandleTokenExchange_Personas is the table-driven Go-test replacement
+// for the "Dev Token Endpoint > should return a valid token for the
+// <persona>" Playwright cases in frontend/e2e/multi-persona.spec.ts. Each
+// row asserts the same response-shape invariants the browser tests asserted
+// (id_token present, email echoed back, expected group membership, non-zero
+// expiry) without paying the browser-start cost.
+func TestHandleTokenExchange_Personas(t *testing.T) {
+	state := newDexState(t)
+
+	cases := []struct {
+		name       string
+		email      string
+		wantGroups []string
+	}{
+		{
+			name:       "platform engineer persona returns owner group",
+			email:      oidc.EmailPlatform,
+			wantGroups: []string{"owner"},
+		},
+		{
+			name:       "product engineer persona returns editor group",
+			email:      oidc.EmailProduct,
+			wantGroups: []string{"editor"},
+		},
+		{
+			name:       "SRE persona returns viewer group",
+			email:      oidc.EmailSRE,
+			wantGroups: []string{"viewer"},
+		},
+		{
+			name:       "admin persona returns owner group",
+			email:      oidc.EmailAdmin,
+			wantGroups: []string{"owner"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(oidc.TokenExchangeRequest{Email: tc.email})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+
+			rr := postTokenExchange(t, state, string(body))
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+
+			resp := decodeTokenResponse(t, rr)
+
+			if resp.IDToken == "" {
+				t.Error("id_token is empty")
+			}
+			if resp.Email != tc.email {
+				t.Errorf("email = %q, want %q", resp.Email, tc.email)
+			}
+			if resp.ExpiresIn <= 0 {
+				t.Errorf("expires_in = %d, want > 0", resp.ExpiresIn)
+			}
+			if len(resp.Groups) != len(tc.wantGroups) {
+				t.Fatalf("groups = %v, want %v", resp.Groups, tc.wantGroups)
+			}
+			for i, g := range tc.wantGroups {
+				if resp.Groups[i] != g {
+					t.Errorf("groups[%d] = %q, want %q", i, resp.Groups[i], g)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleTokenExchange_SignatureVerification exercises the signature-
+// verification invariant that the browser tests implicitly relied on when
+// they injected the returned id_token into sessionStorage and expected
+// subsequent RPCs to authenticate. It parses the JWS with the algorithm
+// declared by Dex's signing key and verifies it against the public key
+// exposed via state.Storage.GetKeys.
+func TestHandleTokenExchange_SignatureVerification(t *testing.T) {
+	state := newDexState(t)
+
+	for _, email := range []string{
+		oidc.EmailAdmin,
+		oidc.EmailPlatform,
+		oidc.EmailProduct,
+		oidc.EmailSRE,
+	} {
+		t.Run(email, func(t *testing.T) {
+			body, err := json.Marshal(oidc.TokenExchangeRequest{Email: email})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+
+			rr := postTokenExchange(t, state, string(body))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+			resp := decodeTokenResponse(t, rr)
+
+			// Verify the JWS signature using the Dex signing public key.
+			claims := verifiedClaims(t, state, resp.IDToken)
+
+			// Spot-check that the verified claims carry the requester's email.
+			gotEmail, _ := claims["email"].(string)
+			if gotEmail != email {
+				t.Errorf("verified claims email = %q, want %q", gotEmail, email)
+			}
+		})
+	}
+}
+
+// TestHandleTokenExchange_ClaimContents asserts the OIDC claim contents each
+// persona's id_token carries. This is the signed-token analogue of the
+// persona-email assertions the browser tests performed after persona
+// switch (the profile page's rendered email came from the email claim),
+// plus the issuer/audience/subject/email_verified claims that any
+// downstream JWT verifier cares about.
+func TestHandleTokenExchange_ClaimContents(t *testing.T) {
+	state := newDexState(t)
+
+	cases := []struct {
+		name         string
+		email        string
+		wantGroup    string
+		wantAudience string
+		wantIssuer   string
+	}{
+		{
+			name:         "platform engineer claims",
+			email:        oidc.EmailPlatform,
+			wantGroup:    "owner",
+			wantAudience: "test-client",
+			wantIssuer:   "https://test.example.com/dex",
+		},
+		{
+			name:         "product engineer claims",
+			email:        oidc.EmailProduct,
+			wantGroup:    "editor",
+			wantAudience: "test-client",
+			wantIssuer:   "https://test.example.com/dex",
+		},
+		{
+			name:         "SRE claims",
+			email:        oidc.EmailSRE,
+			wantGroup:    "viewer",
+			wantAudience: "test-client",
+			wantIssuer:   "https://test.example.com/dex",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(oidc.TokenExchangeRequest{Email: tc.email})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+			rr := postTokenExchange(t, state, string(body))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+			resp := decodeTokenResponse(t, rr)
+
+			claims := verifiedClaims(t, state, resp.IDToken)
+
+			if got, _ := claims["iss"].(string); got != tc.wantIssuer {
+				t.Errorf("iss = %q, want %q", got, tc.wantIssuer)
+			}
+			// Dex encodes a single-element audience as a string, not an
+			// array (see audience.MarshalJSON in token_exchange.go).
+			if got, _ := claims["aud"].(string); got != tc.wantAudience {
+				t.Errorf("aud = %q, want %q", got, tc.wantAudience)
+			}
+			if got, _ := claims["email"].(string); got != tc.email {
+				t.Errorf("email = %q, want %q", got, tc.email)
+			}
+			if got, _ := claims["email_verified"].(bool); !got {
+				t.Errorf("email_verified = %v, want true", claims["email_verified"])
+			}
+
+			// groups is a JSON array; the JWT-decoded value is []any.
+			groupsAny, ok := claims["groups"].([]any)
+			if !ok {
+				t.Fatalf("groups claim missing or wrong type: %T", claims["groups"])
+			}
+			if len(groupsAny) != 1 {
+				t.Fatalf("groups = %v, want single-element [%q]", groupsAny, tc.wantGroup)
+			}
+			if got, _ := groupsAny[0].(string); got != tc.wantGroup {
+				t.Errorf("groups[0] = %q, want %q", got, tc.wantGroup)
+			}
+
+			// sub must be a non-empty base64-url-encoded protobuf subject.
+			if got, _ := claims["sub"].(string); got == "" {
+				t.Error("sub claim is empty")
+			}
+
+			// iat and exp are floats in generic JSON decoding.
+			iat, _ := claims["iat"].(float64)
+			exp, _ := claims["exp"].(float64)
+			if iat == 0 {
+				t.Error("iat claim missing or zero")
+			}
+			if exp == 0 {
+				t.Error("exp claim missing or zero")
+			}
+			if exp <= iat {
+				t.Errorf("exp (%v) must be after iat (%v)", exp, iat)
+			}
+
+			// The claim window must match the handler's declared
+			// expires_in of 1 hour (see mintIDToken in
+			// token_exchange.go). Allow a small clock skew.
+			window := time.Duration(exp-iat) * time.Second
+			wantWindow := time.Duration(resp.ExpiresIn) * time.Second
+			if delta := window - wantWindow; delta < -5*time.Second || delta > 5*time.Second {
+				t.Errorf("claim window = %v, want ~%v", window, wantWindow)
+			}
+		})
 	}
 }
 
@@ -103,19 +377,37 @@ func TestHandleTokenExchange_AllUsers(t *testing.T) {
 	}
 }
 
+// TestHandleTokenExchange_UnknownEmail is the Go-test replacement for the
+// "Dev Token Endpoint > should reject unknown email addresses" Playwright
+// case. It asserts the 400 status and the "unknown test user email" body
+// fragment the E2E test asserted on.
 func TestHandleTokenExchange_UnknownEmail(t *testing.T) {
 	state := newDexState(t)
-	handler := oidc.HandleTokenExchange(state)
 
-	body := `{"email":"nobody@localhost"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/dev/token", bytes.NewBufferString(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
+	cases := []struct {
+		name  string
+		email string
+	}{
+		{name: "simple unknown", email: "nobody@localhost"},
+		{name: "multi-persona spec literal", email: "unknown@example.com"},
+	}
 
-	handler(rr, req)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(oidc.TokenExchangeRequest{Email: tc.email})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
 
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusBadRequest, rr.Body.String())
+			rr := postTokenExchange(t, state, string(body))
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusBadRequest, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), "unknown test user email") {
+				t.Errorf("body = %q, want to contain %q", rr.Body.String(), "unknown test user email")
+			}
+		})
 	}
 }
 

--- a/docs/agents/e2e-refactor-audit.md
+++ b/docs/agents/e2e-refactor-audit.md
@@ -27,7 +27,7 @@ Measured from the CI `E2E Tests` job on the last three `main` merges before this
 
 ## Spec Inventory
 
-`frontend/e2e/` originally contained **11 spec files** totalling **1,576 test-lines** across **58 `test(...)` blocks** (plus `helpers.ts` at 250 lines). After HOL-653 landed, `profile.spec.ts` and `navigation.spec.ts` were deleted and their coverage folded into Vitest unit tests. After HOL-654 landed, `create-dialogs.spec.ts` was also deleted. After HOL-655 landed, `deployments.spec.ts` and `org-settings.spec.ts` were also deleted; the remaining tables still list all five for historical context.
+`frontend/e2e/` originally contained **11 spec files** totalling **1,576 test-lines** across **58 `test(...)` blocks** (plus `helpers.ts` at 250 lines). After HOL-653 landed, `profile.spec.ts` and `navigation.spec.ts` were deleted and their coverage folded into Vitest unit tests. After HOL-654 landed, `create-dialogs.spec.ts` was also deleted. After HOL-655 landed, `deployments.spec.ts` and `org-settings.spec.ts` were also deleted. After HOL-656 landed, the `Dev Token Endpoint` and `Persona Switching` describes in `multi-persona.spec.ts` were deleted (the `Multi-Persona RBAC` describe remains, keeping 3 tests in the spec); the remaining tables still list all six for historical context.
 
 ### Summary Table
 
@@ -43,8 +43,8 @@ Measured from the CI `E2E Tests` job on the last three `main` merges before this
 | `folder-rbac.spec.ts` | 3 | **Keep** (K8s RBAC cascade) | keep |
 | `folder-templates.spec.ts` | 2 | **Keep** (K8s template release) | keep |
 | `secrets.spec.ts` | 6 | **Split** (4 Keep, 1 Refactor, 1 Delete) | pending (HOL-658) |
-| `multi-persona.spec.ts` | 10 | **Split** (4 → Go tests, 2 → unit, 1 Delete, 3 Keep) | pending (HOL-656) |
-| **Total** | **58** | **Keep: 32, Refactor: 23, Delete: 3** | HOL-653 + HOL-654 + HOL-655 complete: 17 tests removed from E2E |
+| `multi-persona.spec.ts` | 10 | **Split** (4 → Go tests, 2 → unit, 1 Delete, 3 Keep) | **done (HOL-656)** — 7 tests removed from E2E |
+| **Total** | **58** | **Keep: 32, Refactor: 23, Delete: 3** | HOL-653 + HOL-654 + HOL-655 + HOL-656 complete: 24 tests removed from E2E |
 
 Projected reduction: **~45% of E2E test bodies** leave the E2E suite (26 of 58) — 23 move to unit/Go tests, 3 are deleted as redundant with existing coverage. The remaining E2E job is focused on OIDC auth and real K8s round-trips.
 
@@ -53,6 +53,8 @@ Projected reduction: **~45% of E2E test bodies** leave the E2E suite (26 of 58) 
 **HOL-654 delta**: After this phase, `frontend/e2e/` holds **8 spec files** and **46 `test(...)` blocks** (5 create-dialogs deleted). The new Vitest coverage lives in `frontend/src/components/create-project-dialog.test.tsx` (3 new tests: auto-derived-slug submit + navigate, manual override + reset affordance, pending submit), `frontend/src/components/create-org-dialog.test.tsx` (1 new test: pending submit), and `frontend/src/components/app-sidebar.test.tsx` (4 new tests across two describes: org-picker with existing orgs surfaces a "New Organization" item below the listed orgs, and the symmetric project-picker assertion for "New Project").
 
 **HOL-655 delta**: After this phase, `frontend/e2e/` holds **6 spec files** and **41 `test(...)` blocks** (3 deployments + 2 org-settings deleted). The audit plan was satisfied almost entirely by coverage that already existed in `-new.test.tsx`, `-index.test.tsx`, `-settings.test.tsx`, and `app-sidebar.test.tsx` (the no-templates affordance, Create Deployment link wiring, RBAC-driven button visibility, `Org Settings` sidebar link, and display-name / description / sharing form state were all already asserted at the component level). Two small anti-regression tests were added to preserve invariants the E2E suite uniquely exercised: `renders as a standalone page (not inside a dialog)` in `frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx` (guards against the Create Deployment modal regression from issue #396), and `renders the {orgName} / Settings breadcrumb on the page header` in `frontend/src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx` (guards the `"{orgName} / Settings"` header string the E2E sidebar-click test asserted). No `deployments.spec.ts` case required a K8s round-trip to observe persistence — the Deployment creation round-trip lives entirely under `folder-templates.spec.ts` — so the spec was fully removed rather than split.
+
+**HOL-656 delta**: After this phase, `frontend/e2e/` holds **6 spec files** and **34 `test(...)` blocks** (4 Dev Token Endpoint cases + 3 Persona Switching cases removed from `multi-persona.spec.ts`; the 3 Multi-Persona RBAC cases remain). The new Go coverage lives in `console/oidc/token_exchange_test.go`: `TestHandleTokenExchange_Personas` (4 sub-tests — admin/platform/product/SRE response-shape table), `TestHandleTokenExchange_SignatureVerification` (4 sub-tests — JWS parse + public-key verify per persona, covering the invariant the browser tests implicitly relied on when they injected the returned id_token into sessionStorage), `TestHandleTokenExchange_ClaimContents` (3 sub-tests — iss/aud/sub/email/email_verified/groups/iat/exp claims plus the 1-hour expiry window), and an extended `TestHandleTokenExchange_UnknownEmail` (2 sub-tests that assert the `"unknown test user email"` body fragment the E2E case checked, including the exact `unknown@example.com` literal). The new Vitest coverage lives in `frontend/src/routes/_authenticated/-profile.test.tsx` under `ProfilePage persona email rendering`: an `it.each` over all four persona emails plus a rerender test that swaps useAuth's return value and asserts the displayed email updates. `getPersonaToken`, `switchPersona`, and `loginAsPersona` stay in `frontend/e2e/helpers.ts` — the remaining three RBAC tests still use them.
 
 ---
 
@@ -216,7 +218,7 @@ CRUD tests exercise the real Kubernetes secrets API, which unit tests cannot rep
 
 The two mobile tests are the only refactor candidates in this spec; the CRUD tests stay. This phase (if scoped) would live in **HOL-658** cleanup.
 
-### `multi-persona.spec.ts` — Split (4 → Go tests, 3 → unit, 3 Keep)
+### `multi-persona.spec.ts` — Split (4 → Go tests, 3 → unit, 3 Keep) — **DONE (HOL-656)**
 
 The first four tests call `POST /api/dev/token` and assert the response shape — they do **not** need a browser. Move them to Go tests against the `HandleTokenExchange` handler in `console/oidc/token_exchange_test.go` (which already contains similar unit tests via `httptest`). The three persona-switching tests exercise UI email display; the three RBAC grant tests require K8s.
 
@@ -226,23 +228,23 @@ The first four tests call `POST /api/dev/token` and assert the response shape �
 
 | Test | Verdict | Target | Notes |
 | --- | --- | --- | --- |
-| `Dev Token Endpoint > should return a valid token for the platform engineer persona` | **Refactor to Go** | `console/oidc/token_exchange_test.go` | New: `TestHandleTokenExchange_PlatformEngineer` — POST to the handler with `platform@localhost`, assert response includes `id_token`, `email`, `groups: ["owner"]`, `expires_in > 0`. |
-| `Dev Token Endpoint > should return a valid token for the product engineer persona` | **Refactor to Go** | `console/oidc/token_exchange_test.go` | New: `TestHandleTokenExchange_ProductEngineer` — symmetric, `groups: ["editor"]`. |
-| `Dev Token Endpoint > should return a valid token for the SRE persona` | **Refactor to Go** | `console/oidc/token_exchange_test.go` | New: `TestHandleTokenExchange_SRE` — symmetric, `groups: ["viewer"]`. |
-| `Dev Token Endpoint > should reject unknown email addresses` | **Refactor to Go** | `console/oidc/token_exchange_test.go` | New: `TestHandleTokenExchange_UnknownEmail` — POST with `unknown@example.com`, assert status 400 and body contains `"unknown test user email"`. |
-| `Persona Switching > should login as platform engineer and show correct email` | **Refactor-to-unit** | `-profile.test.tsx` | New: `"shows platform engineer email when useAuth returns platform profile"` — mock `useAuth` with `email: 'platform@localhost'`, assert visible. |
-| `Persona Switching > should switch from admin to SRE persona` | **Refactor-to-unit** | `-profile.test.tsx` | New: combined render test that rerenders with two different `useAuth` return values and asserts the email updates. Note: this is a shallow equivalence to the browser-based test; the sessionStorage/reload mechanics don't need coverage because they're covered by the auth-layout and transport unit tests (`-_authenticated.test.tsx`, `transport.test.ts`). |
-| `Persona Switching > should switch between all three non-admin personas` | **Delete (redundant)** | — | A single cycle-through-emails unit test covers the same logic as the three-step browser test. Skip this one. |
+| `Dev Token Endpoint > should return a valid token for the platform engineer persona` | **Refactored to Go** | `console/oidc/token_exchange_test.go` | Added as the `platform engineer persona returns owner group` row in `TestHandleTokenExchange_Personas` (table-driven); spot-checks `id_token`, `email`, `groups: ["owner"]`, `expires_in > 0`. Signature verification and claim contents are asserted by `TestHandleTokenExchange_SignatureVerification` / `TestHandleTokenExchange_ClaimContents`. |
+| `Dev Token Endpoint > should return a valid token for the product engineer persona` | **Refactored to Go** | `console/oidc/token_exchange_test.go` | Added as the `product engineer persona returns editor group` row in `TestHandleTokenExchange_Personas` (table-driven). |
+| `Dev Token Endpoint > should return a valid token for the SRE persona` | **Refactored to Go** | `console/oidc/token_exchange_test.go` | Added as the `SRE persona returns viewer group` row in `TestHandleTokenExchange_Personas` (table-driven). |
+| `Dev Token Endpoint > should reject unknown email addresses` | **Refactored to Go** | `console/oidc/token_exchange_test.go` | Extended `TestHandleTokenExchange_UnknownEmail` to a two-row table that covers both `nobody@localhost` and the E2E literal `unknown@example.com`, and added the body-fragment assertion (`strings.Contains(body, "unknown test user email")`). |
+| `Persona Switching > should login as platform engineer and show correct email` | **Refactored to unit** | `-profile.test.tsx` | Added `ProfilePage persona email rendering` describe with an `it.each` over all four persona emails (platform, product, SRE, admin); each row mocks `useAuth` with the persona's email and asserts it renders on the profile page. |
+| `Persona Switching > should switch from admin to SRE persona` | **Refactored to unit** | `-profile.test.tsx` | Added `updates the displayed email when useAuth rerenders with a new persona` — renders as admin, rerenders with SRE's email, asserts the new email appears and the old one is gone. |
+| `Persona Switching > should switch between all three non-admin personas` | **Deleted (redundant)** | — | The `it.each` over all four personas plus the rerender test together cover the same logic as the three-step browser test. Deleted rather than split. |
 | `Multi-Persona RBAC > platform engineer can create an org and grant SRE viewer access` | **Keep** | — | K8s org create + RBAC grant. |
 | `Multi-Persona RBAC > SRE can list the org after being granted viewer access` | **Keep** | — | K8s list with persona-scoped RBAC. |
 | `Multi-Persona RBAC > product engineer can access the org with editor privileges` | **Keep** | — | K8s list with editor-scoped RBAC. |
 
-After the refactor:
-- Delete the `Dev Token Endpoint` describe (4 tests moved to Go).
-- Delete the `Persona Switching` describe (2 refactored to unit, 1 deleted).
-- Keep the `Multi-Persona RBAC` describe intact.
+After the refactor (landed in HOL-656):
+- The `Dev Token Endpoint` describe was deleted from `multi-persona.spec.ts`; the 4 response-shape cases plus their signature-verification and claim-content invariants moved to `console/oidc/token_exchange_test.go`.
+- The `Persona Switching` describe was deleted from `multi-persona.spec.ts`; 2 cases moved to `-profile.test.tsx` (per-persona email render + rerender-swap), the three-persona cycle was dropped as redundant.
+- The `Multi-Persona RBAC` describe is unchanged; it still covers org create + RBAC grants against a real K8s cluster.
 
-**Result: `multi-persona.spec.ts` shrinks from 9 tests to 3.** This phase lives in **HOL-656**.
+**Result: `multi-persona.spec.ts` shrank from 10 tests to 3.** This phase lived in **HOL-656**.
 
 ---
 
@@ -253,7 +255,7 @@ After the refactor:
 | HOL-653 | profile.spec.ts (5), navigation.spec.ts (1) | 6 tests → Vitest |
 | HOL-654 | create-dialogs.spec.ts (5) | 5 tests → Vitest |
 | HOL-655 | deployments.spec.ts (3), org-settings.spec.ts (2) | 5 tests → Vitest (DONE) |
-| HOL-656 | multi-persona.spec.ts Dev Token (4), Persona Switching (3) | 4 → Go, 3 → Vitest |
+| HOL-656 | multi-persona.spec.ts Dev Token (4), Persona Switching (3) | 4 → Go, 3 → Vitest (DONE) |
 | HOL-657 | — | Measure E2E CI wall-clock after the four refactor phases; compare against the 11m 23s baseline. |
 | HOL-658 | auth.spec.ts trims, helpers.ts cleanup, mobile consolidation | Remove dead helpers, trim auth-spec overlaps, decide on mobile responsive tests. |
 

--- a/frontend/e2e/multi-persona.spec.ts
+++ b/frontend/e2e/multi-persona.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test'
 import {
   loginAsPersona,
-  switchPersona,
-  getPersonaToken,
   apiCreateOrg,
   apiDeleteOrg,
   apiGrantOrgAccess,
@@ -13,141 +11,29 @@ import {
 } from './helpers'
 
 /**
- * E2E tests for multi-persona token acquisition and RBAC verification.
+ * E2E tests for multi-persona RBAC verification across a real K8s cluster.
  *
- * These tests verify that:
- * 1. The dev token endpoint returns valid tokens for each persona
- * 2. Persona switching works correctly in the browser session
- * 3. RBAC grants are respected across different personas
+ * After HOL-656 only the RBAC-grant cases remain here. The dev-token-endpoint
+ * contract tests and the persona-switching UI rendering tests live at:
+ *   - console/oidc/token_exchange_test.go (token claim contents, signature
+ *     verification, rejection of unknown emails — the four cases that used
+ *     to make up the "Dev Token Endpoint" describe block)
+ *   - frontend/src/routes/_authenticated/-profile.test.tsx (per-persona email
+ *     rendering — the cases that used to make up the "Persona Switching"
+ *     describe block)
  *
- * The dev token endpoint (/api/dev/token) is available whenever
- * --enable-insecure-dex is enabled, which is always the case in E2E tests.
+ * The tests below verify that:
+ * 1. A non-admin owner (platform engineer) can create an org and grant
+ *    viewer/editor access to other personas.
+ * 2. A viewer (SRE) can list the org they were granted access to.
+ * 3. An editor (product engineer) can list the org they were granted access
+ *    to.
  *
- * Tests that create K8s resources (orgs) require a running cluster.
- * Run with: make test-e2e
+ * These require a real K8s cluster because org creation writes a namespace
+ * and the RBAC grants are persisted as namespace annotations; they are the
+ * legitimate multi-persona use case for E2E (the audit doc lists them as
+ * Keep). Run with: make test-e2e
  */
-
-test.describe('Dev Token Endpoint', () => {
-  test('should return a valid token for the platform engineer persona', async ({
-    page,
-  }) => {
-    // Navigate to /profile to establish a page context with the app loaded
-    await page.goto('/profile')
-    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
-    // Wait for the page to settle (auto-login may redirect)
-    await page.waitForLoadState('networkidle')
-
-    const tokenData = await getPersonaToken(page, PLATFORM_ENGINEER_EMAIL)
-
-    expect(tokenData.id_token).toBeTruthy()
-    expect(tokenData.email).toBe(PLATFORM_ENGINEER_EMAIL)
-    expect(tokenData.groups).toContain('owner')
-    expect(tokenData.expires_in).toBeGreaterThan(0)
-  })
-
-  test('should return a valid token for the product engineer persona', async ({
-    page,
-  }) => {
-    await page.goto('/profile')
-    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
-    await page.waitForLoadState('networkidle')
-
-    const tokenData = await getPersonaToken(page, PRODUCT_ENGINEER_EMAIL)
-
-    expect(tokenData.id_token).toBeTruthy()
-    expect(tokenData.email).toBe(PRODUCT_ENGINEER_EMAIL)
-    expect(tokenData.groups).toContain('editor')
-    expect(tokenData.expires_in).toBeGreaterThan(0)
-  })
-
-  test('should return a valid token for the SRE persona', async ({ page }) => {
-    await page.goto('/profile')
-    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
-    await page.waitForLoadState('networkidle')
-
-    const tokenData = await getPersonaToken(page, SRE_EMAIL)
-
-    expect(tokenData.id_token).toBeTruthy()
-    expect(tokenData.email).toBe(SRE_EMAIL)
-    expect(tokenData.groups).toContain('viewer')
-    expect(tokenData.expires_in).toBeGreaterThan(0)
-  })
-
-  test('should reject unknown email addresses', async ({ page }) => {
-    await page.goto('/profile')
-    await page.waitForURL(/\/dex\/|\/pkce\/verify|\/profile/, { timeout: 15000 })
-    await page.waitForLoadState('networkidle')
-
-    const error = await page
-      .evaluate(async () => {
-        const resp = await fetch('/api/dev/token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: 'unknown@example.com' }),
-        })
-        return { status: resp.status, body: await resp.text() }
-      })
-      .catch((err) => ({ status: 0, body: String(err) }))
-
-    expect(error.status).toBe(400)
-    expect(error.body).toContain('unknown test user email')
-  })
-})
-
-test.describe('Persona Switching', () => {
-  test('should login as platform engineer and show correct email', async ({
-    page,
-  }) => {
-    await loginAsPersona(page, PLATFORM_ENGINEER_EMAIL)
-
-    // Verify the profile page shows the platform engineer's email
-    await page.goto('/profile')
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText(PLATFORM_ENGINEER_EMAIL)).toBeVisible({
-      timeout: 10000,
-    })
-  })
-
-  test('should switch from admin to SRE persona', async ({ page }) => {
-    // Start as admin
-    await loginAsPersona(page, ADMIN_EMAIL)
-    await page.goto('/profile')
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText(ADMIN_EMAIL)).toBeVisible({ timeout: 10000 })
-
-    // Switch to SRE
-    await switchPersona(page, SRE_EMAIL)
-    await page.goto('/profile')
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText(SRE_EMAIL)).toBeVisible({ timeout: 10000 })
-  })
-
-  test('should switch between all three non-admin personas', async ({
-    page,
-  }) => {
-    // Login as platform engineer
-    await loginAsPersona(page, PLATFORM_ENGINEER_EMAIL)
-    await page.goto('/profile')
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText(PLATFORM_ENGINEER_EMAIL)).toBeVisible({
-      timeout: 10000,
-    })
-
-    // Switch to product engineer
-    await switchPersona(page, PRODUCT_ENGINEER_EMAIL)
-    await page.goto('/profile')
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText(PRODUCT_ENGINEER_EMAIL)).toBeVisible({
-      timeout: 10000,
-    })
-
-    // Switch to SRE
-    await switchPersona(page, SRE_EMAIL)
-    await page.goto('/profile')
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByText(SRE_EMAIL)).toBeVisible({ timeout: 10000 })
-  })
-})
 
 test.describe('Multi-Persona RBAC', () => {
   // These tests require a K8s cluster for org creation.

--- a/frontend/src/routes/_authenticated/-profile.test.tsx
+++ b/frontend/src/routes/_authenticated/-profile.test.tsx
@@ -285,3 +285,39 @@ describe('ProfilePage token claims — Raw view', () => {
     expect(screen.getByRole('button', { name: /copy to clipboard/i })).toBeInTheDocument()
   })
 })
+
+// HOL-656: per-persona email rendering. These tests replace the
+// `Persona Switching > should login as platform engineer ...` and
+// `Persona Switching > should switch from admin to SRE persona` cases from
+// `frontend/e2e/multi-persona.spec.ts`. The E2E tests asserted that after
+// swapping the OIDC `sessionStorage` entry for a persona's dev token, the
+// profile page rendered the new email. At the component level we mock
+// `useAuth` with the persona's profile directly — the sessionStorage/reload
+// mechanics are covered by `transport.test.ts` and `-_authenticated.test.tsx`.
+describe('ProfilePage persona email rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ['platform engineer', 'platform@localhost'],
+    ['product engineer', 'product@localhost'],
+    ['SRE', 'sre@localhost'],
+    ['admin', 'admin@localhost'],
+  ])('renders %s email when useAuth returns the %s profile', (_persona, email) => {
+    setAuthState({ user: makeUser({}, { email }) })
+    render(<ProfilePage />)
+    expect(screen.getByText(email)).toBeInTheDocument()
+  })
+
+  it('updates the displayed email when useAuth rerenders with a new persona', () => {
+    setAuthState({ user: makeUser({}, { email: 'admin@localhost' }) })
+    const { rerender } = render(<ProfilePage />)
+    expect(screen.getByText('admin@localhost')).toBeInTheDocument()
+
+    setAuthState({ user: makeUser({}, { email: 'sre@localhost' }) })
+    rerender(<ProfilePage />)
+    expect(screen.getByText('sre@localhost')).toBeInTheDocument()
+    expect(screen.queryByText('admin@localhost')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Extend `console/oidc/token_exchange_test.go` with table-driven Go tests that cover every invariant the four `Dev Token Endpoint` E2E cases in `frontend/e2e/multi-persona.spec.ts` asserted: response-shape per persona (admin/platform/product/SRE), JWS signature verification against Dex's public key, OIDC claim contents (iss/aud/sub/email/email_verified/groups/iat/exp + 1-hour expires_in window), and the unknown-email rejection (body contains `"unknown test user email"`, including the exact `unknown@example.com` literal).
- Delete the `Dev Token Endpoint` and `Persona Switching` describes from `frontend/e2e/multi-persona.spec.ts`; keep the three `Multi-Persona RBAC` tests (they are the legitimate K8s-requiring E2E case).
- Add `ProfilePage persona email rendering` in `-profile.test.tsx`: an `it.each` over the four persona emails plus a rerender test that swaps `useAuth`'s return value and asserts the email updates. The three-persona cycle case is dropped as redundant per the audit plan.
- Update `docs/agents/e2e-refactor-audit.md`: mark HOL-656 DONE, rewrite the per-row outcomes for the multi-persona table with the names of the new Go and Vitest tests, add a HOL-656 delta paragraph, and update the summary totals to "24 tests removed from E2E" (HOL-653+HOL-654+HOL-655+HOL-656).

Fixes HOL-656

## Test plan

- [x] `go test -count=1 ./console/oidc/...` passes (2.4s, 69.7% coverage)
- [x] `go test -count=1 -v -run 'TestHandleTokenExchange_(Personas|SignatureVerification|ClaimContents|UnknownEmail)' ./console/oidc/...` — all 13 new sub-tests pass
- [x] `npx vitest run` — 1171 tests across 77 files (was 1166; +5 persona rendering)
- [x] `npx vitest run src/routes/_authenticated/-profile.test.tsx` — 27 tests pass (was 22)
- [x] `npx playwright test --list e2e/multi-persona.spec.ts` lists exactly the 3 remaining Multi-Persona RBAC cases
- [x] `npx playwright test --list` total: 34 chromium tests (down from 41 after HOL-655)
- [x] `go vet ./...` clean
- [x] `gofmt -l console/oidc/` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint e2e/multi-persona.spec.ts src/routes/_authenticated/-profile.test.tsx` clean

> Local `make test-e2e` was not run in this worktree — the RBAC describe requires a k3d cluster. The spec parses and lists correctly with `playwright test --list`, and CI's E2E job will gate the PR against a real cluster.
> `make test-go` shows the pre-existing `TestScripts/{version,grpc_reflection}` race flakes in `console/` that reproduce on origin/main without this patch; they are unrelated to HOL-656 (the HOL-656 changes are all in `console/oidc`, which passes cleanly).

Generated with [Claude Code](https://claude.com/claude-code)