### PR TITLE
feat(frontend): Linear-style workspace menu replaces sidebar pickers

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -141,15 +141,14 @@ test.describe('Profile Page', () => {
     await expect(page.getByText('ID Token Status')).toBeVisible({ timeout: 10000 })
   })
 
-  test('should navigate to profile page from sidebar', async ({ page }) => {
+  test('should navigate to profile page from workspace menu', async ({ page }) => {
     // Login + cross-page navigation takes extra time on mobile CI.
     test.setTimeout(60_000)
 
     await loginViaProfilePage(page)
 
-    // Navigate away from profile to test sidebar navigation. Use a project
-    // route rather than /about (sidebar footer, adjacent to Profile) to avoid
-    // the About link intercepting clicks on Profile on mobile.
+    // Navigate away from profile so the sidebar workspace menu is the route
+    // under test.
     await page.goto('/projects/e2e-auth-nav-test/secrets')
     await page.waitForLoadState('networkidle')
 
@@ -161,8 +160,10 @@ test.describe('Profile Page', () => {
       await page.waitForTimeout(500)
     }
 
-    // Click Profile link in sidebar
-    await page.getByRole('link', { name: 'Profile' }).click()
+    // HOL-603 moved Profile from the sidebar footer into the workspace menu
+    // dropdown at the top of the sidebar. Open the menu, then click Profile.
+    await page.getByTestId('workspace-menu').click()
+    await page.getByTestId('workspace-menu-item-profile').click()
 
     // Verify URL is /profile
     await expect(page).toHaveURL(/\/profile/)

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -299,21 +299,27 @@ export async function apiDeleteFolder(
 }
 
 /**
- * Select an org in the sidebar org picker.
- * Navigates to /profile to ensure the sidebar is loaded with org data.
+ * Select an org via the /organizations page. HOL-603 removed the sidebar
+ * org picker in favor of the workspace menu -> "Switch organization" flow,
+ * which lands on /organizations. We navigate there, filter the table by
+ * org name, and click the matching row. This both sets the org in
+ * OrgContext and navigates to the org-scoped projects index.
  */
 export async function selectOrg(page: Page, orgName: string): Promise<void> {
-  await page.goto('/profile')
+  await page.goto('/organizations')
   await page.waitForLoadState('networkidle')
 
-  const sidebarTrigger = page.getByRole('button', { name: /toggle sidebar/i })
-  if (await sidebarTrigger.isVisible({ timeout: 2000 }).catch(() => false)) {
-    await sidebarTrigger.click()
-  }
+  const search = page.getByPlaceholder(/search organizations/i)
+  await search.waitFor({ timeout: 5000 })
+  await search.fill(orgName)
 
-  await page.getByTestId('org-picker').waitFor({ timeout: 5000 })
-  await page.getByTestId('org-picker').click()
-  await page.getByRole('menuitem', { name: orgName }).click()
+  await page
+    .getByRole('row')
+    .filter({ hasText: orgName })
+    .first()
+    .click()
+
+  await page.waitForURL(new RegExp(`/orgs/${orgName}/projects`), { timeout: 5000 })
 }
 
 /**

--- a/frontend/e2e/multi-persona.spec.ts
+++ b/frontend/e2e/multi-persona.spec.ts
@@ -82,23 +82,14 @@ test.describe('Multi-Persona RBAC', () => {
     // Login as SRE (who was granted VIEWER on the org in the previous test)
     await loginAsPersona(page, SRE_EMAIL)
 
-    // Navigate to profile and verify the org is accessible via the sidebar.
-    // Use /profile so the sidebar is loaded with org data.
-    await page.goto('/profile')
+    // HOL-603 moved org switching from a sidebar picker to the /organizations
+    // page reached via the workspace menu. The org should be listed there for
+    // a user granted VIEWER access.
+    await page.goto('/organizations')
     await page.waitForLoadState('networkidle')
 
-    // On mobile viewports, open the sidebar drawer first.
-    const sidebarTrigger = page.getByRole('button', { name: /toggle sidebar/i })
-    if (await sidebarTrigger.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await sidebarTrigger.click()
-      await page.waitForTimeout(500) // Wait for drawer animation
-    }
-
-    // The org should appear in the sidebar org picker.
-    await page.getByTestId('org-picker').waitFor({ timeout: 5000 })
-    await page.getByTestId('org-picker').click()
     await expect(
-      page.getByRole('menuitem', { name: orgName }),
+      page.getByRole('row').filter({ hasText: orgName }).first(),
     ).toBeVisible({ timeout: 5000 })
   })
 
@@ -108,22 +99,13 @@ test.describe('Multi-Persona RBAC', () => {
     // Login as product engineer (who was granted EDITOR on the org)
     await loginAsPersona(page, PRODUCT_ENGINEER_EMAIL)
 
-    // Navigate to profile and verify the org is accessible via the sidebar.
-    await page.goto('/profile')
+    // HOL-603 moved org switching to the /organizations page (reached via
+    // the workspace menu). Verify the org is listed for the granted user.
+    await page.goto('/organizations')
     await page.waitForLoadState('networkidle')
 
-    // On mobile viewports, open the sidebar drawer first.
-    const sidebarTrigger = page.getByRole('button', { name: /toggle sidebar/i })
-    if (await sidebarTrigger.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await sidebarTrigger.click()
-      await page.waitForTimeout(500) // Wait for drawer animation
-    }
-
-    // The org should appear in the sidebar org picker.
-    await page.getByTestId('org-picker').waitFor({ timeout: 5000 })
-    await page.getByTestId('org-picker').click()
     await expect(
-      page.getByRole('menuitem', { name: orgName }),
+      page.getByRole('row').filter({ hasText: orgName }).first(),
     ).toBeVisible({ timeout: 5000 })
   })
 })

--- a/frontend/e2e/secrets.spec.ts
+++ b/frontend/e2e/secrets.spec.ts
@@ -251,7 +251,8 @@ test.describe('Mobile Responsive Layout', () => {
     // Tap hamburger to open drawer
     await page.getByRole('button', { name: /toggle sidebar/i }).click()
 
-    // Profile link should be visible in the drawer (always present)
-    await expect(page.getByRole('link', { name: 'Profile' })).toBeVisible({ timeout: 5000 })
+    // Workspace menu trigger (HOL-603) is rendered at the top of the sidebar
+    // and is always present, so it acts as the drawer-visible sentinel.
+    await expect(page.getByTestId('workspace-menu')).toBeVisible({ timeout: 5000 })
   })
 })

--- a/frontend/src/components/-app-sidebar.test.tsx
+++ b/frontend/src/components/-app-sidebar.test.tsx
@@ -46,23 +46,12 @@ vi.mock('@/components/ui/sidebar', () => ({
   SidebarSeparator: () => <hr />,
 }))
 
-vi.mock('@/components/ui/dropdown-menu', () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => <div onClick={onClick}>{children}</div>,
-  DropdownMenuSeparator: () => <hr />,
-  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}))
-
-vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children: React.ReactNode; variant?: string; size?: string }) => <button {...props}>{children}</button>,
-}))
-
-vi.mock('@/components/create-org-dialog', () => ({
-  CreateOrgDialog: () => null,
-}))
-vi.mock('@/components/create-project-dialog', () => ({
-  CreateProjectDialog: () => null,
+// Stub WorkspaceMenu so the AppSidebar test stays focused on sidebar nav
+// composition; WorkspaceMenu has its own dedicated test file. WorkspaceMenu
+// owns the dropdown-menu and dialog wiring after HOL-603, so AppSidebar no
+// longer imports those primitives directly.
+vi.mock('@/components/workspace-menu', () => ({
+  WorkspaceMenu: () => <div data-testid="workspace-menu" />,
 }))
 
 import { useOrg } from '@/lib/org-context'

--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -35,7 +35,6 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('@/components/ui/sidebar', () => ({
   Sidebar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SidebarFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarGroupContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarGroupLabel: ({ children }: { children: React.ReactNode }) => (
@@ -49,53 +48,21 @@ vi.mock('@/components/ui/sidebar', () => ({
   SidebarSeparator: () => <hr />,
 }))
 
-vi.mock('@/components/ui/dropdown-menu', () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({
-    children,
-    onClick,
-  }: {
-    children: React.ReactNode
-    onClick?: () => void
-  }) => <div onClick={onClick}>{children}</div>,
-  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuSeparator: () => <hr />,
+// Stub the workspace menu so AppSidebar tests stay focused on sidebar
+// composition; WorkspaceMenu has its own dedicated test file.
+vi.mock('@/components/workspace-menu', () => ({
+  WorkspaceMenu: () => <div data-testid="workspace-menu" />,
 }))
 
 vi.mock('@/lib/org-context', () => ({ useOrg: vi.fn() }))
 vi.mock('@/lib/project-context', () => ({ useProject: vi.fn() }))
 vi.mock('@/queries/version', () => ({ useVersion: vi.fn() }))
 vi.mock('@/queries/project-settings', () => ({ useGetProjectSettings: vi.fn() }))
-vi.mock('@/queries/organizations', () => ({
-  useListOrganizations: vi.fn().mockReturnValue({ data: { organizations: [] }, isLoading: false }),
-  useCreateOrganization: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
-}))
-vi.mock('@/queries/projects', () => ({
-  useListProjects: vi.fn().mockReturnValue({ data: { projects: [] }, isLoading: false }),
-  useCreateProject: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
-}))
-// The dialog mocks respect the `open` prop so tests can assert the sidebar's
-// CTAs actually open the dialog. Without this, a regression in the
-// "click New Organization opens the dialog" wiring would go undetected by
-// make test-ui (HOL-654 review round 1).
-vi.mock('@/components/create-org-dialog', () => ({
-  CreateOrgDialog: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="create-org-dialog" /> : null,
-}))
-vi.mock('@/components/create-project-dialog', () => ({
-  CreateProjectDialog: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="create-project-dialog" /> : null,
-}))
-vi.mock('@/lib/console-config', () => ({
-  getConsoleConfig: vi.fn(),
-}))
 
 import { useOrg } from '@/lib/org-context'
 import { useProject } from '@/lib/project-context'
 import { useVersion } from '@/queries/version'
 import { useGetProjectSettings } from '@/queries/project-settings'
-import { getConsoleConfig } from '@/lib/console-config'
 import { AppSidebar } from './app-sidebar'
 
 function setDefaults() {
@@ -113,7 +80,6 @@ function setDefaults() {
   })
   ;(useVersion as Mock).mockReturnValue({ data: { version: 'v0.0.0-test' } })
   ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: false }, isPending: false })
-  ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: false })
 }
 
 describe('AppSidebar', () => {
@@ -121,6 +87,11 @@ describe('AppSidebar', () => {
     vi.clearAllMocks()
     mockNavigate.mockReset()
     setDefaults()
+  })
+
+  it('renders the workspace menu in the header', () => {
+    render(<AppSidebar />)
+    expect(screen.getByTestId('workspace-menu')).toBeInTheDocument()
   })
 
   it('renders without a theme toggle button', () => {
@@ -139,23 +110,29 @@ describe('AppSidebar', () => {
     expect(screen.getByText('v0.0.0-test')).toBeDefined()
   })
 
-  it('renders About link in sidebar footer', () => {
+  // HOL-603 moves Profile, About, and Dev Tools off the sidebar footer and
+  // into the workspace menu. The footer is no longer rendered at all in this
+  // phase. These regression tests guard against re-introducing those entries
+  // at the sidebar level by accident.
+  it('does not render an About link in the sidebar (moved to workspace menu)', () => {
     render(<AppSidebar />)
-    expect(screen.getByText('About')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^about$/i })).toBeNull()
   })
 
-  it('renders Profile link in sidebar footer', () => {
+  it('does not render a Profile link in the sidebar (moved to workspace menu)', () => {
     render(<AppSidebar />)
-    expect(screen.getByText('Profile')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^profile$/i })).toBeNull()
   })
 
-  it('About appears before Profile in DOM order', () => {
+  it('does not render a Dev Tools link in the sidebar (moved to workspace menu)', () => {
     render(<AppSidebar />)
-    const items = screen.getAllByRole('listitem')
-    const aboutIdx = items.findIndex((el) => el.textContent?.includes('About'))
-    const profileIdx = items.findIndex((el) => el.textContent?.includes('Profile'))
-    expect(aboutIdx).toBeGreaterThanOrEqual(0)
-    expect(profileIdx).toBeGreaterThan(aboutIdx)
+    expect(screen.queryByRole('link', { name: /dev tools/i })).toBeNull()
+  })
+
+  it('does not render OrgPicker or ProjectPicker dropdowns (replaced by workspace menu)', () => {
+    render(<AppSidebar />)
+    expect(screen.queryByTestId('org-picker')).toBeNull()
+    expect(screen.queryByTestId('project-picker')).toBeNull()
   })
 
   it('does not render project nav links when no project is selected', () => {
@@ -175,12 +152,6 @@ describe('AppSidebar — org selected', () => {
       setSelectedOrg: vi.fn(),
       isLoading: false,
     })
-  })
-
-  it('renders project picker area when an org is selected', () => {
-    render(<AppSidebar />)
-    // With no projects, ProjectPicker shows the empty state with "New Project" button.
-    expect(screen.getByRole('button', { name: /new project/i })).toBeDefined()
   })
 
   it('renders org Settings link labeled "Org Settings" with correct href', () => {
@@ -217,342 +188,6 @@ describe('AppSidebar — org selected', () => {
     })
     render(<AppSidebar />)
     expect(screen.queryByTestId('sidebar-group-label')).toBeNull()
-  })
-})
-
-describe('AppSidebar — OrgPicker navigation', () => {
-  const setSelectedOrg = vi.fn()
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockNavigate.mockReset()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [
-        { name: 'org-a', displayName: 'Org A' },
-        { name: 'org-b', displayName: 'Org B' },
-      ],
-      selectedOrg: 'org-a',
-      setSelectedOrg,
-      isLoading: false,
-    })
-  })
-
-  it('navigates to org projects page when an org is selected in the picker', async () => {
-    const { userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    render(<AppSidebar />)
-    const orgBItem = screen.getByText('Org B')
-    await user.click(orgBItem)
-    expect(setSelectedOrg).toHaveBeenCalledWith('org-b')
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/orgs/$orgName/projects',
-      params: { orgName: 'org-b' },
-    })
-  })
-})
-
-describe('AppSidebar — OrgPicker empty state', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    // organizations is empty and not loading
-  })
-
-  it('renders "New Organization" button when no orgs and not loading', () => {
-    render(<AppSidebar />)
-    expect(screen.getByRole('button', { name: /new organization/i })).toBeDefined()
-  })
-
-  it('does not render org picker dropdown when no orgs', () => {
-    render(<AppSidebar />)
-    expect(screen.queryByTestId('org-picker')).toBeNull()
-  })
-})
-
-// The two tests below cover behaviour migrated from
-// frontend/e2e/create-dialogs.spec.ts (HOL-654). The E2E suite exercised the
-// bottom-of-dropdown "New Organization" / "New Project" affordances against
-// the real K8s backend; here we assert the same DOM ordering with mocked
-// query hooks, per the E2E refactor audit.
-describe('AppSidebar — OrgPicker menu with existing orgs', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [
-        { name: 'org-a', displayName: 'Org A' },
-        { name: 'org-b', displayName: 'Org B' },
-      ],
-      selectedOrg: 'org-a',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-  })
-
-  it('renders the org-picker dropdown trigger', () => {
-    render(<AppSidebar />)
-    expect(screen.getByTestId('org-picker')).toBeDefined()
-  })
-
-  it('includes a New Organization item in the menu after the listed orgs', () => {
-    render(<AppSidebar />)
-
-    // The mocked DropdownMenuItem renders as a div (not role=menuitem), so we
-    // locate the entry by its visible text.
-    const newOrgItem = screen.getByText(/new organization/i)
-    expect(newOrgItem).toBeDefined()
-
-    // Assert DOM ordering: "New Organization" must appear after the last org
-    // in the picker (matches the E2E assertion that it sits at the *bottom*
-    // of the dropdown).
-    const orgBNode = screen.getByText('Org B')
-    expect(orgBNode.compareDocumentPosition(newOrgItem) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-  })
-})
-
-describe('AppSidebar — ProjectPicker menu with existing projects', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [{ name: 'my-org', displayName: 'My Org' }],
-      selectedOrg: 'my-org',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-    ;(useProject as Mock).mockReturnValue({
-      projects: [
-        { name: 'project-a', displayName: 'Project A' },
-        { name: 'project-b', displayName: 'Project B' },
-      ],
-      selectedProject: null,
-      setSelectedProject: vi.fn(),
-      isLoading: false,
-    })
-  })
-
-  it('renders the project-picker dropdown trigger', () => {
-    render(<AppSidebar />)
-    expect(screen.getByTestId('project-picker')).toBeDefined()
-  })
-
-  it('includes a New Project item in the menu after the listed projects', () => {
-    render(<AppSidebar />)
-
-    const newProjectMatches = screen.getAllByText(/new project/i)
-    // The ProjectPicker renders "New Project" once — inside the dropdown. The
-    // empty-state CTA button with the same label is NOT rendered here because
-    // projects.length > 0.
-    expect(newProjectMatches.length).toBeGreaterThanOrEqual(1)
-
-    const lastProject = screen.getByText('Project B')
-    const newProjectItem = newProjectMatches[newProjectMatches.length - 1]
-    expect(lastProject.compareDocumentPosition(newProjectItem) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-  })
-})
-
-// Sidebar-launches-dialog coverage migrated from
-// frontend/e2e/create-dialogs.spec.ts (HOL-654 review round 1). These tests
-// assert that clicking the sidebar's "New Organization" / "New Project"
-// affordances opens the corresponding dialog. Without these, a regression in
-// the dialog-open wiring would silently break the create flow the deleted E2E
-// suite exercised end-to-end.
-describe('AppSidebar — New Organization CTA opens the dialog', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    // Empty orgs: OrgPicker renders the New Organization button (not a menu).
-  })
-
-  it('empty-state New Organization button opens the create-org dialog', async () => {
-    const { userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    render(<AppSidebar />)
-
-    // Dialog is closed before the click.
-    expect(screen.queryByTestId('create-org-dialog')).toBeNull()
-
-    const button = screen.getByRole('button', { name: /new organization/i })
-    await user.click(button)
-
-    expect(screen.getByTestId('create-org-dialog')).toBeDefined()
-  })
-})
-
-describe('AppSidebar — New Organization menu item opens the dialog when orgs exist', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [{ name: 'org-a', displayName: 'Org A' }],
-      selectedOrg: 'org-a',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-  })
-
-  it('clicking the New Organization dropdown item opens the create-org dialog', async () => {
-    const { userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    render(<AppSidebar />)
-
-    expect(screen.queryByTestId('create-org-dialog')).toBeNull()
-
-    // The "New Organization" dropdown item renders as a div (mocked
-    // DropdownMenuItem). userEvent can still click on it.
-    const newOrgItem = screen.getByText(/new organization/i)
-    await user.click(newOrgItem)
-
-    expect(screen.getByTestId('create-org-dialog')).toBeDefined()
-  })
-})
-
-describe('AppSidebar — New Project CTA opens the dialog', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [{ name: 'my-org', displayName: 'My Org' }],
-      selectedOrg: 'my-org',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-    // Projects list empty: ProjectPicker renders the New Project button.
-  })
-
-  it('empty-state New Project button opens the create-project dialog', async () => {
-    const { userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    render(<AppSidebar />)
-
-    expect(screen.queryByTestId('create-project-dialog')).toBeNull()
-
-    const button = screen.getByRole('button', { name: /new project/i })
-    await user.click(button)
-
-    expect(screen.getByTestId('create-project-dialog')).toBeDefined()
-  })
-})
-
-describe('AppSidebar — New Project menu item opens the dialog when projects exist', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [{ name: 'my-org', displayName: 'My Org' }],
-      selectedOrg: 'my-org',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-    ;(useProject as Mock).mockReturnValue({
-      projects: [{ name: 'project-a', displayName: 'Project A' }],
-      selectedProject: null,
-      setSelectedProject: vi.fn(),
-      isLoading: false,
-    })
-  })
-
-  it('clicking the New Project dropdown item opens the create-project dialog', async () => {
-    const { userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    render(<AppSidebar />)
-
-    expect(screen.queryByTestId('create-project-dialog')).toBeNull()
-
-    const newProjectItem = screen.getByText(/new project/i)
-    await user.click(newProjectItem)
-
-    expect(screen.getByTestId('create-project-dialog')).toBeDefined()
-  })
-})
-
-describe('AppSidebar — ProjectPicker empty state', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [{ name: 'my-org', displayName: 'My Org' }],
-      selectedOrg: 'my-org',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-    // projects is empty and not loading
-  })
-
-  it('renders "New Project" button when org is selected but no projects', () => {
-    render(<AppSidebar />)
-    expect(screen.getByRole('button', { name: /new project/i })).toBeDefined()
-  })
-
-  it('does not render project picker dropdown when no projects', () => {
-    render(<AppSidebar />)
-    expect(screen.queryByTestId('project-picker')).toBeNull()
-  })
-})
-
-describe('AppSidebar — ProjectPicker navigation', () => {
-  const setSelectedProject = vi.fn()
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockNavigate.mockReset()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [{ name: 'my-org', displayName: 'My Org' }],
-      selectedOrg: 'my-org',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-    ;(useProject as Mock).mockReturnValue({
-      projects: [
-        { name: 'project-a', displayName: 'Project A' },
-        { name: 'project-b', displayName: 'Project B' },
-      ],
-      selectedProject: null,
-      setSelectedProject,
-      isLoading: false,
-    })
-  })
-
-  it('selecting a project in the picker navigates directly to its secrets page', async () => {
-    const { userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    render(<AppSidebar />)
-
-    // The picker renders each project's display name as a menuitem.
-    const projectBItem = screen.getByText('Project B')
-    await user.click(projectBItem)
-
-    expect(setSelectedProject).toHaveBeenCalledWith('project-b')
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/projects/$projectName/secrets',
-      params: { projectName: 'project-b' },
-    })
-  })
-
-  it('selecting "All Projects" in the picker navigates to the org projects page and clears selection', async () => {
-    const { userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    render(<AppSidebar />)
-
-    // "All Projects" appears twice: once as the picker trigger label (a button
-    // with data-testid="project-picker") and once as the first dropdown menu
-    // item. The dropdown item is rendered by the mocked DropdownMenuItem as a
-    // clickable div — pick the text element that is *not* inside the trigger
-    // button.
-    const allProjectsNodes = screen.getAllByText('All Projects')
-    const menuItemNode = allProjectsNodes.find(
-      (el) => !el.closest('button[data-testid="project-picker"]'),
-    )
-    expect(menuItemNode).toBeDefined()
-    await user.click(menuItemNode!)
-
-    expect(setSelectedProject).toHaveBeenCalledWith(null)
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/orgs/$orgName/projects',
-      params: { orgName: 'my-org' },
-    })
   })
 })
 
@@ -668,41 +303,5 @@ describe('AppSidebar — Templates nav item conditional visibility', () => {
     render(<AppSidebar />)
     const link = screen.getByRole('link', { name: /^deployments$/i })
     expect(link.getAttribute('href')).toBe('/projects/my-project/deployments')
-  })
-})
-
-describe('AppSidebar — Dev Tools conditional visibility', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-  })
-
-  it('renders Dev Tools link when devToolsEnabled is true', () => {
-    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
-    render(<AppSidebar />)
-    expect(screen.getByText('Dev Tools')).toBeInTheDocument()
-  })
-
-  it('does not render Dev Tools link when devToolsEnabled is false', () => {
-    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: false })
-    render(<AppSidebar />)
-    expect(screen.queryByText('Dev Tools')).not.toBeInTheDocument()
-  })
-
-  it('Dev Tools link points to /dev-tools', () => {
-    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
-    render(<AppSidebar />)
-    const link = screen.getByRole('link', { name: /dev tools/i })
-    expect(link.getAttribute('href')).toBe('/dev-tools')
-  })
-
-  it('Dev Tools appears before About in DOM order', () => {
-    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
-    render(<AppSidebar />)
-    const items = screen.getAllByRole('listitem')
-    const devToolsIdx = items.findIndex((el) => el.textContent?.includes('Dev Tools'))
-    const aboutIdx = items.findIndex((el) => el.textContent?.includes('About'))
-    expect(devToolsIdx).toBeGreaterThanOrEqual(0)
-    expect(aboutIdx).toBeGreaterThan(devToolsIdx)
   })
 })

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,24 +1,17 @@
-import { useState } from 'react'
 import type React from 'react'
 import { Link, useRouter } from '@tanstack/react-router'
 import {
-  Info,
   KeyRound,
   Folder,
   FolderKanban,
   LayoutTemplate,
   Layers,
-  Plus,
   Settings,
   Shield,
-  User,
-  Wrench,
-  ChevronsUpDown,
 } from 'lucide-react'
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -28,32 +21,11 @@ import {
   SidebarMenuItem,
   SidebarSeparator,
 } from '@/components/ui/sidebar'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { Button } from '@/components/ui/button'
 import { useOrg } from '@/lib/org-context'
 import { useProject } from '@/lib/project-context'
-import { getConsoleConfig } from '@/lib/console-config'
 import { useVersion } from '@/queries/version'
 import { useGetProjectSettings } from '@/queries/project-settings'
-import { CreateOrgDialog } from '@/components/create-org-dialog'
-import { CreateProjectDialog } from '@/components/create-project-dialog'
-
-function getBottomItems() {
-  const { devToolsEnabled } = getConsoleConfig()
-  return [
-    ...(devToolsEnabled
-      ? [{ label: 'Dev Tools', to: '/dev-tools' as const, icon: Wrench }]
-      : []),
-    { label: 'About', to: '/about' as const, icon: Info },
-    { label: 'Profile', to: '/profile' as const, icon: User },
-  ]
-}
+import { WorkspaceMenu } from '@/components/workspace-menu'
 
 export function AppSidebar() {
   const { data: versionData } = useVersion()
@@ -168,17 +140,20 @@ export function AppSidebar() {
 
   return (
     <Sidebar>
-      <SidebarHeader className="px-4 py-3">
-        <div className="font-semibold text-lg">Holos Console</div>
+      <SidebarHeader className="px-2 py-2">
+        {/*
+          HOL-603 replaces the previous stacked OrgPicker + ProjectPicker
+          with a single Linear-style workspace menu. Profile / Dev Tools
+          have moved off the footer and into this menu so all "global" nav
+          lives in one place at the top of the sidebar.
+        */}
+        <WorkspaceMenu />
         {versionData?.version && (
-          <div className="text-xs text-muted-foreground">{versionData.version}</div>
+          <div className="px-2 pt-1 text-xs text-muted-foreground">
+            {versionData.version}
+          </div>
         )}
       </SidebarHeader>
-
-      <SidebarSeparator />
-
-      <OrgPicker />
-      <ProjectPicker />
 
       <SidebarSeparator />
 
@@ -230,185 +205,6 @@ export function AppSidebar() {
           </SidebarGroup>
         )}
       </SidebarContent>
-
-      <SidebarFooter>
-        <SidebarSeparator />
-        <SidebarMenu>
-          {getBottomItems().map((item) => (
-            <SidebarMenuItem key={item.label}>
-              <SidebarMenuButton asChild isActive={pathname.startsWith(item.to)}>
-                <Link to={item.to}>
-                  <item.icon className="h-4 w-4" />
-                  <span>{item.label}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
-        <SidebarSeparator />
-      </SidebarFooter>
     </Sidebar>
-  )
-}
-
-function OrgPicker() {
-  const { organizations, selectedOrg, setSelectedOrg, isLoading } = useOrg()
-  const router = useRouter()
-  const [createOpen, setCreateOpen] = useState(false)
-
-  if (isLoading) return null
-
-  if (organizations.length === 0) {
-    return (
-      <div className="px-2 py-1">
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full"
-          onClick={() => setCreateOpen(true)}
-        >
-          <Plus className="h-4 w-4 mr-2" /> New Organization
-        </Button>
-        <CreateOrgDialog
-          open={createOpen}
-          onOpenChange={setCreateOpen}
-          onCreated={(name) => setSelectedOrg(name)}
-        />
-      </div>
-    )
-  }
-
-  const selectedOrgObj = organizations.find((o) => o.name === selectedOrg)
-  const displayLabel = selectedOrgObj
-    ? (selectedOrgObj.displayName || selectedOrgObj.name)
-    : 'All Organizations'
-
-  return (
-    <div className="px-2 py-1">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button data-testid="org-picker" className="flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-accent">
-            <span className="truncate">{displayLabel}</span>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56" align="start">
-          <DropdownMenuItem onClick={() => setSelectedOrg(null)}>
-            All Organizations
-          </DropdownMenuItem>
-          {organizations.map((org) => (
-            <DropdownMenuItem
-              key={org.name}
-              onClick={() => {
-                setSelectedOrg(org.name)
-                router.navigate({
-                  to: '/orgs/$orgName/projects',
-                  params: { orgName: org.name },
-                })
-              }}
-            >
-              {org.displayName || org.name}
-            </DropdownMenuItem>
-          ))}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" /> New Organization
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <CreateOrgDialog
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-        onCreated={(name) => setSelectedOrg(name)}
-      />
-    </div>
-  )
-}
-
-function ProjectPicker() {
-  const { selectedOrg } = useOrg()
-  const { projects, selectedProject, setSelectedProject, isLoading } = useProject()
-  const router = useRouter()
-  const [createOpen, setCreateOpen] = useState(false)
-
-  // Only show when an org is selected
-  if (!selectedOrg) return null
-  if (isLoading) return null
-
-  if (projects.length === 0) {
-    return (
-      <div className="px-2 py-1">
-        <p className="px-1 pb-1 text-sm text-muted-foreground">No projects yet.</p>
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full"
-          onClick={() => setCreateOpen(true)}
-        >
-          <Plus className="h-4 w-4 mr-2" /> New Project
-        </Button>
-        <CreateProjectDialog
-          open={createOpen}
-          onOpenChange={setCreateOpen}
-          defaultOrganization={selectedOrg}
-          onCreated={(name) => setSelectedProject(name)}
-        />
-      </div>
-    )
-  }
-
-  const selectedProjectObj = projects.find((p) => p.name === selectedProject)
-  const displayLabel = selectedProjectObj
-    ? (selectedProjectObj.displayName || selectedProjectObj.name)
-    : 'All Projects'
-
-  return (
-    <div className="px-2 py-1">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button data-testid="project-picker" className="flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-accent">
-            <span className="truncate">{displayLabel}</span>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56" align="start">
-          <DropdownMenuItem
-            onClick={() => {
-              setSelectedProject(null)
-              router.navigate({
-                to: '/orgs/$orgName/projects',
-                params: { orgName: selectedOrg },
-              })
-            }}
-          >
-            All Projects
-          </DropdownMenuItem>
-          {projects.map((project) => (
-            <DropdownMenuItem
-              key={project.name}
-              onClick={() => {
-                setSelectedProject(project.name)
-                router.navigate({
-                  to: '/projects/$projectName/secrets',
-                  params: { projectName: project.name },
-                })
-              }}
-            >
-              {project.displayName || project.name}
-            </DropdownMenuItem>
-          ))}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" /> New Project
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <CreateProjectDialog
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-        defaultOrganization={selectedOrg}
-        onCreated={(name) => setSelectedProject(name)}
-      />
-    </div>
   )
 }

--- a/frontend/src/components/workspace-menu.test.tsx
+++ b/frontend/src/components/workspace-menu.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    params,
+    ...rest
+  }: {
+    children: React.ReactNode
+    to: string
+    params?: Record<string, string>
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    let href = to
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => {
+        href = href.replace(`$${k}`, v)
+      })
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+// shadcn dropdown is portaled and animation-driven; flatten it for the unit
+// tests so menu items are queryable without simulating an open click.
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="workspace-menu-content">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => (asChild ? <>{children}</> : <div>{children}</div>),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => (asChild ? <>{children}</> : <div>{children}</div>),
+}))
+
+vi.mock('@/lib/org-context', () => ({ useOrg: vi.fn() }))
+vi.mock('@/lib/project-context', () => ({ useProject: vi.fn() }))
+vi.mock('@/lib/console-config', () => ({ getConsoleConfig: vi.fn() }))
+
+import { useOrg } from '@/lib/org-context'
+import { useProject } from '@/lib/project-context'
+import { getConsoleConfig } from '@/lib/console-config'
+import { WorkspaceMenu } from './workspace-menu'
+
+function setDefaults() {
+  ;(useOrg as Mock).mockReturnValue({
+    organizations: [],
+    selectedOrg: null,
+    setSelectedOrg: vi.fn(),
+    isLoading: false,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    projects: [],
+    selectedProject: null,
+    setSelectedProject: vi.fn(),
+    isLoading: false,
+  })
+  ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: false })
+}
+
+describe('WorkspaceMenu — trigger label', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setDefaults()
+  })
+
+  it('falls back to "Holos Console" when no org or project is selected', () => {
+    render(<WorkspaceMenu />)
+    const trigger = screen.getByTestId('workspace-menu')
+    expect(trigger.textContent).toContain('Holos Console')
+  })
+
+  it('shows the org display name when only an org is selected', () => {
+    ;(useOrg as Mock).mockReturnValue({
+      organizations: [{ name: 'my-org', displayName: 'My Org' }],
+      selectedOrg: 'my-org',
+      setSelectedOrg: vi.fn(),
+      isLoading: false,
+    })
+    render(<WorkspaceMenu />)
+    const trigger = screen.getByTestId('workspace-menu')
+    expect(trigger.textContent).toContain('My Org')
+  })
+
+  it('falls back to org slug when displayName is empty', () => {
+    ;(useOrg as Mock).mockReturnValue({
+      organizations: [{ name: 'org-slug', displayName: '' }],
+      selectedOrg: 'org-slug',
+      setSelectedOrg: vi.fn(),
+      isLoading: false,
+    })
+    render(<WorkspaceMenu />)
+    expect(screen.getByTestId('workspace-menu').textContent).toContain('org-slug')
+  })
+
+  it('prefers the project display name when a project is selected', () => {
+    ;(useOrg as Mock).mockReturnValue({
+      organizations: [{ name: 'my-org', displayName: 'My Org' }],
+      selectedOrg: 'my-org',
+      setSelectedOrg: vi.fn(),
+      isLoading: false,
+    })
+    ;(useProject as Mock).mockReturnValue({
+      projects: [{ name: 'my-project', displayName: 'My Project' }],
+      selectedProject: 'my-project',
+      setSelectedProject: vi.fn(),
+      isLoading: false,
+    })
+    render(<WorkspaceMenu />)
+    const trigger = screen.getByTestId('workspace-menu')
+    expect(trigger.textContent).toContain('My Project')
+    expect(trigger.textContent).not.toContain('My Org')
+  })
+})
+
+describe('WorkspaceMenu — items', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setDefaults()
+  })
+
+  it('renders About → /about', () => {
+    render(<WorkspaceMenu />)
+    const link = screen.getByTestId('workspace-menu-item-about')
+    expect(link.getAttribute('href')).toBe('/about')
+  })
+
+  it('renders Switch organization → /organizations', () => {
+    render(<WorkspaceMenu />)
+    const link = screen.getByTestId('workspace-menu-item-switch-organization')
+    expect(link.getAttribute('href')).toBe('/organizations')
+  })
+
+  it('renders Profile → /profile', () => {
+    render(<WorkspaceMenu />)
+    const link = screen.getByTestId('workspace-menu-item-profile')
+    expect(link.getAttribute('href')).toBe('/profile')
+  })
+
+  it('hides Settings when no org is selected (no global settings route exists)', () => {
+    render(<WorkspaceMenu />)
+    expect(screen.queryByTestId('workspace-menu-item-settings')).toBeNull()
+  })
+
+  it('renders Settings → /orgs/$orgName/settings when an org is selected', () => {
+    ;(useOrg as Mock).mockReturnValue({
+      organizations: [{ name: 'my-org', displayName: 'My Org' }],
+      selectedOrg: 'my-org',
+      setSelectedOrg: vi.fn(),
+      isLoading: false,
+    })
+    render(<WorkspaceMenu />)
+    const link = screen.getByTestId('workspace-menu-item-settings')
+    expect(link.getAttribute('href')).toBe('/orgs/my-org/settings')
+  })
+
+  it('renders Dev Tools when devToolsEnabled is true', () => {
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
+    render(<WorkspaceMenu />)
+    const link = screen.getByTestId('workspace-menu-item-dev-tools')
+    expect(link.getAttribute('href')).toBe('/dev-tools')
+  })
+
+  it('hides Dev Tools when devToolsEnabled is false', () => {
+    render(<WorkspaceMenu />)
+    expect(screen.queryByTestId('workspace-menu-item-dev-tools')).toBeNull()
+  })
+
+  it('renders items in the canonical order: About, Settings, Switch organization, Profile, Dev Tools', () => {
+    ;(useOrg as Mock).mockReturnValue({
+      organizations: [{ name: 'my-org', displayName: 'My Org' }],
+      selectedOrg: 'my-org',
+      setSelectedOrg: vi.fn(),
+      isLoading: false,
+    })
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
+    render(<WorkspaceMenu />)
+
+    const content = screen.getByTestId('workspace-menu-content')
+    const labels = Array.from(
+      content.querySelectorAll('a[data-testid^="workspace-menu-item-"]'),
+    ).map((el) => el.getAttribute('data-testid'))
+
+    expect(labels).toEqual([
+      'workspace-menu-item-about',
+      'workspace-menu-item-settings',
+      'workspace-menu-item-switch-organization',
+      'workspace-menu-item-profile',
+      'workspace-menu-item-dev-tools',
+    ])
+  })
+})

