### PR TITLE
chore(storage): shared envtest helper + v1alpha2 annotation sweep (HOL-663)

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -121,42 +121,32 @@ const (
 	// this label upward to collect templates and resolve permissions (ADR 020
 	// Decision 3 and Decision 6).
 	AnnotationParent = "console.holos.run/parent"
-	// AnnotationLinkedOrgTemplates stores the list of explicitly linked platform
-	// template names as a JSON array on a deployment template ConfigMap.
-	// Superseded in v1alpha2 by AnnotationLinkedTemplates (which also carries
-	// scope information and version constraints).
+	// AnnotationLinkedOrgTemplates stores the list of explicitly linked
+	// platform template names as a JSON array on a legacy v1alpha2
+	// deployment template ConfigMap. Read-only compatibility shim —
+	// new deployments serialize linked templates via the
+	// templates.holos.run Template CRD (HOL-621); this annotation is
+	// only consulted when migrating older ConfigMap-shaped deployment
+	// templates forward. No production code writes this annotation.
 	// Example: ["microservice-v2", "istio-gateway"]
 	AnnotationLinkedOrgTemplates = "console.holos.run/linked-org-templates"
-	// AnnotationLinkedTemplates stores the list of explicitly linked cross-level
-	// template references as a JSON array of LinkedTemplateRef objects on a
-	// template ConfigMap. Replaces AnnotationLinkedOrgTemplates in v1alpha2.
+	// AnnotationLinkedTemplates is the wire format used to bridge
+	// Template CRDs to the deployment handler. Template CRD storage
+	// keeps linked refs in a structured Spec field (HOL-621), but the
+	// deployment handler still consumes deployment-template ConfigMaps
+	// and reads the linked refs off this JSON-annotation. The
+	// templateCRDToConfigMap adapter in console/templates writes the
+	// annotation on the fly so deployments can keep its existing
+	// reader. Once the deployments package is ported off ConfigMaps
+	// (HOL-615 Phase 6 and friends), this constant and its adapter
+	// both go away.
 	// Example: [{"scope":"organization","scope_name":"acme","name":"microservice-v2"}]
 	AnnotationLinkedTemplates = "console.holos.run/linked-templates"
-	// LabelTemplateScope identifies the hierarchy level of a template ConfigMap.
+	// LabelTemplateScope identifies the hierarchy level of a Template.
 	// Values: "organization", "folder", "project" (ADR 021 Decision 4).
+	// Still surfaced on CRD-stored Templates via the scheme label
+	// setters in console/templates.
 	LabelTemplateScope = "console.holos.run/template-scope"
-	// AnnotationTemplatePolicyRules stores the JSON-serialized list of
-	// TemplatePolicyRule entries for a TemplatePolicy ConfigMap. The handler
-	// serializes the proto rules on write and round-trips them back on read;
-	// this mirrors the AnnotationLinkedTemplates pattern used on Template
-	// ConfigMaps (HOL-556).
-	AnnotationTemplatePolicyRules = "console.holos.run/template-policy-rules"
-	// AnnotationTemplatePolicyBindingPolicyRef stores the JSON-serialized
-	// scope-qualified reference to the TemplatePolicy a
-	// TemplatePolicyBinding attaches. The wire shape is
-	// `{"scope":"organization|folder","scopeName":"<slug>","name":"<slug>"}`.
-	// A binding always references exactly one policy; use multiple
-	// bindings to attach multiple policies to overlapping target sets
-	// (ADR 029, HOL-590).
-	AnnotationTemplatePolicyBindingPolicyRef = "console.holos.run/template-policy-binding-policy-ref"
-	// AnnotationTemplatePolicyBindingTargetRefs stores the JSON-serialized
-	// list of explicit render targets a TemplatePolicyBinding applies its
-	// policy to. The wire shape is a JSON array of
-	// `{"kind":"project-template|deployment","name":"<slug>","projectName":"<slug>"}`
-	// entries. Handlers MUST reject duplicates — two entries with the
-	// same (kind, projectName, name) triple — and MUST reject
-	// UNSPECIFIED kind. Order is not significant (ADR 029, HOL-590).
-	AnnotationTemplatePolicyBindingTargetRefs = "console.holos.run/template-policy-binding-target-refs"
 
 	// AnnotationExternalLinkPrefix is the Holos-authored annotation-key
 	// prefix for external links surfaced on a deployment. Links are keyed

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -138,47 +138,34 @@
 // Decision 3 and Decision 6).
 #AnnotationParent: "console.holos.run/parent"
 
-// AnnotationLinkedOrgTemplates stores the list of explicitly linked platform
-// template names as a JSON array on a deployment template ConfigMap.
-// Superseded in v1alpha2 by AnnotationLinkedTemplates (which also carries
-// scope information and version constraints).
+// AnnotationLinkedOrgTemplates stores the list of explicitly linked
+// platform template names as a JSON array on a legacy v1alpha2
+// deployment template ConfigMap. Read-only compatibility shim —
+// new deployments serialize linked templates via the
+// templates.holos.run Template CRD (HOL-621); this annotation is
+// only consulted when migrating older ConfigMap-shaped deployment
+// templates forward. No production code writes this annotation.
 // Example: ["microservice-v2", "istio-gateway"]
 #AnnotationLinkedOrgTemplates: "console.holos.run/linked-org-templates"
 
-// AnnotationLinkedTemplates stores the list of explicitly linked cross-level
-// template references as a JSON array of LinkedTemplateRef objects on a
-// template ConfigMap. Replaces AnnotationLinkedOrgTemplates in v1alpha2.
+// AnnotationLinkedTemplates is the wire format used to bridge
+// Template CRDs to the deployment handler. Template CRD storage
+// keeps linked refs in a structured Spec field (HOL-621), but the
+// deployment handler still consumes deployment-template ConfigMaps
+// and reads the linked refs off this JSON-annotation. The
+// templateCRDToConfigMap adapter in console/templates writes the
+// annotation on the fly so deployments can keep its existing
+// reader. Once the deployments package is ported off ConfigMaps
+// (HOL-615 Phase 6 and friends), this constant and its adapter
+// both go away.
 // Example: [{"scope":"organization","scope_name":"acme","name":"microservice-v2"}]
 #AnnotationLinkedTemplates: "console.holos.run/linked-templates"
 
-// LabelTemplateScope identifies the hierarchy level of a template ConfigMap.
+// LabelTemplateScope identifies the hierarchy level of a Template.
 // Values: "organization", "folder", "project" (ADR 021 Decision 4).
+// Still surfaced on CRD-stored Templates via the scheme label
+// setters in console/templates.
 #LabelTemplateScope: "console.holos.run/template-scope"
-
-// AnnotationTemplatePolicyRules stores the JSON-serialized list of
-// TemplatePolicyRule entries for a TemplatePolicy ConfigMap. The handler
-// serializes the proto rules on write and round-trips them back on read;
-// this mirrors the AnnotationLinkedTemplates pattern used on Template
-// ConfigMaps (HOL-556).
-#AnnotationTemplatePolicyRules: "console.holos.run/template-policy-rules"
-
-// AnnotationTemplatePolicyBindingPolicyRef stores the JSON-serialized
-// scope-qualified reference to the TemplatePolicy a
-// TemplatePolicyBinding attaches. The wire shape is
-// `{"scope":"organization|folder","scopeName":"<slug>","name":"<slug>"}`.
-// A binding always references exactly one policy; use multiple
-// bindings to attach multiple policies to overlapping target sets
-// (ADR 029, HOL-590).
-#AnnotationTemplatePolicyBindingPolicyRef: "console.holos.run/template-policy-binding-policy-ref"
-
-// AnnotationTemplatePolicyBindingTargetRefs stores the JSON-serialized
-// list of explicit render targets a TemplatePolicyBinding applies its
-// policy to. The wire shape is a JSON array of
-// `{"kind":"project-template|deployment","name":"<slug>","projectName":"<slug>"}`
-// entries. Handlers MUST reject duplicates — two entries with the
-// same (kind, projectName, name) triple — and MUST reject
-// UNSPECIFIED kind. Order is not significant (ADR 029, HOL-590).
-#AnnotationTemplatePolicyBindingTargetRefs: "console.holos.run/template-policy-binding-target-refs"
 
 // AnnotationExternalLinkPrefix is the Holos-authored annotation-key
 // prefix for external links surfaced on a deployment. Links are keyed

--- a/console/console.go
+++ b/console/console.go
@@ -359,12 +359,18 @@ func (s *Server) Serve(ctx context.Context) error {
 		// Unified templates K8s client (replaces both templates.K8sClient and
 		// org_templates.K8sClient from v1alpha1 — ADR 021 Decision 1).
 		//
-		// HOL-621: Template CRUD now routes through the embedded controller
-		// manager's cache-backed client.Client; Release CRUD still uses the
-		// client-go kubernetes.Interface until the Release CRD lands
-		// (HOL-615 Phase 6). The template client is only wired when the
-		// controller manager was successfully initialized above — without
-		// it there is no cache to read from.
+		// HOL-621 / HOL-661: Template CRUD routes through the embedded
+		// controller-runtime manager's cache-backed client.Client — reads
+		// observe the shared informer cache, writes fall through to the
+		// apiserver. The same manager block above guarantees that a
+		// non-nil k8sClientset implies a non-nil controllerMgr, but we
+		// keep the defensive nil-check so a future refactor that
+		// decouples those paths doesn't silently panic.
+		//
+		// The k8sClientset handle is still needed here because Release
+		// CRUD reads and writes ConfigMaps via client-go — HOL-615 Phase 6
+		// will migrate Releases to a CRD, at which point the
+		// kubernetes.Interface parameter drops out entirely.
 		var templateCtrlClient ctrlclient.Client
 		if s.controllerMgr != nil {
 			templateCtrlClient = s.controllerMgr.GetClient()

--- a/console/crdmgr/testing/envtest.go
+++ b/console/crdmgr/testing/envtest.go
@@ -22,9 +22,15 @@
 //   - Each StartManager(t) call builds a new controller-runtime Manager
 //     against the shared REST config, primes the informers the caller
 //     asks for, and registers t.Cleanup so the Manager is shut down at
-//     test-end. The underlying envtest binaries keep running until the
-//     process exits — Go's test binary calls os.Exit, which the
-//     envtest.Environment's background apiserver tolerates cleanly.
+//     test-end.
+//
+//   - The underlying envtest.Environment itself (the kube-apiserver +
+//     etcd subprocesses and their temp data dirs) is owned by the shared
+//     singleton. Consumers wire up deterministic teardown by calling
+//     RunTestsWithSharedEnv from their package's TestMain so the
+//     apiserver is stopped after every test in the package runs. A
+//     SIGINT / SIGTERM handler is also installed as a safety net so an
+//     interrupted `go test` run does not leak the apiserver.
 //
 // Skip semantics: when KUBEBUILDER_ASSETS is unset and no cached
 // kubebuilder-envtest download is present, StartManager calls t.Skip so
@@ -36,10 +42,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -298,10 +306,13 @@ func ensureSharedEnv(t *testing.T) {
 			return
 		}
 		shared = &sharedEnv{env: e, cfg: cfg}
-		// No Stop() registered: the envtest kube-apiserver binary is
-		// reaped when the Go test binary exits. Registering a shutdown
-		// hook via t.Cleanup would scope termination to the first
-		// test, breaking every subsequent test in the package.
+		// The singleton owns the apiserver/etcd subprocesses for the
+		// rest of the test binary's lifetime. Deterministic shutdown
+		// happens via RunTestsWithSharedEnv (invoked from the test
+		// package's TestMain); the signal handler below is a safety
+		// net that catches ^C / SIGTERM so an interrupted `go test`
+		// run does not leak envtest children.
+		installShutdownSignalHandler()
 	})
 	if sharedEnvErr != nil {
 		if errors.Is(sharedEnvErr, errSkipNoEnvtest) {
@@ -450,6 +461,66 @@ func detectEnvtestAssets() string {
 		}
 	}
 	return best
+}
+
+// RunTestsWithSharedEnv is the TestMain wrapper a consumer package uses
+// to guarantee the shared envtest.Environment is stopped after every
+// test in the package runs, rather than relying on the apiserver
+// subprocess being reaped when the test binary exits.
+//
+// Usage in a consumer package:
+//
+//	func TestMain(m *testing.M) {
+//	    os.Exit(crdmgrtesting.RunTestsWithSharedEnv(m))
+//	}
+//
+// The returned code is the exit code from m.Run(); callers pass it to
+// os.Exit themselves so os.Exit defers (such as this package's deferred
+// stopSharedEnv) run before the process actually exits.
+func RunTestsWithSharedEnv(m *testing.M) int {
+	code := m.Run()
+	stopSharedEnv()
+	return code
+}
+
+// stopSharedEnv shuts down the process-singleton envtest environment if
+// one was started. Idempotent: subsequent calls are no-ops. Safe to call
+// from both RunTestsWithSharedEnv and the signal handler.
+func stopSharedEnv() {
+	sharedStopOnce.Do(func() {
+		if shared == nil || shared.env == nil {
+			return
+		}
+		if err := shared.env.Stop(); err != nil {
+			// Stop() failures are logged but not fatal: we are already
+			// on the exit path, and leaving a stray message on stderr
+			// is the most useful thing we can do.
+			fmt.Fprintf(os.Stderr, "crdmgrtesting: envtest.Environment.Stop: %v\n", err)
+		}
+	})
+}
+
+var sharedStopOnce sync.Once
+
+// installShutdownSignalHandler registers a one-shot SIGINT / SIGTERM
+// handler that stops the shared envtest environment before re-raising
+// the signal default behavior (process exit with the conventional
+// 128+signo code). Installed from inside sharedEnvOnce so it is only
+// wired up if the shared env actually started.
+func installShutdownSignalHandler() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-ch
+		stopSharedEnv()
+		// Restore default disposition and re-raise so the process exits
+		// with the expected 128+signo code rather than swallowing the
+		// signal.
+		signal.Reset(sig.(syscall.Signal))
+		if p, err := os.FindProcess(os.Getpid()); err == nil {
+			_ = p.Signal(sig)
+		}
+	}()
 }
 
 // findRepoRoot walks up from this source file looking for go.mod.

