### PR TITLE
feat(console): implement SearchTemplates and ListResources handlers

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -41,6 +41,7 @@ import (
 	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/projects"
 	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/resources"
 	"github.com/holos-run/holos-console/console/rpc"
 	"github.com/holos-run/holos-console/console/scopeshim"
 	"github.com/holos-run/holos-console/console/secrets"
@@ -478,6 +479,19 @@ func (s *Server) Serve(ctx context.Context) error {
 		projectsHandler := projects.NewHandler(projectsK8s, orgGrantResolver)
 		projectsPath, projectsHTTPHandler := consolev1connect.NewProjectServiceHandler(projectsHandler, protectedInterceptors)
 		mux.Handle(projectsPath, projectsHTTPHandler)
+
+		// ResourceService — cross-kind listing of folders + projects with
+		// each entry's root→leaf ancestor path. Powers the Linear-style
+		// navigation (HOL-553); wired in HOL-602. Composes the existing
+		// folders / projects / organizations K8s clients so RBAC and label
+		// semantics stay defined in exactly one place per kind.
+		resourcesHandler := resources.NewHandler(
+			resources.NewK8sClient(foldersK8s, projectsK8s, orgsK8s),
+			nsResolver,
+			nsWalker,
+		)
+		resourcesPath, resourcesHTTPHandler := consolev1connect.NewResourceServiceHandler(resourcesHandler, protectedInterceptors)
+		mux.Handle(resourcesPath, resourcesHTTPHandler)
 
 		// Secrets service with project grant fallback and ancestor default-share cascade.
 		secretsK8s := secrets.NewK8sClient(k8sClientset, nsResolver)

--- a/console/resources/handler.go
+++ b/console/resources/handler.go
@@ -1,0 +1,316 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/folders"
+	"github.com/holos-run/holos-console/console/projects"
+	"github.com/holos-run/holos-console/console/rbac"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/rpc"
+	"github.com/holos-run/holos-console/console/secrets"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
+)
+
+const auditResourceType = "resources"
+
+// Handler implements the ResourceService introduced in HOL-602.
+//
+// Per HOL-602's acceptance criteria:
+//   - the RPC returns folders and projects in a single flat list;
+//   - each entry carries its ancestor path in root→leaf order, with the
+//     organization first and the entry's immediate parent last;
+//   - the response respects the caller's RBAC on each entry — list
+//     permission is checked per entry against the entry's own share-users
+//     and share-roles grants;
+//   - the optional organization filter restricts results to a single org;
+//   - the optional types filter restricts results to folders, projects, or
+//     both. RESOURCE_TYPE_UNSPECIFIED in the types list is silently
+//     ignored.
+type Handler struct {
+	consolev1connect.UnimplementedResourceServiceHandler
+	k8s      *K8sClient
+	resolver *resolver.Resolver
+	walker   *resolver.Walker
+}
+
+// NewHandler builds a ResourceService handler from a composite K8sClient,
+// a namespace resolver, and a walker. The walker is used to compute each
+// entry's ancestor chain — wired in production from the controller-runtime
+// cache-backed getter so the per-hop namespace lookups don't pay an
+// apiserver round-trip.
+func NewHandler(k8s *K8sClient, r *resolver.Resolver, walker *resolver.Walker) *Handler {
+	return &Handler{k8s: k8s, resolver: r, walker: walker}
+}
+
+// ListResources returns the flat cross-kind list per the ResourceService
+// contract in resources.proto. Implementation notes:
+//
+//   - Authentication is enforced first; unauthenticated callers receive
+//     CodeUnauthenticated.
+//   - The optional types filter is normalised: an empty list (or a list
+//     containing only RESOURCE_TYPE_UNSPECIFIED) means "both kinds".
+//   - For each candidate namespace the handler walks ancestors via the
+//     shared Walker, classifies each ancestor with the resolver, and
+//     emits a PathElement per hop in root→leaf order. The leaf entry is
+//     not repeated in the path — Resource.name / Resource.display_name
+//     carry that information.
+//   - RBAC is per-entry: a folder is included when the caller has
+//     PERMISSION_FOLDERS_LIST against the folder's own grants; a project
+//     is included when the caller has PERMISSION_PROJECTS_LIST against
+//     the project's own grants. Mirrors the existing per-kind handlers
+//     (no cross-kind cascade in this phase).
+//   - A per-request walker cache (CachedWalker) memoises ancestor chains
+//     so a deeply-nested project shared with siblings doesn't pay the
+//     walk cost twice.
+func (h *Handler) ListResources(
+	ctx context.Context,
+	req *connect.Request[consolev1.ListResourcesRequest],
+) (*connect.Response[consolev1.ListResourcesResponse], error) {
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+
+	includeFolders, includeProjects := normalizeTypes(req.Msg.GetTypes())
+
+	cachedWalker := h.walker.CachedWalker()
+	orgDisplayCache := make(map[string]string)
+	now := time.Now()
+
+	var resources []*consolev1.Resource
+
+	if includeFolders {
+		folderNamespaces, err := h.k8s.ListFolders(ctx, req.Msg.GetOrganization())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("listing folders: %w", err))
+		}
+		for _, ns := range folderNamespaces {
+			if !h.callerCanListFolder(claims, ns, now) {
+				continue
+			}
+			res, err := h.buildResource(ctx, ns, consolev1.ResourceType_RESOURCE_TYPE_FOLDER, cachedWalker, orgDisplayCache)
+			if err != nil {
+				slog.WarnContext(ctx, "skipping folder with unresolvable ancestor chain",
+					slog.String("namespace", ns.Name),
+					slog.Any("error", err),
+				)
+				continue
+			}
+			resources = append(resources, res)
+		}
+	}
+
+	if includeProjects {
+		projectNamespaces, err := h.k8s.ListProjects(ctx, req.Msg.GetOrganization())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("listing projects: %w", err))
+		}
+		for _, ns := range projectNamespaces {
+			if !h.callerCanListProject(claims, ns, now) {
+				continue
+			}
+			res, err := h.buildResource(ctx, ns, consolev1.ResourceType_RESOURCE_TYPE_PROJECT, cachedWalker, orgDisplayCache)
+			if err != nil {
+				slog.WarnContext(ctx, "skipping project with unresolvable ancestor chain",
+					slog.String("namespace", ns.Name),
+					slog.Any("error", err),
+				)
+				continue
+			}
+			resources = append(resources, res)
+		}
+	}
+
+	slog.InfoContext(ctx, "resources listed",
+		slog.String("action", "resources_list"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("organization", req.Msg.GetOrganization()),
+		slog.String("sub", claims.Sub),
+		slog.String("email", claims.Email),
+		slog.Int("total", len(resources)),
+	)
+
+	return connect.NewResponse(&consolev1.ListResourcesResponse{
+		Resources: resources,
+	}), nil
+}
+
+// normalizeTypes converts the optional types filter into two booleans.
+// Per the proto contract, RESOURCE_TYPE_UNSPECIFIED is silently ignored;
+// an empty (or all-UNSPECIFIED) list means "both kinds" so the navigation
+// UI can issue a single unfiltered request.
+func normalizeTypes(types []consolev1.ResourceType) (includeFolders, includeProjects bool) {
+	if len(types) == 0 {
+		return true, true
+	}
+	any := false
+	for _, t := range types {
+		switch t {
+		case consolev1.ResourceType_RESOURCE_TYPE_FOLDER:
+			includeFolders = true
+			any = true
+		case consolev1.ResourceType_RESOURCE_TYPE_PROJECT:
+			includeProjects = true
+			any = true
+		}
+	}
+	if !any {
+		return true, true
+	}
+	return includeFolders, includeProjects
+}
+
+// callerCanListFolder reports whether the caller has list permission on
+// the folder's own grants. Mirrors folders.CheckFolderListAccess so the
+// cross-kind RPC and the per-kind ListFolders return the same set.
+func (h *Handler) callerCanListFolder(claims *rpc.Claims, ns *corev1.Namespace, now time.Time) bool {
+	shareUsers, _ := folders.GetShareUsers(ns)
+	shareRoles, _ := folders.GetShareRoles(ns)
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+	return rbac.CheckAccessGrants(claims.Email, claims.Roles, activeUsers, activeRoles, rbac.PermissionFoldersList) == nil
+}
+
+// callerCanListProject reports whether the caller has list permission on
+// the project's own grants. Project list intentionally does NOT cascade
+// from the parent organization (ADR 007).
+func (h *Handler) callerCanListProject(claims *rpc.Claims, ns *corev1.Namespace, now time.Time) bool {
+	shareUsers, _ := projects.GetShareUsers(ns)
+	shareRoles, _ := projects.GetShareRoles(ns)
+	activeUsers := secrets.ActiveGrantsMap(shareUsers, now)
+	activeRoles := secrets.ActiveGrantsMap(shareRoles, now)
+	return rbac.CheckAccessGrants(claims.Email, claims.Roles, activeUsers, activeRoles, rbac.PermissionProjectsList) == nil
+}
+
+// buildResource assembles a single Resource entry. The ancestor path is
+// produced by walking the namespace hierarchy via the cached walker,
+// dropping the leaf (which is the entry itself), and reversing the
+// child→parent walk into the root→leaf order required by the proto.
+func (h *Handler) buildResource(
+	ctx context.Context,
+	ns *corev1.Namespace,
+	entryType consolev1.ResourceType,
+	cachedWalker *resolver.CachedWalker,
+	orgDisplayCache map[string]string,
+) (*consolev1.Resource, error) {
+	chain, err := cachedWalker.WalkAncestors(ctx, ns.Name)
+	if err != nil {
+		return nil, fmt.Errorf("walking ancestors of %q: %w", ns.Name, err)
+	}
+	if len(chain) == 0 {
+		return nil, fmt.Errorf("walker returned empty chain for %q", ns.Name)
+	}
+
+	// The walker returns child→parent (entry first, org last). Drop the
+	// leaf (the entry itself) and reverse the rest to get root→leaf.
+	ancestors := chain[1:]
+	path := make([]*consolev1.PathElement, 0, len(ancestors))
+	for i := len(ancestors) - 1; i >= 0; i-- {
+		ancestor := ancestors[i]
+		element, err := h.pathElementFromNamespace(ctx, ancestor, orgDisplayCache)
+		if err != nil {
+			return nil, fmt.Errorf("building path element for %q: %w", ancestor.Name, err)
+		}
+		path = append(path, element)
+	}
+
+	return &consolev1.Resource{
+		Type:        entryType,
+		Path:        path,
+		DisplayName: displayName(ns),
+		Name:        leafName(h.resolver, ns),
+	}, nil
+}
+
+// pathElementFromNamespace produces a single PathElement from an ancestor
+// namespace. The element's name field is the user-facing slug (org name,
+// folder slug) — never the Kubernetes namespace prefix-stamped name.
+func (h *Handler) pathElementFromNamespace(
+	ctx context.Context,
+	ns *corev1.Namespace,
+	orgDisplayCache map[string]string,
+) (*consolev1.PathElement, error) {
+	kind, name, err := h.resolver.ResourceTypeFromNamespace(ns.Name)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case v1alpha2.ResourceTypeOrganization:
+		// The proto contract says path[0] for an org root is
+		// RESOURCE_TYPE_UNSPECIFIED — orgs are not a ResourceType (only
+		// folders and projects are returned as Resource entries).
+		return &consolev1.PathElement{
+			Name:        name,
+			DisplayName: h.orgDisplayName(ctx, name, ns, orgDisplayCache),
+			Type:        consolev1.ResourceType_RESOURCE_TYPE_UNSPECIFIED,
+		}, nil
+	case v1alpha2.ResourceTypeFolder:
+		return &consolev1.PathElement{
+			Name:        name,
+			DisplayName: displayName(ns),
+			Type:        consolev1.ResourceType_RESOURCE_TYPE_FOLDER,
+		}, nil
+	case v1alpha2.ResourceTypeProject:
+		// Projects shouldn't appear as ancestors (only orgs and folders
+		// can parent another resource), but emit a defensive entry so a
+		// misconfigured cluster doesn't drop the entire chain.
+		return &consolev1.PathElement{
+			Name:        name,
+			DisplayName: displayName(ns),
+			Type:        consolev1.ResourceType_RESOURCE_TYPE_PROJECT,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected resource type %q on namespace %q", kind, ns.Name)
+	}
+}
+
+// orgDisplayName returns the org's human-readable display name. The
+// ancestor walk already returned the org's namespace object, so the
+// display annotation is read directly from it. The cache exists so that
+// repeated walks across siblings of the same org don't repeat the lookup.
+func (h *Handler) orgDisplayName(_ context.Context, name string, orgNs *corev1.Namespace, cache map[string]string) string {
+	if cached, ok := cache[name]; ok {
+		return cached
+	}
+	display := displayName(orgNs)
+	cache[name] = display
+	return display
+}
+
+// displayName reads the human-readable display name annotation, returning
+// the empty string if unset. Callers (and the proto contract) say clients
+// MUST fall back to `name` when this is empty — keeping the empty value
+// here preserves that contract end-to-end.
+func displayName(ns *corev1.Namespace) string {
+	if ns.Annotations == nil {
+		return ""
+	}
+	return ns.Annotations[v1alpha2.AnnotationDisplayName]
+}
+
+// leafName returns the user-facing slug for the entry namespace. Reading
+// from labels is the cheap path; falling back to the resolver handles
+// label-stripped fixtures.
+func leafName(r *resolver.Resolver, ns *corev1.Namespace) string {
+	if ns.Labels != nil {
+		if folder := ns.Labels[v1alpha2.LabelFolder]; folder != "" {
+			return folder
+		}
+		if project := ns.Labels[v1alpha2.LabelProject]; project != "" {
+			return project
+		}
+	}
+	if _, name, err := r.ResourceTypeFromNamespace(ns.Name); err == nil {
+		return name
+	}
+	return ns.Name
+}

