### PR TITLE
test(envtest): admission-policy negative-path suite for secrets API

### DIFF
--- a/api/secrets/v1alpha1/crd_test.go
+++ b/api/secrets/v1alpha1/crd_test.go
@@ -1,0 +1,689 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	v1alpha1 "github.com/holos-run/holos-console/api/secrets/v1alpha1"
+	envtesthelpers "github.com/holos-run/holos-console/internal/envtest"
+)
+
+// Each admission policy has at least one negative path (the scope-escape
+// the policy was written to close) and one positive path (the legitimate
+// request shape). Every rejected-error log line prints the server-side
+// message so a CEL regression surfaces the exact guard that fired.
+
+type secretsEnvtestSuite struct {
+	env    *envtest.Environment
+	client client.Client
+}
+
+// setupSecretsEnvTest boots an envtest API server with the four
+// secrets.holos.run CRDs plus all nine ValidatingAdmissionPolicies
+// under config/secret-injector/admission. Skips (not fails) when
+// envtest binaries are not available so developers and CI jobs that do
+// not pre-install envtest do not see a spurious failure; the skip path
+// is intentionally noisy so a missing envtest setup is not mistaken for
+// a passing test.
+func setupSecretsEnvTest(t *testing.T) *secretsEnvtestSuite {
+	t.Helper()
+
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		if assets := envtesthelpers.DetectAssets(); assets != "" {
+			t.Setenv("KUBEBUILDER_ASSETS", assets)
+		} else {
+			t.Skip("envtest binaries not found; set KUBEBUILDER_ASSETS or run `setup-envtest use` to download")
+		}
+	}
+
+	repoRoot, err := envtesthelpers.FindRepoRoot()
+	if err != nil {
+		t.Fatalf("finding repo root: %v", err)
+	}
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "secret-injector", "crd")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("starting envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if stopErr := env.Stop(); stopErr != nil {
+			t.Logf("stopping envtest: %v", stopErr)
+		}
+	})
+
+	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("registering secrets v1alpha1 scheme: %v", err)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("constructing controller-runtime client: %v", err)
+	}
+
+	ctx := context.Background()
+	admissionDir := filepath.Join(repoRoot, "config", "secret-injector", "admission")
+	if err := envtesthelpers.ApplyYAMLFilesInDir(ctx, c, admissionDir); err != nil {
+		t.Fatalf("applying admission policies: %v", err)
+	}
+
+	// Block until every VAP this suite asserts against has landed in
+	// the API server's policy cache. Envtest does not synchronise VAP
+	// registration with Start(), so racing a Create ahead of the guard
+	// produces flaky false-negative rejections that look like unrelated
+	// bugs.
+	for _, name := range []string{
+		"credential-authn-type-apikey-only",
+		"credential-upstreamref-same-namespace",
+		"namespace-scope-label-immutable",
+		"secretinjectionpolicy-authn-type-apikey-only",
+		"secretinjectionpolicy-folder-or-org-only",
+		"secretinjectionpolicybinding-folder-or-org-only",
+		"secretinjectionpolicybinding-policyref-same-namespace-or-ancestor",
+		"upstreamsecret-project-only",
+		"upstreamsecret-valuetemplate-no-control-chars",
+	} {
+		envtesthelpers.WaitForAdmissionPolicy(t, ctx, c, name)
+	}
+
+	// Functional readiness probe. VAP + binding existence is necessary
+	// but not sufficient: the API server still needs to compile the CEL
+	// programs and wire them into the admission plugin. Issue a known-bad
+	// namespace UPDATE and poll until the server actually rejects it —
+	// only then has the policy cache observably activated. Without this,
+	// the first few admission-denying tests race the compile step and
+	// pass through, producing flaky "expected rejection, got nil".
+	waitAdmissionActive(t, ctx, c)
+
+	return &secretsEnvtestSuite{env: env, client: c}
+}
+
+// waitAdmissionActive creates a throwaway namespace labeled "project",
+// then attempts to mutate the resource-type label. The namespace-scope
+// -label-immutable policy rejects this; once we see the rejection, the
+// API server has observably wired the admission plugin. Polls up to
+// 30s, cleans up the probe namespace before returning.
+func waitAdmissionActive(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+	const probe = "holos-admission-probe"
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   probe,
+			Labels: map[string]string{"console.holos.run/resource-type": "project"},
+		},
+	}
+	if err := c.Create(ctx, ns); err != nil {
+		t.Fatalf("admission-probe create namespace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: probe}})
+	})
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		got := &corev1.Namespace{}
+		if err := c.Get(ctx, types.NamespacedName{Name: probe}, got); err != nil {
+			t.Fatalf("admission-probe get: %v", err)
+		}
+		got.Labels["console.holos.run/resource-type"] = "folder"
+		err := c.Update(ctx, got)
+		if err != nil && (apierrors.IsInvalid(err) || apierrors.IsForbidden(err)) {
+			return
+		}
+		// Not yet active — reset the label and retry.
+		if err == nil {
+			got.Labels["console.holos.run/resource-type"] = "project"
+			_ = c.Update(ctx, got)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatal("admission policies did not become active within deadline")
+}
+
+// makeNamespace writes a namespace with the console.holos.run/resource-type
+// label set to resourceType. Several admission policies key off that label;
+// having a single builder keeps the per-test setup terse and uniform. Extra
+// labels land via the labels map — the hierarchy (parent, organization)
+// labels attach here in the cross-tenant policyRef tests.
+func makeNamespace(t *testing.T, ctx context.Context, c client.Client, name, resourceType string, extra map[string]string) {
+	t.Helper()
+	labels := map[string]string{"console.holos.run/resource-type": resourceType}
+	for k, v := range extra {
+		labels[k] = v
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+	if err := c.Create(ctx, ns); err != nil {
+		t.Fatalf("creating namespace %q: %v", name, err)
+	}
+}
+
+// checkAdmission asserts err is (a) non-nil and Invalid/Forbidden when
+// wantRejected, or (b) nil when !wantRejected. On rejection it t.Logs
+// the server message so the CEL branch that fired is visible in the
+// test output — the AC calls this out explicitly as a debuggability
+// requirement for policy regressions.
+func checkAdmission(t *testing.T, err error, wantRejected bool) {
+	t.Helper()
+	if wantRejected {
+		if err == nil {
+			t.Fatalf("expected admission rejection, got nil")
+		}
+		if !apierrors.IsInvalid(err) && !apierrors.IsForbidden(err) {
+			t.Fatalf("expected Invalid/Forbidden admission error, got %T: %v", err, err)
+		}
+		t.Logf("admission rejection (expected): %v", err)
+		return
+	}
+	if err != nil {
+		t.Fatalf("expected admission to accept, got %T: %v", err, err)
+	}
+}
+
+// TestAdmission_SecretInjectionPolicy_FolderOrOrgOnly covers the
+// secretinjectionpolicy-folder-or-org-only policy: a SecretInjectionPolicy
+// must live in a namespace whose console.holos.run/resource-type label is
+// NOT "project". The CEL expression short-circuits on missing/absent
+// labels, so the two real-world failure modes (project-labeled namespace)
+// and the success modes (folder- and org-labeled namespaces) are what
+// this regression guards.
+func TestAdmission_SecretInjectionPolicy_FolderOrOrgOnly(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		nsName       string
+		nsType       string
+		wantRejected bool
+	}{
+		{"project-rejected", "holos-prj-sip-rej", "project", true},
+		{"folder-accepted", "holos-fld-sip-acc", "folder", false},
+		{"organization-accepted", "holos-org-sip-acc", "organization", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			makeNamespace(t, ctx, s.client, tc.nsName, tc.nsType, nil)
+			sip := &v1alpha1.SecretInjectionPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: tc.nsName},
+				Spec: v1alpha1.SecretInjectionPolicySpec{
+					Direction: v1alpha1.DirectionEgress,
+					CallerAuth: v1alpha1.CallerAuth{
+						Type: v1alpha1.AuthenticationTypeAPIKey,
+					},
+					UpstreamRef: v1alpha1.UpstreamRef{
+						Scope:     v1alpha1.UpstreamScopeProject,
+						ScopeName: "p1",
+						Name:      "u1",
+					},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, sip), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_SecretInjectionPolicyBinding_FolderOrOrgOnly covers the
+// secretinjectionpolicybinding-folder-or-org-only policy: SIPB shares
+// the folder/org scope restriction with SIP.
+func TestAdmission_SecretInjectionPolicyBinding_FolderOrOrgOnly(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		nsName       string
+		nsType       string
+		wantRejected bool
+	}{
+		{"project-rejected", "holos-prj-sipb-rej", "project", true},
+		{"folder-accepted", "holos-fld-sipb-acc", "folder", false},
+		{"organization-accepted", "holos-org-sipb-acc", "organization", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			makeNamespace(t, ctx, s.client, tc.nsName, tc.nsType, nil)
+			sipb := &v1alpha1.SecretInjectionPolicyBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: tc.nsName},
+				Spec: v1alpha1.SecretInjectionPolicyBindingSpec{
+					PolicyRef: v1alpha1.PolicyRef{
+						// Self-reference keeps the policyRef check
+						// trivially satisfied; the other guard under
+						// test here is purely the ns-scope label.
+						Scope:     v1alpha1.PolicyRefScopeFolder,
+						Namespace: tc.nsName,
+						Name:      "p1",
+					},
+					TargetRefs: []v1alpha1.TargetRef{{
+						Kind:      v1alpha1.TargetRefKindServiceAccount,
+						Namespace: tc.nsName,
+						Name:      "sa1",
+					}},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, sipb), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_SecretInjectionPolicyBinding_PolicyRefSameNamespaceOrAncestor
+// covers the secretinjectionpolicybinding-policyref-same-namespace-or-ancestor
+// policy. The binding lives in a folder namespace; policyRef.namespace must
+// be the binding's own namespace (covered), the value of the namespace's
+// console.holos.run/parent label (covered), the value of
+// console.holos.run/organization projected through the default "holos-org-"
+// prefix (covered), or a cross-tenant namespace (rejected).
+func TestAdmission_SecretInjectionPolicyBinding_PolicyRefScope(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	bindingNS := "holos-fld-policyref-scope"
+	parentNS := "holos-fld-policyref-parent"
+	orgShort := "acme"
+	orgNS := "holos-org-" + orgShort
+	crossTenantNS := "holos-fld-cross-tenant"
+
+	// Pre-stage namespaces referenced by the accept-path subtests so the
+	// hierarchy labels are in place before the test body runs.
+	makeNamespace(t, ctx, s.client, parentNS, "folder", nil)
+	makeNamespace(t, ctx, s.client, orgNS, "organization", nil)
+	makeNamespace(t, ctx, s.client, crossTenantNS, "folder", nil)
+	makeNamespace(t, ctx, s.client, bindingNS, "folder", map[string]string{
+		"console.holos.run/parent":       parentNS,
+		"console.holos.run/organization": orgShort,
+	})
+
+	tests := []struct {
+		name            string
+		policyNamespace string
+		wantRejected    bool
+	}{
+		{"same-namespace-accepted", bindingNS, false},
+		{"parent-accepted", parentNS, false},
+		{"organization-accepted", orgNS, false},
+		{"cross-tenant-rejected", crossTenantNS, true},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sipb := &v1alpha1.SecretInjectionPolicyBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "b" + string(rune('a'+i)),
+					Namespace: bindingNS,
+				},
+				Spec: v1alpha1.SecretInjectionPolicyBindingSpec{
+					PolicyRef: v1alpha1.PolicyRef{
+						Scope:     v1alpha1.PolicyRefScopeFolder,
+						Namespace: tc.policyNamespace,
+						Name:      "p1",
+					},
+					TargetRefs: []v1alpha1.TargetRef{{
+						Kind:      v1alpha1.TargetRefKindServiceAccount,
+						Namespace: bindingNS,
+						Name:      "sa1",
+					}},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, sipb), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_UpstreamSecret_ProjectOnly covers the
+// upstreamsecret-project-only policy: UpstreamSecret must live in a
+// project-labeled namespace. The inverse of the SIP/SIPB folder/org
+// restriction — folder or org namespaces reject the create.
+func TestAdmission_UpstreamSecret_ProjectOnly(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		nsName       string
+		nsType       string
+		wantRejected bool
+	}{
+		{"project-accepted", "holos-prj-us-acc", "project", false},
+		{"folder-rejected", "holos-fld-us-rej", "folder", true},
+		{"organization-rejected", "holos-org-us-rej", "organization", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			makeNamespace(t, ctx, s.client, tc.nsName, tc.nsType, nil)
+			us := &v1alpha1.UpstreamSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: tc.nsName},
+				Spec: v1alpha1.UpstreamSecretSpec{
+					SecretRef: v1alpha1.SecretKeyReference{Name: "src", Key: "k"},
+					Upstream: v1alpha1.Upstream{
+						Host:   "example.test",
+						Scheme: "https",
+					},
+					Injection: v1alpha1.Injection{
+						Header:        "Authorization",
+						ValueTemplate: "Bearer {{.Value}}",
+					},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, us), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_SecretInjectionPolicy_AuthnAPIKeyOnly covers the
+// secretinjectionpolicy-authn-type-apikey-only policy: callerAuth.type
+// must be APIKey in v1alpha1; OIDC is rejected until the M2 data-plane
+// path ships.
+func TestAdmission_SecretInjectionPolicy_AuthnAPIKeyOnly(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	nsName := "holos-fld-sip-authn"
+	makeNamespace(t, ctx, s.client, nsName, "folder", nil)
+
+	tests := []struct {
+		name         string
+		authnType    v1alpha1.AuthenticationType
+		wantRejected bool
+	}{
+		{"apikey-accepted", v1alpha1.AuthenticationTypeAPIKey, false},
+		{"oidc-rejected", v1alpha1.AuthenticationTypeOIDC, true},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sip := &v1alpha1.SecretInjectionPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "p" + string(rune('a'+i)),
+					Namespace: nsName,
+				},
+				Spec: v1alpha1.SecretInjectionPolicySpec{
+					Direction:  v1alpha1.DirectionEgress,
+					CallerAuth: v1alpha1.CallerAuth{Type: tc.authnType},
+					UpstreamRef: v1alpha1.UpstreamRef{
+						Scope:     v1alpha1.UpstreamScopeProject,
+						ScopeName: "p1",
+						Name:      "u1",
+					},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, sip), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_Credential_UpstreamRefSameNamespace covers the
+// credential-upstreamref-same-namespace policy: the optional
+// upstreamSecretRef.namespace must be either empty or the Credential's
+// own namespace — cross-namespace refs would cross the RBAC boundary
+// the backing v1.Secret relies on.
+func TestAdmission_Credential_UpstreamRefSameNamespace(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	nsName := "holos-prj-cred-upstream"
+	otherNS := "holos-prj-cred-other"
+	makeNamespace(t, ctx, s.client, nsName, "project", nil)
+	makeNamespace(t, ctx, s.client, otherNS, "project", nil)
+
+	tests := []struct {
+		name         string
+		refNamespace string
+		wantRejected bool
+	}{
+		{"omitted-accepted", "", false},
+		{"same-namespace-accepted", nsName, false},
+		{"cross-namespace-rejected", otherNS, true},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cred := &v1alpha1.Credential{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "c" + string(rune('a'+i)),
+					Namespace: nsName,
+				},
+				Spec: v1alpha1.CredentialSpec{
+					Authentication: v1alpha1.Authentication{
+						Type:   v1alpha1.AuthenticationTypeAPIKey,
+						APIKey: &v1alpha1.APIKeySettings{HeaderName: "X-API-Key"},
+					},
+					UpstreamSecretRef: v1alpha1.NamespacedSecretKeyReference{
+						Namespace: tc.refNamespace,
+						Name:      "src",
+						Key:       "k",
+					},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, cred), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_Credential_AuthnAPIKeyOnly covers the
+// credential-authn-type-apikey-only policy.
+func TestAdmission_Credential_AuthnAPIKeyOnly(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	nsName := "holos-prj-cred-authn"
+	makeNamespace(t, ctx, s.client, nsName, "project", nil)
+
+	tests := []struct {
+		name         string
+		authnType    v1alpha1.AuthenticationType
+		wantRejected bool
+	}{
+		{"apikey-accepted", v1alpha1.AuthenticationTypeAPIKey, false},
+		{"oidc-rejected", v1alpha1.AuthenticationTypeOIDC, true},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cred := &v1alpha1.Credential{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "c" + string(rune('a'+i)),
+					Namespace: nsName,
+				},
+				Spec: v1alpha1.CredentialSpec{
+					Authentication: v1alpha1.Authentication{
+						Type:   tc.authnType,
+						APIKey: &v1alpha1.APIKeySettings{HeaderName: "X-API-Key"},
+					},
+					UpstreamSecretRef: v1alpha1.NamespacedSecretKeyReference{
+						Name: "src",
+						Key:  "k",
+					},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, cred), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_UpstreamSecret_ValueTemplateNoControlChars covers the
+// upstreamsecret-valuetemplate-no-control-chars policy. The valueTemplate
+// must not contain control characters or a colon — either would give a
+// malicious template author an HTTP header smuggling primitive.
+func TestAdmission_UpstreamSecret_ValueTemplateNoControlChars(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	nsName := "holos-prj-us-template"
+	makeNamespace(t, ctx, s.client, nsName, "project", nil)
+
+	tests := []struct {
+		name         string
+		valueTpl     string
+		wantRejected bool
+	}{
+		{"clean-accepted", "Bearer {{.Value}}", false},
+		{"crlf-rejected", "Bearer {{.Value}}\r\nX-Evil: x", true},
+		{"colon-rejected", "Bearer: {{.Value}}", true},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			us := &v1alpha1.UpstreamSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "u" + string(rune('a'+i)),
+					Namespace: nsName,
+				},
+				Spec: v1alpha1.UpstreamSecretSpec{
+					SecretRef: v1alpha1.SecretKeyReference{Name: "src", Key: "k"},
+					Upstream: v1alpha1.Upstream{
+						Host:   "example.test",
+						Scheme: "https",
+					},
+					Injection: v1alpha1.Injection{
+						Header:        "Authorization",
+						ValueTemplate: tc.valueTpl,
+					},
+				},
+			}
+			checkAdmission(t, s.client.Create(ctx, us), tc.wantRejected)
+		})
+	}
+}
+
+// TestAdmission_NamespaceScopeLabelImmutable covers the
+// namespace-scope-label-immutable policy. The test client runs as
+// cluster admin (NOT the platform-controller SA), so every label
+// transition is rejected; a same-label update is accepted. The
+// platform-controller exemption path is not exercised here because
+// envtest does not wire RBAC impersonation into the default client —
+// the accept-on-unchanged-label case is the observable guarantee this
+// test locks in.
+func TestAdmission_NamespaceScopeLabelImmutable(t *testing.T) {
+	s := setupSecretsEnvTest(t)
+	ctx := context.Background()
+
+	build := func(name, label string) *corev1.Namespace {
+		labels := map[string]string{}
+		if label != "" {
+			labels["console.holos.run/resource-type"] = label
+		}
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		}
+	}
+
+	updateNamespace := func(t *testing.T, name string, mutate func(ns *corev1.Namespace)) error {
+		t.Helper()
+		got := &corev1.Namespace{}
+		if err := s.client.Get(ctx, types.NamespacedName{Name: name}, got); err != nil {
+			t.Fatalf("get namespace %q: %v", name, err)
+		}
+		mutate(got)
+		return s.client.Update(ctx, got)
+	}
+
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T) string // returns the namespace name
+		mutate       func(ns *corev1.Namespace)
+		wantRejected bool
+	}{
+		{
+			name: "change-label-rejected",
+			setup: func(t *testing.T) string {
+				n := "holos-imm-change"
+				if err := s.client.Create(ctx, build(n, "project")); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				return n
+			},
+			mutate: func(ns *corev1.Namespace) {
+				ns.Labels["console.holos.run/resource-type"] = "folder"
+			},
+			wantRejected: true,
+		},
+		{
+			name: "set-label-from-unset-rejected",
+			setup: func(t *testing.T) string {
+				n := "holos-imm-set"
+				if err := s.client.Create(ctx, build(n, "")); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				return n
+			},
+			mutate: func(ns *corev1.Namespace) {
+				if ns.Labels == nil {
+					ns.Labels = map[string]string{}
+				}
+				ns.Labels["console.holos.run/resource-type"] = "project"
+			},
+			wantRejected: true,
+		},
+		{
+			name: "unset-label-rejected",
+			setup: func(t *testing.T) string {
+				n := "holos-imm-unset"
+				if err := s.client.Create(ctx, build(n, "project")); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				return n
+			},
+			mutate: func(ns *corev1.Namespace) {
+				delete(ns.Labels, "console.holos.run/resource-type")
+			},
+			wantRejected: true,
+		},
+		{
+			name: "unchanged-label-accepted",
+			setup: func(t *testing.T) string {
+				n := "holos-imm-unchanged"
+				if err := s.client.Create(ctx, build(n, "project")); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				return n
+			},
+			mutate: func(ns *corev1.Namespace) {
+				// Touch a different label so the UPDATE is meaningful.
+				ns.Labels["unrelated.example.test/touched"] = "yes"
+			},
+			wantRejected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name := tc.setup(t)
+			checkAdmission(t, updateNamespace(t, name, tc.mutate), tc.wantRejected)
+		})
+	}
+}

--- a/api/templates/v1alpha1/crd_test.go
+++ b/api/templates/v1alpha1/crd_test.go
@@ -18,26 +18,22 @@ package v1alpha1_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	envtesthelpers "github.com/holos-run/holos-console/internal/envtest"
 )
 
 // envtestSuite wraps the test env so each package-level test can share one
@@ -59,17 +55,14 @@ func setupEnvTest(t *testing.T) *envtestSuite {
 	t.Helper()
 
 	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
-		// setup-envtest places binaries under
-		// ~/.local/share/kubebuilder-envtest/k8s/<version>-<os>-<arch>. We
-		// search for the highest-version directory; failing that, we skip.
-		if assets := detectEnvtestAssets(); assets != "" {
+		if assets := envtesthelpers.DetectAssets(); assets != "" {
 			t.Setenv("KUBEBUILDER_ASSETS", assets)
 		} else {
 			t.Skip("envtest binaries not found; set KUBEBUILDER_ASSETS or run `setup-envtest use` to download")
 		}
 	}
 
-	repoRoot, err := findRepoRoot()
+	repoRoot, err := envtesthelpers.FindRepoRoot()
 	if err != nil {
 		t.Fatalf("finding repo root: %v", err)
 	}
@@ -105,143 +98,11 @@ func setupEnvTest(t *testing.T) *envtestSuite {
 	// in lockstep with the actual policy surface.
 	ctx := context.Background()
 	admissionDir := filepath.Join(repoRoot, "config", "admission")
-	if err := applyYAMLFilesInDir(ctx, c, admissionDir); err != nil {
+	if err := envtesthelpers.ApplyYAMLFilesInDir(ctx, c, admissionDir); err != nil {
 		t.Fatalf("applying admission policies: %v", err)
 	}
 
 	return &envtestSuite{env: env, client: c}
-}
-
-// applyYAMLFilesInDir reads every *.yaml file in dir and server-side applies
-// each document through the controller-runtime client. Used to install the
-// CEL ValidatingAdmissionPolicy manifests after envtest.Environment.Start()
-// returns — envtest itself has no built-in VAP installer.
-func applyYAMLFilesInDir(ctx context.Context, c client.Client, dir string) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return fmt.Errorf("read dir: %w", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
-		if err != nil {
-			return fmt.Errorf("read %s: %w", e.Name(), err)
-		}
-		// Split on YAML document separator and apply each doc
-		// individually. The VAP manifests ship one policy + one binding
-		// per file joined with "---".
-		for _, doc := range splitYAMLDocuments(data) {
-			if len(strings.TrimSpace(string(doc))) == 0 {
-				continue
-			}
-			// Try each known kind in order — VAP and VAPBinding are
-			// both registered in admissionregistration/v1.
-			if err := applyAdmissionDoc(ctx, c, doc); err != nil {
-				return fmt.Errorf("apply doc from %s: %w", e.Name(), err)
-			}
-		}
-	}
-	return nil
-}
-
-func splitYAMLDocuments(data []byte) [][]byte {
-	// Very small splitter — envtest manifests are authored in-repo and
-	// never contain the "---" sequence inside a string, so a line-wise
-	// split is sufficient.
-	var docs [][]byte
-	var current []byte
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(line) == "---" {
-			if len(current) > 0 {
-				docs = append(docs, current)
-			}
-			current = nil
-			continue
-		}
-		current = append(current, []byte(line+"\n")...)
-	}
-	if len(current) > 0 {
-		docs = append(docs, current)
-	}
-	return docs
-}
-
-func applyAdmissionDoc(ctx context.Context, c client.Client, doc []byte) error {
-	// Probe the Kind field to pick the correct runtime type. We keep this
-	// narrow to the two kinds we ship in config/admission/.
-	kindProbe := struct {
-		Kind string `json:"kind"`
-	}{}
-	if err := yaml.Unmarshal(doc, &kindProbe); err != nil {
-		return fmt.Errorf("unmarshal kind: %w", err)
-	}
-	switch kindProbe.Kind {
-	case "ValidatingAdmissionPolicy":
-		policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-		if err := yaml.Unmarshal(doc, policy); err != nil {
-			return fmt.Errorf("unmarshal policy: %w", err)
-		}
-		return c.Create(ctx, policy)
-	case "ValidatingAdmissionPolicyBinding":
-		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-		if err := yaml.Unmarshal(doc, binding); err != nil {
-			return fmt.Errorf("unmarshal binding: %w", err)
-		}
-		return c.Create(ctx, binding)
-	default:
-		return fmt.Errorf("unsupported admission kind %q", kindProbe.Kind)
-	}
-}
-
-// findRepoRoot walks up from the current test file to find the nearest
-// go.mod, which gives us an absolute path to the holos-console repo root so
-// the envtest CRDDirectoryPaths are stable regardless of the caller's CWD.
-func findRepoRoot() (string, error) {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", errors.New("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("no go.mod above %q", file)
-		}
-		dir = parent
-	}
-}
-
-// detectEnvtestAssets finds the highest-version envtest asset directory under
-// the user's XDG data dir. Returns empty string when nothing is found so the
-// caller can decide whether to skip.
-func detectEnvtestAssets() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	base := filepath.Join(home, ".local", "share", "kubebuilder-envtest", "k8s")
-	entries, err := os.ReadDir(base)
-	if err != nil {
-		return ""
-	}
-	var best string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		candidate := filepath.Join(base, e.Name())
-		if _, err := os.Stat(filepath.Join(candidate, "kube-apiserver")); err == nil {
-			if best == "" || e.Name() > filepath.Base(best) {
-				best = candidate
-			}
-		}
-	}
-	return best
 }
 
 // createNamespace provisions a namespace labeled for the given resource-type.