--- a/console/crdmgr/testing/envtest.go
+++ b/console/crdmgr/testing/envtest.go
@@ -1,0 +1,475 @@
+// Package crdmgrtesting exposes a shared envtest bootstrap for the three
+// HOL-661 / HOL-662 storage suites in console/templates,
+// console/templatepolicies, and console/templatepolicybindings. Before
+// HOL-663 each of those packages carried a ~80-line inline copy of the
+// same envtest.Environment + controller-runtime Manager wiring; this
+// package extracts that boilerplate so a storage test suite can spin up
+// a cache-backed Manager in a single call.
+//
+// Design:
+//
+//   - One envtest.Environment per process, guarded by a sync.Once. The
+//     three storage suites issue per-test unique namespace and resource
+//     names, so they do not contend on the shared apiserver — and the
+//     ~3s envtest startup cost (kube-apiserver + etcd binaries) amortizes
+//     across every test in the package rather than every test function.
+//
+//   - The CRDs in config/crd/ are installed at startup time. The
+//     ValidatingAdmissionPolicy manifests in config/admission/ are
+//     applied once and their registration is awaited so the CEL compiler
+//     is warm before any test runs.
+//
+//   - Each StartManager(t) call builds a new controller-runtime Manager
+//     against the shared REST config, primes the informers the caller
+//     asks for, and registers t.Cleanup so the Manager is shut down at
+//     test-end. The underlying envtest binaries keep running until the
+//     process exits — Go's test binary calls os.Exit, which the
+//     envtest.Environment's background apiserver tolerates cleanly.
+//
+// Skip semantics: when KUBEBUILDER_ASSETS is unset and no cached
+// kubebuilder-envtest download is present, StartManager calls t.Skip so
+// developers without `setup-envtest use` can still run `go test ./...`.
+package crdmgrtesting
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtimepkg "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// Env bundles the shared envtest primitives a storage test suite needs.
+// The REST config is shared across tests in the same process; every other
+// field is per-StartManager and scoped to the current test via
+// t.Cleanup.
+type Env struct {
+	// Cfg is the shared REST config pointing at the process-wide envtest
+	// kube-apiserver. Tests that need to construct additional clients
+	// (for example, a second cache-backed Manager for multi-freshness
+	// assertions) reuse this Cfg.
+	Cfg *rest.Config
+	// Client is the cache-backed delegating client from the test's
+	// Manager. Reads come from informers primed by StartManager; writes
+	// fall through to the apiserver. This is the client production
+	// wires into NewK8sClient(...), so using it here keeps the
+	// cache-freshness regressions honest.
+	Client ctrlclient.Client
+	// Direct is an uncached controller-runtime client that round-trips
+	// to the apiserver on every Get / List. Tests use it for seed
+	// writes (namespace Create, pre-populated fixtures) so the test
+	// body is not tangled with Eventually-wraps on trivial setup.
+	Direct ctrlclient.Client
+	// Core is a client-go Interface built from Cfg. The templates
+	// storage layer still reads and writes Release ConfigMaps through
+	// client-go (they are not part of the CRD surface), so tests wiring
+	// NewK8sClient need this handle in addition to the ctrlclient.
+	Core kubernetes.Interface
+}
+
+// Options controls what StartManager primes in the cache before
+// returning. Callers pass the CRD kinds their suite operates on so the
+// informer is registered and synced before any test writes land.
+type Options struct {
+	// Scheme must register every kind the test suite reads or writes,
+	// including templates.holos.run/v1alpha1 and core/v1. Typically the
+	// caller constructs this once per package and reuses it.
+	Scheme *runtimepkg.Scheme
+	// InformerObjects is the set of typed objects whose informers the
+	// Manager primes before starting. Each entry must be registered in
+	// Scheme. Without priming, the first List through the delegating
+	// client lazily starts a watch and can race a just-completed Create.
+	InformerObjects []ctrlclient.Object
+	// WaitForAdmissionPolicies names the ValidatingAdmissionPolicies the
+	// caller expects to be live before tests run. StartManager waits
+	// for each name to appear on the apiserver so test bodies do not
+	// race the CEL compiler.
+	WaitForAdmissionPolicies []string
+}
+
+// sharedEnv holds the process-singleton envtest state. Populated by the
+// first StartManager call; subsequent calls reuse it. stopped is set by
+// stopSharedEnv at process-exit paths (not t.Cleanup, because t outlives
+// a single test but the process outlives all tests).
+type sharedEnv struct {
+	env *envtest.Environment
+	cfg *rest.Config
+	// admissionInstalled guards one-time application of the
+	// config/admission/*.yaml manifests. After the first suite primes
+	// them, subsequent suites only need to wait for registration; the
+	// VAPs themselves are apiserver-wide state.
+	admissionInstalled sync.Once
+	admissionErr       error
+}
+
+var (
+	sharedEnvOnce sync.Once
+	sharedEnvErr  error
+	shared        *sharedEnv
+)
+
+// StartManager boots (or reuses) the process-singleton envtest
+// environment, constructs a controller-runtime Manager primed with the
+// requested informers, and returns an Env value the test suite can
+// inject into its K8sClient.
+//
+// StartManager calls t.Skip when the envtest binaries are not
+// discoverable, so a developer without `setup-envtest use` installed
+// still gets a green `go test ./...` run.
+func StartManager(t *testing.T, opts Options) *Env {
+	t.Helper()
+
+	if opts.Scheme == nil {
+		t.Fatalf("crdmgrtesting.StartManager: Options.Scheme is required")
+	}
+
+	ensureSharedEnv(t)
+	if shared == nil {
+		// ensureSharedEnv already called t.Skip or t.Fatalf.
+		return nil
+	}
+
+	// The VAPs are apiserver-wide state; install them once per process.
+	// Subsequent calls still wait for the named policies to be visible
+	// via the current test's client so the CEL compiler is warm before
+	// the test body runs.
+	shared.admissionInstalled.Do(func() {
+		repoRoot, err := findRepoRoot()
+		if err != nil {
+			shared.admissionErr = fmt.Errorf("find repo root: %w", err)
+			return
+		}
+		admDir := filepath.Join(repoRoot, "config", "admission")
+		if _, err := os.Stat(admDir); err != nil {
+			// No admission dir — this is fine; the suite just won't
+			// have VAPs to wait on.
+			return
+		}
+		direct, err := ctrlclient.New(shared.cfg, ctrlclient.Options{Scheme: opts.Scheme})
+		if err != nil {
+			shared.admissionErr = fmt.Errorf("construct direct client for admission install: %w", err)
+			return
+		}
+		if err := applyAdmissionYAMLFiles(context.Background(), direct, admDir); err != nil {
+			shared.admissionErr = fmt.Errorf("apply admission policies: %w", err)
+			return
+		}
+	})
+	if shared.admissionErr != nil {
+		t.Fatalf("installing admission policies: %v", shared.admissionErr)
+	}
+
+	// Uncached client for test setup (namespace Create, seed writes,
+	// fixture pre-population). Each StartManager call builds its own
+	// against the shared REST config — cheap, and keeps the scheme
+	// scoped to the caller's needs.
+	direct, err := ctrlclient.New(shared.cfg, ctrlclient.Options{Scheme: opts.Scheme})
+	if err != nil {
+		t.Fatalf("constructing direct client: %v", err)
+	}
+
+	// Cache-backed delegating Manager. Mirrors the production wiring in
+	// console.go: writes go to the apiserver, reads go through the
+	// informer cache.
+	mgr, err := ctrl.NewManager(shared.cfg, ctrl.Options{
+		Scheme: opts.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // disable metrics listener in tests
+		},
+		HealthProbeBindAddress: "0", // disable readiness listener
+	})
+	if err != nil {
+		t.Fatalf("constructing manager: %v", err)
+	}
+
+	// Prime informers before Start so the cache has watches registered
+	// against the apiserver before the first List. Without this the
+	// first cache-backed read lazily starts a watch and can race a
+	// just-issued Create — the exact flake the acceptance criterion
+	// calls out.
+	for _, obj := range opts.InformerObjects {
+		if _, err := mgr.GetCache().GetInformer(context.Background(), obj); err != nil {
+			t.Fatalf("priming informer for %T: %v", obj, err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.Start(ctx)
+	}()
+
+	// Bound the cache-sync wait so a broken CRD install or scheme
+	// mismatch fails the test promptly rather than timing out on the
+	// first List.
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer waitCancel()
+	if !mgr.GetCache().WaitForCacheSync(waitCtx) {
+		cancel()
+		t.Fatalf("manager cache did not sync within deadline")
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Logf("manager exit: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Logf("manager did not shut down within deadline")
+		}
+	})
+
+	// Wait for each requested VAP to appear before returning so the
+	// test body never races the CEL compiler. The policies themselves
+	// were installed by the admissionInstalled.Do branch above
+	// (possibly in a prior suite); this loop just observes
+	// registration.
+	for _, name := range opts.WaitForAdmissionPolicies {
+		waitForAdmissionPolicy(t, context.Background(), direct, name)
+	}
+
+	core, err := kubernetes.NewForConfig(shared.cfg)
+	if err != nil {
+		t.Fatalf("constructing core client: %v", err)
+	}
+
+	return &Env{
+		Cfg:    shared.cfg,
+		Client: mgr.GetClient(),
+		Direct: direct,
+		Core:   core,
+	}
+}
+
+// ensureSharedEnv starts the process-singleton envtest.Environment on
+// first use. t.Skip is called with a helpful message when envtest
+// binaries are not installed.
+func ensureSharedEnv(t *testing.T) {
+	t.Helper()
+
+	sharedEnvOnce.Do(func() {
+		if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+			if assets := detectEnvtestAssets(); assets != "" {
+				// setenv here (not t.Setenv) because this runs once
+				// per process and the setting must persist across
+				// every subsequent StartManager call.
+				if err := os.Setenv("KUBEBUILDER_ASSETS", assets); err != nil {
+					sharedEnvErr = fmt.Errorf("setenv KUBEBUILDER_ASSETS: %w", err)
+					return
+				}
+			} else {
+				sharedEnvErr = errSkipNoEnvtest
+				return
+			}
+		}
+
+		repoRoot, err := findRepoRoot()
+		if err != nil {
+			sharedEnvErr = fmt.Errorf("find repo root: %w", err)
+			return
+		}
+
+		e := &envtest.Environment{
+			CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd")},
+			ErrorIfCRDPathMissing: true,
+		}
+		cfg, err := e.Start()
+		if err != nil {
+			sharedEnvErr = fmt.Errorf("start envtest: %w", err)
+			return
+		}
+		shared = &sharedEnv{env: e, cfg: cfg}
+		// No Stop() registered: the envtest kube-apiserver binary is
+		// reaped when the Go test binary exits. Registering a shutdown
+		// hook via t.Cleanup would scope termination to the first
+		// test, breaking every subsequent test in the package.
+	})
+	if sharedEnvErr != nil {
+		if errors.Is(sharedEnvErr, errSkipNoEnvtest) {
+			t.Skip("envtest binaries not found; set KUBEBUILDER_ASSETS or run `setup-envtest use` to download")
+			return
+		}
+		t.Fatalf("starting shared envtest environment: %v", sharedEnvErr)
+	}
+}
+
+// errSkipNoEnvtest is a sentinel for the "envtest binaries missing"
+// branch of ensureSharedEnv so the t.Skip path is distinguishable from
+// a real bootstrap failure.
+var errSkipNoEnvtest = errors.New("envtest binaries not found")
+
+// applyAdmissionYAMLFiles reads every *.yaml file in dir and applies
+// each ValidatingAdmissionPolicy / ValidatingAdmissionPolicyBinding
+// document through the controller-runtime client. Pre-HOL-663 each
+// storage suite carried its own copy of this helper; this is the
+// single authoritative implementation.
+func applyAdmissionYAMLFiles(ctx context.Context, c ctrlclient.Client, dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		for _, doc := range splitYAMLDocuments(data) {
+			if len(strings.TrimSpace(string(doc))) == 0 {
+				continue
+			}
+			if err := applyAdmissionDoc(ctx, c, doc); err != nil {
+				return fmt.Errorf("apply doc from %s: %w", e.Name(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// splitYAMLDocuments splits a multi-doc YAML stream on "---" lines.
+// Preserves the exact behavior of the pre-HOL-663 copies so existing
+// config/admission/*.yaml files continue to parse unchanged.
+func splitYAMLDocuments(data []byte) [][]byte {
+	var docs [][]byte
+	var current []byte
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "---" {
+			if len(current) > 0 {
+				docs = append(docs, current)
+			}
+			current = nil
+			continue
+		}
+		current = append(current, []byte(line+"\n")...)
+	}
+	if len(current) > 0 {
+		docs = append(docs, current)
+	}
+	return docs
+}
+
+// applyAdmissionDoc decodes a single YAML doc and Creates it through
+// the controller-runtime client. AlreadyExists is treated as success so
+// repeat applies are idempotent — the process-singleton env may have
+// already installed the policy in a prior suite run.
+func applyAdmissionDoc(ctx context.Context, c ctrlclient.Client, doc []byte) error {
+	kindProbe := struct {
+		Kind string `json:"kind"`
+	}{}
+	if err := yaml.Unmarshal(doc, &kindProbe); err != nil {
+		return fmt.Errorf("unmarshal kind: %w", err)
+	}
+	switch kindProbe.Kind {
+	case "ValidatingAdmissionPolicy":
+		policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		if err := yaml.Unmarshal(doc, policy); err != nil {
+			return fmt.Errorf("unmarshal policy: %w", err)
+		}
+		if err := c.Create(ctx, policy); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	case "ValidatingAdmissionPolicyBinding":
+		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+		if err := yaml.Unmarshal(doc, binding); err != nil {
+			return fmt.Errorf("unmarshal binding: %w", err)
+		}
+		if err := c.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported admission kind %q", kindProbe.Kind)
+	}
+}
+
+// waitForAdmissionPolicy polls for a ValidatingAdmissionPolicy to be
+// registered with the API server. Without this poll, the first Create
+// races the apiserver's CEL compiler and the calling test sees a false
+// negative (admission should have rejected, but the policy wasn't
+// compiled yet).
+func waitForAdmissionPolicy(t *testing.T, ctx context.Context, c ctrlclient.Client, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		if err := c.Get(ctx, types.NamespacedName{Name: name}, vap); err == nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("admission policy %q not registered within deadline", name)
+}
+
+// detectEnvtestAssets probes the default kubebuilder-envtest cache
+// location for an installed apiserver. Returns an empty string when no
+// cached install is present; callers interpret that as a Skip trigger.
+// Matches the helper the pre-HOL-663 suites carried inline so the same
+// environments continue to satisfy the bootstrap.
+func detectEnvtestAssets() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	base := filepath.Join(home, ".local", "share", "kubebuilder-envtest", "k8s")
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return ""
+	}
+	var best string
+	for _, en := range entries {
+		if !en.IsDir() {
+			continue
+		}
+		cand := filepath.Join(base, en.Name())
+		if _, err := os.Stat(filepath.Join(cand, "kube-apiserver")); err == nil {
+			if best == "" || en.Name() > filepath.Base(best) {
+				best = cand
+			}
+		}
+	}
+	return best
+}
+
+// findRepoRoot walks up from this source file looking for go.mod.
+// Mirrors the inline copies the pre-HOL-663 suites carried; the
+// runtime.Caller frame resolves to this file's directory so the walk
+// starts inside console/crdmgr/testing/.
+func findRepoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod above %q", file)
+		}
+		dir = parent
+	}
+}

