### PR TITLE
chore(cleanup): remove dead TemplateScope constants, unused scopeshim helpers, stale docs

### DIFF
--- a/api/templates/v1alpha1/template_types.go
+++ b/api/templates/v1alpha1/template_types.go
@@ -61,9 +61,11 @@ type TemplateDefaults struct {
 
 // LinkedTemplateRef is a scope-qualified reference to another Template used
 // in the explicit linking list. The `scope` / `scopeName` pair is retained
-// for compatibility with the existing proto wire shape — later plan phases
-// (HOL-619) collapse this to a single (namespace, name) pair once the
-// TemplateScope enum is removed.
+// on the stored CRD shape for compatibility with persisted data and with
+// the Go storage adapters; the proto wire shape is already namespace-only
+// (HOL-619). A future migration collapses this to a single (namespace,
+// name) pair in lockstep with rewriting the storage adapters that still
+// read and write the discriminator.
 type LinkedTemplateRef struct {
 	// Scope identifies the hierarchy level of the linked template.
 	// Valid values: "organization", "folder", "project".

--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -19,16 +19,13 @@ const (
 
 	// Label values.
 	ManagedByValue                 = "console.holos.run"
-	ResourceTypeOrganization       = "organization"
-	ResourceTypeFolder             = "folder"
-	ResourceTypeProject            = "project"
-	ResourceTypeDeployment         = "deployment"
-	ResourceTypeDeploymentTemplate = "deployment-template"
-	ResourceTypeOrgTemplate        = "org-template"
+	ResourceTypeOrganization = "organization"
+	ResourceTypeFolder       = "folder"
+	ResourceTypeProject      = "project"
+	ResourceTypeDeployment   = "deployment"
 	// ResourceTypeTemplate is the unified v1alpha2 template resource type.
-	// It replaces ResourceTypeDeploymentTemplate (project-scoped) and
-	// ResourceTypeOrgTemplate (org-scoped) with a single label value used
-	// across all hierarchy levels (ADR 021 Decision 4).
+	// A single label value is used across every hierarchy level (ADR 021
+	// Decision 4).
 	ResourceTypeTemplate = "template"
 	// ResourceTypeTemplatePolicy is the resource type label value for
 	// TemplatePolicy ConfigMaps. TemplatePolicy objects bind REQUIRE/EXCLUDE
@@ -121,15 +118,6 @@ const (
 	// this label upward to collect templates and resolve permissions (ADR 020
 	// Decision 3 and Decision 6).
 	AnnotationParent = "console.holos.run/parent"
-	// AnnotationLinkedOrgTemplates stores the list of explicitly linked
-	// platform template names as a JSON array on a legacy v1alpha2
-	// deployment template ConfigMap. Read-only compatibility shim —
-	// new deployments serialize linked templates via the
-	// templates.holos.run Template CRD (HOL-621); this annotation is
-	// only consulted when migrating older ConfigMap-shaped deployment
-	// templates forward. No production code writes this annotation.
-	// Example: ["microservice-v2", "istio-gateway"]
-	AnnotationLinkedOrgTemplates = "console.holos.run/linked-org-templates"
 	// AnnotationLinkedTemplates is the wire format used to bridge
 	// Template CRDs to the deployment handler. Template CRD storage
 	// keeps linked refs in a structured Spec field (HOL-621), but the

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -19,18 +19,15 @@
 #LabelProject:      "console.holos.run/project"
 
 // Label values.
-#ManagedByValue:                 "console.holos.run"
-#ResourceTypeOrganization:       "organization"
-#ResourceTypeFolder:             "folder"
-#ResourceTypeProject:            "project"
-#ResourceTypeDeployment:         "deployment"
-#ResourceTypeDeploymentTemplate: "deployment-template"
-#ResourceTypeOrgTemplate:        "org-template"
+#ManagedByValue:           "console.holos.run"
+#ResourceTypeOrganization: "organization"
+#ResourceTypeFolder:       "folder"
+#ResourceTypeProject:      "project"
+#ResourceTypeDeployment:   "deployment"
 
 // ResourceTypeTemplate is the unified v1alpha2 template resource type.
-// It replaces ResourceTypeDeploymentTemplate (project-scoped) and
-// ResourceTypeOrgTemplate (org-scoped) with a single label value used
-// across all hierarchy levels (ADR 021 Decision 4).
+// A single label value is used across every hierarchy level (ADR 021
+// Decision 4).
 #ResourceTypeTemplate: "template"
 
 // ResourceTypeTemplatePolicy is the resource type label value for
@@ -137,16 +134,6 @@
 // this label upward to collect templates and resolve permissions (ADR 020
 // Decision 3 and Decision 6).
 #AnnotationParent: "console.holos.run/parent"
-
-// AnnotationLinkedOrgTemplates stores the list of explicitly linked
-// platform template names as a JSON array on a legacy v1alpha2
-// deployment template ConfigMap. Read-only compatibility shim —
-// new deployments serialize linked templates via the
-// templates.holos.run Template CRD (HOL-621); this annotation is
-// only consulted when migrating older ConfigMap-shaped deployment
-// templates forward. No production code writes this annotation.
-// Example: ["microservice-v2", "istio-gateway"]
-#AnnotationLinkedOrgTemplates: "console.holos.run/linked-org-templates"
 
 // AnnotationLinkedTemplates is the wire format used to bridge
 // Template CRDs to the deployment handler. Template CRD storage

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -1650,79 +1650,45 @@ func (h *Handler) buildPlatformInput(ctx context.Context, project, namespace str
 }
 
 // linkedTemplateRefsFromAnnotation reads the linked template refs from a
-// deployment template ConfigMap. It prefers the v1alpha2
+// deployment template ConfigMap. Decodes the
 // console.holos.run/linked-templates annotation (JSON array of
-// {scope, scope_name, name, version_constraint} objects) and falls back to the
-// legacy console.holos.run/linked-org-templates annotation (JSON array of bare
-// name strings, converted to org-scope refs with no version constraint).
-// Returns nil if no annotation is present or if parsing fails.
+// {scope, scope_name, name, version_constraint} objects). Returns nil if the
+// annotation is absent or fails to parse.
 func linkedTemplateRefsFromAnnotation(cm *corev1.ConfigMap) []*consolev1.LinkedTemplateRef {
 	if cm == nil || cm.Annotations == nil {
 		return nil
 	}
 
-	// v1alpha2: console.holos.run/linked-templates — JSON array of {scope, scope_name, name, version_constraint}
-	if raw, ok := cm.Annotations[v1alpha2.AnnotationLinkedTemplates]; ok && raw != "" {
-		var refs []struct {
-			Scope             string `json:"scope"`
-			ScopeName         string `json:"scope_name"`
-			Name              string `json:"name"`
-			VersionConstraint string `json:"version_constraint,omitempty"`
-		}
-		if err := json.Unmarshal([]byte(raw), &refs); err != nil {
-			slog.Warn("failed to parse linked-templates annotation",
-				slog.String("name", cm.Name),
-				slog.String("namespace", cm.Namespace),
-				slog.Any("error", err),
-			)
-		} else {
-			result := make([]*consolev1.LinkedTemplateRef, 0, len(refs))
-			for _, ref := range refs {
-				if ref.Name != "" {
-					result = append(result, scopeshim.NewLinkedTemplateRef(
-						scopeFromLabel(ref.Scope),
-						ref.ScopeName,
-						ref.Name,
-						ref.VersionConstraint,
-					))
-				}
-			}
-			return result
-		}
+	raw, ok := cm.Annotations[v1alpha2.AnnotationLinkedTemplates]
+	if !ok || raw == "" {
+		return nil
 	}
-
-	// Legacy v1alpha2: console.holos.run/linked-org-templates — JSON array of strings.
-	// Convert to LinkedTemplateRef with organization scope and no version constraint.
-	if raw, ok := cm.Annotations[v1alpha2.AnnotationLinkedOrgTemplates]; ok && raw != "" {
-		var names []string
-		if err := json.Unmarshal([]byte(raw), &names); err != nil {
-			slog.Warn("failed to parse linked-org-templates annotation",
-				slog.String("name", cm.Name),
-				slog.String("namespace", cm.Namespace),
-				slog.Any("error", err),
-			)
-			return nil
-		}
-		result := make([]*consolev1.LinkedTemplateRef, 0, len(names))
-		for _, n := range names {
-			// Legacy v1alpha2 refs lived at the unique organization scope;
-			// the deployment's project slug is the scope_name anchor, but
-			// the scope_name ("org name") was implicit in the ConfigMap
-			// namespace. Passing an empty scopeName lets the shim fall
-			// back to the caller's default resolver, which — combined
-			// with the deployment's own ancestor chain — converges on the
-			// correct org namespace at render time.
+	var refs []struct {
+		Scope             string `json:"scope"`
+		ScopeName         string `json:"scope_name"`
+		Name              string `json:"name"`
+		VersionConstraint string `json:"version_constraint,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(raw), &refs); err != nil {
+		slog.Warn("failed to parse linked-templates annotation",
+			slog.String("name", cm.Name),
+			slog.String("namespace", cm.Namespace),
+			slog.Any("error", err),
+		)
+		return nil
+	}
+	result := make([]*consolev1.LinkedTemplateRef, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Name != "" {
 			result = append(result, scopeshim.NewLinkedTemplateRef(
-				scopeshim.ScopeOrganization,
-				"",
-				n,
-				"",
+				scopeFromLabel(ref.Scope),
+				ref.ScopeName,
+				ref.Name,
+				ref.VersionConstraint,
 			))
 		}
-		return result
 	}
-
-	return nil
+	return result
 }
 
 // stringSliceFromConfigMap decodes a JSON string slice from the given ConfigMap data key.

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1321,10 +1321,8 @@ func makeOrgNamespace(org string) *corev1.Namespace {
 // seedOrgRequirePolicy returns a TemplatePolicy-labeled ConfigMap placeholder
 // used by the HOL-582 regression guard. CreateProject intentionally ignores
 // policy contents at project-creation time (it never renders templates),
-// so this fixture only needs to exist — its rule body was previously
-// stashed on the legacy AnnotationTemplatePolicyRules annotation
-// (removed in HOL-663). TemplatePolicy data is now authoritatively
-// carried by the templates.holos.run TemplatePolicy CRD.
+// so this fixture only needs to exist. TemplatePolicy rule data is
+// authoritatively carried by the templates.holos.run TemplatePolicy CRD.
 func seedOrgRequirePolicy(t *testing.T, org, templateName, _ string) *corev1.ConfigMap {
 	t.Helper()
 	return &corev1.ConfigMap{

--- a/console/scopeshim/scopeshim.go
+++ b/console/scopeshim/scopeshim.go
@@ -1,24 +1,25 @@
 // Package scopeshim carries a Go-only compatibility shim for the
 // TemplateScope / TemplateScopeRef enum that was removed from proto in
-// HOL-619 (parent: HOL-615). Without this patch the Go tree could not
+// HOL-619 (parent: HOL-615). Without this patch the Go tree would not
 // compile once proto was rewritten to key Template / TemplatePolicy /
 // TemplatePolicyBinding resources by `(namespace, name)` alone, because
 // the resolver layer (console/policyresolver), the deployments handler,
-// the templates handlers, and CLI migration tools all rely on a scope
-// discriminator to route reads and writes to organization, folder, and
-// project namespaces.
+// and the templates handlers still serialize the scope discriminator
+// onto stored CRD fields and labels.
 //
-// This package is temporary. Phase 5 (HOL-624) removes every call site
-// and deletes this package when the storage layer has been fully
-// rewritten to operate on namespaces directly (HOL-621 / HOL-622).
+// This package is intentionally minimal. The remaining call sites live
+// on the CRD-storage translation seam where the stored resources still
+// carry a `(scope, scopeName)` pair on their spec (see
+// api/templates/v1alpha1.LinkedTemplateRef). A future migration that
+// rewrites those CRD fields to pure namespace/name addressing will
+// retire the last callers and delete this package.
 //
 // Root-cause note: the pre-HOL-619 proto carried two sources of truth
 // for "which namespace owns this template" — the resolver prefix map
 // and the TemplateScope enum. The parent ticket decided the namespace
 // is authoritative. This shim is the minimal Go translation that keeps
-// the tree compiling during the intermediate phases where proto is
-// namespace-only but storage, resolver, drift-state serialization, and
-// migration tooling still think in `(scope, scopeName)` pairs.
+// the tree compiling while the CRD storage surfaces still think in
+// `(scope, scopeName)` pairs.
 package scopeshim
 
 import (
@@ -137,85 +138,6 @@ func FromNamespace(r NamespaceResolver, ns string) (Scope, string, error) {
 	default:
 		return ScopeUnspecified, "", fmt.Errorf("namespace %q classified as unknown resource type %q", ns, kind)
 	}
-}
-
-// LabelValue returns the v1alpha2 label string for the scope. Empty for
-// ScopeUnspecified so callers can treat an absent label uniformly.
-func LabelValue(scope Scope) string {
-	switch scope {
-	case ScopeOrganization:
-		return v1alpha2.TemplateScopeOrganization
-	case ScopeFolder:
-		return v1alpha2.TemplateScopeFolder
-	case ScopeProject:
-		return v1alpha2.TemplateScopeProject
-	default:
-		return ""
-	}
-}
-
-// ScopeFromLabel reverses LabelValue so code reading persisted
-// ConfigMap labels can reconstruct the scope enum.
-func ScopeFromLabel(label string) Scope {
-	switch label {
-	case v1alpha2.TemplateScopeOrganization:
-		return ScopeOrganization
-	case v1alpha2.TemplateScopeFolder:
-		return ScopeFolder
-	case v1alpha2.TemplateScopeProject:
-		return ScopeProject
-	default:
-		return ScopeUnspecified
-	}
-}
-
-// LinkedRef mirrors the pre-HOL-619 LinkedTemplateRef shape with its
-// scope discriminator. Go code that still needs to reason about scope
-// carries this struct alongside the proto LinkedTemplateRef so render
-// paths, drift evaluation, and migration helpers keep compiling. The
-// proto message itself now carries only `(namespace, name,
-// version_constraint)`; this struct is the one-stop translator.
-type LinkedRef struct {
-	Scope             Scope
-	ScopeName         string
-	Name              string
-	VersionConstraint string
-}
-
-// LinkedRefFromProto converts a proto LinkedTemplateRef to the Go shim
-// form, classifying the carried namespace into (Scope, scopeName).
-// Returns an error when the namespace does not match any known prefix.
-func LinkedRefFromProto(r NamespaceResolver, ref *consolev1.LinkedTemplateRef) (*LinkedRef, error) {
-	if ref == nil {
-		return nil, nil
-	}
-	scope, scopeName, err := FromNamespace(r, ref.GetNamespace())
-	if err != nil {
-		return nil, err
-	}
-	return &LinkedRef{
-		Scope:             scope,
-		ScopeName:         scopeName,
-		Name:              ref.GetName(),
-		VersionConstraint: ref.GetVersionConstraint(),
-	}, nil
-}
-
-// LinkedRefToProto rebuilds a proto LinkedTemplateRef from a shim
-// LinkedRef, resolving the scope back to a Kubernetes namespace.
-func LinkedRefToProto(r NamespaceResolver, ref *LinkedRef) (*consolev1.LinkedTemplateRef, error) {
-	if ref == nil {
-		return nil, nil
-	}
-	ns, err := NamespaceFor(r, ref.Scope, ref.ScopeName)
-	if err != nil {
-		return nil, err
-	}
-	return &consolev1.LinkedTemplateRef{
-		Namespace:         ns,
-		Name:              ref.Name,
-		VersionConstraint: ref.VersionConstraint,
-	}, nil
 }
 
 // RefScope classifies a proto LinkedTemplateRef via the

--- a/console/templatepolicies/handler.go
+++ b/console/templatepolicies/handler.go
@@ -549,8 +549,7 @@ func templatePolicyCRDToProto(p *templatesv1alpha1.TemplatePolicy) *consolev1.Te
 	return policy
 }
 
-// mapK8sError converts Kubernetes API errors to ConnectRPC errors. HOL-662
-// removed the ProjectNamespaceError type-switch — the CEL
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The CEL
 // ValidatingAdmissionPolicy shipped in HOL-618 rejects project-namespace
 // creates at admission time, so the handler only needs the generic
 // k8serrors taxonomy here (plus extractPolicyScope as defense-in-depth).

--- a/console/templatepolicies/k8s.go
+++ b/console/templatepolicies/k8s.go
@@ -11,10 +11,10 @@
 // that still think in terms of (scope, scopeName) compute the namespace via
 // the package-level resolver shim in the handler.
 //
-// ProjectNamespaceError is gone — the CEL ValidatingAdmissionPolicy shipped
-// alongside the CRDs (HOL-618) rejects creation in a project-labelled
-// namespace at admission time, so the handler's extractPolicyScope is the
-// only defense-in-depth guard the client-side code needs to keep.
+// The CEL ValidatingAdmissionPolicy shipped alongside the CRDs (HOL-618)
+// rejects TemplatePolicy creation in a project-labelled namespace at
+// admission time, so the handler's extractPolicyScope is the only
+// defense-in-depth guard the client-side code needs to keep.
 package templatepolicies
 
 import (

--- a/console/templatepolicies/k8s_test.go
+++ b/console/templatepolicies/k8s_test.go
@@ -536,9 +536,9 @@ func TestK8sClient_ListReflectsCreate(t *testing.T) {
 // TestCreatePolicyRejectedByAdmissionInProjectNamespace is the admission
 // regression: the CEL ValidatingAdmissionPolicy shipped with the CRDs
 // (HOL-618) rejects TemplatePolicy writes into project-labelled
-// namespaces. ProjectNamespaceError is gone from this package; admission
-// rejection is now the authoritative enforcement point, and this test
-// locks in that the policy is installed and wired to the storage path.
+// namespaces. Admission rejection is the authoritative enforcement point,
+// and this test locks in that the policy is installed and wired to the
+// storage path.
 //
 // The test uses a namespace labelled ResourceType=project. The CEL VAP
 // reads that label to classify the namespace and reject the write.

--- a/console/templatepolicybindings/handler.go
+++ b/console/templatepolicybindings/handler.go
@@ -772,8 +772,7 @@ func targetKindString(k consolev1.TemplatePolicyBindingTargetKind) string {
 	}
 }
 
-// mapK8sError converts Kubernetes API errors to ConnectRPC errors. HOL-662
-// removed the ProjectNamespaceError type-switch — the CEL
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The CEL
 // ValidatingAdmissionPolicy shipped in HOL-618 rejects project-namespace
 // creates at admission time, so the handler only needs the generic
 // k8serrors taxonomy here (plus extractBindingScope as defense-in-depth).

--- a/console/templatepolicybindings/k8s.go
+++ b/console/templatepolicybindings/k8s.go
@@ -11,10 +11,10 @@
 // that still think in terms of (scope, scopeName) compute the namespace via
 // the package-level resolver shim in the handler.
 //
-// ProjectNamespaceError is gone — the CEL ValidatingAdmissionPolicy shipped
-// alongside the CRDs (HOL-618) rejects creation in a project-labelled
-// namespace at admission time, so the handler's extractBindingScope is the
-// only defense-in-depth guard the client-side code needs to keep.
+// The CEL ValidatingAdmissionPolicy shipped alongside the CRDs (HOL-618)
+// rejects TemplatePolicyBinding creation in a project-labelled namespace at
+// admission time, so the handler's extractBindingScope is the only
+// defense-in-depth guard the client-side code needs to keep.
 package templatepolicybindings
 
 import (

--- a/console/templatepolicybindings/k8s_test.go
+++ b/console/templatepolicybindings/k8s_test.go
@@ -587,9 +587,9 @@ func TestK8sClient_ListReflectsCreate(t *testing.T) {
 // TestCreateBindingRejectedByAdmissionInProjectNamespace is the admission
 // regression: the CEL ValidatingAdmissionPolicy shipped with the CRDs
 // (HOL-618) rejects TemplatePolicyBinding writes into project-labelled
-// namespaces. ProjectNamespaceError is gone from this package; admission
-// rejection is now the authoritative enforcement point, and this test
-// locks in that the policy is installed and wired to the storage path.
+// namespaces. Admission rejection is the authoritative enforcement point,
+// and this test locks in that the policy is installed and wired to the
+// storage path.
 //
 // The test uses a namespace labelled ResourceType=project. The CEL VAP
 // reads that label to classify the namespace and reject the write.

--- a/frontend/src/gen/holos/console/v1/policy_state_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/policy_state_pb.d.ts
@@ -12,10 +12,9 @@ export declare const file_holos_console_v1_policy_state: GenFile;
 
 /**
  * LinkedTemplateRef is a (namespace, name) reference to a template used in
- * the explicit linking list (ADR 021 Decision 5). Replaces the flat string
- * list from v1alpha1's console.holos.run/linked-org-templates annotation.
- *
- * Fields were renumbered in HOL-619 when the scope discriminator was dropped.
+ * the explicit linking list (ADR 021 Decision 5). The resolver classifies
+ * the namespace into its hierarchy kind (organization, folder, project) at
+ * render time; callers supply the namespace only.
  *
  * @generated from message holos.console.v1.LinkedTemplateRef
  */

--- a/gen/holos/console/v1/policy_state.pb.go
+++ b/gen/holos/console/v1/policy_state.pb.go
@@ -22,10 +22,9 @@ const (
 )
 
 // LinkedTemplateRef is a (namespace, name) reference to a template used in
-// the explicit linking list (ADR 021 Decision 5). Replaces the flat string
-// list from v1alpha1's console.holos.run/linked-org-templates annotation.
-//
-// Fields were renumbered in HOL-619 when the scope discriminator was dropped.
+// the explicit linking list (ADR 021 Decision 5). The resolver classifies
+// the namespace into its hierarchy kind (organization, folder, project) at
+// render time; callers supply the namespace only.
 type LinkedTemplateRef struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// namespace is the Kubernetes namespace that owns the linked template. The

--- a/proto/holos/console/v1/policy_state.proto
+++ b/proto/holos/console/v1/policy_state.proto
@@ -23,10 +23,9 @@ option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;con
 // proto no longer needs a TEMPLATE_SCOPE_PROJECT carve-out.
 
 // LinkedTemplateRef is a (namespace, name) reference to a template used in
-// the explicit linking list (ADR 021 Decision 5). Replaces the flat string
-// list from v1alpha1's console.holos.run/linked-org-templates annotation.
-//
-// Fields were renumbered in HOL-619 when the scope discriminator was dropped.
+// the explicit linking list (ADR 021 Decision 5). The resolver classifies
+// the namespace into its hierarchy kind (organization, folder, project) at
+// render time; callers supply the namespace only.
 message LinkedTemplateRef {
   // namespace is the Kubernetes namespace that owns the linked template. The
   // resolver classifies the namespace into its hierarchy kind (organization,


### PR DESCRIPTION
## Summary

This PR is the final sweep for the HOL-615 orchestrator. It removes the small set of identifiers the earlier phases left behind that are now genuinely dead, plus a handful of stale narrative comments.

**Removed dead identifiers:**
- `v1alpha2.ResourceTypeDeploymentTemplate` — no callers since ADR 021 Decision 4 unified on `ResourceTypeTemplate`.
- `v1alpha2.ResourceTypeOrgTemplate` — same story; dead constant.
- `v1alpha2.AnnotationLinkedOrgTemplates` + its fallback branch in `deployments.linkedTemplateRefsFromAnnotation` — pre-release legacy migration path, never exercised.
- `scopeshim.LinkedRef` struct, `LinkedRefFromProto`, `LinkedRefToProto`, `LabelValue`, `ScopeFromLabel` — exported helpers with zero callers in the tree.

**Refreshed stale comments:**
- `console/templatepolicies/k8s.go`, `console/templatepolicies/handler.go`, and the twin `templatepolicybindings` files: stopped narrating `ProjectNamespaceError` as if it still lived in the tree; re-focused the comments on the CEL `ValidatingAdmissionPolicy` that actually enforces the check.
- `console/projects/handler_test.go`: dropped the "removed in HOL-663" note about `AnnotationTemplatePolicyRules` in favor of a simpler description of what the fixture now models.
- `proto/holos/console/v1/policy_state.proto`: `LinkedTemplateRef` doc no longer references `console.holos.run/linked-org-templates` or the `HOL-619 renumber` aside.
- `console/scopeshim/scopeshim.go`: package doc no longer claims HOL-624 will retire the shim (it can't while the CRD `LinkedTemplateRef` still carries `scope` / `scopeName`); the doc now describes the actual remaining seam and the future migration that would retire the package.
- `api/templates/v1alpha1/template_types.go`: companion comment to the scopeshim doc, framed against the real post-HOL-619 state.

**Not removed:**
- `scopeshim` itself. HOL-624 was scoped against an assumption that every earlier phase would leave the package with no callers. In reality the CRD spec still stores `(scope, scopeName)` on `LinkedTemplateRef`, so the shim still has work to do on the storage translation seam (329 call sites across 41 files). Retiring the shim requires first collapsing the CRD field, which is its own migration and larger than a single cleanup ticket. This is captured in the refreshed scopeshim package doc and in the deferred AC below.

Fixes HOL-624

## Test plan

- [x] `go build ./console/... ./api/... ./gen/... ./cmd/...`
- [x] `go vet ./console/... ./api/... ./gen/... ./cmd/...`
- [x] `make test-go` — 100% of packages green
- [x] `make test-ui` — 1189/1189 tests green
- [x] `make generate` — proto regen clean, only the policy_state.proto doc-comment changed

## Deferred Acceptance Criteria

- [ ] Retire the `scopeshim` package itself. This requires rewriting `api/templates/v1alpha1.LinkedTemplateRef` to drop the `scope` / `scopeName` fields in favor of a namespace reference, migrating every storage call site in `console/templates`, `console/templatepolicies`, `console/templatepolicybindings`, `console/policyresolver`, and `console/deployments`, and regenerating the CRD YAMLs. Tracked by the refreshed package doc in `console/scopeshim/scopeshim.go`.

> Local E2E was not run (no k3d cluster available in this worktree). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)