### PR TITLE
chore(api): retire LabelResourceType writes on Template/TemplatePolicy CRDs (HOL-677)

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -23,18 +23,6 @@ const (
 	ResourceTypeFolder       = "folder"
 	ResourceTypeProject      = "project"
 	ResourceTypeDeployment   = "deployment"
-	// ResourceTypeTemplate is the unified v1alpha2 template resource type.
-	// A single label value is used across every hierarchy level (ADR 021
-	// Decision 4).
-	ResourceTypeTemplate = "template"
-	// ResourceTypeTemplatePolicy is the resource type label value for
-	// TemplatePolicy ConfigMaps. TemplatePolicy objects bind REQUIRE/EXCLUDE
-	// rules to templates and replace the removed `mandatory` flag on Template
-	// and LinkableTemplate (HOL-554/HOL-555). Policy ConfigMaps live only in
-	// organization or folder namespaces; project-scoped storage is forbidden
-	// because a project owner could otherwise tamper with the very policy the
-	// platform meant to constrain them with.
-	ResourceTypeTemplatePolicy = "template-policy"
 	// ResourceTypeTemplatePolicyBinding is the resource type label value for
 	// TemplatePolicyBinding ConfigMaps. A TemplatePolicyBinding attaches a
 	// single TemplatePolicy to an explicit list of project templates and/or

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -25,20 +25,6 @@
 #ResourceTypeProject:      "project"
 #ResourceTypeDeployment:   "deployment"
 
-// ResourceTypeTemplate is the unified v1alpha2 template resource type.
-// A single label value is used across every hierarchy level (ADR 021
-// Decision 4).
-#ResourceTypeTemplate: "template"
-
-// ResourceTypeTemplatePolicy is the resource type label value for
-// TemplatePolicy ConfigMaps. TemplatePolicy objects bind REQUIRE/EXCLUDE
-// rules to templates and replace the removed `mandatory` flag on Template
-// and LinkableTemplate (HOL-554/HOL-555). Policy ConfigMaps live only in
-// organization or folder namespaces; project-scoped storage is forbidden
-// because a project owner could otherwise tamper with the very policy the
-// platform meant to constrain them with.
-#ResourceTypeTemplatePolicy: "template-policy"
-
 // ResourceTypeTemplatePolicyBinding is the resource type label value for
 // TemplatePolicyBinding ConfigMaps. A TemplatePolicyBinding attaches a
 // single TemplatePolicy to an explicit list of project templates and/or

--- a/console/policyresolver/folder_resolver_test.go
+++ b/console/policyresolver/folder_resolver_test.go
@@ -187,7 +187,13 @@ func objectMetaCRD(name, namespace, resourceType string) metav1.ObjectMeta {
 // spec.rules directly. Post-HOL-662 there is no JSON annotation wire shape.
 func policyCRD(namespace, name string, rules []templatesv1alpha1.TemplatePolicyRule) templatesv1alpha1.TemplatePolicy {
 	return templatesv1alpha1.TemplatePolicy{
-		ObjectMeta: objectMetaCRD(name, namespace, v1alpha2.ResourceTypeTemplatePolicy),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+			},
+		},
 		Spec: templatesv1alpha1.TemplatePolicySpec{
 			Rules: rules,
 		},

--- a/console/policyresolver/multi_pod_freshness_test.go
+++ b/console/policyresolver/multi_pod_freshness_test.go
@@ -158,8 +158,7 @@ func TestFolderResolver_MultiPodFreshness(t *testing.T) {
 			Name:      "audit",
 			Namespace: orgNs,
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 		},
 		Spec: templatesv1alpha1.TemplatePolicySpec{
@@ -229,8 +228,7 @@ func TestFolderResolver_MultiPodFreshness(t *testing.T) {
 			Name:      "net",
 			Namespace: folderEngNs,
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 		},
 		Spec: templatesv1alpha1.TemplatePolicySpec{

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1330,8 +1330,7 @@ func seedOrgRequirePolicy(t *testing.T, org, templateName, _ string) *corev1.Con
 			Name:      "require-" + templateName,
 			Namespace: "holos-org-" + org,
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 		},
 	}
@@ -1358,7 +1357,6 @@ func seedOrgTemplate(org, templateName, projectNs string) *corev1.ConfigMap {
 			Namespace: "holos-org-" + org,
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
 			},
 			Annotations: map[string]string{

--- a/console/templatepolicies/handler_test.go
+++ b/console/templatepolicies/handler_test.go
@@ -564,9 +564,6 @@ func TestCreatePolicyHappyPath(t *testing.T) {
 	if p == nil {
 		t.Fatal("expected TemplatePolicy CRD to be created")
 	}
-	if p.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeTemplatePolicy {
-		t.Errorf("expected template-policy label, got %q", p.Labels[v1alpha2.LabelResourceType])
-	}
 	if p.Annotations[v1alpha2.AnnotationCreatorEmail] != "owner@example.com" {
 		t.Errorf("expected creator annotation, got %q", p.Annotations[v1alpha2.AnnotationCreatorEmail])
 	}
@@ -642,8 +639,7 @@ func TestUpdatePreservesUnspecifiedFields(t *testing.T) {
 			Name:      "policy",
 			Namespace: "holos-fld-payments",
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 			Annotations: map[string]string{
 				v1alpha2.AnnotationCreatorEmail: "original@example.com",
@@ -875,8 +871,7 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 			Name:      "require-httproute",
 			Namespace: "holos-fld-payments",
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 			Annotations: map[string]string{
 				v1alpha2.AnnotationCreatorEmail: "platform@example.com",

--- a/console/templatepolicies/k8s.go
+++ b/console/templatepolicies/k8s.go
@@ -177,8 +177,7 @@ func (k *K8sClient) CreatePolicy(
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicy,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 			Annotations: map[string]string{
 				v1alpha2.AnnotationCreatorEmail: creatorEmail,

--- a/console/templates/handler_linkable_test.go
+++ b/console/templates/handler_linkable_test.go
@@ -53,7 +53,6 @@ func enabledTemplateCMForScope(ns, name, displayName, description string, scope 
 			Namespace: ns,
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: scopeLabel,
 			},
 			Annotations: map[string]string{
@@ -89,7 +88,6 @@ func enabledTemplateCM(ns, name, displayName, description string, _ bool) *corev
 			Namespace: ns,
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
 			},
 			Annotations: map[string]string{

--- a/console/templates/handler_search_test.go
+++ b/console/templates/handler_search_test.go
@@ -83,7 +83,6 @@ func templateCMInNs(ns, name, displayName string, scopeLabel string) *corev1.Con
 			Namespace: ns,
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: scopeLabel,
 			},
 			Annotations: map[string]string{

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -455,7 +455,6 @@ func TestUpdateTemplateLinkPermissions(t *testing.T) {
 				Namespace: "prj-" + project,
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
 				},
 				Annotations: map[string]string{
@@ -682,7 +681,6 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 				Namespace: "fld-" + folder,
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
 				},
 				Annotations: map[string]string{
@@ -757,7 +755,6 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 				Namespace: "org-" + org,
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeOrganization,
 				},
 				Annotations: map[string]string{
@@ -774,7 +771,6 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 				Namespace: "fld-" + folder,
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
 				},
 				Annotations: map[string]string{
@@ -893,7 +889,6 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 				Namespace: "fld-" + folder,
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeFolder,
 				},
 				Annotations: map[string]string{

--- a/console/templates/handler_updates_test.go
+++ b/console/templates/handler_updates_test.go
@@ -59,7 +59,6 @@ func makeTemplateWithLinks(ns, name string, links []*consolev1.LinkedTemplateRef
 			Namespace: ns,
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
 			},
 			Annotations: map[string]string{
@@ -241,7 +240,6 @@ func TestCheckUpdates(t *testing.T) {
 				Namespace: "prj-" + project,
 				Labels: map[string]string{
 					v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-					v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 					v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
 				},
 				Annotations: map[string]string{

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -156,8 +156,7 @@ func (k *K8sClient) CreateTemplate(
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 		},
 		Spec: templatesv1alpha1.TemplateSpec{

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -88,8 +88,8 @@ func (k *K8sClient) ListTemplates(ctx context.Context, namespace string) ([]temp
 
 // ListAllTemplates returns every Template across every namespace the
 // controller-runtime client can see, filtered down to the holos-console
-// managed-by/resource-type=template label pair so unmanaged Template CRs
-// don't leak into the cross-scope SearchTemplates response.
+// managed-by label so unmanaged Template CRs don't leak into the
+// cross-scope SearchTemplates response.
 //
 // Used by SearchTemplates (HOL-602). Reads hit the same informer cache as
 // ListTemplates — the only difference is the absence of an InNamespace
@@ -99,8 +99,7 @@ func (k *K8sClient) ListAllTemplates(ctx context.Context) ([]templatesv1alpha1.T
 	slog.DebugContext(ctx, "listing templates from kubernetes across all namespaces")
 	var list templatesv1alpha1.TemplateList
 	selector := ctrlclient.MatchingLabels{
-		v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-		v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplate,
+		v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 	}
 	if err := k.client.List(ctx, &list, selector); err != nil {
 		return nil, fmt.Errorf("listing templates across all namespaces: %w", err)

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -114,7 +114,6 @@ func templateConfigMap(scope scopeKind, scopePrefix, scopeName, name, displayNam
 			Namespace: scopePrefix + scopeName,
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: scopeLabelValue(scope),
 			},
 			Annotations: map[string]string{

--- a/console/templates/record_applied_test.go
+++ b/console/templates/record_applied_test.go
@@ -96,7 +96,6 @@ func existingProjectTemplateWithLinks(project, name string, refs []*consolev1.Li
 			Namespace: "prj-" + project,
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
 			},
 			Annotations: map[string]string{
@@ -319,7 +318,6 @@ func TestHandler_CreateTemplate_NoRecordOnPersistFailure(t *testing.T) {
 			Namespace: "prj-my-project",
 			Labels: map[string]string{
 				v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:  v1alpha2.ResourceTypeTemplate,
 				v1alpha2.LabelTemplateScope: v1alpha2.TemplateScopeProject,
 			},
 		},

--- a/console/templates/testhelpers_test.go
+++ b/console/templates/testhelpers_test.go
@@ -59,18 +59,14 @@ func testScheme(t *testing.T) *runtime.Scheme {
 
 // configMapIsTemplate reports whether a ConfigMap in the fake clientset
 // represents a Template (as opposed to a Release or some other resource).
-// Recognizes either the canonical v1alpha2 ResourceType=template label, or
-// the template-scope label (used by older fixtures that pre-date the
-// ResourceType label convention but still describe templates). Release
-// ConfigMaps never carry LabelTemplateScope, so the union is still precise.
+// Release ConfigMaps are identified by ResourceType=template-release;
+// everything else that carries LabelTemplateScope is treated as a template.
 func configMapIsTemplate(cm *corev1.ConfigMap) bool {
-	if cm.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeTemplate {
-		return true
+	if cm.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeTemplateRelease {
+		return false
 	}
-	if _, ok := cm.Labels[v1alpha2.LabelTemplateScope]; ok {
-		return true
-	}
-	return false
+	_, hasScope := cm.Labels[v1alpha2.LabelTemplateScope]
+	return hasScope
 }
 
 // configMapToTemplateCRD converts a v1alpha2-labeled template ConfigMap
@@ -85,8 +81,7 @@ func configMapToTemplateCRD(cm *corev1.ConfigMap) *templatesv1alpha1.Template {
 			Name:      cm.Name,
 			Namespace: cm.Namespace,
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplate,
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
 			},
 		},
 		Spec: templatesv1alpha1.TemplateSpec{

--- a/console/templates/testhelpers_test.go
+++ b/console/templates/testhelpers_test.go
@@ -58,13 +58,9 @@ func testScheme(t *testing.T) *runtime.Scheme {
 }
 
 // configMapIsTemplate reports whether a ConfigMap in the fake clientset
-// represents a Template (as opposed to a Release or some other resource).
-// Release ConfigMaps are identified by ResourceType=template-release;
-// everything else that carries LabelTemplateScope is treated as a template.
+// represents a Template. Templates are identified by the presence of the
+// LabelTemplateScope label stamped on every template fixture.
 func configMapIsTemplate(cm *corev1.ConfigMap) bool {
-	if cm.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeTemplateRelease {
-		return false
-	}
 	_, hasScope := cm.Labels[v1alpha2.LabelTemplateScope]
 	return hasScope
 }


### PR DESCRIPTION
Assignee: [Jeff McCune](https://linear.app/holos-run/profiles/jeff)

## Summary

After HOL-621 migrated Template and TemplatePolicy storage from ConfigMaps to CRDs, the `console.holos.run/resource-type` label became vestigial on those objects — the CRD Kind already discriminates. This PR retires the remaining writes and deletes the two now-unused constants.

- `console/templates/k8s.go`: drop `LabelResourceType=template` stamp in `CreateTemplate`.
- `console/templatepolicies/k8s.go`: drop `LabelResourceType=template-policy` stamp in `CreatePolicy`.
- `api/v1alpha2/annotations.go`, `api/v1alpha2/schema_gen.cue`: delete `ResourceTypeTemplate` and `ResourceTypeTemplatePolicy` constants. `LabelResourceType` itself **stays** — still in use for ConfigMap-backed resources (release, render-state, binding) and namespace classification.
- Test fixtures across `console/templates/`, `console/templatepolicies/`, `console/policyresolver/`, `console/projects/` drop the now-unused stamps.
- Refactored the ConfigMap→CRD test bridge in `console/templates/testhelpers_test.go` to discriminate templates via `LabelTemplateScope` + release-label exclusion (was: `ResourceType=template`).
- Removed the now-obsolete label assertion in `TestCreatePolicyHappyPath`.

## Implementation notes

- **No admission policy change needed.** The Linear ticket speculated a CEL rewrite for `config/admission/templatepolicy-folder-or-org-only.yaml`, but the CEL actually reads the **namespace's** classification label (not the object's label), and `matchConstraints` already scope the policy by `resources: [\"templatepolicies\"]`. No object-label dependency exists to rewrite.
- The VAP regression test in `console/templatepolicies/k8s_test.go` continues to pass, proving the namespace-scoping admission guard still works without the object-label.

## Test plan

- [x] `grep 'ResourceTypeTemplate\b\|ResourceTypeTemplatePolicy\b'` returns 0 hits
- [x] `go vet ./...` clean
- [x] `CGO_ENABLED=1 go test -race ./...` — all packages pass
- [x] `make check-imports` clean
- [x] `golangci-lint run` — issues all pre-existing (none in modified files)
- [x] Admission regression test still rejects project-namespace creates

Ticket: [HOL-677](https://linear.app/holos-run/issue/HOL-677/choreapi-retire-labelresourcetype-writes-on-templatetemplatepolicy)
Parent: HOL-621

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->