--- a/console/crdmgr/testing/envtest_test.go
+++ b/console/crdmgr/testing/envtest_test.go
@@ -1,0 +1,123 @@
+// envtest_test.go smoke-tests the shared envtest bootstrap introduced
+// in HOL-663. The storage suites in console/templates,
+// console/templatepolicies, and console/templatepolicybindings exercise
+// the real behavior (cache-backed reads, admission-policy enforcement);
+// this test just confirms that StartManager returns a working cache,
+// direct client, and core client, and that repeat calls within the same
+// process reuse the underlying envtest rather than booting a second
+// apiserver.
+package crdmgrtesting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+)
+
+// testScheme returns a runtime.Scheme registered with core + templates
+// v1alpha1 types, mirroring what the storage suites build in their
+// testhelpers_test.go files.
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("register clientgo scheme: %v", err)
+	}
+	if err := templatesv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("register templates scheme: %v", err)
+	}
+	return s
+}
+
+// TestStartManager_BasicCRUD confirms the cache-backed client returned
+// by StartManager reflects writes issued through the direct client
+// within the informer watch window. This exercises the same
+// write-direct / read-through-cache contract every storage suite
+// relies on.
+func TestStartManager_BasicCRUD(t *testing.T) {
+	scheme := testScheme(t)
+	env := StartManager(t, Options{
+		Scheme:          scheme,
+		InformerObjects: []ctrlclient.Object{&templatesv1alpha1.Template{}},
+	})
+	if env == nil {
+		return // Skipped: envtest binaries not installed.
+	}
+
+	nsName := "crdmgrtesting-smoke-basic"
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	if err := env.Direct.Create(context.Background(), ns); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+
+	tmpl := &templatesv1alpha1.Template{
+		ObjectMeta: metav1.ObjectMeta{Name: "probe", Namespace: nsName},
+		Spec: templatesv1alpha1.TemplateSpec{
+			DisplayName: "Probe",
+			Enabled:     true,
+			CueTemplate: "package holos\n",
+		},
+	}
+	if err := env.Direct.Create(context.Background(), tmpl); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+
+	// Poll the cache-backed client until it observes the seed write.
+	// A single immediate read would race the watch propagation window.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var list templatesv1alpha1.TemplateList
+		if err := env.Client.List(context.Background(), &list, ctrlclient.InNamespace(nsName)); err != nil {
+			t.Fatalf("cache list: %v", err)
+		}
+		if len(list.Items) >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("cache-backed list did not observe seed template within deadline")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if env.Core == nil {
+		t.Fatalf("Env.Core was nil; Core is required for Release ConfigMap paths")
+	}
+	if env.Cfg == nil {
+		t.Fatalf("Env.Cfg was nil; Cfg is required for multi-manager fixtures")
+	}
+}
+
+// TestStartManager_ReusesSharedEnv verifies that two StartManager calls
+// within the same test binary process reuse the same apiserver. We
+// assert this indirectly: both calls must surface the same Cfg.Host.
+// If sharedEnvOnce were broken, the second StartManager would boot a
+// second kube-apiserver on a different random port.
+func TestStartManager_ReusesSharedEnv(t *testing.T) {
+	scheme := testScheme(t)
+	env1 := StartManager(t, Options{
+		Scheme:          scheme,
+		InformerObjects: []ctrlclient.Object{&templatesv1alpha1.Template{}},
+	})
+	if env1 == nil {
+		return // Skipped.
+	}
+	env2 := StartManager(t, Options{
+		Scheme:          scheme,
+		InformerObjects: []ctrlclient.Object{&templatesv1alpha1.Template{}},
+	})
+	if env2 == nil {
+		t.Fatalf("second StartManager call unexpectedly skipped")
+	}
+	if env1.Cfg.Host != env2.Cfg.Host {
+		t.Fatalf("StartManager booted a second apiserver: first host=%q second host=%q",
+			env1.Cfg.Host, env2.Cfg.Host)
+	}
+}

