### PR TITLE
chore(console): remove legacy_shim breadcrumb comments (HOL-681)

### DIFF
--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -1476,16 +1476,9 @@ func (h *Handler) checkLinkedUpdate(ctx context.Context, ref *consolev1.LinkedTe
 	return update, nil
 }
 
-// extractScope converts an incoming namespace to the legacy
-// `(scope, scopeName)` pair the handler still uses for RBAC checks and
-// slog attributes. Returns InvalidArgument when the namespace is empty or
-// cannot be classified, matching the pre-HOL-619 contract that rejected
-// TEMPLATE_SCOPE_UNSPECIFIED.
-//
-// HOL-621 moved this helper out of the now-deleted legacy_shim.go and
-// into handler.go alongside the other scope plumbing; the RBAC tables
-// are keyed on scope, so the handler still needs the enum even though
-// storage no longer does.
+// extractScope converts an incoming namespace to the (scope, scopeName)
+// pair the handler uses for RBAC checks and slog attributes. Returns
+// InvalidArgument when the namespace is empty or cannot be classified.
 func (h *Handler) extractScope(namespace string) (scopeshim.Scope, string, error) {
 	if namespace == "" {
 		return scopeshim.ScopeUnspecified, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("namespace is required"))

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -153,13 +153,6 @@ func (k *K8sClient) GetTemplate(ctx context.Context, namespace, name string) (*t
 }
 
 // CreateTemplate creates a new Template CRD in the given namespace.
-//
-// The proto-level LinkedTemplateRef list is translated into the CRD's
-// structured spec field here — no JSON annotation round-trip is used any
-// more. HOL-619's annotation-based storage path is the main reason
-// legacy_shim.go needed to exist; with the CRD carrying linked refs as a
-// first-class field, callers can read and write them without parsing
-// JSON.
 func (k *K8sClient) CreateTemplate(
 	ctx context.Context,
 	namespace, name, displayName, description, cueTemplate string,


### PR DESCRIPTION
## Summary

- Trim two leftover breadcrumb comments in `console/templates/` that named the deleted `legacy_shim.go` file and the retired HOL-619 annotation path.
- `CreateTemplate` godoc in `console/templates/k8s.go` is now a single-line summary of what the function does. The prior narrative about the LinkedTemplateRef proto translation and why `legacy_shim.go` had to exist is pure history.
- `extractScope` godoc in `console/templates/handler.go` is now three lines describing the conversion, its callers, and the error contract. The prior paragraphs referenced the pre-HOL-619 contract and the HOL-621 move out of `legacy_shim.go`; both are backstop history.

The sibling `ProjectNamespaceError` breadcrumbs listed on the ticket were already removed as part of HOL-662 and HOL-663 once rebased onto main, so no edits were needed for the `templatepolicies` or `templatepolicybindings` packages.

Fixes HOL-681

## Test plan

- [x] `grep -r 'legacy_shim' console/` returns zero hits.
- [x] `grep -r 'ProjectNamespaceError' console/` returns zero hits.
- [x] `go test ./console/templates/...` passes.
- [ ] `make lint` inherits 31 pre-existing issues on main; my change adds none. (Confirmed by running lint with and without the change.)

> Local E2E was not run — comment-only change, no behavior touched.

Generated with [Claude Code](https://claude.com/claude-code)