### PR TITLE
chore(repo): add CODEOWNERS with non-overlapping templates / injector boundaries (HOL-690)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,55 @@
+# CODEOWNERS for holos-console
+#
+# GitHub automatically requests review from the owners listed below when a pull
+# request modifies matching paths. See
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners
+# for the file format: `<glob> <owners...>`, and note that the LAST matching
+# rule wins.
+#
+# This file establishes non-overlapping ownership boundaries between the
+# templates/console code (the original holos-console product surface) and the
+# new secret-injector workload, per the HOL-674 M0 Foundation plan and
+# ADR-031. The smoke-test invariant is that a PR touching only
+# `api/templates/**` must request templates owners and NOT secret-injector
+# owners, and vice versa for `api/secrets/**` / `internal/secretinjector/**`.
+#
+# Team handles below are placeholders pending creation / confirmation of the
+# actual GitHub teams. See `HOL-690` for the human-action checklist.
+#
+#   @holos-run/templates-owners       — templates / console API, controller,
+#                                        cmd/holos-console, console-focused
+#                                        config, Dockerfile.console (+ symlink)
+#   @holos-run/secret-injector-owners — api/secrets, internal/secretinjector,
+#                                        cmd/secret-injector, config/secret-injector,
+#                                        Dockerfile.secret-injector
+#   @holos-run/frontend-owners        — frontend/**
+#   @holos-run/maintainers            — catch-all default owner
+#
+# Ordering note: later rules override earlier rules for the same path. The
+# catch-all MUST remain the first rule below so that the more specific path
+# rules that follow take precedence.
+
+# Default owner for anything not matched by a more specific rule (root files
+# like Makefile, go.mod, go.sum, README.md, LICENSE, etc.).
+* @holos-run/maintainers
+
+# --- Templates / console ownership -----------------------------------------
+/api/templates/ @holos-run/templates-owners
+/internal/controller/ @holos-run/templates-owners
+/cmd/holos-console/ @holos-run/templates-owners
+/config/crd/ @holos-run/templates-owners
+/config/rbac/ @holos-run/templates-owners
+/config/admission/ @holos-run/templates-owners
+/config/samples/ @holos-run/templates-owners
+/Dockerfile.console @holos-run/templates-owners
+/Dockerfile @holos-run/templates-owners
+
+# --- Secret-injector ownership ---------------------------------------------
+/api/secrets/ @holos-run/secret-injector-owners
+/internal/secretinjector/ @holos-run/secret-injector-owners
+/cmd/secret-injector/ @holos-run/secret-injector-owners
+/config/secret-injector/ @holos-run/secret-injector-owners
+/Dockerfile.secret-injector @holos-run/secret-injector-owners
+
+# --- Frontend ownership ----------------------------------------------------
+/frontend/ @holos-run/frontend-owners


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` establishing path-disjoint ownership between the templates/console subsystem and the new secret-injector workload (per ADR-031 and the HOL-674 M0 plan).
- Templates/console owners cover `api/templates/`, `internal/controller/`, `cmd/holos-console/`, `config/{crd,rbac,admission,samples}/`, `Dockerfile.console`, and the `Dockerfile` symlink.
- Secret-injector owners cover `api/secrets/`, `internal/secretinjector/`, `cmd/secret-injector/`, `config/secret-injector/`, and `Dockerfile.secret-injector`.
- Frontend owners cover `frontend/`.
- Catch-all `@holos-run/maintainers` rule is listed first so the more-specific rules below override it (GitHub's last-matching-rule-wins semantics).

Fixes HOL-690

## Human action required before merge

The ticket's implementation notes explicitly allow placeholder team handles because the implementing agent does not have authority to create GitHub teams. The following handles do NOT yet exist in the `holos-run` org and MUST either be created (Owner action) or rewritten to existing handles before merge so GitHub's CODEOWNERS validation passes:

- `@holos-run/templates-owners` — proposed new team covering console/templates maintainers
- `@holos-run/secret-injector-owners` — proposed new team covering secret-injector maintainers
- `@holos-run/frontend-owners` — proposed new team covering frontend maintainers

`@holos-run/maintainers` is already a real team and requires no action.

Current validation state (branch pushed, PR not yet merged):

```
gh api "repos/holos-run/holos-console/codeowners/errors?ref=feat/hol-690-add-codeowners-templates-injector-boundaries"
```

returns 15 `Unknown owner` errors, one per placeholder usage. These will resolve to `errors: []` once the three teams above are created in the org (or the handles are rewritten in this file). See HOL-690 for the full checklist.

## Test plan

- [x] `.github/CODEOWNERS` exists.
- [x] Path globs are disjoint — manually traced; no path matches both a templates rule and a secret-injector rule.
- [x] Catch-all `* @holos-run/maintainers` is present as the first rule; all more-specific rules below it.
- [ ] `gh api repos/holos-run/holos-console/codeowners/errors --jq .errors` returns `[]` — **blocked on human creation of the three placeholder teams**; tracked in the Deferred ACs section below.
- [ ] Smoke test #1: draft PR touching only `api/templates/v1alpha1/template_types.go` requests templates owners only — **blocked on team creation**; once teams exist, a reviewer can open a throwaway draft PR to confirm.
- [ ] Smoke test #2: draft PR touching only `internal/secretinjector/controller/doc.go` requests secret-injector owners only — **blocked on team creation**; same as above.

## Deferred Acceptance Criteria

- [ ] `codeowners/errors` returns `[]` — requires the three GitHub teams (`templates-owners`, `secret-injector-owners`, `frontend-owners`) to be created in the `holos-run` org by an org Owner, or the handles in `.github/CODEOWNERS` to be rewritten to existing teams/users, before this validates cleanly. The implementing agent does not have `admin:org` scope.
- [ ] Smoke-test PRs verifying disjoint review-request routing — depends on the teams existing and having write access to the repo so GitHub actually routes review requests to them.

## Notes

- The rules use path prefixes with trailing `/` (e.g., `/api/templates/`) which GitHub treats as recursive matches equivalent to `/api/templates/**`. This matches the AC phrasing and GitHub's documented semantics.
- No code, tests, or generated artifacts changed; `.github/CODEOWNERS` is the only file touched.

Generated with [Claude Code](https://claude.com/claude-code)