--- a/console/crdmgr/testing/main_test.go
+++ b/console/crdmgr/testing/main_test.go
@@ -1,0 +1,14 @@
+// main_test.go wires TestMain for the shared-helper's own smoke tests
+// so the process-singleton envtest Environment is Stop()'d after every
+// test in this package runs, matching the pattern the three consumer
+// storage suites use.
+package crdmgrtesting
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(RunTestsWithSharedEnv(m))
+}

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1318,35 +1318,15 @@ func makeOrgNamespace(org string) *corev1.Namespace {
 	}
 }
 
-// marshalFixtureRules serializes a minimal rule fixture in the shape
-// templatepolicies.UnmarshalRules expects on the annotation.
-func marshalFixtureRules(t *testing.T, rules []map[string]any) string {
+// seedOrgRequirePolicy returns a TemplatePolicy-labeled ConfigMap placeholder
+// used by the HOL-582 regression guard. CreateProject intentionally ignores
+// policy contents at project-creation time (it never renders templates),
+// so this fixture only needs to exist — its rule body was previously
+// stashed on the legacy AnnotationTemplatePolicyRules annotation
+// (removed in HOL-663). TemplatePolicy data is now authoritatively
+// carried by the templates.holos.run TemplatePolicy CRD.
+func seedOrgRequirePolicy(t *testing.T, org, templateName, _ string) *corev1.ConfigMap {
 	t.Helper()
-	raw, err := json.Marshal(rules)
-	if err != nil {
-		t.Fatalf("marshal fixture rules: %v", err)
-	}
-	return string(raw)
-}
-
-// seedOrgRequirePolicy returns a TemplatePolicy ConfigMap containing a single
-// REQUIRE rule that mandates the named organization-scope template for every
-// project matching projectPattern.
-func seedOrgRequirePolicy(t *testing.T, org, templateName, projectPattern string) *corev1.ConfigMap {
-	t.Helper()
-	rules := []map[string]any{
-		{
-			"kind": "require",
-			"template": map[string]any{
-				"scope":      v1alpha2.TemplateScopeOrganization,
-				"scope_name": org,
-				"name":       templateName,
-			},
-			"target": map[string]any{
-				"project_pattern": projectPattern,
-			},
-		},
-	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "require-" + templateName,
@@ -1354,9 +1334,6 @@ func seedOrgRequirePolicy(t *testing.T, org, templateName, projectPattern string
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
 				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
-			},
-			Annotations: map[string]string{
-				v1alpha2.AnnotationTemplatePolicyRules: marshalFixtureRules(t, rules),
 			},
 		},
 	}

--- a/console/templatepolicies/k8s_test.go
+++ b/console/templatepolicies/k8s_test.go
@@ -1,8 +1,7 @@
 // k8s_test.go exercises the HOL-662 rewrite of the TemplatePolicy CRUD
-// surface against the TemplatePolicy CRD. Each CRUD test starts its own
-// envtest.Environment with the templates.holos.run CRDs installed
-// (shared-envtest extraction is the HOL-663 follow-up), builds a K8sClient
-// backed by a cache-backed controller-runtime client, and exercises one
+// surface against the TemplatePolicy CRD. Each CRUD test builds a
+// K8sClient backed by the shared envtest bootstrap in
+// console/crdmgr/testing (extracted in HOL-663) and exercises one
 // operation table-driven.
 //
 // Cache freshness is covered by TestK8sClient_ListReflectsCreate, which
@@ -14,30 +13,21 @@ package templatepolicies
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/scopeshim"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
@@ -65,242 +55,31 @@ func sampleRule() *consolev1.TemplatePolicyRule {
 	}
 }
 
-// envtestEnv wraps an envtest.Environment + direct client + cache-backed
-// client + client-go Interface. Each CRUD test spins up its own isolated
-// API server — one Environment per test keeps tests independent. HOL-663
-// will extract a shared helper.
-type envtestEnv struct {
-	env    *envtest.Environment
-	cfg    *rest.Config
-	client ctrlclient.Client // cache-backed delegating client from the manager
-	direct ctrlclient.Client // uncached client (API-server round-trip) for setup
-	core   kubernetes.Interface
-}
-
-// startEnvtest boots envtest with the templates.holos.run CRDs (plus the
-// CEL ValidatingAdmissionPolicy that enforces the folder/org-only
-// storage-isolation guardrail) installed, and returns a cache-backed
-// controller-runtime client + an uncached client for setup plus a
-// client-go Interface. Skips (does not fail) when envtest binaries are not
-// installed so developers without `setup-envtest use` can still run
-// `go test ./...`.
+// newEnvtestK8sClient builds a K8sClient backed by the shared envtest
+// bootstrap in console/crdmgr/testing. The K8sClient receives the
+// manager's cache-backed client so every Get / List the CRUD tests
+// exercise goes through the informer cache — the HOL-662 acceptance
+// criterion the suite regresses against. Writes go straight to the API
+// server (controller-runtime default), so the create-then-list
+// freshness test catches any regression where the cache-backed read
+// path is bypassed.
 //
