### PR TITLE
feat(frontend): consume server-configured namespace prefixes (HOL-722)

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -152,8 +152,18 @@ type OIDCConfig struct {
 
 // ConsoleConfig is the console configuration injected into the frontend
 // via window.__CONSOLE_CONFIG__.
+//
+// The four prefix fields mirror the Config fields of the same name so the
+// frontend can translate between logical resource names and Kubernetes
+// namespace names using the same layout the backend resolver uses (see
+// `console/resolver`). Per HOL-722 these are exposed unconditionally so
+// deployments that override the default prefixes see the UI match the server.
 type ConsoleConfig struct {
-	DevToolsEnabled bool `json:"devToolsEnabled"`
+	DevToolsEnabled    bool   `json:"devToolsEnabled"`
+	NamespacePrefix    string `json:"namespacePrefix"`
+	OrganizationPrefix string `json:"organizationPrefix"`
+	FolderPrefix       string `json:"folderPrefix"`
+	ProjectPrefix      string `json:"projectPrefix"`
 }
 
 // deriveRedirectURI derives the OIDC redirect URI from the console origin.
@@ -682,10 +692,17 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 	}
 
-	// Create console config for frontend injection
-	var consoleConfig *ConsoleConfig
-	if s.cfg.EnableDevTools {
-		consoleConfig = &ConsoleConfig{DevToolsEnabled: true}
+	// Create console config for frontend injection.
+	// The namespace prefixes are always injected so the frontend's
+	// scope-label helpers (see `frontend/src/lib/scope-labels.ts`) stay
+	// aligned with the server resolver even when an operator overrides the
+	// defaults (HOL-722). DevTools remains off by default.
+	consoleConfig := &ConsoleConfig{
+		DevToolsEnabled:    s.cfg.EnableDevTools,
+		NamespacePrefix:    s.cfg.NamespacePrefix,
+		OrganizationPrefix: s.cfg.OrganizationPrefix,
+		FolderPrefix:       s.cfg.FolderPrefix,
+		ProjectPrefix:      s.cfg.ProjectPrefix,
 	}
 
 	uiHandler := newUIHandler(uiContent, oidcConfig, consoleConfig)

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -80,14 +80,21 @@ func TestHandleUserInfo_Removed(t *testing.T) {
 
 func TestServeIndex_InjectsConsoleConfig(t *testing.T) {
 	// When ConsoleConfig is provided, serveIndex should inject
-	// window.__CONSOLE_CONFIG__ into the HTML <head>.
+	// window.__CONSOLE_CONFIG__ into the HTML <head>, including the namespace
+	// prefix fields the frontend uses for scope-label derivation (HOL-722).
 	fakeFS := fstest.MapFS{
 		"index.html": &fstest.MapFile{
 			Data: []byte(`<!DOCTYPE html><html><head></head><body></body></html>`),
 		},
 	}
 
-	consoleConfig := &ConsoleConfig{DevToolsEnabled: true}
+	consoleConfig := &ConsoleConfig{
+		DevToolsEnabled:    true,
+		NamespacePrefix:    "holos-",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
 	h := newUIHandler(fakeFS, nil, consoleConfig)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -95,8 +102,40 @@ func TestServeIndex_InjectsConsoleConfig(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	body := rec.Body.String()
-	if !strings.Contains(body, `window.__CONSOLE_CONFIG__={"devToolsEnabled":true}`) {
-		t.Errorf("expected console config injection in HTML, got:\n%s", body)
+	const want = `window.__CONSOLE_CONFIG__={"devToolsEnabled":true,"namespacePrefix":"holos-","organizationPrefix":"org-","folderPrefix":"fld-","projectPrefix":"prj-"}`
+	if !strings.Contains(body, want) {
+		t.Errorf("expected console config injection %q, got:\n%s", want, body)
+	}
+}
+
+func TestServeIndex_InjectsNonDefaultPrefixes(t *testing.T) {
+	// Operators can override the default namespace prefixes via CLI flags.
+	// The frontend's scope-label helpers source the live values through
+	// window.__CONSOLE_CONFIG__, so the server must emit whatever the
+	// operator configured (HOL-722).
+	fakeFS := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body></body></html>`),
+		},
+	}
+
+	consoleConfig := &ConsoleConfig{
+		DevToolsEnabled:    false,
+		NamespacePrefix:    "ci-",
+		OrganizationPrefix: "organization-",
+		FolderPrefix:       "folder-",
+		ProjectPrefix:      "project-",
+	}
+	h := newUIHandler(fakeFS, nil, consoleConfig)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	const want = `window.__CONSOLE_CONFIG__={"devToolsEnabled":false,"namespacePrefix":"ci-","organizationPrefix":"organization-","folderPrefix":"folder-","projectPrefix":"project-"}`
+	if !strings.Contains(body, want) {
+		t.Errorf("expected non-default prefix injection %q, got:\n%s", want, body)
 	}
 }
 
@@ -122,14 +161,21 @@ func TestServeIndex_NoConsoleConfig(t *testing.T) {
 }
 
 func TestServeIndex_ConsoleConfigDevToolsDisabled(t *testing.T) {
-	// When DevToolsEnabled is false, the injection should reflect that.
+	// When DevToolsEnabled is false, the injection should reflect that
+	// alongside the default namespace prefix fields.
 	fakeFS := fstest.MapFS{
 		"index.html": &fstest.MapFile{
 			Data: []byte(`<!DOCTYPE html><html><head></head><body></body></html>`),
 		},
 	}
 
-	consoleConfig := &ConsoleConfig{DevToolsEnabled: false}
+	consoleConfig := &ConsoleConfig{
+		DevToolsEnabled:    false,
+		NamespacePrefix:    "holos-",
+		OrganizationPrefix: "org-",
+		FolderPrefix:       "fld-",
+		ProjectPrefix:      "prj-",
+	}
 	h := newUIHandler(fakeFS, nil, consoleConfig)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -137,7 +183,7 @@ func TestServeIndex_ConsoleConfigDevToolsDisabled(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	body := rec.Body.String()
-	if !strings.Contains(body, `window.__CONSOLE_CONFIG__={"devToolsEnabled":false}`) {
+	if !strings.Contains(body, `"devToolsEnabled":false`) {
 		t.Errorf("expected devToolsEnabled:false in console config, got:\n%s", body)
 	}
 }

--- a/frontend/src/lib/console-config.ts
+++ b/frontend/src/lib/console-config.ts
@@ -1,21 +1,54 @@
 /**
  * Console configuration injected by the Go server into index.html
  * via window.__CONSOLE_CONFIG__.
+ *
+ * The `namespacePrefix` / `organizationPrefix` / `folderPrefix` / `projectPrefix`
+ * fields mirror the backend resolver flags (`--namespace-prefix`,
+ * `--organization-prefix`, `--folder-prefix`, `--project-prefix`). The frontend
+ * must consume these at runtime so operators who customize the namespace
+ * layout see the UI match the server.
  */
 interface ConsoleConfig {
   devToolsEnabled: boolean
+  namespacePrefix: string
+  organizationPrefix: string
+  folderPrefix: string
+  projectPrefix: string
 }
 
 declare global {
   interface Window {
-    __CONSOLE_CONFIG__?: ConsoleConfig
+    __CONSOLE_CONFIG__?: Partial<ConsoleConfig>
   }
 }
 
 /**
+ * Default prefix values mirror the Go server's defaults (see `console/console.go`
+ * Config struct: NamespacePrefix="holos-", OrganizationPrefix="org-",
+ * FolderPrefix="fld-", ProjectPrefix="prj-"). These apply when the global is
+ * not injected (tests, static preview) or when a field is absent.
+ */
+const DEFAULT_CONFIG: ConsoleConfig = {
+  devToolsEnabled: false,
+  namespacePrefix: 'holos-',
+  organizationPrefix: 'org-',
+  folderPrefix: 'fld-',
+  projectPrefix: 'prj-',
+}
+
+/**
  * Returns the console configuration, falling back to safe defaults
- * when the global is not injected (e.g., during tests or static preview).
+ * when the global is not injected (e.g., during tests or static preview)
+ * or when the server omits individual fields.
  */
 export function getConsoleConfig(): ConsoleConfig {
-  return window.__CONSOLE_CONFIG__ ?? { devToolsEnabled: false }
+  const injected = window.__CONSOLE_CONFIG__ ?? {}
+  return {
+    devToolsEnabled: injected.devToolsEnabled ?? DEFAULT_CONFIG.devToolsEnabled,
+    namespacePrefix: injected.namespacePrefix ?? DEFAULT_CONFIG.namespacePrefix,
+    organizationPrefix:
+      injected.organizationPrefix ?? DEFAULT_CONFIG.organizationPrefix,
+    folderPrefix: injected.folderPrefix ?? DEFAULT_CONFIG.folderPrefix,
+    projectPrefix: injected.projectPrefix ?? DEFAULT_CONFIG.projectPrefix,
+  }
 }

--- a/frontend/src/lib/scope-labels.test.ts
+++ b/frontend/src/lib/scope-labels.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
   TemplateScope,
   namespaceForOrg,
@@ -11,6 +11,10 @@ import {
 } from './scope-labels'
 
 describe('scope-labels', () => {
+  afterEach(() => {
+    delete window.__CONSOLE_CONFIG__
+  })
+
   describe('namespaceForOrg / Folder / Project', () => {
     it('builds the holos-org- prefixed namespace', () => {
       expect(namespaceForOrg('acme')).toBe('holos-org-acme')
@@ -87,6 +91,94 @@ describe('scope-labels', () => {
       { ns: '', label: '' },
     ])('returns "$label" for $ns', ({ ns, label }) => {
       expect(scopeDisplayLabel(ns)).toBe(label)
+    })
+  })
+
+  describe('with non-default prefixes from window.__CONSOLE_CONFIG__', () => {
+    it.each([
+      {
+        title: 'operator uses ci- global prefix and renames scope suffixes',
+        config: {
+          namespacePrefix: 'ci-',
+          organizationPrefix: 'organization-',
+          folderPrefix: 'folder-',
+          projectPrefix: 'project-',
+        },
+        org: 'acme',
+        folder: 'engineering',
+        project: 'web-app',
+        expected: {
+          orgNs: 'ci-organization-acme',
+          folderNs: 'ci-folder-engineering',
+          projectNs: 'ci-project-web-app',
+          orgLabel: 'org' as const,
+          folderLabel: 'folder' as const,
+          projectLabel: 'project' as const,
+        },
+      },
+      {
+        title: 'operator disables global prefix (empty namespacePrefix)',
+        config: {
+          namespacePrefix: '',
+          organizationPrefix: 'org-',
+          folderPrefix: 'fld-',
+          projectPrefix: 'prj-',
+        },
+        org: 'acme',
+        folder: 'engineering',
+        project: 'web-app',
+        expected: {
+          orgNs: 'org-acme',
+          folderNs: 'fld-engineering',
+          projectNs: 'prj-web-app',
+          orgLabel: 'org' as const,
+          folderLabel: 'folder' as const,
+          projectLabel: 'project' as const,
+        },
+      },
+      {
+        title: 'operator picks fully custom short suffixes',
+        config: {
+          namespacePrefix: 'qa-',
+          organizationPrefix: 'o-',
+          folderPrefix: 'f-',
+          projectPrefix: 'p-',
+        },
+        org: 'acme',
+        folder: 'engineering',
+        project: 'web-app',
+        expected: {
+          orgNs: 'qa-o-acme',
+          folderNs: 'qa-f-engineering',
+          projectNs: 'qa-p-web-app',
+          orgLabel: 'org' as const,
+          folderLabel: 'folder' as const,
+          projectLabel: 'project' as const,
+        },
+      },
+    ])('$title', ({ config, org, folder, project, expected }) => {
+      window.__CONSOLE_CONFIG__ = {
+        devToolsEnabled: false,
+        ...config,
+      }
+
+      expect(namespaceForOrg(org)).toBe(expected.orgNs)
+      expect(namespaceForFolder(folder)).toBe(expected.folderNs)
+      expect(namespaceForProject(project)).toBe(expected.projectNs)
+
+      expect(scopeLabelFromNamespace(expected.orgNs)).toBe(expected.orgLabel)
+      expect(scopeLabelFromNamespace(expected.folderNs)).toBe(expected.folderLabel)
+      expect(scopeLabelFromNamespace(expected.projectNs)).toBe(expected.projectLabel)
+
+      expect(scopeNameFromNamespace(expected.orgNs)).toBe(org)
+      expect(scopeNameFromNamespace(expected.folderNs)).toBe(folder)
+      expect(scopeNameFromNamespace(expected.projectNs)).toBe(project)
+
+      // A namespace that would have matched the default prefixes must NOT match
+      // when the operator has configured non-default prefixes.
+      if (expected.orgNs !== 'holos-org-acme') {
+        expect(scopeLabelFromNamespace('holos-org-acme')).toBeUndefined()
+      }
     })
   })
 })

--- a/frontend/src/lib/scope-labels.ts
+++ b/frontend/src/lib/scope-labels.ts
@@ -3,29 +3,20 @@
 //
 // Per HOL-619 the Template / TemplatePolicy / TemplatePolicyBinding proto API
 // is keyed by `(namespace, name)` only; the legacy `TemplateScope` enum and
-// `(scope, scopeName)` pairs were removed from the wire protocol. This module
-// replaces the temporary `scope-shim.ts` introduced while the UI still
-// reasoned in `(scope, scopeName)` pairs. HOL-623 unifies the editor routes
-// and swaps query hooks onto `namespace: string`.
+// `(scope, scopeName)` pairs were removed from the wire protocol. HOL-623
+// unified the editor routes and swapped query hooks onto `namespace: string`.
 //
-// ## Annotation key contract
-//
-// `scopeLabelFromNamespace` is a pure prefix-based derivation: it does NOT
-// require a NamespaceMetadata lookup. The server assigns namespace prefixes
-// deterministically when an Organization/Folder/Project resource is created:
-//
-//   * Organization → `holos-org-<orgName>`
-//   * Folder       → `holos-fld-<folderName>`
-//   * Project      → `holos-prj-<projectName>`
-//
-// These prefixes are stable identifiers that the console relies on to derive
-// the *scope label* ("Organization" / "Folder" / "Project") without a second
-// round-trip. The equivalent annotation key the backend stamps on each
-// namespace — `holos.run/scope` set to `org`/`folder`/`project` — is still
-// the authoritative source should a future rename ever decouple the prefix
-// from the scope. Until then the prefix is cheaper and correct. If/when the
-// bootstrap config endpoint exposes the prefix values for non-default
-// deployments, read them here.
+// Namespaces encode the scope via the prefix layout
+// `{NamespacePrefix}{ResourcePrefix}{name}`. The four prefix values are
+// configurable on the server (CLI flags `--namespace-prefix`,
+// `--organization-prefix`, `--folder-prefix`, `--project-prefix`; see
+// `console/console.go` Config). Per HOL-722 this module reads the live
+// prefixes from `window.__CONSOLE_CONFIG__` via `getConsoleConfig()` so the
+// UI stays aligned with deployments that customize the namespace layout.
+// `getConsoleConfig()` is a synchronous read of a value injected once into
+// `index.html` by the server, so there is no per-render network cost.
+
+import { getConsoleConfig } from './console-config'
 
 /**
  * Scope label values returned by `scopeLabelFromNamespace`.
@@ -48,43 +39,48 @@ export const TemplateScope = {
 } as const
 export type TemplateScope = (typeof TemplateScope)[keyof typeof TemplateScope]
 
-const NAMESPACE_PREFIX = 'holos-'
-const ORG_SUFFIX = 'org-'
-const FOLDER_SUFFIX = 'fld-'
-const PROJECT_SUFFIX = 'prj-'
+interface ScopePrefixes {
+  org: string
+  folder: string
+  project: string
+}
 
-const FULL_ORG_PREFIX = NAMESPACE_PREFIX + ORG_SUFFIX
-const FULL_FOLDER_PREFIX = NAMESPACE_PREFIX + FOLDER_SUFFIX
-const FULL_PROJECT_PREFIX = NAMESPACE_PREFIX + PROJECT_SUFFIX
+function scopePrefixes(): ScopePrefixes {
+  const cfg = getConsoleConfig()
+  return {
+    org: cfg.namespacePrefix + cfg.organizationPrefix,
+    folder: cfg.namespacePrefix + cfg.folderPrefix,
+    project: cfg.namespacePrefix + cfg.projectPrefix,
+  }
+}
 
 /** Build the namespace string for an organization-scoped resource. */
 export function namespaceForOrg(orgName: string): string {
-  return orgName ? FULL_ORG_PREFIX + orgName : ''
+  return orgName ? scopePrefixes().org + orgName : ''
 }
 
 /** Build the namespace string for a folder-scoped resource. */
 export function namespaceForFolder(folderName: string): string {
-  return folderName ? FULL_FOLDER_PREFIX + folderName : ''
+  return folderName ? scopePrefixes().folder + folderName : ''
 }
 
 /** Build the namespace string for a project-scoped resource. */
 export function namespaceForProject(projectName: string): string {
-  return projectName ? FULL_PROJECT_PREFIX + projectName : ''
+  return projectName ? scopePrefixes().project + projectName : ''
 }
 
 /**
- * Return the scope label for a namespace, derived from the namespace prefix.
- *
- * See the module-level "Annotation key contract" comment for the prefix
- * meanings and a note on the equivalent `holos.run/scope` annotation.
+ * Return the scope label for a namespace, derived from the server-configured
+ * namespace prefixes.
  */
 export function scopeLabelFromNamespace(
   ns: string | undefined | null,
 ): ScopeLabel | undefined {
   if (!ns) return undefined
-  if (ns.startsWith(FULL_ORG_PREFIX)) return 'org'
-  if (ns.startsWith(FULL_FOLDER_PREFIX)) return 'folder'
-  if (ns.startsWith(FULL_PROJECT_PREFIX)) return 'project'
+  const p = scopePrefixes()
+  if (ns.startsWith(p.org)) return 'org'
+  if (ns.startsWith(p.folder)) return 'folder'
+  if (ns.startsWith(p.project)) return 'project'
   return undefined
 }
 
@@ -95,9 +91,10 @@ export function scopeLabelFromNamespace(
  */
 export function scopeNameFromNamespace(ns: string | undefined | null): string {
   if (!ns) return ''
-  if (ns.startsWith(FULL_ORG_PREFIX)) return ns.slice(FULL_ORG_PREFIX.length)
-  if (ns.startsWith(FULL_FOLDER_PREFIX)) return ns.slice(FULL_FOLDER_PREFIX.length)
-  if (ns.startsWith(FULL_PROJECT_PREFIX)) return ns.slice(FULL_PROJECT_PREFIX.length)
+  const p = scopePrefixes()
+  if (ns.startsWith(p.org)) return ns.slice(p.org.length)
+  if (ns.startsWith(p.folder)) return ns.slice(p.folder.length)
+  if (ns.startsWith(p.project)) return ns.slice(p.project.length)
   return ''
 }
 


### PR DESCRIPTION
## Summary

- Extend `window.__CONSOLE_CONFIG__` (served by `console/console.go`) to carry the four namespace prefix fields (`namespacePrefix`, `organizationPrefix`, `folderPrefix`, `projectPrefix`) the backend resolver already exposes via CLI flags.
- Rework `frontend/src/lib/scope-labels.ts` to read those prefixes at call time via `getConsoleConfig()`. Removed the hardcoded `holos-`, `org-`, `fld-`, `prj-` literals.
- Emit `ConsoleConfig` unconditionally (previously only when DevTools was enabled) so the browser always has the live prefixes.
- Added a table-driven Vitest test that exercises three non-default prefix configurations and a new Go `TestServeIndex_InjectsNonDefaultPrefixes`.

`getConsoleConfig()` is a synchronous read of a value injected once into `index.html`, so there are zero new network calls per render — cleaner than a React Query hook and no cache to manage.

Fixes HOL-722

## Test plan

- [x] `cd frontend && npm test` → 1192/1192 passing (78 files).
- [x] `go test ./console/...` → all packages pass, including updated `TestServeIndex_*` tests.
- [x] `go vet ./...` clean.
- [x] `npx tsc --noEmit` clean.
- [x] `grep -c "'org-'\|'fld-'\|'prj-'\|'holos-'" frontend/src/lib/scope-labels.ts` → `0` (AC: no hardcoded prefix literals).
- [ ] Manual smoke: operator overrides `--organization-prefix=organization-` → UI correctly builds / parses `holos-organization-acme` namespaces. (Not run locally — relying on CI.)

> Local E2E was not run (no k3d cluster available). Relying on CI E2E check.

Generated with [Claude Code](https://claude.com/claude-code)