### PR TITLE
chore(secret-injector): scaffold disjoint package tree and PROJECT entries

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -41,4 +41,29 @@ resources:
   kind: TemplatePolicyBinding
   path: github.com/holos-run/holos-console/api/templates/v1alpha1
   version: v1alpha1
+# The secrets.holos.run entries below are M0 placeholders scaffolded by
+# HOL-687. The exact kinds and scope land in M1; ADR 031 locks the group
+# name, version, and the "CRs carry refs, not material" guardrail that the
+# M1 types will enforce. Placeholder kinds: Secret and SecretBinding (per
+# HOL-687 acceptance criteria). Printer columns and the precise scope
+# follow the HOL-615 conventions (Ready/Generation/Age, plus ResolvedRefs
+# for kinds with cross-object references) once M1 lands.
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: holos.run
+  group: secrets
+  kind: Secret
+  path: github.com/holos-run/holos-console/api/secrets/v1alpha1
+  version: v1alpha1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: holos.run
+  group: secrets
+  kind: SecretBinding
+  path: github.com/holos-run/holos-console/api/secrets/v1alpha1
+  version: v1alpha1
 version: "3"

--- a/api/secrets/v1alpha1/groupversion_info.go
+++ b/api/secrets/v1alpha1/groupversion_info.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains API Schema definitions for the secrets.holos.run
+// v1alpha1 API group. See docs/adrs/031-secret-injection-service.md for the
+// architectural decisions behind this package — the group and version are
+// locked by ADR 031 §1 and mirror the api/templates/v1alpha1 layout.
+//
+// +kubebuilder:object:generate=true
+// +groupName=secrets.holos.run
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+var (
+	// GroupVersion is group version used to register these objects.
+	GroupVersion = schema.GroupVersion{Group: "secrets.holos.run", Version: "v1alpha1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)

--- a/internal/secretinjector/authz/doc.go
+++ b/internal/secretinjector/authz/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package authz hosts the ext_authz gRPC server for the holos-secret-injector
+// binary. The server runs as a manager.Runnable registered on the
+// controller-runtime manager so it shares the reconcilers' cache, lifecycle,
+// and readiness gate. See docs/adrs/031-secret-injection-service.md §2 for
+// the rationale. Nothing under this tree imports internal/controller/... and
+// vice versa.
+package authz

--- a/internal/secretinjector/cli/doc.go
+++ b/internal/secretinjector/cli/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cli wires the Cobra command tree for the holos-secret-injector
+// binary. See docs/adrs/031-secret-injection-service.md for the architectural
+// boundary: this package is the entry-point wiring that cmd/secret-injector
+// imports in the binary-split phase (HOL-688). Nothing under this tree imports
+// internal/controller/... and vice versa.
+package cli

--- a/internal/secretinjector/config/doc.go
+++ b/internal/secretinjector/config/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config carries typed configuration for the holos-secret-injector
+// binary — flags, environment bindings, and validated runtime settings
+// consumed by cli, controller, and authz. See
+// docs/adrs/031-secret-injection-service.md. Nothing under this tree imports
+// internal/controller/... and vice versa.
+package config

--- a/internal/secretinjector/controller/doc.go
+++ b/internal/secretinjector/controller/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller hosts the controller-runtime reconcilers for the
+// secrets.holos.run/v1alpha1 API group owned by the holos-secret-injector
+// binary. See docs/adrs/031-secret-injection-service.md. One reconciler per
+// kind lands here under M1; this file scaffolds the package so subsequent
+// phases can land types and reconcilers without tree churn. Nothing under
+// this tree imports internal/controller/... and vice versa.
+package controller


### PR DESCRIPTION
## Summary

- Create empty `package <name>` shells under `internal/secretinjector/{cli,controller,authz,config}/` so the binary-split phase (HOL-688) is a pure wiring move, not a tree-churn + behavior combination.
- Add `api/secrets/v1alpha1/groupversion_info.go` mirroring `api/templates/v1alpha1/groupversion_info.go` — `+kubebuilder:object:generate=true`, `+groupName=secrets.holos.run`, and the standard `GroupVersion` / `SchemeBuilder` / `AddToScheme` triple. Group and version are locked by ADR 031 §1.
- Append two placeholder `resources:` entries to `PROJECT` for `secrets.holos.run/Secret` and `secrets.holos.run/SecretBinding`, with a header comment noting they are M0 placeholders and that M1 finalises scope / printer columns per HOL-615 conventions.
- Every new file carries the Apache 2.0 header used elsewhere in the repo.
- Nothing under `internal/secretinjector/` imports `internal/controller/...` and vice versa (verified by grep; depguard rule lands once both trees have content, per the ticket AC).

No behavior changes. `go vet ./...` is clean, `make build` still produces `bin/holos-console`, `make test-go` passes with the new packages discovered as `[no test files]` (expected — M1 lands the types and their tests).

Fixes HOL-687

## Test plan

- [x] `go vet ./...` clean
- [x] `make build` produces `bin/holos-console`
- [x] `make test-go` passes with new packages listed
- [x] No `internal/controller` imports under `internal/secretinjector/` (grep)
- [x] No `internal/secretinjector` imports under `internal/controller/` (grep)

> Local E2E was not run; this change is Go-only scaffolding with no UI, OIDC, or RPC surface touched. E2E is not relevant per the step-12a decision table.

Generated with [Claude Code](https://claude.com/claude-code)