-// Using the manager's cache-backed client is load-bearing for the HOL-662
-// acceptance criterion that TemplatePolicy reads go through the informer
-// cache — without it, TestK8sClient_ListReflectsCreate would pass even if
-// K8sClient regressed to a direct API read.
-func startEnvtest(t *testing.T) *envtestEnv {
+// The helper also applies the folder/org-only CEL admission policies
+// from config/admission/ once per process and waits for the policy
+// this suite depends on (templatepolicy-folder-or-org-only) to be
+// registered so the admission-rejection regression does not race the
+// CEL compiler.
+func newEnvtestK8sClient(t *testing.T) (*crdmgrtesting.Env, *K8sClient) {
 	t.Helper()
-
-	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
-		if assets := detectEnvtestAssets(); assets != "" {
-			t.Setenv("KUBEBUILDER_ASSETS", assets)
-		} else {
-			t.Skip("envtest binaries not found; run `setup-envtest use` to download")
-		}
-	}
-
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		t.Fatalf("finding repo root: %v", err)
-	}
-
-	e := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd")},
-		ErrorIfCRDPathMissing: true,
-	}
-	cfg, err := e.Start()
-	if err != nil {
-		t.Fatalf("starting envtest: %v", err)
-	}
-	t.Cleanup(func() {
-		if stopErr := e.Stop(); stopErr != nil {
-			t.Logf("stopping envtest: %v", stopErr)
-		}
+	env := crdmgrtesting.StartManager(t, crdmgrtesting.Options{
+		Scheme:                   testScheme(t),
+		InformerObjects:          []ctrlclient.Object{&templatesv1alpha1.TemplatePolicy{}},
+		WaitForAdmissionPolicies: []string{"templatepolicy-folder-or-org-only"},
 	})
-
-	scheme := testScheme(t)
-
-	// Uncached client for test setup (namespace Create, seed-write, etc.).
-	direct, err := ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
-	if err != nil {
-		t.Fatalf("constructing direct client: %v", err)
+	if env == nil {
+		t.SkipNow()
 	}
-
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-		HealthProbeBindAddress: "0",
-	})
-	if err != nil {
-		t.Fatalf("constructing manager: %v", err)
-	}
-
-	// Prime the TemplatePolicy informer so the cache has the watch
-	// registered before the manager starts. Without this, the first List
-	// through the cache-backed client lazily registers the informer and
-	// may race the test write.
-	if _, err := mgr.GetCache().GetInformer(context.Background(), &templatesv1alpha1.TemplatePolicy{}); err != nil {
-		t.Fatalf("priming TemplatePolicy informer: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- mgr.Start(ctx)
-	}()
-
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer waitCancel()
-	if !mgr.GetCache().WaitForCacheSync(waitCtx) {
-		cancel()
-		t.Fatalf("manager cache did not sync within deadline")
-	}
-
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case err := <-errCh:
-			if err != nil && !errors.Is(err, context.Canceled) {
-				t.Logf("manager exit: %v", err)
-			}
-		case <-time.After(10 * time.Second):
-			t.Logf("manager did not shut down within deadline")
-		}
-	})
-
-	core, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		t.Fatalf("constructing core client: %v", err)
-	}
-
-	// envtest has no built-in ValidatingAdmissionPolicy installer — the VAP
-	// manifests live in config/admission/ and must be applied through the
-	// generic client after Start() returns. This keeps the
-	// TestCreatePolicyRejectedByAdmissionInProjectNamespace regression in
-	// lockstep with the production policy surface.
-	ctx2 := context.Background()
-	if err := applyAdmissionYAMLFiles(ctx2, direct, filepath.Join(repoRoot, "config", "admission")); err != nil {
-		t.Fatalf("applying admission policies: %v", err)
-	}
-	// Wait for the VAP relevant to this package to be registered. envtest
-	// acknowledges the Create immediately; the apiserver's CEL compiler
-	// needs a tick to pick it up before the guard starts rejecting writes.
-	waitForAdmissionPolicy(t, ctx2, direct, "templatepolicy-folder-or-org-only")
-
-	return &envtestEnv{env: e, cfg: cfg, client: mgr.GetClient(), direct: direct, core: core}
-}
-
-// applyAdmissionYAMLFiles reads every *.yaml file in dir and applies each
-// ValidatingAdmissionPolicy / ValidatingAdmissionPolicyBinding document
-// through the controller-runtime client. Mirrors the helper used by
-// api/templates/v1alpha1/crd_test.go — duplicated here so this package does
-// not import the v1alpha1 test package (test packages cannot be imported).
-func applyAdmissionYAMLFiles(ctx context.Context, c ctrlclient.Client, dir string) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return fmt.Errorf("read dir: %w", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
-		if err != nil {
-			return fmt.Errorf("read %s: %w", e.Name(), err)
-		}
-		for _, doc := range splitYAMLDocuments(data) {
-			if len(strings.TrimSpace(string(doc))) == 0 {
-				continue
-			}
-			if err := applyAdmissionDoc(ctx, c, doc); err != nil {
-				return fmt.Errorf("apply doc from %s: %w", e.Name(), err)
-			}
-		}
-	}
-	return nil
-}
-
-func splitYAMLDocuments(data []byte) [][]byte {
-	var docs [][]byte
-	var current []byte
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(line) == "---" {
-			if len(current) > 0 {
-				docs = append(docs, current)
-			}
-			current = nil
-			continue
-		}
-		current = append(current, []byte(line+"\n")...)
-	}
-	if len(current) > 0 {
-		docs = append(docs, current)
-	}
-	return docs
-}
-
-func applyAdmissionDoc(ctx context.Context, c ctrlclient.Client, doc []byte) error {
-	kindProbe := struct {
-		Kind string `json:"kind"`
-	}{}
-	if err := yaml.Unmarshal(doc, &kindProbe); err != nil {
-		return fmt.Errorf("unmarshal kind: %w", err)
-	}
-	switch kindProbe.Kind {
-	case "ValidatingAdmissionPolicy":
-		policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-		if err := yaml.Unmarshal(doc, policy); err != nil {
-			return fmt.Errorf("unmarshal policy: %w", err)
-		}
-		if err := c.Create(ctx, policy); err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-		return nil
-	case "ValidatingAdmissionPolicyBinding":
-		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-		if err := yaml.Unmarshal(doc, binding); err != nil {
-			return fmt.Errorf("unmarshal binding: %w", err)
-		}
-		if err := c.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-		return nil
-	default:
-		return fmt.Errorf("unsupported admission kind %q", kindProbe.Kind)
-	}
-}
-
-// waitForAdmissionPolicy polls for a ValidatingAdmissionPolicy to be
-// registered with the API server. Mirrors the helper in crd_test.go.
-// Without this poll, the first Create race the apiserver's CEL compiler
-// and the test sees a false negative.
-func waitForAdmissionPolicy(t *testing.T, ctx context.Context, c ctrlclient.Client, name string) {
-	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
-		vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-		if err := c.Get(ctx, types.NamespacedName{Name: name}, vap); err == nil {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("admission policy %q not registered within deadline", name)
-}
-
-// newEnvtestK8sClient builds a K8sClient backed by an envtest API server.
-// The K8sClient receives the manager's cache-backed client so every Get /
-// List the CRUD tests exercise goes through the informer cache — the
-// HOL-662 acceptance criterion the suite regresses against. Writes go
-// straight to the API server (controller-runtime default), so the
-// create-then-list freshness test catches any regression where the
-// cache-backed read path is bypassed.
-func newEnvtestK8sClient(t *testing.T) (*envtestEnv, *K8sClient) {
-	t.Helper()
-	e := startEnvtest(t)
-	return e, NewK8sClient(e.client, newTestResolver())
+	return env, NewK8sClient(env.Client, newTestResolver())
 }
 
 // ensureNamespace creates a namespace if it does not already exist.
@@ -451,14 +230,14 @@ func TestListPolicies(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ensureNamespace(t, e.direct, tc.namespace, v1alpha2.ResourceTypeFolder)
+			ensureNamespace(t, e.Direct, tc.namespace, v1alpha2.ResourceTypeFolder)
 			for _, p := range tc.seed {
-				ensureNamespace(t, e.direct, p.Namespace, v1alpha2.ResourceTypeFolder)
-				if err := e.direct.Create(context.Background(), p); err != nil {
+				ensureNamespace(t, e.Direct, p.Namespace, v1alpha2.ResourceTypeFolder)
+				if err := e.Direct.Create(context.Background(), p); err != nil {
 					t.Fatalf("seed create: %v", err)
 				}
 				t.Cleanup(func() {
-					_ = e.direct.Delete(context.Background(), p)
+					_ = e.Direct.Delete(context.Background(), p)
 				})
 			}
 
@@ -479,7 +258,7 @@ func TestGetPolicy(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-get"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	seed := &templatesv1alpha1.TemplatePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "require-httproute", Namespace: ns},
@@ -496,7 +275,7 @@ func TestGetPolicy(t *testing.T) {
 			},
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	_ = eventuallyGetPolicy(t, k, ns, "require-httproute")
@@ -539,7 +318,7 @@ func TestCreatePolicy(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-create"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	cases := []struct {
 		name         string
@@ -590,7 +369,7 @@ func TestCreatePolicy(t *testing.T) {
 
 			// Read-your-own-write via direct client Get.
 			read := &templatesv1alpha1.TemplatePolicy{}
-			if err := e.direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: tc.resourceName}, read); err != nil {
+			if err := e.Direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: tc.resourceName}, read); err != nil {
 				t.Fatalf("Get after Create: %v", err)
 			}
 			if read.Spec.DisplayName != tc.displayName {
@@ -607,7 +386,7 @@ func TestUpdatePolicy(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-update"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	seed := &templatesv1alpha1.TemplatePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "pol", Namespace: ns},
@@ -624,7 +403,7 @@ func TestUpdatePolicy(t *testing.T) {
 			},
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	// UpdatePolicy internally calls GetPolicy via the cache-backed client,
@@ -676,7 +455,7 @@ func TestDeletePolicy(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-delete"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	seed := &templatesv1alpha1.TemplatePolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "goner", Namespace: ns},
@@ -692,7 +471,7 @@ func TestDeletePolicy(t *testing.T) {
 			},
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	_ = eventuallyGetPolicy(t, k, ns, "goner")
@@ -701,7 +480,7 @@ func TestDeletePolicy(t *testing.T) {
 		t.Fatalf("DeletePolicy: %v", err)
 	}
 	read := &templatesv1alpha1.TemplatePolicy{}
-	err := e.direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "goner"}, read)
+	err := e.Direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "goner"}, read)
 	if err == nil {
 		t.Fatal("expected NotFound after delete")
 	}
@@ -729,7 +508,7 @@ func TestK8sClient_ListReflectsCreate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-cache"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	if _, err := k.CreatePolicy(
 		context.Background(), ns, "fresh", "Fresh", "", "creator@example.com",
@@ -767,7 +546,7 @@ func TestCreatePolicyRejectedByAdmissionInProjectNamespace(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-prj-billing-web"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeProject)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeProject)
 
 	_, err := k.CreatePolicy(
 		context.Background(), ns, "policy-test", "Test", "", "creator@example.com",
@@ -821,54 +600,6 @@ func TestPackageDoesNotCallProjectNamespace(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("package must not call %s — found in: %v", target, matches)
-	}
-}
-
-// ------------------------------------------------------------------------
-// envtest helpers — detectEnvtestAssets + findRepoRoot mirror the copies
-// in console/templates/k8s_test.go. HOL-663 will extract a shared helper.
-// ------------------------------------------------------------------------
-
-func detectEnvtestAssets() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	base := filepath.Join(home, ".local", "share", "kubebuilder-envtest", "k8s")
-	entries, err := os.ReadDir(base)
-	if err != nil {
-		return ""
-	}
-	var best string
-	for _, en := range entries {
-		if !en.IsDir() {
-			continue
-		}
-		cand := filepath.Join(base, en.Name())
-		if _, err := os.Stat(filepath.Join(cand, "kube-apiserver")); err == nil {
-			if best == "" || en.Name() > filepath.Base(best) {
-				best = cand
-			}
-		}
-	}
-	return best
-}
-
-func findRepoRoot() (string, error) {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", errors.New("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("no go.mod above %q", file)
-		}
-		dir = parent
 	}
 }
 

--- a/console/templatepolicies/main_test.go
+++ b/console/templatepolicies/main_test.go
@@ -12,10 +12,14 @@ import (
 	"os"
 	"testing"
 
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
 	"github.com/holos-run/holos-console/console/scopeshim"
 )
 
 func TestMain(m *testing.M) {
 	scopeshim.SetDefaultResolver(newTestResolver())
-	os.Exit(m.Run())
+	// Wrap m.Run through crdmgrtesting.RunTestsWithSharedEnv so the
+	// process-singleton envtest Environment is Stop()'d after the last
+	// test in this package runs.
+	os.Exit(crdmgrtesting.RunTestsWithSharedEnv(m))
 }

--- a/console/templatepolicybindings/k8s_test.go
+++ b/console/templatepolicybindings/k8s_test.go
@@ -1,9 +1,8 @@
 // k8s_test.go exercises the HOL-662 rewrite of the TemplatePolicyBinding
 // CRUD surface against the TemplatePolicyBinding CRD. Each CRUD test
-// starts its own envtest.Environment with the templates.holos.run CRDs
-// installed (shared-envtest extraction is the HOL-663 follow-up), builds
-// a K8sClient backed by a cache-backed controller-runtime client, and
-// exercises one operation table-driven.
+// builds a K8sClient backed by the shared envtest bootstrap in
+// console/crdmgr/testing (extracted in HOL-663) and exercises one
+// operation table-driven.
 //
 // Cache freshness is covered by TestK8sClient_ListReflectsCreate, which
 // creates a TemplatePolicyBinding through the delegating client and
@@ -15,30 +14,21 @@ package templatepolicybindings
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/scopeshim"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
@@ -72,242 +62,31 @@ func sampleTargetRef() *consolev1.TemplatePolicyBindingTargetRef {
 	}
 }
 