@@ -527,8 +388,8 @@ func TestAdmission_FolderOrOrgOnly(t *testing.T) {
 	// Wait for the admission policy to be registered before issuing
 	// writes; envtest loads VAP manifests asynchronously after the API
 	// server starts and a raced create can slip through the guard.
-	waitForAdmissionPolicy(t, ctx, s.client, "templatepolicy-folder-or-org-only")
-	waitForAdmissionPolicy(t, ctx, s.client, "templatepolicybinding-folder-or-org-only")
+	envtesthelpers.WaitForAdmissionPolicy(t, ctx, s.client, "templatepolicy-folder-or-org-only")
+	envtesthelpers.WaitForAdmissionPolicy(t, ctx, s.client, "templatepolicybinding-folder-or-org-only")
 
 	tests := []struct {
 		name          string
@@ -680,21 +541,4 @@ func TestAdmission_FolderOrOrgOnly(t *testing.T) {
 			}
 		})
 	}
-}
-
-// waitForAdmissionPolicy polls for a registered ValidatingAdmissionPolicy by
-// name. envtest starts the API server immediately but does not block Start()
-// on VAP manifest application; racing a Create ahead of the guard leads to
-// flaky false-negative admission tests.
-func waitForAdmissionPolicy(t *testing.T, ctx context.Context, c client.Client, name string) {
-	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
-		vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-		if err := c.Get(ctx, types.NamespacedName{Name: name}, vap); err == nil {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("admission policy %q not registered within deadline", name)
 }

--- a/internal/envtest/envtest.go
+++ b/internal/envtest/envtest.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package envtest collects the boot helpers shared by every CRD
+// round-trip and admission regression suite in the repo. Per-package
+// test files still own their own envtest.Environment{} construction —
+// CRD directories and scheme registrations differ per group — but the
+// four mechanical chores they share (finding an envtest assets
+// directory, locating the repo root, splitting + applying
+// ValidatingAdmissionPolicy manifests, and polling for a VAP to
+// register) live here so drift between api/templates/v1alpha1 and
+// api/secrets/v1alpha1 is not possible.
+package envtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DetectAssets finds the highest-version envtest asset directory under
+// the user's XDG data dir. Returns empty string when nothing is found so
+// the caller can decide whether to skip. setup-envtest places binaries
+// under ~/.local/share/kubebuilder-envtest/k8s/<version>-<os>-<arch>.
+func DetectAssets() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	base := filepath.Join(home, ".local", "share", "kubebuilder-envtest", "k8s")
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return ""
+	}
+	var best string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(base, e.Name())
+		if _, err := os.Stat(filepath.Join(candidate, "kube-apiserver")); err == nil {
+			if best == "" || e.Name() > filepath.Base(best) {
+				best = candidate
+			}
+		}
+	}
+	return best
+}
+
+// FindRepoRoot walks up from the current file to find the nearest
+// go.mod, which gives an absolute path to the holos-console repo root
+// so envtest CRDDirectoryPaths are stable regardless of the caller's
+// CWD. Walks up from this source file (internal/envtest/envtest.go), so
+// the walk is invariant to the caller's package location.
+func FindRepoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod above %q", file)
+		}
+		dir = parent
+	}
+}
+
+// SplitYAMLDocuments splits a byte buffer on the YAML "---" document
+// separator. Envtest manifests are authored in-repo and never contain
+// the separator inside a string, so a line-wise split is sufficient and
+// intentionally simpler than a full YAML parser.
+func SplitYAMLDocuments(data []byte) [][]byte {
+	var docs [][]byte
+	var current []byte
+	flush := func() {
+		if len(strings.TrimSpace(string(current))) > 0 {
+			docs = append(docs, current)
+		}
+		current = nil
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "---" {
+			flush()
+			continue
+		}
+		current = append(current, []byte(line+"\n")...)
+	}
+	flush()
+	return docs
+}
+
+// ApplyAdmissionDoc decodes a single YAML document and creates the
+// corresponding admissionregistration/v1 object via the
+// controller-runtime client. Supported kinds are
+// ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding —
+// anything else returns an error so an accidentally committed
+// non-admission YAML does not silently slip through the bootstrap.
+func ApplyAdmissionDoc(ctx context.Context, c client.Client, doc []byte) error {
+	kindProbe := struct {
+		Kind string `json:"kind"`
+	}{}
+	if err := yaml.Unmarshal(doc, &kindProbe); err != nil {
+		return fmt.Errorf("unmarshal kind: %w", err)
+	}
+	switch kindProbe.Kind {
+	case "ValidatingAdmissionPolicy":
+		policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		if err := yaml.Unmarshal(doc, policy); err != nil {
+			return fmt.Errorf("unmarshal policy: %w", err)
+		}
+		return c.Create(ctx, policy)
+	case "ValidatingAdmissionPolicyBinding":
+		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+		if err := yaml.Unmarshal(doc, binding); err != nil {
+			return fmt.Errorf("unmarshal binding: %w", err)
+		}
+		return c.Create(ctx, binding)
+	default:
+		return fmt.Errorf("unsupported admission kind %q", kindProbe.Kind)
+	}
+}
+
+// ApplyYAMLFilesInDir reads every *.yaml file in dir and applies each
+// document it contains through ApplyAdmissionDoc. Used to install the
+// CEL ValidatingAdmissionPolicy manifests after
+// envtest.Environment.Start() returns — envtest has no built-in VAP
+// installer. Kustomization.yaml is skipped because it is a kustomize
+// index file, not a runtime manifest.
+func ApplyYAMLFilesInDir(ctx context.Context, c client.Client, dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		if e.Name() == "kustomization.yaml" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		for _, doc := range SplitYAMLDocuments(data) {
+			if len(strings.TrimSpace(string(doc))) == 0 {
+				continue
+			}
+			if err := ApplyAdmissionDoc(ctx, c, doc); err != nil {
+				return fmt.Errorf("apply doc from %s: %w", e.Name(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// WaitForAdmissionPolicy polls for a registered
+// ValidatingAdmissionPolicy and its same-named binding. envtest starts
+// the API server immediately but does not block Start() on VAP
+// manifest application; racing a Create ahead of the guard leads to
+// flaky false-negative admission tests. Waiting for the binding is
+// required too — the admission plugin only compiles and activates a
+// policy once BOTH the VAP and its binding are visible in the API
+// server's policy cache. Our admission manifests follow a one-VAP +
+// one-same-named-binding convention, so this helper assumes the
+// binding shares the policy's name.
+func WaitForAdmissionPolicy(t *testing.T, ctx context.Context, c client.Client, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		vapErr := c.Get(ctx, types.NamespacedName{Name: name}, vap)
+		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+		bindingErr := c.Get(ctx, types.NamespacedName{Name: name}, binding)
+		if vapErr == nil && bindingErr == nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("admission policy %q not registered within deadline", name)
+}

--- a/internal/envtest/envtest_test.go
+++ b/internal/envtest/envtest_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/holos-run/holos-console/internal/envtest"
+)
+
+// TestFindRepoRoot returns a directory that contains go.mod, regardless
+// of the caller's CWD. The helper is consumed from test files that live
+// deep in the package tree, so the walk must reliably surface the
+// module root.
+func TestFindRepoRoot(t *testing.T) {
+	root, err := envtest.FindRepoRoot()
+	if err != nil {
+		t.Fatalf("FindRepoRoot: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("expected go.mod under %q: %v", root, err)
+	}
+}
+
+// TestSplitYAMLDocuments covers the degenerate boundaries we hit in
+// real manifests: empty input, single doc, two docs separated by "---",
+// and trailing separator. Any regression here would corrupt the
+// admission-policy installer.
+func TestSplitYAMLDocuments(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "empty", in: "", want: 0},
+		{name: "single", in: "a: 1\n", want: 1},
+		{name: "two-docs", in: "a: 1\n---\nb: 2\n", want: 2},
+		{name: "leading-separator", in: "---\na: 1\n", want: 1},
+		{name: "trailing-separator", in: "a: 1\n---\n", want: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := envtest.SplitYAMLDocuments([]byte(tc.in))
+			if len(got) != tc.want {
+				t.Fatalf("want %d docs, got %d (%q)", tc.want, len(got), got)
+			}
+		})
+	}
+}
+
+// TestDetectAssets exercises the search path but accepts either a
+// found path (developer already ran setup-envtest) or the empty string
+// (clean machine). It asserts only that the returned path, when
+// non-empty, actually contains a kube-apiserver binary so a stale
+// XDG layout does not mask a broken detection.
+func TestDetectAssets(t *testing.T) {
+	got := envtest.DetectAssets()
+	if got == "" {
+		return
+	}
+	if _, err := os.Stat(filepath.Join(got, "kube-apiserver")); err != nil {
+		t.Fatalf("DetectAssets returned %q without a kube-apiserver binary: %v", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract shared envtest helpers into `internal/envtest` (`DetectAssets`, `FindRepoRoot`, `SplitYAMLDocuments`, `ApplyAdmissionDoc`, `ApplyYAMLFilesInDir`, `WaitForAdmissionPolicy`) so `api/templates/v1alpha1` and `api/secrets/v1alpha1` cannot drift.
- Refactor `api/templates/v1alpha1/crd_test.go` to consume the helper package (move, not copy).
- Add `api/secrets/v1alpha1/crd_test.go` with a table-driven positive + negative path for every one of the nine CEL `ValidatingAdmissionPolicies` under `config/secret-injector/admission/`. Each rejected subtest logs the server-side admission message so CEL regressions surface the exact guard that fired.
- Setup waits on VAP + binding existence and then runs a functional readiness probe (a known-bad namespace UPDATE) before returning — without the probe, the first admission-denying test would race the API server's CEL compile step.
- Tests `t.Skip` when `KUBEBUILDER_ASSETS` is unset and `setup-envtest` layout is missing.

Fixes HOL-708

## Test plan

- [x] `KUBEBUILDER_ASSETS=... go test -count=1 ./api/secrets/v1alpha1/... ./api/templates/v1alpha1/... ./internal/envtest/...` — all green.
- [x] `HOME=/tmp KUBEBUILDER_ASSETS="" go test ...` — tests `t.Skip` cleanly.
- [x] `go vet` clean on all touched packages.

Generated with [Claude Code](https://claude.com/claude-code)