--- a/console/resources/handler.go
+++ b/console/resources/handler.go
@@ -97,14 +97,7 @@ func (h *Handler) ListResources(
 			if !h.callerCanListFolder(claims, ns, now) {
 				continue
 			}
-			res, err := h.buildResource(ctx, ns, consolev1.ResourceType_RESOURCE_TYPE_FOLDER, cachedWalker, orgDisplayCache)
-			if err != nil {
-				slog.WarnContext(ctx, "skipping folder with unresolvable ancestor chain",
-					slog.String("namespace", ns.Name),
-					slog.Any("error", err),
-				)
-				continue
-			}
+			res := h.buildResource(ctx, ns, consolev1.ResourceType_RESOURCE_TYPE_FOLDER, cachedWalker, orgDisplayCache)
 			resources = append(resources, res)
 		}
 	}
@@ -118,14 +111,7 @@ func (h *Handler) ListResources(
 			if !h.callerCanListProject(claims, ns, now) {
 				continue
 			}
-			res, err := h.buildResource(ctx, ns, consolev1.ResourceType_RESOURCE_TYPE_PROJECT, cachedWalker, orgDisplayCache)
-			if err != nil {
-				slog.WarnContext(ctx, "skipping project with unresolvable ancestor chain",
-					slog.String("namespace", ns.Name),
-					slog.Any("error", err),
-				)
-				continue
-			}
+			res := h.buildResource(ctx, ns, consolev1.ResourceType_RESOURCE_TYPE_PROJECT, cachedWalker, orgDisplayCache)
 			resources = append(resources, res)
 		}
 	}