-// envtestEnv wraps an envtest.Environment + direct client + cache-backed
-// client + client-go Interface. Each CRUD test spins up its own isolated
-// API server — one Environment per test keeps tests independent. HOL-663
-// will extract a shared helper.
-type envtestEnv struct {
-	env    *envtest.Environment
-	cfg    *rest.Config
-	client ctrlclient.Client // cache-backed delegating client from the manager
-	direct ctrlclient.Client // uncached client (API-server round-trip) for setup
-	core   kubernetes.Interface
-}
-
-// startEnvtest boots envtest with the templates.holos.run CRDs (plus the
-// CEL ValidatingAdmissionPolicy that enforces the folder/org-only
-// storage-isolation guardrail) installed, and returns a cache-backed
-// controller-runtime client + an uncached client for setup plus a
-// client-go Interface. Skips (does not fail) when envtest binaries are not
-// installed so developers without `setup-envtest use` can still run
-// `go test ./...`.
+// newEnvtestK8sClient builds a K8sClient backed by the shared envtest
+// bootstrap in console/crdmgr/testing. The K8sClient receives the
+// manager's cache-backed client so every Get / List the CRUD tests
+// exercise goes through the informer cache — the HOL-662 acceptance
+// criterion the suite regresses against. Writes go straight to the API
+// server (controller-runtime default), so the create-then-list
+// freshness test catches any regression where the cache-backed read
+// path is bypassed.
 //