--- a/frontend/src/components/workspace-menu.test.tsx
+++ b/frontend/src/components/workspace-menu.test.tsx
@@ -38,10 +38,20 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenuItem: ({
     children,
     asChild,
+    disabled,
+    ...rest
   }: {
     children: React.ReactNode
     asChild?: boolean
-  }) => (asChild ? <>{children}</> : <div>{children}</div>),
+    disabled?: boolean
+  } & React.HTMLAttributes<HTMLDivElement>) =>
+    asChild ? (
+      <>{children}</>
+    ) : (
+      <div aria-disabled={disabled ? 'true' : undefined} {...rest}>
+        {children}
+      </div>
+    ),
   DropdownMenuSeparator: () => <hr />,
   DropdownMenuTrigger: ({
     children,
@@ -156,9 +166,12 @@ describe('WorkspaceMenu — items', () => {
     expect(link.getAttribute('href')).toBe('/profile')
   })
 
-  it('hides Settings when no org is selected (no global settings route exists)', () => {
+  it('renders Settings disabled (not a link) when no org is selected', () => {
     render(<WorkspaceMenu />)
-    expect(screen.queryByTestId('workspace-menu-item-settings')).toBeNull()
+    const settings = screen.getByTestId('workspace-menu-item-settings')
+    expect(settings.tagName).toBe('DIV')
+    expect(settings.getAttribute('aria-disabled')).toBe('true')
+    expect(settings.textContent).toContain('Settings')
   })
 
   it('renders Settings → /orgs/$orgName/settings when an org is selected', () => {
@@ -197,7 +210,25 @@ describe('WorkspaceMenu — items', () => {
 
     const content = screen.getByTestId('workspace-menu-content')
     const labels = Array.from(
-      content.querySelectorAll('a[data-testid^="workspace-menu-item-"]'),
+      content.querySelectorAll('[data-testid^="workspace-menu-item-"]'),
+    ).map((el) => el.getAttribute('data-testid'))
+
+    expect(labels).toEqual([
+      'workspace-menu-item-about',
+      'workspace-menu-item-settings',
+      'workspace-menu-item-switch-organization',
+      'workspace-menu-item-profile',
+      'workspace-menu-item-dev-tools',
+    ])
+  })
+
+  it('keeps the canonical order when no org is selected (Settings is disabled but present)', () => {
+    ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
+    render(<WorkspaceMenu />)
+
+    const content = screen.getByTestId('workspace-menu-content')
+    const labels = Array.from(
+      content.querySelectorAll('[data-testid^="workspace-menu-item-"]'),
     ).map((el) => el.getAttribute('data-testid'))
 
     expect(labels).toEqual([

--- a/frontend/src/components/workspace-menu.tsx
+++ b/frontend/src/components/workspace-menu.tsx
@@ -20,8 +20,9 @@ import { getConsoleConfig } from '@/lib/console-config'
  *
  * Dev Tools is only visible when the server gates it on via `--enable-dev-tools`
  * (mirrored to the frontend via `getConsoleConfig().devToolsEnabled`). The
- * `Settings` item routes to org settings when an org is selected and is hidden
- * otherwise, since there is no global settings route.
+ * `Settings` item routes to org settings when an org is selected; when no org
+ * is selected it is rendered disabled (there is no global settings route) so
+ * the canonical item order stays visible in every state.
  */
 export function WorkspaceMenu() {
   const { selectedOrg, organizations } = useOrg()
@@ -81,7 +82,12 @@ export function WorkspaceMenu() {
                 <span>Settings</span>
               </Link>
             </DropdownMenuItem>
-          ) : null}
+          ) : (
+            <DropdownMenuItem disabled data-testid="workspace-menu-item-settings">
+              <Settings className="h-4 w-4" />
+              <span>Settings</span>
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem asChild>
             <Link to="/organizations" data-testid="workspace-menu-item-switch-organization">
               <ArrowRightLeft className="h-4 w-4" />

--- a/frontend/src/components/workspace-menu.tsx
+++ b/frontend/src/components/workspace-menu.tsx
@@ -1,0 +1,110 @@
+import { Link } from '@tanstack/react-router'
+import { Box, ChevronsUpDown, Info, Settings, ArrowRightLeft, User, Wrench } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useOrg } from '@/lib/org-context'
+import { useProject } from '@/lib/project-context'
+import { getConsoleConfig } from '@/lib/console-config'
+
+/**
+ * WorkspaceMenu is the Linear-style "Holos Console" menu rendered at the top
+ * of the sidebar. It replaces the previous stacked OrgPicker + ProjectPicker
+ * dropdowns. Menu items appear in the canonical order:
+ *
+ *   About, Settings, Switch organization, Profile, Dev Tools
+ *
+ * Dev Tools is only visible when the server gates it on via `--enable-dev-tools`
+ * (mirrored to the frontend via `getConsoleConfig().devToolsEnabled`). The
+ * `Settings` item routes to org settings when an org is selected and is hidden
+ * otherwise, since there is no global settings route.
+ */
+export function WorkspaceMenu() {
+  const { selectedOrg, organizations } = useOrg()
+  const { selectedProject, projects } = useProject()
+  const { devToolsEnabled } = getConsoleConfig()
+
+  const selectedOrgObj = organizations.find((o) => o.name === selectedOrg)
+  const orgDisplayName = selectedOrgObj
+    ? selectedOrgObj.displayName || selectedOrgObj.name
+    : null
+
+  const selectedProjectObj = projects.find((p) => p.name === selectedProject)
+  const projectDisplayName = selectedProjectObj
+    ? selectedProjectObj.displayName || selectedProjectObj.name
+    : null
+
+  // Trigger label priority: Project > Org > "Holos Console". This mirrors the
+  // Linear convention of surfacing the most specific scope at the top of the
+  // sidebar.
+  const triggerLabel = projectDisplayName ?? orgDisplayName ?? 'Holos Console'
+
+  return (
+    <div className="px-2 py-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            data-testid="workspace-menu"
+            className="flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-accent"
+          >
+            <span className="flex items-center gap-2 truncate">
+              {/*
+                Placeholder project glyph. HOL-603 deliberately picks a
+                generic icon (Box) so we can swap in a user-customizable
+                logo in a follow-up phase without changing the layout.
+              */}
+              <Box className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+              <span className="truncate">{triggerLabel}</span>
+            </span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56" align="start">
+          <DropdownMenuItem asChild>
+            <Link to="/about" data-testid="workspace-menu-item-about">
+              <Info className="h-4 w-4" />
+              <span>About</span>
+            </Link>
+          </DropdownMenuItem>
+          {selectedOrg ? (
+            <DropdownMenuItem asChild>
+              <Link
+                to="/orgs/$orgName/settings"
+                params={{ orgName: selectedOrg }}
+                data-testid="workspace-menu-item-settings"
+              >
+                <Settings className="h-4 w-4" />
+                <span>Settings</span>
+              </Link>
+            </DropdownMenuItem>
+          ) : null}
+          <DropdownMenuItem asChild>
+            <Link to="/organizations" data-testid="workspace-menu-item-switch-organization">
+              <ArrowRightLeft className="h-4 w-4" />
+              <span>Switch organization</span>
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem asChild>
+            <Link to="/profile" data-testid="workspace-menu-item-profile">
+              <User className="h-4 w-4" />
+              <span>Profile</span>
+            </Link>
+          </DropdownMenuItem>
+          {devToolsEnabled ? (
+            <DropdownMenuItem asChild>
+              <Link to="/dev-tools" data-testid="workspace-menu-item-dev-tools">
+                <Wrench className="h-4 w-4" />
+                <span>Dev Tools</span>
+              </Link>
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/frontend/src/routes/_authenticated/organizations/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/-index.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+const mockSetSelectedOrg = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({}),
+    Link: ({
+      children,
+      className,
+      to,
+      params,
+    }: {
+      children: React.ReactNode
+      className?: string
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => mockNavigate,
+    useRouter: () => ({ state: { location: { pathname: '/organizations' } } }),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useListOrganizations: vi.fn(),
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+
+// CreateOrgDialog visibility is asserted via the testid the mock emits when
+// `open` is true. The real dialog is portaled and would require fully
+// instantiating Radix in jsdom otherwise.
+vi.mock('@/components/create-org-dialog', () => ({
+  CreateOrgDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-org-dialog" /> : null,
+}))
+
+import { useListOrganizations } from '@/queries/organizations'
+import { useOrg } from '@/lib/org-context'
+import { OrganizationsIndexPage } from './index'
+
+function makeOrg(name: string, displayName = '', description = '') {
+  return {
+    name,
+    displayName,
+    description,
+  }
+}
+
+function setupMocks(organizations = [makeOrg('test-org', 'Test Org')]) {
+  ;(useListOrganizations as Mock).mockReturnValue({
+    data: { organizations },
+    isLoading: false,
+    error: null,
+  })
+  ;(useOrg as Mock).mockReturnValue({
+    setSelectedOrg: mockSetSelectedOrg,
+    selectedOrg: null,
+    organizations,
+    isLoading: false,
+  })
+}
+
+describe('OrganizationsIndexPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders loading skeletons while query is pending', () => {
+    ;(useListOrganizations as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+    ;(useOrg as Mock).mockReturnValue({
+      setSelectedOrg: mockSetSelectedOrg,
+      selectedOrg: null,
+      organizations: [],
+      isLoading: true,
+    })
+    render(<OrganizationsIndexPage />)
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders empty-state prompt when organization list is empty', () => {
+    setupMocks([])
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByText(/no organizations/i)).toBeInTheDocument()
+  })
+
+  it('renders a table row for each organization returned by the mock query', () => {
+    setupMocks([
+      makeOrg('alpha', 'Alpha Org'),
+      makeOrg('beta', 'Beta Org'),
+    ])
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByText('Alpha Org')).toBeInTheDocument()
+    expect(screen.getByText('Beta Org')).toBeInTheDocument()
+  })
+
+  it('shows slug in name column', () => {
+    setupMocks([makeOrg('my-slug', 'My Org')])
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByText('my-slug')).toBeInTheDocument()
+  })
+
+  it('search input filters visible rows by display name', () => {
+    setupMocks([
+      makeOrg('alpha', 'Alpha Org'),
+      makeOrg('beta', 'Beta Org'),
+    ])
+    render(<OrganizationsIndexPage />)
+    const searchInput = screen.getByPlaceholderText(/search/i)
+    fireEvent.change(searchInput, { target: { value: 'alpha' } })
+    expect(screen.getByText('Alpha Org')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Org')).not.toBeInTheDocument()
+  })
+
+  it('search input filters visible rows by slug', () => {
+    setupMocks([
+      makeOrg('alpha-slug', 'Alpha Org'),
+      makeOrg('beta-slug', 'Beta Org'),
+    ])
+    render(<OrganizationsIndexPage />)
+    const searchInput = screen.getByPlaceholderText(/search/i)
+    fireEvent.change(searchInput, { target: { value: 'beta-slug' } })
+    expect(screen.queryByText('Alpha Org')).not.toBeInTheDocument()
+    expect(screen.getByText('Beta Org')).toBeInTheDocument()
+  })
+
+  it('clicking an organization row sets selectedOrg via OrgContext and navigates to its projects index', () => {
+    setupMocks([makeOrg('my-org', 'My Org')])
+    render(<OrganizationsIndexPage />)
+    const row = screen.getByText('My Org').closest('tr')!
+    fireEvent.click(row)
+    expect(mockSetSelectedOrg).toHaveBeenCalledWith('my-org')
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/orgs/$orgName/projects',
+      params: { orgName: 'my-org' },
+    })
+  })
+
+  it('renders error alert when query fails', () => {
+    ;(useListOrganizations as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('failed to load organizations'),
+    })
+    ;(useOrg as Mock).mockReturnValue({
+      setSelectedOrg: mockSetSelectedOrg,
+      selectedOrg: null,
+      organizations: [],
+      isLoading: false,
+    })
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByText(/failed to load organizations/i)).toBeInTheDocument()
+  })
+
+  it('Create Organization button is visible', () => {
+    setupMocks([])
+    render(<OrganizationsIndexPage />)
+    const buttons = screen.getAllByRole('button', { name: /create organization/i })
+    expect(buttons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('pagination controls appear when organizations exceed page size', () => {
+    const manyOrgs = Array.from({ length: 30 }, (_, i) =>
+      makeOrg(`org-${i}`, `Org ${i}`),
+    )
+    setupMocks(manyOrgs)
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument()
+  })
+
+  it('pagination next button advances to second page', () => {
+    const manyOrgs = Array.from({ length: 30 }, (_, i) =>
+      makeOrg(
+        `org-${i.toString().padStart(2, '0')}`,
+        `Org ${i.toString().padStart(2, '0')}`,
+      ),
+    )
+    setupMocks(manyOrgs)
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByText('Org 00')).toBeInTheDocument()
+    expect(screen.queryByText('Org 25')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(screen.queryByText('Org 00')).not.toBeInTheDocument()
+    expect(screen.getByText('Org 25')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/index.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  flexRender,
+  createColumnHelper,
+} from '@tanstack/react-table'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Plus } from 'lucide-react'
+import { useListOrganizations } from '@/queries/organizations'
+import { useOrg } from '@/lib/org-context'
+import { CreateOrgDialog } from '@/components/create-org-dialog'
+import type { Organization } from '@/gen/holos/console/v1/organizations_pb'
+
+export const Route = createFileRoute('/_authenticated/organizations/')({
+  component: OrganizationsIndexPage,
+})
+
+const columnHelper = createColumnHelper<Organization>()
+
+export function OrganizationsIndexPage() {
+  const navigate = useNavigate()
+  const { setSelectedOrg } = useOrg()
+  const { data, isLoading, error } = useListOrganizations()
+  const organizations = data?.organizations ?? []
+
+  const [globalFilter, setGlobalFilter] = useState('')
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const columns = [
+    columnHelper.accessor((row) => row.displayName || row.name, {
+      id: 'displayName',
+      header: 'Display Name',
+      cell: ({ row }) => (
+        <span className="font-medium">{row.original.displayName || row.original.name}</span>
+      ),
+    }),
+    columnHelper.accessor('name', {
+      header: 'Name',
+      cell: ({ getValue }) => (
+        <span className="text-muted-foreground font-mono text-sm">{getValue()}</span>
+      ),
+    }),
+    columnHelper.accessor('description', {
+      header: 'Description',
+      cell: ({ getValue }) => {
+        const desc = getValue()
+        if (!desc) return <span className="text-muted-foreground">—</span>
+        return (
+          <span className="text-muted-foreground truncate max-w-[40ch] block">
+            {desc.length > 40 ? `${desc.slice(0, 40)}…` : desc}
+          </span>
+        )
+      },
+    }),
+  ]
+
+  const table = useReactTable({
+    data: organizations,
+    columns,
+    state: { globalFilter },
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: 'includesString',
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 25 } },
+  })
+
+  const handleRowClick = (org: Organization) => {
+    // Switching organizations from this page sets the selected org and lands
+    // on the org's projects index (the org-scope home view). The picker
+    // dropdown previously did the same thing; reusing OrgContext keeps the
+    // selection persistent across reloads.
+    setSelectedOrg(org.name)
+    navigate({
+      to: '/orgs/$orgName/projects',
+      params: { orgName: org.name },
+    })
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <CardTitle>Organizations</CardTitle>
+          <Button size="sm" disabled>
+            <Plus className="h-4 w-4 mr-1" />
+            Create Organization
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <CardTitle>Organizations</CardTitle>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            Create Organization
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {organizations.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <p className="text-muted-foreground">No organizations yet. Create one.</p>
+              <Button size="sm" onClick={() => setCreateOpen(true)}>
+                Create Organization
+              </Button>
+            </div>
+          ) : (
+            <>
+              <div className="mb-3">
+                <Input
+                  placeholder="Search organizations…"
+                  value={globalFilter}
+                  onChange={(e) => setGlobalFilter(e.target.value)}
+                  className="max-w-sm"
+                />
+              </div>
+              <Table>
+                <TableHeader>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <TableHead key={header.id}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(header.column.columnDef.header, header.getContext())}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.map((row) => (
+                    <TableRow
+                      key={row.id}
+                      className="cursor-pointer"
+                      onClick={() => handleRowClick(row.original)}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {table.getPageCount() > 1 && (
+                <div className="flex items-center justify-end gap-2 mt-3">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => table.previousPage()}
+                    disabled={!table.getCanPreviousPage()}
+                  >
+                    Previous
+                  </Button>
+                  <span className="text-sm text-muted-foreground">
+                    Page {table.getState().pagination.pageIndex + 1} of{' '}
+                    {table.getPageCount()}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => table.nextPage()}
+                    disabled={!table.getCanNextPage()}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <CreateOrgDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={(name) => setSelectedOrg(name)}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- Replaces the stacked OrgPicker + ProjectPicker dropdowns at the top of the sidebar with a single Linear-style workspace menu (`WorkspaceMenu` component). Trigger shows a placeholder Box icon and the most-specific scope label (Project > Org > "Holos Console"). Menu items in canonical order: About, Settings, Switch organization, Profile, Dev Tools. Settings is gated on a selected org; Dev Tools is gated on `--enable-dev-tools`.
- Removes the sidebar footer (Profile / Dev Tools / About moved into the workspace menu).
- Adds `/organizations` — a TanStack Table data grid with global filter input, backed by `useListOrganizations`. Row click sets `OrgContext.selectedOrg` and navigates to the org's projects index.
- Vitest + RTL coverage: 12 new tests for `WorkspaceMenu`, 11 new tests for `OrganizationsIndexPage`, and a rewritten `app-sidebar.test.tsx` that asserts the workspace-menu wiring and the absence of the deprecated pickers / footer items.

Fixes HOL-603

## Test plan

- [x] `cd frontend && npm test -- --run` → 1197 passed (up from 1192 baseline)
- [x] `npm run lint` → same 65 problems as baseline (no new errors)
- [x] `npm run build` → regenerates `routeTree.gen.ts` to register `/organizations`
- [x] `make test-go` → all packages pass
- [ ] Manual: navigate to `/organizations` and verify the data grid + search behave like the projects index
- [ ] Manual: open the workspace menu, confirm About/Settings/Switch organization/Profile/Dev Tools route to the right paths

> Local E2E was not run — this is a UI-only refactor of the sidebar header and a new client-only route; relying on CI E2E checks.

Generated with [Claude Code](https://claude.com/claude-code)