@@ -195,19 +181,42 @@ func (h *Handler) callerCanListProject(claims *rpc.Claims, ns *corev1.Namespace,
 // produced by walking the namespace hierarchy via the cached walker,
 // dropping the leaf (which is the entry itself), and reversing the
 // child→parent walk into the root→leaf order required by the proto.
+//
+// Resilience: a folder/project the caller is allowed to see MUST appear in
+// the response even when its ancestor chain is partially unresolvable
+// (transient apiserver hiccup, an ancestor namespace that was just deleted
+// or reparented, an ancestor of an unexpected kind). In those cases the
+// path is truncated at the deepest resolvable hop and the failure is
+// recorded as a structured warning so an operator can investigate without
+// the missing entry vanishing from navigation. This matches the behavior
+// of ListFolders / ListProjects — they too return the entry itself even
+// when its parent chain cannot be fully classified.
 func (h *Handler) buildResource(
 	ctx context.Context,
 	ns *corev1.Namespace,
 	entryType consolev1.ResourceType,
 	cachedWalker *resolver.CachedWalker,
 	orgDisplayCache map[string]string,
-) (*consolev1.Resource, error) {
+) *consolev1.Resource {
+	res := &consolev1.Resource{
+		Type:        entryType,
+		DisplayName: displayName(ns),
+		Name:        leafName(h.resolver, ns),
+	}
+
 	chain, err := cachedWalker.WalkAncestors(ctx, ns.Name)
 	if err != nil {
-		return nil, fmt.Errorf("walking ancestors of %q: %w", ns.Name, err)
+		slog.WarnContext(ctx, "ancestor walk failed; returning resource with empty path",
+			slog.String("namespace", ns.Name),
+			slog.Any("error", err),
+		)
+		return res
 	}
 	if len(chain) == 0 {
-		return nil, fmt.Errorf("walker returned empty chain for %q", ns.Name)
+		slog.WarnContext(ctx, "ancestor walk returned empty chain; returning resource with empty path",
+			slog.String("namespace", ns.Name),
+		)
+		return res
 	}
 
 	// The walker returns child→parent (entry first, org last). Drop the
@@ -218,17 +227,18 @@ func (h *Handler) buildResource(
 		ancestor := ancestors[i]
 		element, err := h.pathElementFromNamespace(ctx, ancestor, orgDisplayCache)
 		if err != nil {
-			return nil, fmt.Errorf("building path element for %q: %w", ancestor.Name, err)
+			slog.WarnContext(ctx, "skipping unclassifiable ancestor; truncating path",
+				slog.String("namespace", ns.Name),
+				slog.String("ancestor", ancestor.Name),
+				slog.Any("error", err),
+			)
+			break
 		}
 		path = append(path, element)
 	}
+	res.Path = path
 
-	return &consolev1.Resource{
-		Type:        entryType,
-		Path:        path,
-		DisplayName: displayName(ns),
-		Name:        leafName(h.resolver, ns),
-	}, nil
+	return res
 }
 
 // pathElementFromNamespace produces a single PathElement from an ancestor

--- a/console/resources/handler_test.go
+++ b/console/resources/handler_test.go
@@ -430,6 +430,43 @@ func TestListResources_RBACFilters(t *testing.T) {
 	})
 }
 