-// Using the manager's cache-backed client is load-bearing for the HOL-662
-// acceptance criterion that TemplatePolicyBinding reads go through the
-// informer cache — without it, TestK8sClient_ListReflectsCreate would
-// pass even if K8sClient regressed to a direct API read.
-func startEnvtest(t *testing.T) *envtestEnv {
+// The helper also applies the folder/org-only CEL admission policies
+// from config/admission/ once per process and waits for the policy
+// this suite depends on (templatepolicybinding-folder-or-org-only) to
+// be registered so the admission-rejection regression does not race
+// the CEL compiler.
+func newEnvtestK8sClient(t *testing.T) (*crdmgrtesting.Env, *K8sClient) {
 	t.Helper()
-
-	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
-		if assets := detectEnvtestAssets(); assets != "" {
-			t.Setenv("KUBEBUILDER_ASSETS", assets)
-		} else {
-			t.Skip("envtest binaries not found; run `setup-envtest use` to download")
-		}
-	}
-
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		t.Fatalf("finding repo root: %v", err)
-	}
-
-	e := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd")},
-		ErrorIfCRDPathMissing: true,
-	}
-	cfg, err := e.Start()
-	if err != nil {
-		t.Fatalf("starting envtest: %v", err)
-	}
-	t.Cleanup(func() {
-		if stopErr := e.Stop(); stopErr != nil {
-			t.Logf("stopping envtest: %v", stopErr)
-		}
+	env := crdmgrtesting.StartManager(t, crdmgrtesting.Options{
+		Scheme:                   testScheme(t),
+		InformerObjects:          []ctrlclient.Object{&templatesv1alpha1.TemplatePolicyBinding{}},
+		WaitForAdmissionPolicies: []string{"templatepolicybinding-folder-or-org-only"},
 	})
-
-	scheme := testScheme(t)
-
-	// Uncached client for test setup (namespace Create, seed-write, etc.).
-	direct, err := ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
-	if err != nil {
-		t.Fatalf("constructing direct client: %v", err)
+	if env == nil {
+		t.SkipNow()
 	}
-
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-		HealthProbeBindAddress: "0",
-	})
-	if err != nil {
-		t.Fatalf("constructing manager: %v", err)
-	}
-
-	// Prime the TemplatePolicyBinding informer so the cache has the watch
-	// registered before the manager starts. Without this, the first List
-	// through the cache-backed client lazily registers the informer and
-	// may race the test write.
-	if _, err := mgr.GetCache().GetInformer(context.Background(), &templatesv1alpha1.TemplatePolicyBinding{}); err != nil {
-		t.Fatalf("priming TemplatePolicyBinding informer: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- mgr.Start(ctx)
-	}()
-
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer waitCancel()
-	if !mgr.GetCache().WaitForCacheSync(waitCtx) {
-		cancel()
-		t.Fatalf("manager cache did not sync within deadline")
-	}
-
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case err := <-errCh:
-			if err != nil && !errors.Is(err, context.Canceled) {
-				t.Logf("manager exit: %v", err)
-			}
-		case <-time.After(10 * time.Second):
-			t.Logf("manager did not shut down within deadline")
-		}
-	})
-
-	core, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		t.Fatalf("constructing core client: %v", err)
-	}
-
-	// envtest has no built-in ValidatingAdmissionPolicy installer — the VAP
-	// manifests live in config/admission/ and must be applied through the
-	// generic client after Start() returns. This keeps the
-	// TestCreateBindingRejectedByAdmissionInProjectNamespace regression in
-	// lockstep with the production policy surface.
-	ctx2 := context.Background()
-	if err := applyAdmissionYAMLFiles(ctx2, direct, filepath.Join(repoRoot, "config", "admission")); err != nil {
-		t.Fatalf("applying admission policies: %v", err)
-	}
-	// Wait for the VAP relevant to this package to be registered. envtest
-	// acknowledges the Create immediately; the apiserver's CEL compiler
-	// needs a tick to pick it up before the guard starts rejecting writes.
-	waitForAdmissionPolicy(t, ctx2, direct, "templatepolicybinding-folder-or-org-only")
-
-	return &envtestEnv{env: e, cfg: cfg, client: mgr.GetClient(), direct: direct, core: core}
-}
-
-// applyAdmissionYAMLFiles reads every *.yaml file in dir and applies each
-// ValidatingAdmissionPolicy / ValidatingAdmissionPolicyBinding document
-// through the controller-runtime client. Mirrors the helper used by
-// api/templates/v1alpha1/crd_test.go — duplicated here so this package does
-// not import the v1alpha1 test package (test packages cannot be imported).
-func applyAdmissionYAMLFiles(ctx context.Context, c ctrlclient.Client, dir string) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return fmt.Errorf("read dir: %w", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
-		if err != nil {
-			return fmt.Errorf("read %s: %w", e.Name(), err)
-		}
-		for _, doc := range splitYAMLDocuments(data) {
-			if len(strings.TrimSpace(string(doc))) == 0 {
-				continue
-			}
-			if err := applyAdmissionDoc(ctx, c, doc); err != nil {
-				return fmt.Errorf("apply doc from %s: %w", e.Name(), err)
-			}
-		}
-	}
-	return nil
-}
-
-func splitYAMLDocuments(data []byte) [][]byte {
-	var docs [][]byte
-	var current []byte
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(line) == "---" {
-			if len(current) > 0 {
-				docs = append(docs, current)
-			}
-			current = nil
-			continue
-		}
-		current = append(current, []byte(line+"\n")...)
-	}
-	if len(current) > 0 {
-		docs = append(docs, current)
-	}
-	return docs
-}
-
-func applyAdmissionDoc(ctx context.Context, c ctrlclient.Client, doc []byte) error {
-	kindProbe := struct {
-		Kind string `json:"kind"`
-	}{}
-	if err := yaml.Unmarshal(doc, &kindProbe); err != nil {
-		return fmt.Errorf("unmarshal kind: %w", err)
-	}
-	switch kindProbe.Kind {
-	case "ValidatingAdmissionPolicy":
-		policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-		if err := yaml.Unmarshal(doc, policy); err != nil {
-			return fmt.Errorf("unmarshal policy: %w", err)
-		}
-		if err := c.Create(ctx, policy); err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-		return nil
-	case "ValidatingAdmissionPolicyBinding":
-		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-		if err := yaml.Unmarshal(doc, binding); err != nil {
-			return fmt.Errorf("unmarshal binding: %w", err)
-		}
-		if err := c.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-		return nil
-	default:
-		return fmt.Errorf("unsupported admission kind %q", kindProbe.Kind)
-	}
-}
-
-// waitForAdmissionPolicy polls for a ValidatingAdmissionPolicy to be
-// registered with the API server. Mirrors the helper in crd_test.go.
-// Without this poll, the first Create race the apiserver's CEL compiler
-// and the test sees a false negative.
-func waitForAdmissionPolicy(t *testing.T, ctx context.Context, c ctrlclient.Client, name string) {
-	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
-		vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-		if err := c.Get(ctx, types.NamespacedName{Name: name}, vap); err == nil {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("admission policy %q not registered within deadline", name)
-}
-
-// newEnvtestK8sClient builds a K8sClient backed by an envtest API server.
-// The K8sClient receives the manager's cache-backed client so every Get /
-// List the CRUD tests exercise goes through the informer cache — the
-// HOL-662 acceptance criterion the suite regresses against. Writes go
-// straight to the API server (controller-runtime default), so the
-// create-then-list freshness test catches any regression where the
-// cache-backed read path is bypassed.
-func newEnvtestK8sClient(t *testing.T) (*envtestEnv, *K8sClient) {
-	t.Helper()
-	e := startEnvtest(t)
-	return e, NewK8sClient(e.client, newTestResolver())
+	return env, NewK8sClient(env.Client, newTestResolver())
 }
 
 // ensureNamespace creates a namespace if it does not already exist.
@@ -462,14 +241,14 @@ func TestListBindings(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ensureNamespace(t, e.direct, tc.namespace, v1alpha2.ResourceTypeFolder)
+			ensureNamespace(t, e.Direct, tc.namespace, v1alpha2.ResourceTypeFolder)
 			for _, b := range tc.seed {
-				ensureNamespace(t, e.direct, b.Namespace, v1alpha2.ResourceTypeFolder)
-				if err := e.direct.Create(context.Background(), b); err != nil {
+				ensureNamespace(t, e.Direct, b.Namespace, v1alpha2.ResourceTypeFolder)
+				if err := e.Direct.Create(context.Background(), b); err != nil {
 					t.Fatalf("seed create: %v", err)
 				}
 				t.Cleanup(func() {
-					_ = e.direct.Delete(context.Background(), b)
+					_ = e.Direct.Delete(context.Background(), b)
 				})
 			}
 
@@ -490,7 +269,7 @@ func TestGetBinding(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-get"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	seed := &templatesv1alpha1.TemplatePolicyBinding{
 		ObjectMeta: metav1.ObjectMeta{Name: "bind-a", Namespace: ns},
@@ -509,7 +288,7 @@ func TestGetBinding(t *testing.T) {
 			},
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	_ = eventuallyGetBinding(t, k, ns, "bind-a")
@@ -552,7 +331,7 @@ func TestCreateBinding(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-create"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	cases := []struct {
 		name         string
@@ -607,7 +386,7 @@ func TestCreateBinding(t *testing.T) {
 
 			// Read-your-own-write via direct client Get.
 			read := &templatesv1alpha1.TemplatePolicyBinding{}
-			if err := e.direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: tc.resourceName}, read); err != nil {
+			if err := e.Direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: tc.resourceName}, read); err != nil {
 				t.Fatalf("Get after Create: %v", err)
 			}
 			if read.Spec.DisplayName != tc.displayName {
@@ -627,7 +406,7 @@ func TestUpdateBinding(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-update"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	seed := &templatesv1alpha1.TemplatePolicyBinding{
 		ObjectMeta: metav1.ObjectMeta{Name: "bind", Namespace: ns},
@@ -646,7 +425,7 @@ func TestUpdateBinding(t *testing.T) {
 			},
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	// UpdateBinding internally calls GetBinding via the cache-backed
@@ -725,7 +504,7 @@ func TestDeleteBinding(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-delete"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	seed := &templatesv1alpha1.TemplatePolicyBinding{
 		ObjectMeta: metav1.ObjectMeta{Name: "goner", Namespace: ns},
@@ -743,7 +522,7 @@ func TestDeleteBinding(t *testing.T) {
 			},
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	_ = eventuallyGetBinding(t, k, ns, "goner")
@@ -752,7 +531,7 @@ func TestDeleteBinding(t *testing.T) {
 		t.Fatalf("DeleteBinding: %v", err)
 	}
 	read := &templatesv1alpha1.TemplatePolicyBinding{}
-	err := e.direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "goner"}, read)
+	err := e.Direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "goner"}, read)
 	if err == nil {
 		t.Fatal("expected NotFound after delete")
 	}
@@ -780,7 +559,7 @@ func TestK8sClient_ListReflectsCreate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-fld-cache"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeFolder)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeFolder)
 
 	if _, err := k.CreateBinding(
 		context.Background(), ns, "fresh", "Fresh", "", "creator@example.com",
@@ -818,7 +597,7 @@ func TestCreateBindingRejectedByAdmissionInProjectNamespace(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "holos-prj-billing-web"
-	ensureNamespace(t, e.direct, ns, v1alpha2.ResourceTypeProject)
+	ensureNamespace(t, e.Direct, ns, v1alpha2.ResourceTypeProject)
 
 	_, err := k.CreateBinding(
 		context.Background(), ns, "binding-test", "Test", "", "creator@example.com",
@@ -883,54 +662,6 @@ func TestPackageDoesNotCallProjectNamespace(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("package must not call %s — found in: %v", target, matches)
-	}
-}
-
-// ------------------------------------------------------------------------
-// envtest helpers — detectEnvtestAssets + findRepoRoot mirror the copies
-// in console/templates/k8s_test.go. HOL-663 will extract a shared helper.
-// ------------------------------------------------------------------------
-
-func detectEnvtestAssets() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	base := filepath.Join(home, ".local", "share", "kubebuilder-envtest", "k8s")
-	entries, err := os.ReadDir(base)
-	if err != nil {
-		return ""
-	}
-	var best string
-	for _, en := range entries {
-		if !en.IsDir() {
-			continue
-		}
-		cand := filepath.Join(base, en.Name())
-		if _, err := os.Stat(filepath.Join(cand, "kube-apiserver")); err == nil {
-			if best == "" || en.Name() > filepath.Base(best) {
-				best = cand
-			}
-		}
-	}
-	return best
-}
-
-func findRepoRoot() (string, error) {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", errors.New("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("no go.mod above %q", file)
-		}
-		dir = parent
 	}
 }
 

--- a/console/templatepolicybindings/main_test.go
+++ b/console/templatepolicybindings/main_test.go
@@ -10,10 +10,14 @@ import (
 	"os"
 	"testing"
 
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
 	"github.com/holos-run/holos-console/console/scopeshim"
 )
 
 func TestMain(m *testing.M) {
 	scopeshim.SetDefaultResolver(newTestResolver())
-	os.Exit(m.Run())
+	// Wrap m.Run through crdmgrtesting.RunTestsWithSharedEnv so the
+	// process-singleton envtest Environment is Stop()'d after the last
+	// test in this package runs.
+	os.Exit(crdmgrtesting.RunTestsWithSharedEnv(m))
 }

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -1,28 +1,22 @@
 // k8s_test.go exercises the HOL-661 rewrite of the Template CRUD surface
-// against the Template CRD. The tests run inline-envtest style: each test
-// starts its own envtest.Environment with the templates.holos.run CRDs
-// installed (shared-envtest extraction is the HOL-663 follow-up), builds a
-// K8sClient backed by a direct controller-runtime client, and exercises one
-// CRUD operation table-driven.
+// against the Template CRD. Each CRUD test builds a K8sClient against a
+// cache-backed controller-runtime client backed by the shared envtest
+// bootstrap in console/crdmgr/testing (extracted in HOL-663), and
+// exercises one operation table-driven.
 //
 // Cache freshness is covered by TestK8sClient_ListReflectsCreate, which
 // creates a Template and asserts a subsequent List reflects it within the
-// resync window. The remaining fake-client tests (ListEffectiveTemplateSources,
-// LinkedTemplatesAnnotation) continue to run against a fake
-// controller-runtime client because their inputs are still expressed as
-// ConfigMap fixtures and the bridge in testhelpers_test.go materializes
-// them into CRs — this keeps HOL-661's blast radius inside k8s.go and
-// k8s_test.go while the surrounding packages wait for HOL-662/HOL-663.
+// resync window. The remaining fake-client tests
+// (ListEffectiveTemplateSources, LinkedTemplatesAnnotation) continue to run
+// against a fake controller-runtime client because their inputs are still
+// expressed as ConfigMap fixtures and the bridge in testhelpers_test.go
+// materializes them into CRs.
 package templates
 
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -30,16 +24,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
 	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/scopeshim"
@@ -155,143 +145,26 @@ func boolStr(b bool) string {
 	return "false"
 }
 
-// envtestEnv wraps an envtest.Environment + direct client + rest config so
-// every CRUD test spins up its own isolated API server. One Environment per
-// test keeps tests independent when they need custom resolver settings or
-// different CRD fixtures — the shared-env helper comes in HOL-663.
-type envtestEnv struct {
-	env    *envtest.Environment
-	cfg    *rest.Config
-	client ctrlclient.Client // cache-backed delegating client from the manager
-	direct ctrlclient.Client // uncached client (API-server round-trip) for setup
-	core   kubernetes.Interface
-}
-
-// startEnvtest boots envtest with the templates.holos.run CRDs installed and
-// returns a cache-backed controller-runtime client + an uncached client for
-// setup plus a client-go Interface. Skips (does not fail) when envtest
-// binaries are not installed so developers without `setup-envtest use` can
-// still run `go test ./...`.
-//
-// Using the manager's cache-backed client is load-bearing for the HOL-661
-// acceptance criterion that Template reads go through the informer cache —
-// without it, TestK8sClient_ListReflectsCreate would pass even if K8sClient
-// regressed to a direct API read. The manager is started with the Template
-// scheme so its cache is populated via a watch on Templates.
-func startEnvtest(t *testing.T) *envtestEnv {
-	t.Helper()
-
-	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
-		if assets := detectEnvtestAssets(); assets != "" {
-			t.Setenv("KUBEBUILDER_ASSETS", assets)
-		} else {
-			t.Skip("envtest binaries not found; run `setup-envtest use` to download")
-		}
-	}
-
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		t.Fatalf("finding repo root: %v", err)
-	}
-
-	e := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd")},
-		ErrorIfCRDPathMissing: true,
-	}
-	cfg, err := e.Start()
-	if err != nil {
-		t.Fatalf("starting envtest: %v", err)
-	}
-	t.Cleanup(func() {
-		if stopErr := e.Stop(); stopErr != nil {
-			t.Logf("stopping envtest: %v", stopErr)
-		}
-	})
-
-	scheme := testScheme(t)
-
-	// Uncached client for test setup (namespace Create, seed-write, etc.).
-	// Using the cache for setup would need Eventually-wrapped waits on every
-	// seed write, which tangles the test body — keep setup strict-read/write
-	// against the API server and reserve the cache client for the
-	// under-test K8sClient.
-	direct, err := ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
-	if err != nil {
-		t.Fatalf("constructing direct client: %v", err)
-	}
-
-	// Cache-backed delegating client: writes go to the API server, reads
-	// come from the informer cache. Mirrors the production wiring in
-	// console.go where K8sClient receives mgr.GetClient().
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // disable metrics listener in tests
-		},
-		HealthProbeBindAddress: "0", // disable readiness listener
-	})
-	if err != nil {
-		t.Fatalf("constructing manager: %v", err)
-	}
-
-	// Prime the Template informer so the cache has the watch registered
-	// before we start the manager. Without this, the first List through the
-	// cache-backed client lazily registers the informer and may race the
-	// test write.
-	if _, err := mgr.GetCache().GetInformer(context.Background(), &templatesv1alpha1.Template{}); err != nil {
-		t.Fatalf("priming Template informer: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- mgr.Start(ctx)
-	}()
-
-	// Wait for the cache to sync before returning — every test that reads
-	// through K8sClient expects a hot cache. A manager that fails to sync
-	// inside the deadline indicates a broken CRD install or scheme
-	// mismatch, so abort loudly rather than let tests time out on List.
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer waitCancel()
-	if !mgr.GetCache().WaitForCacheSync(waitCtx) {
-		cancel()
-		t.Fatalf("manager cache did not sync within deadline")
-	}
-
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case err := <-errCh:
-			if err != nil && !errors.Is(err, context.Canceled) {
-				t.Logf("manager exit: %v", err)
-			}
-		case <-time.After(10 * time.Second):
-			t.Logf("manager did not shut down within deadline")
-		}
-	})
-
-	core, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		t.Fatalf("constructing core client: %v", err)
-	}
-	return &envtestEnv{env: e, cfg: cfg, client: mgr.GetClient(), direct: direct, core: core}
-}
-
-// newEnvtestK8sClient builds a K8sClient backed by an envtest API server.
-// The K8sClient receives the manager's cache-backed client so every Get /
-// List the CRUD tests exercise goes through the informer cache — the
-// HOL-661 acceptance criterion the suite is supposed to regress against.
-// Writes go straight to the API server (controller-runtime default), so
-// the create-then-list freshness test catches any regression where the
+// newEnvtestK8sClient builds a K8sClient backed by the shared envtest
+// bootstrap in console/crdmgr/testing. The K8sClient receives the
+// manager's cache-backed client so every Get / List the CRUD tests
+// exercise goes through the informer cache — the HOL-661 acceptance
+// criterion the suite is supposed to regress against. Writes go
+// straight to the API server (controller-runtime default), so the
+// create-then-list freshness test catches any regression where the
 // cache-backed read path is bypassed.
-func newEnvtestK8sClient(t *testing.T) (*envtestEnv, *K8sClient) {
+func newEnvtestK8sClient(t *testing.T) (*crdmgrtesting.Env, *K8sClient) {
 	t.Helper()
-	e := startEnvtest(t)
-	// K8sClient receives the manager's cache-backed client so Get/List
-	// exercise the informer cache path; writes (Create/Update/Delete) flow
-	// through the same delegating client straight to the API server.
-	return e, NewK8sClient(e.core, e.client, testResolver())
+	env := crdmgrtesting.StartManager(t, crdmgrtesting.Options{
+		Scheme:          testScheme(t),
+		InformerObjects: []ctrlclient.Object{&templatesv1alpha1.Template{}},
+	})
+	if env == nil {
+		// Helper called t.Skip because envtest binaries are missing;
+		// propagate the skip to the caller.
+		t.SkipNow()
+	}
+	return env, NewK8sClient(env.Core, env.Client, testResolver())
 }
 
 // ensureNamespace creates a namespace if it does not already exist.
@@ -391,14 +264,14 @@ func TestListTemplates(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ensureNamespace(t, e.direct, tc.namespace)
+			ensureNamespace(t, e.Direct, tc.namespace)
 			for _, tmpl := range tc.seed {
-				ensureNamespace(t, e.direct, tmpl.Namespace)
-				if err := e.direct.Create(context.Background(), tmpl); err != nil {
+				ensureNamespace(t, e.Direct, tmpl.Namespace)
+				if err := e.Direct.Create(context.Background(), tmpl); err != nil {
 					t.Fatalf("seed create: %v", err)
 				}
 				t.Cleanup(func() {
-					_ = e.direct.Delete(context.Background(), tmpl)
+					_ = e.Direct.Delete(context.Background(), tmpl)
 				})
 			}
 
@@ -423,7 +296,7 @@ func TestGetTemplate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "prj-get"
-	ensureNamespace(t, e.direct, ns)
+	ensureNamespace(t, e.Direct, ns)
 
 	seed := &templatesv1alpha1.Template{
 		ObjectMeta: metav1.ObjectMeta{Name: "web-app", Namespace: ns},
@@ -434,7 +307,7 @@ func TestGetTemplate(t *testing.T) {
 			Enabled:     true,
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	// Wait for the cache to observe the seed before the first read so
@@ -479,7 +352,7 @@ func TestCreateTemplate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "prj-create"
-	ensureNamespace(t, e.direct, ns)
+	ensureNamespace(t, e.Direct, ns)
 
 	cases := []struct {
 		name            string
@@ -533,7 +406,7 @@ func TestCreateTemplate(t *testing.T) {
 
 			// Read-your-own-write via direct client Get.
 			read := &templatesv1alpha1.Template{}
-			if err := e.direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: tc.resourceName}, read); err != nil {
+			if err := e.Direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: tc.resourceName}, read); err != nil {
 				t.Fatalf("Get after Create: %v", err)
 			}
 			if read.Spec.DisplayName != tc.displayName {
@@ -556,7 +429,7 @@ func TestUpdateTemplate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "prj-update"
-	ensureNamespace(t, e.direct, ns)
+	ensureNamespace(t, e.Direct, ns)
 
 	seed := &templatesv1alpha1.Template{
 		ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: ns},
@@ -564,7 +437,7 @@ func TestUpdateTemplate(t *testing.T) {
 			DisplayName: "Before", Description: "before-desc", CueTemplate: "package holos\n",
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	// UpdateTemplate internally calls GetTemplate via the cache-backed
@@ -596,7 +469,7 @@ func TestDeleteTemplate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "prj-delete"
-	ensureNamespace(t, e.direct, ns)
+	ensureNamespace(t, e.Direct, ns)
 
 	seed := &templatesv1alpha1.Template{
 		ObjectMeta: metav1.ObjectMeta{Name: "goner", Namespace: ns},
@@ -604,7 +477,7 @@ func TestDeleteTemplate(t *testing.T) {
 			DisplayName: "Goner", CueTemplate: "package holos\n",
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	// Delete does not read through the cache, but keeping a sync barrier
@@ -617,7 +490,7 @@ func TestDeleteTemplate(t *testing.T) {
 		t.Fatalf("DeleteTemplate: %v", err)
 	}
 	read := &templatesv1alpha1.Template{}
-	err := e.direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "goner"}, read)
+	err := e.Direct.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "goner"}, read)
 	if err == nil {
 		t.Fatal("expected NotFound after delete")
 	}
@@ -650,7 +523,7 @@ func TestK8sClient_ListReflectsCreate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "prj-cache"
-	ensureNamespace(t, e.direct, ns)
+	ensureNamespace(t, e.Direct, ns)
 
 	if _, err := k.CreateTemplate(
 		context.Background(), ns, "fresh", "Fresh", "", "package holos\n",
@@ -685,7 +558,7 @@ func TestCloneTemplate(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "prj-clone"
-	ensureNamespace(t, e.direct, ns)
+	ensureNamespace(t, e.Direct, ns)
 
 	seed := &templatesv1alpha1.Template{
 		ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: ns},
@@ -693,7 +566,7 @@ func TestCloneTemplate(t *testing.T) {
 			DisplayName: "Src", Description: "desc", CueTemplate: "package holos\nfoo: true\n", Enabled: true,
 		},
 	}
-	if err := e.direct.Create(context.Background(), seed); err != nil {
+	if err := e.Direct.Create(context.Background(), seed); err != nil {
 		t.Fatalf("seed create: %v", err)
 	}
 	// CloneTemplate calls GetTemplate on the source via the cache-backed
@@ -978,7 +851,7 @@ func TestLinkedTemplatesAnnotation(t *testing.T) {
 
 	ns := "prj-links"
 	ctx := context.Background()
-	ensureNamespace(t, e.direct, ns)
+	ensureNamespace(t, e.Direct, ns)
 
 	t.Run("CreateTemplate stores linked refs in spec", func(t *testing.T) {
 		linked := []*consolev1.LinkedTemplateRef{
@@ -1044,56 +917,6 @@ func TestDefaultsJSONRoundTrip(t *testing.T) {
 	}
 	if tmpl.Spec.Defaults.Image != "ghcr.io/app" {
 		t.Errorf("image=%q want ghcr.io/app", tmpl.Spec.Defaults.Image)
-	}
-}
-
-// ------------------------------------------------------------------------
-// envtest helpers — detectEnvtestAssets + findRepoRoot mirror the copies in
-// internal/controller/suite_test.go and api/templates/v1alpha1/crd_test.go.
-// HOL-663 will extract a shared helper; for now we duplicate so the
-// templates package has zero test-only dependency on the other suites.
-// ------------------------------------------------------------------------
-
-func detectEnvtestAssets() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	base := filepath.Join(home, ".local", "share", "kubebuilder-envtest", "k8s")
-	entries, err := os.ReadDir(base)
-	if err != nil {
-		return ""
-	}
-	var best string
-	for _, en := range entries {
-		if !en.IsDir() {
-			continue
-		}
-		cand := filepath.Join(base, en.Name())
-		if _, err := os.Stat(filepath.Join(cand, "kube-apiserver")); err == nil {
-			if best == "" || en.Name() > filepath.Base(best) {
-				best = cand
-			}
-		}
-	}
-	return best
-}
-
-func findRepoRoot() (string, error) {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", errors.New("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("no go.mod above %q", file)
-		}
-		dir = parent
 	}
 }
 

--- a/console/templates/main_test.go
+++ b/console/templates/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"testing"
 
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/scopeshim"
 )
@@ -22,5 +23,10 @@ func TestMain(m *testing.M) {
 		FolderPrefix:       "fld-",
 		ProjectPrefix:      "prj-",
 	})
-	os.Exit(m.Run())
+	// Wrap m.Run through crdmgrtesting.RunTestsWithSharedEnv so the
+	// process-singleton envtest Environment is Stop()'d after the last
+	// test in this package, rather than being reaped on os.Exit and
+	// leaving kube-apiserver/etcd subprocesses behind for a long-enough
+	// `go test` shutdown to race.
+	os.Exit(crdmgrtesting.RunTestsWithSharedEnv(m))
 }


### PR DESCRIPTION
## Summary

Final phase of HOL-621. Three cleanup concerns:

1. Extracts the inline envtest bootstrap duplicated across three CRD storage suites into a shared helper at `console/crdmgr/testing/`. One apiserver process per test binary (nested `sync.Once`) instead of three; one drift site instead of three.
2. Sharpens the wiring comment in `console/console.go` around the `templates.NewK8sClient` call so the HOL-621 / HOL-661 invariant (non-nil `k8sClientset` implies non-nil `controllerMgr`) and the rationale for retaining `kubernetes.Interface` (Release CRUD until HOL-615 Phase 6) are visible at the call site. No functional change — wiring was already correct from prior phases.
3. Sweeps the four stranded JSON-annotation constants from `api/v1alpha2/annotations.go` that CRD storage made dead: `AnnotationTemplatePolicyRules`, `AnnotationTemplatePolicyBindingPolicyRef`, `AnnotationTemplatePolicyBindingTargetRefs`. Regenerates `schema_gen.cue`. Migrates the HOL-582 regression guard in `console/projects/handler_test.go` off the dead annotation.

Fixes HOL-663

## Test plan

- [x] `go test ./console/crdmgr/testing/... ./console/templates/... ./console/templatepolicies/... ./console/templatepolicybindings/... ./console/projects/... ./console/deployments/...` — all pass
- [x] `go test ./...` — all pass
- [x] `make generate` — regenerates `api/v1alpha2/schema_gen.cue` deterministically
- [x] `make lint` — no new findings introduced; pre-existing lint issues unchanged

## Deferred Acceptance Criteria

- [ ] Ticket AC lists `ResourceTypeTemplate`, `ResourceTypeTemplatePolicy`, and `LabelResourceType` for removal. Grep evidence shows all three remain in heavy use as CRD labels and VAP matchers — they are NOT dead. They stay alive until a future sweep removes `LabelResourceType` from the CRD label setters. Flagging as a gap because the ticket's literal removal list cannot be fully satisfied.
- [ ] Ticket AC proposes deleting `api/v1alpha2/annotations.go` and the `api/v1alpha2/` directory entirely. This is not possible: the file still declares ~40 live constants (namespace labels, org/folder/project/deployment labels, share-cascade annotations, hierarchy-walk anchors, and Release ConfigMap labels).
- [ ] Ticket AC calls for grep-zero on `legacy_shim` and `ProjectNamespaceError`. No source file of either name exists; remaining matches are intentional breadcrumb comments in `console/templates/{handler,k8s}.go` and `console/templatepolic{ies,ybindings}/{k8s,k8s_test}.go` explaining why the symbol was removed. Left in place as documentation.

## Notes

- `AnnotationLinkedTemplates` was initially pruned, then restored when `go build` revealed it is still the wire format used by the `templateCRDToConfigMap` adapter in `console/templates` to bridge CRD-stored Templates to the deployments handler's ConfigMap reader. Will drop out alongside the adapter when `deployments` is ported off ConfigMaps (HOL-615 Phase 6).
- Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)