+// TestListResources_BrokenAncestorChainStillReturnsEntry asserts the
+// resilience contract: a folder/project the caller can see MUST appear in
+// the response even when its ancestor walk fails (e.g. a parent namespace
+// was just deleted). The entry is returned with a truncated/empty path
+// instead of being silently dropped, matching ListFolders / ListProjects
+// behavior. Without this guarantee the navigation tree would lose visible
+// nodes during transient hierarchy churn.
+func TestListResources_BrokenAncestorChainStillReturnsEntry(t *testing.T) {
+	owner := `[{"principal":"owner@example.com","role":"owner"}]`
+
+	// Project's parent label points at a namespace that does not exist in
+	// the cluster, so WalkAncestors returns an error after fetching the
+	// project itself. The entry must still appear in the response.
+	prj := projectNS("orphan", "", "acme", "holos-fld-deleted-parent", owner)
+
+	handler := newTestHandler(t, prj)
+	ctx := contextWithClaims("owner@example.com")
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resources := resp.Msg.GetResources()
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d (%v)", len(resources), sortedResourceKeys(resources))
+	}
+	got := resources[0]
+	if got.GetType() != consolev1.ResourceType_RESOURCE_TYPE_PROJECT {
+		t.Errorf("expected RESOURCE_TYPE_PROJECT, got %v", got.GetType())
+	}
+	if got.GetName() != "orphan" {
+		t.Errorf("expected name=%q, got %q", "orphan", got.GetName())
+	}
+	if len(got.GetPath()) != 0 {
+		t.Errorf("expected empty path on broken hierarchy, got %d elements", len(got.GetPath()))
+	}
+}
+
 // equalStrings reports element-wise equality of two string slices.
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {

--- a/console/resources/handler_test.go
+++ b/console/resources/handler_test.go
@@ -1,0 +1,444 @@
+// handler_test.go exercises ResourceService.ListResources, the cross-kind
+// "Resources" listing introduced in HOL-602. Each test seeds an organization
+// hierarchy via fake.Clientset namespaces, builds a handler wired with the
+// folders/projects/organizations K8s clients plus a Walker over the same
+// fake clientset, and asserts on the flat list of Resource entries the
+// handler returns.
+//
+// Per the HOL-602 acceptance criteria the tests cover:
+//   - unauthenticated callers receive CodeUnauthenticated;
+//   - the empty cluster returns an empty list;
+//   - a single org with one folder and one project under it returns the
+//     two entries with the correct ancestor path;
+//   - deeply-nested folder hierarchies (3 levels) populate path elements
+//     in root→leaf order;
+//   - the organization filter restricts results to one org;
+//   - the types filter restricts to RESOURCE_TYPE_FOLDER or
+//     RESOURCE_TYPE_PROJECT;
+//   - RBAC at every level filters the response.
+package resources
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/folders"
+	"github.com/holos-run/holos-console/console/organizations"
+	"github.com/holos-run/holos-console/console/projects"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+func testResolver() *resolver.Resolver {
+	return &resolver.Resolver{NamespacePrefix: "holos-", OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+}
+
+func contextWithClaims(email string, roles ...string) context.Context {
+	return rpc.ContextWithClaims(context.Background(), &rpc.Claims{
+		Sub:   "sub-" + email,
+		Email: email,
+		Roles: roles,
+	})
+}
+
+// orgNS builds an organization namespace fixture. shareUsersJSON is written
+// to the share-users annotation when non-empty so RBAC tests can grant
+// access selectively.
+func orgNS(name, displayName, shareUsersJSON string) *corev1.Namespace {
+	annotations := map[string]string{}
+	if shareUsersJSON != "" {
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
+	}
+	if displayName != "" {
+		annotations[v1alpha2.AnnotationDisplayName] = displayName
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-org-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+				v1alpha2.LabelOrganization: name,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// folderNS builds a folder namespace fixture. parentNs is the immediate
+// parent's Kubernetes namespace name (org or another folder).
+func folderNS(name, displayName, org, parentNs, shareUsersJSON string) *corev1.Namespace {
+	annotations := map[string]string{}
+	if shareUsersJSON != "" {
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
+	}
+	if displayName != "" {
+		annotations[v1alpha2.AnnotationDisplayName] = displayName
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-fld-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelFolder:       name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// projectNS builds a project namespace fixture.
+func projectNS(name, displayName, org, parentNs, shareUsersJSON string) *corev1.Namespace {
+	annotations := map[string]string{}
+	if shareUsersJSON != "" {
+		annotations[v1alpha2.AnnotationShareUsers] = shareUsersJSON
+	}
+	if displayName != "" {
+		annotations[v1alpha2.AnnotationDisplayName] = displayName
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "holos-prj-" + name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelProject:      name,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+func newTestHandler(t *testing.T, namespaces ...*corev1.Namespace) *Handler {
+	t.Helper()
+	clientset := fake.NewClientset()
+	for _, ns := range namespaces {
+		if _, err := clientset.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed namespace %q: %v", ns.Name, err)
+		}
+	}
+	r := testResolver()
+	walker := &resolver.Walker{Client: clientset, Resolver: r}
+	return NewHandler(
+		NewK8sClient(folders.NewK8sClient(clientset, r), projects.NewK8sClient(clientset, r), organizations.NewK8sClient(clientset, r)),
+		r,
+		walker,
+	)
+}
+
+// resourceKey produces a stable string key for a Resource so the test
+// assertions don't depend on iteration order.
+func resourceKey(res *consolev1.Resource) string {
+	pathStr := ""
+	for _, p := range res.GetPath() {
+		pathStr += p.GetName() + "/"
+	}
+	return res.GetType().String() + "|" + pathStr + res.GetName()
+}
+
+func sortedResourceKeys(resources []*consolev1.Resource) []string {
+	out := make([]string, 0, len(resources))
+	for _, r := range resources {
+		out = append(out, resourceKey(r))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestListResources_Unauthenticated(t *testing.T) {
+	handler := newTestHandler(t)
+	_, err := handler.ListResources(context.Background(), connect.NewRequest(&consolev1.ListResourcesRequest{}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got, want := connect.CodeOf(err), connect.CodeUnauthenticated; got != want {
+		t.Errorf("expected code %v, got %v", want, got)
+	}
+}
+
+func TestListResources_EmptyCluster(t *testing.T) {
+	handler := newTestHandler(t)
+	ctx := contextWithClaims("alice@example.com")
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(resp.Msg.GetResources()); got != 0 {
+		t.Errorf("expected 0 resources, got %d", got)
+	}
+}
+
+func TestListResources_FlatListWithAncestors(t *testing.T) {
+	const owner = "alice@example.com"
+	grants := `[{"principal":"alice@example.com","role":"owner"}]`
+
+	org := orgNS("acme", "Acme Corp", grants)
+	fld := folderNS("payments", "Payments", "acme", org.Name, grants)
+	prj := projectNS("checkout", "Checkout", "acme", fld.Name, grants)
+
+	handler := newTestHandler(t, org, fld, prj)
+	ctx := contextWithClaims(owner)
+
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := sortedResourceKeys(resp.Msg.GetResources())
+	want := []string{
+		"RESOURCE_TYPE_FOLDER|acme/payments",
+		"RESOURCE_TYPE_PROJECT|acme/payments/checkout",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("resources mismatch:\ngot  %v\nwant %v", got, want)
+	}
+
+	// Verify display names and path elements on the project entry.
+	var prjEntry *consolev1.Resource
+	for _, r := range resp.Msg.GetResources() {
+		if r.GetType() == consolev1.ResourceType_RESOURCE_TYPE_PROJECT {
+			prjEntry = r
+			break
+		}
+	}
+	if prjEntry == nil {
+		t.Fatal("expected project entry, got none")
+	}
+	if got, want := prjEntry.GetDisplayName(), "Checkout"; got != want {
+		t.Errorf("project display_name: got %q, want %q", got, want)
+	}
+	if got, want := len(prjEntry.GetPath()), 2; got != want {
+		t.Fatalf("project path length: got %d, want %d", got, want)
+	}
+	if got, want := prjEntry.GetPath()[0].GetName(), "acme"; got != want {
+		t.Errorf("project path[0].name: got %q, want %q", got, want)
+	}
+	if got, want := prjEntry.GetPath()[0].GetDisplayName(), "Acme Corp"; got != want {
+		t.Errorf("project path[0].display_name: got %q, want %q", got, want)
+	}
+	if got, want := prjEntry.GetPath()[1].GetName(), "payments"; got != want {
+		t.Errorf("project path[1].name: got %q, want %q", got, want)
+	}
+	if got, want := prjEntry.GetPath()[1].GetType(), consolev1.ResourceType_RESOURCE_TYPE_FOLDER; got != want {
+		t.Errorf("project path[1].type: got %v, want %v", got, want)
+	}
+}
+
+func TestListResources_DeeplyNestedFolders(t *testing.T) {
+	const owner = "alice@example.com"
+	grants := `[{"principal":"alice@example.com","role":"owner"}]`
+
+	org := orgNS("acme", "Acme Corp", grants)
+	fld1 := folderNS("eng", "Engineering", "acme", org.Name, grants)
+	fld2 := folderNS("payments", "Payments", "acme", fld1.Name, grants)
+	fld3 := folderNS("settlements", "Settlements", "acme", fld2.Name, grants)
+	prj := projectNS("ledger", "Ledger", "acme", fld3.Name, grants)
+
+	handler := newTestHandler(t, org, fld1, fld2, fld3, prj)
+	ctx := contextWithClaims(owner)
+
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the deepest project entry and check its 4-element path.
+	var ledger *consolev1.Resource
+	for _, r := range resp.Msg.GetResources() {
+		if r.GetName() == "ledger" {
+			ledger = r
+			break
+		}
+	}
+	if ledger == nil {
+		t.Fatal("expected ledger project entry")
+	}
+
+	// Path is root→leaf: org, eng, payments, settlements.
+	wantPath := []string{"acme", "eng", "payments", "settlements"}
+	if got, want := len(ledger.GetPath()), len(wantPath); got != want {
+		t.Fatalf("ledger path length: got %d, want %d", got, want)
+	}
+	for i, want := range wantPath {
+		if got := ledger.GetPath()[i].GetName(); got != want {
+			t.Errorf("ledger path[%d].name: got %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestListResources_OrganizationFilter(t *testing.T) {
+	const owner = "alice@example.com"
+	grants := `[{"principal":"alice@example.com","role":"owner"}]`
+
+	orgA := orgNS("acme", "", grants)
+	orgB := orgNS("other", "", grants)
+	fldA := folderNS("payments", "", "acme", orgA.Name, grants)
+	fldB := folderNS("ops", "", "other", orgB.Name, grants)
+	prjA := projectNS("checkout", "", "acme", fldA.Name, grants)
+	prjB := projectNS("infra", "", "other", fldB.Name, grants)
+
+	handler := newTestHandler(t, orgA, orgB, fldA, fldB, prjA, prjB)
+	ctx := contextWithClaims(owner)
+
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{
+		Organization: "acme",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := sortedResourceKeys(resp.Msg.GetResources())
+	want := []string{
+		"RESOURCE_TYPE_FOLDER|acme/payments",
+		"RESOURCE_TYPE_PROJECT|acme/payments/checkout",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("resources mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestListResources_TypesFilterFoldersOnly(t *testing.T) {
+	const owner = "alice@example.com"
+	grants := `[{"principal":"alice@example.com","role":"owner"}]`
+
+	org := orgNS("acme", "", grants)
+	fld := folderNS("payments", "", "acme", org.Name, grants)
+	prj := projectNS("checkout", "", "acme", fld.Name, grants)
+
+	handler := newTestHandler(t, org, fld, prj)
+	ctx := contextWithClaims(owner)
+
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{
+		Types: []consolev1.ResourceType{consolev1.ResourceType_RESOURCE_TYPE_FOLDER},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := sortedResourceKeys(resp.Msg.GetResources())
+	want := []string{"RESOURCE_TYPE_FOLDER|acme/payments"}
+	if !equalStrings(got, want) {
+		t.Errorf("resources mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestListResources_TypesFilterProjectsOnly(t *testing.T) {
+	const owner = "alice@example.com"
+	grants := `[{"principal":"alice@example.com","role":"owner"}]`
+
+	org := orgNS("acme", "", grants)
+	fld := folderNS("payments", "", "acme", org.Name, grants)
+	prj := projectNS("checkout", "", "acme", fld.Name, grants)
+
+	handler := newTestHandler(t, org, fld, prj)
+	ctx := contextWithClaims(owner)
+
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{
+		Types: []consolev1.ResourceType{consolev1.ResourceType_RESOURCE_TYPE_PROJECT},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := sortedResourceKeys(resp.Msg.GetResources())
+	want := []string{"RESOURCE_TYPE_PROJECT|acme/payments/checkout"}
+	if !equalStrings(got, want) {
+		t.Errorf("resources mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestListResources_TypesFilterIgnoresUnspecified(t *testing.T) {
+	const owner = "alice@example.com"
+	grants := `[{"principal":"alice@example.com","role":"owner"}]`
+
+	org := orgNS("acme", "", grants)
+	fld := folderNS("payments", "", "acme", org.Name, grants)
+	prj := projectNS("checkout", "", "acme", fld.Name, grants)
+
+	handler := newTestHandler(t, org, fld, prj)
+	ctx := contextWithClaims(owner)
+
+	// UNSPECIFIED in the list MUST be ignored, not interpreted as "include
+	// nothing." A list of just UNSPECIFIED should behave like an empty list
+	// (i.e. "both kinds").
+	resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{
+		Types: []consolev1.ResourceType{consolev1.ResourceType_RESOURCE_TYPE_UNSPECIFIED},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := sortedResourceKeys(resp.Msg.GetResources())
+	want := []string{
+		"RESOURCE_TYPE_FOLDER|acme/payments",
+		"RESOURCE_TYPE_PROJECT|acme/payments/checkout",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("resources mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestListResources_RBACFilters(t *testing.T) {
+	// alice has no org/folder/project grants — she should see nothing.
+	// bob has only project-level grants — he should see only the project.
+	const alice = "alice@example.com"
+	const bob = "bob@example.com"
+	bobGrants := `[{"principal":"bob@example.com","role":"viewer"}]`
+	owner := `[{"principal":"owner@example.com","role":"owner"}]`
+
+	org := orgNS("acme", "", owner)
+	fld := folderNS("payments", "", "acme", org.Name, owner)
+	prj := projectNS("checkout", "", "acme", fld.Name, bobGrants)
+
+	t.Run("no grants returns empty", func(t *testing.T) {
+		handler := newTestHandler(t, org, fld, prj)
+		ctx := contextWithClaims(alice)
+		resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := len(resp.Msg.GetResources()); got != 0 {
+			t.Errorf("expected 0 resources, got %d (%v)", got, sortedResourceKeys(resp.Msg.GetResources()))
+		}
+	})
+
+	t.Run("project-only grants returns only project", func(t *testing.T) {
+		handler := newTestHandler(t, org, fld, prj)
+		ctx := contextWithClaims(bob)
+		resp, err := handler.ListResources(ctx, connect.NewRequest(&consolev1.ListResourcesRequest{}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := sortedResourceKeys(resp.Msg.GetResources())
+		want := []string{"RESOURCE_TYPE_PROJECT|acme/payments/checkout"}
+		if !equalStrings(got, want) {
+			t.Errorf("resources mismatch:\ngot  %v\nwant %v", got, want)
+		}
+	})
+}
+
+// equalStrings reports element-wise equality of two string slices.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/console/resources/k8s.go
+++ b/console/resources/k8s.go
@@ -1,0 +1,62 @@
+// Package resources implements the cross-kind ResourceService introduced in
+// HOL-602 (proto in HOL-601). It returns folders and projects together in a
+// single flat list — including each entry's root→leaf ancestor path — so a
+// navigation tree can render the organization hierarchy without first
+// fanning out to ListFolders + ListProjects and stitching the ancestry
+// client-side.
+//
+// This package wraps the existing per-kind K8s clients (folders, projects,
+// organizations) instead of talking to the apiserver directly so RBAC and
+// label semantics stay defined in exactly one place. ResourceService is
+// purely a read-side composition over those primitives.
+package resources
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/holos-run/holos-console/console/folders"
+	"github.com/holos-run/holos-console/console/organizations"
+	"github.com/holos-run/holos-console/console/projects"
+)
+
+// K8sClient composes the folders / projects / organizations K8s clients so
+// the ResourceService handler can list both kinds and walk ancestor display
+// names without holding a kubernetes.Interface itself. The composition lets
+// label-selector behavior, prefix-mismatch filtering, and namespace
+// classification stay defined in the per-kind packages.
+type K8sClient struct {
+	folders       *folders.K8sClient
+	projects      *projects.K8sClient
+	organizations *organizations.K8sClient
+}
+
+// NewK8sClient builds the composite client from the three per-kind clients.
+// All three are required; ListResources walks every level of the hierarchy
+// and depends on each one for label-correct namespace fetches.
+func NewK8sClient(f *folders.K8sClient, p *projects.K8sClient, o *organizations.K8sClient) *K8sClient {
+	return &K8sClient{folders: f, projects: p, organizations: o}
+}
+
+// ListFolders returns every folder namespace, optionally filtered to a
+// single organization. parentNs is intentionally unset — ResourceService
+// returns the full flat list and lets the caller stitch the tree together
+// using each entry's ancestor path.
+func (c *K8sClient) ListFolders(ctx context.Context, org string) ([]*corev1.Namespace, error) {
+	return c.folders.ListFolders(ctx, org, "")
+}
+
+// ListProjects returns every project namespace, optionally filtered to a
+// single organization. See ListFolders for why parentNs is empty.
+func (c *K8sClient) ListProjects(ctx context.Context, org string) ([]*corev1.Namespace, error) {
+	return c.projects.ListProjects(ctx, org, "")
+}
+
+// GetOrganization returns the org namespace by user-facing name. Used to
+// resolve the root PathElement's display name when building Resource
+// entries — folder/project namespaces only carry the org's slug, not its
+// human-readable display name.
+func (c *K8sClient) GetOrganization(ctx context.Context, name string) (*corev1.Namespace, error) {
+	return c.organizations.GetOrganization(ctx, name)
+}

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -214,7 +214,177 @@ func (h *Handler) ListTemplates(
 	}), nil
 }
 
-// GetTemplate returns a single template by name.
+// SearchTemplates returns templates visible to the caller across organization,
+// folder, and project namespaces in a single flat response (HOL-602). The
+// request supports four optional, intersecting filters:
+//
+//   - namespace: when non-empty, only templates owned by the given namespace
+//     are returned. The namespace must classify through the resolver as one
+//     of organization/folder/project for RBAC to apply; an unclassifiable
+//     namespace yields an empty result rather than an error so this RPC
+//     behaves consistently with the "templates visible to the caller"
+//     contract.
+//   - name: exact DNS-label match against Template.name.
+//   - display_name_contains: case-insensitive substring match against
+//     Template.display_name.
+//   - organization: restricts results to namespaces rooted at the given
+//     organization. Combines with namespace when both are set.
+//
+// RBAC is enforced per owning namespace using the same TemplateCascadePerms
+// table that ListTemplates consults — a caller without PermissionTemplatesList
+// at a given scope simply doesn't see that scope's templates. Per-namespace
+// grant lookups are memoized for the duration of one request so a folder with
+// 100 templates pays one folder-grant lookup, not 100.
+func (h *Handler) SearchTemplates(
+	ctx context.Context,
+	req *connect.Request[consolev1.SearchTemplatesRequest],
+) (*connect.Response[consolev1.SearchTemplatesResponse], error) {
+	claims := rpc.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
+	}
+	if h.k8s == nil || h.k8s.Resolver == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("namespace resolver not wired"))
+	}
+
+	nameFilter := req.Msg.GetName()
+	displayNameNeedle := strings.ToLower(req.Msg.GetDisplayNameContains())
+	orgFilter := req.Msg.GetOrganization()
+	nsFilter := req.Msg.GetNamespace()
+
+	var crds []templatesv1alpha1.Template
+	if nsFilter != "" {
+		// Single-namespace path — equivalent to ListTemplates but without
+		// short-circuiting on access denial; if the caller cannot see the
+		// scope, the result is an empty list (visible-to-caller contract).
+		ns := nsFilter
+		scope, scopeName, classifyErr := scopeshim.FromNamespace(h.k8s.Resolver, ns)
+		if classifyErr != nil || scope == scopeshim.ScopeUnspecified {
+			// Unclassifiable namespace — return empty rather than error so
+			// the search RPC stays consistent with cross-scope behavior.
+			return connect.NewResponse(&consolev1.SearchTemplatesResponse{}), nil
+		}
+		// Apply organization filter when the namespace is folder- or
+		// project-scoped (org scope's name == filter target).
+		if orgFilter != "" && !h.namespaceBelongsToOrg(ctx, scope, scopeName, ns, orgFilter) {
+			return connect.NewResponse(&consolev1.SearchTemplatesResponse{}), nil
+		}
+		listed, err := h.k8s.ListTemplates(ctx, ns)
+		if err != nil {
+			return nil, mapK8sError(err)
+		}
+		// Skip the access check when the caller has no permission at this
+		// scope — return an empty list instead of erroring.
+		if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesList); err != nil {
+			return connect.NewResponse(&consolev1.SearchTemplatesResponse{}), nil
+		}
+		crds = listed
+	} else {
+		// Cross-scope path — list every Template the controller-runtime
+		// client can see and filter per template.
+		listed, err := h.k8s.ListAllTemplates(ctx)
+		if err != nil {
+			return nil, mapK8sError(err)
+		}
+		crds = listed
+	}
+
+	// Per-namespace access cache keyed by (ns) so we evaluate RBAC at most
+	// once per scope namespace within this request, even when the namespace
+	// owns N templates.
+	nsAccess := make(map[string]bool, 16)
+	allows := func(ns string) bool {
+		if cached, ok := nsAccess[ns]; ok {
+			return cached
+		}
+		scope, scopeName, classifyErr := scopeshim.FromNamespace(h.k8s.Resolver, ns)
+		if classifyErr != nil || scope == scopeshim.ScopeUnspecified {
+			nsAccess[ns] = false
+			return false
+		}
+		// Org filter: skip namespaces that don't roll up to the requested
+		// organization. For org-scope namespaces the scopeName is the org
+		// name itself; for folder and project namespaces consult the
+		// LabelOrganization stamped at create time (HOL-602).
+		if orgFilter != "" {
+			if !h.namespaceBelongsToOrg(ctx, scope, scopeName, ns, orgFilter) {
+				nsAccess[ns] = false
+				return false
+			}
+		}
+		err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesList)
+		ok := err == nil
+		nsAccess[ns] = ok
+		return ok
+	}
+
+	templates := make([]*consolev1.Template, 0, len(crds))
+	for i := range crds {
+		tmpl := &crds[i]
+		if nameFilter != "" && tmpl.Name != nameFilter {
+			continue
+		}
+		if displayNameNeedle != "" {
+			haystack := strings.ToLower(tmpl.Spec.DisplayName)
+			if !strings.Contains(haystack, displayNameNeedle) {
+				continue
+			}
+		}
+		if !allows(tmpl.Namespace) {
+			continue
+		}
+		scope, _, classifyErr := scopeshim.FromNamespace(h.k8s.Resolver, tmpl.Namespace)
+		if classifyErr != nil {
+			scope = scopeshim.ScopeUnspecified
+		}
+		templates = append(templates, templateCRDToProto(tmpl, scope))
+	}
+
+	slog.InfoContext(ctx, "templates searched",
+		slog.String("action", "templates_search"),
+		slog.String("resource_type", auditResourceType),
+		slog.String("namespace_filter", nsFilter),
+		slog.String("name_filter", nameFilter),
+		slog.String("display_name_contains", req.Msg.GetDisplayNameContains()),
+		slog.String("organization_filter", orgFilter),
+		slog.String("sub", claims.Sub),
+		slog.Int("count", len(templates)),
+	)
+
+	return connect.NewResponse(&consolev1.SearchTemplatesResponse{
+		Templates: templates,
+	}), nil
+}
+
+// namespaceBelongsToOrg reports whether the given namespace rolls up to the
+// given organization. For org-scope namespaces the check is direct against
+// the resolver-derived scope name; for folder and project namespaces it
+// reads the v1alpha2.LabelOrganization stamped on the namespace at create
+// time. The label is present on every managed namespace and is updated on
+// reparent, so a single Get-namespace lookup is enough to attribute the
+// namespace to its root organization without walking the parent chain
+// per template (HOL-602).
+//
+// Lookups are intentionally per-call here — SearchTemplates wraps the
+// allows() check in a per-namespace cache so each unique namespace sees at
+// most one Get-namespace round-trip per request.
+func (h *Handler) namespaceBelongsToOrg(ctx context.Context, scope scopeshim.Scope, scopeName, ns, org string) bool {
+	if scope == scopeshim.ScopeOrganization {
+		return scopeName == org
+	}
+	got, err := h.k8s.GetNamespaceOrg(ctx, ns)
+	if err != nil {
+		// Treat lookup failures as "not in this org" so a misconfigured
+		// fixture or a transient apiserver glitch never widens the search
+		// beyond what the caller asked for.
+		slog.WarnContext(ctx, "failed to resolve namespace organization for SearchTemplates filter",
+			slog.String("namespace", ns),
+			slog.Any("error", err),
+		)
+		return false
+	}
+	return got == org
+}
 func (h *Handler) GetTemplate(
 	ctx context.Context,
 	req *connect.Request[consolev1.GetTemplateRequest],

--- a/console/templates/handler_search_test.go
+++ b/console/templates/handler_search_test.go
@@ -1,0 +1,339 @@
+// handler_search_test.go exercises the cross-scope SearchTemplates RPC
+// introduced in HOL-602. The acceptance criteria are:
+//
+//   - filters across organization, folder, and project namespaces in a single
+//     flat response;
+//   - honors the existing per-scope RBAC on every namespace it visits;
+//   - supports namespace, name (exact), display_name_contains (case-
+//     insensitive substring), and organization filters.
+//
+// Tests follow the same pattern as TestRenderTemplateGroupedFolderScoped:
+// fixtures are expressed as fake.Clientset namespaces plus template
+// ConfigMaps, the testhelpers bridge translates the template ConfigMaps into
+// Template CRDs that the rewritten K8sClient reads through the controller-
+// runtime fake client.
+package templates
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
+	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+const (
+	searchOrg     = "acme"
+	searchFolder  = "payments"
+	searchProject = "checkout"
+)
+
+// folderNSWithParent builds a folder namespace fixture with the given parent
+// namespace label so the resolver/walker chain can traverse from a project
+// back to its root organization through the folder. SearchTemplates does not
+// itself walk ancestors, but exposing the full hierarchy in fixtures keeps
+// the tests aligned with the production wiring.
+func folderNSWithParent(folder, org, parentNs string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fld-" + folder,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelFolder:       folder,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+		},
+	}
+}
+
+// projectNSWithParent builds a project namespace fixture with the given
+// organization and parent namespace labels.
+func projectNSWithParent(project, org, parentNs string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prj-" + project,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+				v1alpha2.LabelOrganization: org,
+				v1alpha2.LabelProject:      project,
+				v1alpha2.AnnotationParent:  parentNs,
+			},
+		},
+	}
+}
+
+// templateCMInNs builds a template ConfigMap fixture in the given namespace.
+// Used to seed cross-scope template fixtures for SearchTemplates tests.
+func templateCMInNs(ns, name, displayName string, scopeLabel string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelTemplateScope: scopeLabel,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationDisplayName: displayName,
+				v1alpha2.AnnotationEnabled:     "true",
+			},
+		},
+		Data: map[string]string{CueTemplateKey: validCue},
+	}
+}
+
+// newSearchTestHandler builds a handler wired against the cross-scope
+// fixtures. The same shareUsers map drives org, folder, and project grant
+// resolvers so callers can assert RBAC behavior at every level by toggling
+// who is in the map and at what role.
+func newSearchTestHandler(t *testing.T, fakeClient *fake.Clientset, shareUsers map[string]string) *Handler {
+	t.Helper()
+	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+	k8s := newTestK8sClient(t, fakeClient, r)
+	handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
+	handler.WithOrgGrantResolver(&stubOrgGrantResolver{users: shareUsers})
+	handler.WithFolderGrantResolver(&stubFolderGrantResolver{users: shareUsers})
+	handler.WithProjectGrantResolver(&stubProjectGrantResolver{users: shareUsers})
+	return handler
+}
+
+// crossScopeFixture builds a fake clientset seeded with one organization
+// namespace, one folder namespace under that org, one project namespace
+// under that folder, and one enabled template per scope. Returns the
+// fake clientset plus the namespace strings for assertions.
+func crossScopeFixture() *fake.Clientset {
+	orgNsObj := orgNS(searchOrg)
+	fldNsObj := folderNSWithParent(searchFolder, searchOrg, "org-"+searchOrg)
+	prjNsObj := projectNSWithParent(searchProject, searchOrg, "fld-"+searchFolder)
+	orgTmpl := templateCMInNs("org-"+searchOrg, "httproute", "HTTPRoute", v1alpha2.TemplateScopeOrganization)
+	fldTmpl := templateCMInNs("fld-"+searchFolder, "payments-policy", "Payments Policy", v1alpha2.TemplateScopeFolder)
+	prjTmpl := templateCMInNs("prj-"+searchProject, "checkout-app", "Checkout App", v1alpha2.TemplateScopeProject)
+	return fake.NewClientset(orgNsObj, fldNsObj, prjNsObj, orgTmpl, fldTmpl, prjTmpl)
+}
+
+// templateNamespaces returns the sorted set of namespaces from a slice of
+// templates so test assertions don't depend on iteration order.
+func templateNamespaces(tmpls []*consolev1.Template) []string {
+	out := make([]string, 0, len(tmpls))
+	for _, tmpl := range tmpls {
+		out = append(out, tmpl.GetNamespace()+"/"+tmpl.GetName())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestSearchTemplates_Unauthenticated(t *testing.T) {
+	handler := newSearchTestHandler(t, crossScopeFixture(), nil)
+	_, err := handler.SearchTemplates(context.Background(), connect.NewRequest(&consolev1.SearchTemplatesRequest{}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got, want := connect.CodeOf(err), connect.CodeUnauthenticated; got != want {
+		t.Errorf("expected code %v, got %v", want, got)
+	}
+}
+
+func TestSearchTemplates_NoFiltersReturnsCrossScope(t *testing.T) {
+	const owner = "platform@localhost"
+	handler := newSearchTestHandler(t, crossScopeFixture(), map[string]string{owner: "owner"})
+	ctx := authedCtx(owner, nil)
+
+	resp, err := handler.SearchTemplates(ctx, connect.NewRequest(&consolev1.SearchTemplatesRequest{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := templateNamespaces(resp.Msg.GetTemplates())
+	want := []string{
+		"fld-" + searchFolder + "/payments-policy",
+		"org-" + searchOrg + "/httproute",
+		"prj-" + searchProject + "/checkout-app",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("templates mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestSearchTemplates_NamespaceFilter(t *testing.T) {
+	const owner = "platform@localhost"
+	handler := newSearchTestHandler(t, crossScopeFixture(), map[string]string{owner: "owner"})
+	ctx := authedCtx(owner, nil)
+
+	resp, err := handler.SearchTemplates(ctx, connect.NewRequest(&consolev1.SearchTemplatesRequest{
+		Namespace: "fld-" + searchFolder,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := templateNamespaces(resp.Msg.GetTemplates())
+	want := []string{"fld-" + searchFolder + "/payments-policy"}
+	if !equalStrings(got, want) {
+		t.Errorf("templates mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestSearchTemplates_NameExactFilter(t *testing.T) {
+	const owner = "platform@localhost"
+	handler := newSearchTestHandler(t, crossScopeFixture(), map[string]string{owner: "owner"})
+	ctx := authedCtx(owner, nil)
+
+	resp, err := handler.SearchTemplates(ctx, connect.NewRequest(&consolev1.SearchTemplatesRequest{
+		Name: "checkout-app",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := templateNamespaces(resp.Msg.GetTemplates())
+	want := []string{"prj-" + searchProject + "/checkout-app"}
+	if !equalStrings(got, want) {
+		t.Errorf("templates mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestSearchTemplates_DisplayNameContainsCaseInsensitive(t *testing.T) {
+	const owner = "platform@localhost"
+	handler := newSearchTestHandler(t, crossScopeFixture(), map[string]string{owner: "owner"})
+	ctx := authedCtx(owner, nil)
+
+	// "Payments Policy" should match "PAYMENTS" case-insensitively.
+	resp, err := handler.SearchTemplates(ctx, connect.NewRequest(&consolev1.SearchTemplatesRequest{
+		DisplayNameContains: "PAYMENTS",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := templateNamespaces(resp.Msg.GetTemplates())
+	want := []string{"fld-" + searchFolder + "/payments-policy"}
+	if !equalStrings(got, want) {
+		t.Errorf("templates mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestSearchTemplates_OrganizationFilter(t *testing.T) {
+	// Add a second organization with its own template — the filter should
+	// exclude it.
+	const otherOrg = "other-org"
+	cs := crossScopeFixture()
+	otherOrgNs := orgNS(otherOrg)
+	otherTmpl := templateCMInNs("org-"+otherOrg, "other-template", "Other Template", v1alpha2.TemplateScopeOrganization)
+	if _, err := cs.CoreV1().Namespaces().Create(context.Background(), otherOrgNs, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed other org: %v", err)
+	}
+	if _, err := cs.CoreV1().ConfigMaps(otherOrgNs.Name).Create(context.Background(), otherTmpl, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed other template: %v", err)
+	}
+
+	const owner = "platform@localhost"
+	handler := newSearchTestHandler(t, cs, map[string]string{owner: "owner"})
+	ctx := authedCtx(owner, nil)
+
+	resp, err := handler.SearchTemplates(ctx, connect.NewRequest(&consolev1.SearchTemplatesRequest{
+		Organization: searchOrg,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := templateNamespaces(resp.Msg.GetTemplates())
+	want := []string{
+		"fld-" + searchFolder + "/payments-policy",
+		"org-" + searchOrg + "/httproute",
+		"prj-" + searchProject + "/checkout-app",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("templates mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestSearchTemplates_RBACFiltersUnauthorizedNamespaces(t *testing.T) {
+	// The viewer email is granted only on the project namespace by virtue of
+	// being in the project's share-users; org and folder grant resolvers
+	// return an empty users map for this email so the caller is filtered
+	// out at those scopes. Org/folder templates must be excluded; the
+	// project template must be included.
+	const viewer = "viewer@localhost"
+	cs := crossScopeFixture()
+	// Stub resolvers all return the same shareUsers map. Distinguish by
+	// installing a per-resolver stub: project grants the viewer; org and
+	// folder do not.
+	r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
+	k8s := newTestK8sClient(t, cs, r)
+	handler := NewHandler(k8s, r, &stubRenderer{}, policyresolver.NewNoopResolver())
+	handler.WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{}})
+	handler.WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{}})
+	handler.WithProjectGrantResolver(&stubProjectGrantResolver{users: map[string]string{viewer: "viewer"}})
+
+	ctx := authedCtx(viewer, nil)
+	resp, err := handler.SearchTemplates(ctx, connect.NewRequest(&consolev1.SearchTemplatesRequest{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := templateNamespaces(resp.Msg.GetTemplates())
+	want := []string{"prj-" + searchProject + "/checkout-app"}
+	if !equalStrings(got, want) {
+		t.Errorf("templates mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+func TestSearchTemplates_NamespaceFilterRespectsRBAC(t *testing.T) {
+	// When namespace is set explicitly to a folder the caller cannot see,
+	// the response is empty (not an error — the contract is "templates
+	// visible to the caller").
+	const otherUser = "other@localhost"
+	handler := newSearchTestHandler(t, crossScopeFixture(), nil) // no grants
+	ctx := authedCtx(otherUser, nil)
+
+	resp, err := handler.SearchTemplates(ctx, connect.NewRequest(&consolev1.SearchTemplatesRequest{
+		Namespace: "fld-" + searchFolder,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(resp.Msg.GetTemplates()); got != 0 {
+		t.Errorf("expected 0 templates, got %d (%v)", got, templateNamespaces(resp.Msg.GetTemplates()))
+	}
+}
+
+// stubOrgGrantResolver is shared with handler_release_test.go but redefined
+// here for clarity: tests in this file may need to wire a fresh stub per
+// scope. The two stubs are structurally identical; the duplication is
+// harmless because handler_release_test.go's stub remains the single
+// definition for that file's tests.
+//
+// Actually: we cannot redefine stubOrgGrantResolver here without a duplicate
+// declaration error. The package-level stubOrgGrantResolver from
+// handler_release_test.go is reused.
+
+// equalStrings returns true if two string slices are element-wise equal.
+// Local helper to avoid pulling in a comparison library for a single use.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// _ = rpc.ClaimsFromContext keeps the import alive in case future tests in
+// this file want to inspect claims directly. The current tests pass through
+// authedCtx which already exercises the rpc package.
+var _ = rpc.ClaimsFromContext

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -139,6 +139,46 @@ func (k *K8sClient) ListTemplates(ctx context.Context, namespace string) ([]temp
 	return list.Items, nil
 }
 
+// ListAllTemplates returns every Template across every namespace the
+// controller-runtime client can see, filtered down to the holos-console
+// managed-by/resource-type=template label pair so unmanaged Template CRs
+// don't leak into the cross-scope SearchTemplates response.
+//
+// Used by SearchTemplates (HOL-602). Reads hit the same informer cache as
+// ListTemplates — the only difference is the absence of an InNamespace
+// option, which makes this a single cluster-wide List rather than one List
+// per scope namespace.
+func (k *K8sClient) ListAllTemplates(ctx context.Context) ([]templatesv1alpha1.Template, error) {
+	slog.DebugContext(ctx, "listing templates from kubernetes across all namespaces")
+	var list templatesv1alpha1.TemplateList
+	selector := ctrlclient.MatchingLabels{
+		v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+		v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplate,
+	}
+	if err := k.client.List(ctx, &list, selector); err != nil {
+		return nil, fmt.Errorf("listing templates across all namespaces: %w", err)
+	}
+	return list.Items, nil
+}
+
+// GetNamespaceOrg returns the v1alpha2.LabelOrganization value on the given
+// namespace, or "" if the namespace is missing or carries no such label.
+// Used by SearchTemplates (HOL-602) to apply the organization filter to
+// folder- and project-scope namespaces — the label is stamped on every
+// managed namespace at create time and is updated on reparent, so reading
+// it is enough to attribute the namespace to its root organization without
+// a Walker round-trip per namespace.
+func (k *K8sClient) GetNamespaceOrg(ctx context.Context, ns string) (string, error) {
+	got, err := k.coreClient.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if got.Labels == nil {
+		return "", nil
+	}
+	return got.Labels[v1alpha2.LabelOrganization], nil
+}
+
 // GetTemplate retrieves a Template by name from the given namespace.
 func (k *K8sClient) GetTemplate(ctx context.Context, namespace, name string) (*templatesv1alpha1.Template, error) {
 	slog.DebugContext(ctx, "getting template from kubernetes",


### PR DESCRIPTION
## Summary

- **SearchTemplates** (`console/templates/handler.go`): cross-scope template discovery. Accepts optional `namespace`, `name`, `display_name_contains`, and `organization` filters and returns a flat list of templates the caller can read across organization, folder, and project scopes. When `namespace` is set the handler delegates to the existing `ListTemplates` path; when unset it enumerates managed Template ConfigMaps cluster-wide and applies per-namespace RBAC via the scoped grant resolvers. Org filter consults `console.holos.run/organization` stamped on every managed namespace at create time.
- **ListResources** (new `console/resources/` package): cross-kind listing for the Linear-style navigation refactor. Returns folders + projects in a single flat list, each entry carrying its root→leaf ancestor `PathElement` chain. Uses `resolver.Walker` (cached per-request) to build paths, classifies each ancestor via `Resolver.ResourceTypeFromNamespace`, and enforces per-entry RBAC against `PermissionFoldersList` / `PermissionProjectsList` (no cross-kind cascade — matches existing per-kind handlers). The new `K8sClient` composes `folders.K8sClient`, `projects.K8sClient`, and `organizations.K8sClient` so label semantics stay defined in one place per kind.
- Wired both into the ConnectRPC surface via `consolev1connect.NewResourceServiceHandler` in `console/console.go`.

Fixes HOL-602

## Test plan

- [x] Unit tests for `SearchTemplates` covering: unauthenticated, no-filter cross-scope, namespace filter, exact name filter, case-insensitive `display_name_contains`, organization filter, RBAC scope filtering, namespace filter respects RBAC. (8 tests, `console/templates/handler_search_test.go`)
- [x] Unit tests for `ListResources` covering: unauthenticated, empty cluster, flat list with ancestors, deeply-nested 4-hop paths, organization filter, types filter (folders-only / projects-only), `RESOURCE_TYPE_UNSPECIFIED` is ignored, RBAC filters at every level (alice with no grants sees nothing; bob with project-only grants sees only the project). (9 tests, `console/resources/handler_test.go`)
- [x] `go test ./console/templates/... ./console/resources/...` — both packages pass; `console/resources` coverage 82.8%, `console/templates` coverage 69.1%.
- [x] `make test-go` — all packages pass after rebase on origin/main.
- [x] `make lint` — no new lint issues introduced (baseline 31 issues unchanged after my changes).
- [ ] Local E2E was not run (no k3d cluster available in this environment). Relying on CI E2E check.

## Notes

- New cross-kind RPC, no behavioral changes to existing `ListFolders` / `ListProjects` / `ListTemplates`.
- The `resolver.Walker.WalkAncestors` API returns child→parent; the handler reverses it and drops the leaf to produce the proto's required root→leaf order with the entry itself excluded from `path[]`.
- Per-request `CachedWalker` memoises ancestor chains across siblings — a deeply-nested project shared with siblings doesn't re-walk.
- Org root `PathElement.type` is `RESOURCE_TYPE_UNSPECIFIED` per the proto contract (organizations are not a `ResourceType`).

Generated with [Claude Code](https://claude.com/claude-code)