### PR TITLE
feat(frontend): sidebar Project tree with tooltip and child nav

### DIFF
--- a/frontend/src/components/-app-sidebar.test.tsx
+++ b/frontend/src/components/-app-sidebar.test.tsx
@@ -36,14 +36,42 @@ vi.mock('@/components/ui/sidebar', () => ({
   Sidebar: ({ children }: { children: React.ReactNode }) => <div data-testid="sidebar">{children}</div>,
   SidebarContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SidebarGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarGroup: ({ children, ...rest }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => <div {...rest}>{children}</div>,
   SidebarGroupContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarGroupLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarHeader: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => <div {...props}>{children}</div>,
   SidebarMenu: ({ children }: { children: React.ReactNode }) => <ul data-testid="sidebar-menu">{children}</ul>,
-  SidebarMenuButton: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => <div {...props}>{children}</div>,
+  SidebarMenuButton: ({ children, asChild, isActive, ...props }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => {
+    void isActive
+    return asChild ? <>{children}</> : <div {...props}>{children}</div>
+  },
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <li>{children}</li>,
+  SidebarMenuSub: ({ children }: { children: React.ReactNode }) => <ul data-testid="sidebar-menu-sub">{children}</ul>,
+  SidebarMenuSubItem: ({ children }: { children: React.ReactNode }) => <li>{children}</li>,
+  SidebarMenuSubButton: ({ children, asChild, isActive, ...props }: React.HTMLAttributes<HTMLElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => {
+    void isActive
+    return asChild ? <>{children}</> : <a {...props}>{children}</a>
+  },
   SidebarSeparator: () => <hr />,
+}))
+
+// Flatten Collapsible / Tooltip primitives so the Project tree renders its
+// children and tooltip content inline without requiring portals or user
+// interaction. The primitives themselves are covered by their dedicated
+// test files; here we only care about AppSidebar composition.
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  CollapsibleTrigger: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) =>
+    asChild ? <>{children}</> : <button>{children}</button>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) =>
+    asChild ? <>{children}</> : <span>{children}</span>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
 // Stub WorkspaceMenu so the AppSidebar test stays focused on sidebar nav

--- a/frontend/src/components/-app-sidebar.tree.test.tsx
+++ b/frontend/src/components/-app-sidebar.tree.test.tsx
@@ -98,12 +98,13 @@ describe('AppSidebar — Project tree toggle (real Collapsible + Tooltip primiti
 
     await user.click(screen.getByTestId('project-tree-trigger'))
 
-    // After collapse, Radix hides the content via data-state=closed. jsdom
-    // doesn't apply the `hidden until found` / CSS rules, but Radix sets the
-    // `hidden` attribute and removes the content from the tree when closed.
-    // Assert via queryByRole with { hidden: false } to exclude hidden nodes.
+    // After collapse, Radix sets the `hidden` attribute on CollapsibleContent
+    // and its descendants. Testing Library's queryByRole excludes elements
+    // that are inaccessible (hidden) by default, so the Secrets link
+    // disappears from the accessible tree even though the DOM node still
+    // exists with `hidden` set.
     expect(
-      screen.queryByRole('link', { name: /^secrets$/i, hidden: false }),
+      screen.queryByRole('link', { name: /^secrets$/i }),
     ).not.toBeInTheDocument()
 
     await user.click(screen.getByTestId('project-tree-trigger'))

--- a/frontend/src/components/-app-sidebar.tree.test.tsx
+++ b/frontend/src/components/-app-sidebar.tree.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// HOL-604 integration test: exercise the Project tree with the real
+// Collapsible + Tooltip primitives to verify the asChild prop-merging chain
+// (CollapsibleTrigger asChild > TooltipTrigger asChild > SidebarMenuButton)
+// correctly forwards click events from the Collapsible primitive through to
+// the underlying button so the children toggle as expected. The primary
+// app-sidebar.test.tsx suite flattens these primitives for content-level
+// assertions.
+//
+// Tooltip open-on-hover is NOT exercised here: Radix Tooltip listens for
+// `onPointerMove` and gates open on `event.pointerType === 'mouse'`, which
+// jsdom does not reliably synthesize (neither user-event's hover() nor
+// fireEvent.pointerMove produces a pointer event Radix treats as a real
+// mouse move). The content-level tooltip assertions in app-sidebar.test.tsx
+// (display name + slug rendered in TooltipContent) are sufficient coverage
+// for HOL-604's acceptance criteria; the hover interaction itself is Radix
+// Tooltip's concern and is covered by upstream tests.
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    params,
+    ...rest
+  }: {
+    children: React.ReactNode
+    to: string
+    params?: Record<string, string>
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    let href = to
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => {
+        href = href.replace(`$${k}`, v)
+      })
+    }
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
+  },
+  useRouter: () => ({ state: { location: { pathname: '/' } }, navigate: vi.fn() }),
+}))
+
+vi.mock('@/components/workspace-menu', () => ({
+  WorkspaceMenu: () => <div data-testid="workspace-menu" />,
+}))
+
+vi.mock('@/lib/org-context', () => ({ useOrg: vi.fn() }))
+vi.mock('@/lib/project-context', () => ({ useProject: vi.fn() }))
+vi.mock('@/queries/version', () => ({ useVersion: () => ({ data: { version: 'v0.0.0-test' } }) }))
+vi.mock('@/queries/project-settings', () => ({
+  useGetProjectSettings: () => ({ data: { deploymentsEnabled: true }, isPending: false }),
+}))
+
+import { useOrg } from '@/lib/org-context'
+import { useProject } from '@/lib/project-context'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { AppSidebar } from './app-sidebar'
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<SidebarProvider>{ui}</SidebarProvider>)
+}
+
+function setupProjectSelected() {
+  ;(useOrg as Mock).mockReturnValue({
+    organizations: [{ name: 'my-org', displayName: 'My Org' }],
+    selectedOrg: 'my-org',
+    setSelectedOrg: vi.fn(),
+    isLoading: false,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    projects: [{ name: 'my-project', displayName: 'My Project' }],
+    selectedProject: 'my-project',
+    setSelectedProject: vi.fn(),
+    isLoading: false,
+  })
+}
+
+describe('AppSidebar — Project tree toggle (real Collapsible + Tooltip primitives)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupProjectSelected()
+  })
+
+  it('toggles child visibility when the Project label is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<AppSidebar />)
+
+    // defaultOpen=true on the Collapsible means children render on mount.
+    expect(screen.getByRole('link', { name: /^secrets$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^deployments$/i })).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('project-tree-trigger'))
+
+    // After collapse, Radix hides the content via data-state=closed. jsdom
+    // doesn't apply the `hidden until found` / CSS rules, but Radix sets the
+    // `hidden` attribute and removes the content from the tree when closed.
+    // Assert via queryByRole with { hidden: false } to exclude hidden nodes.
+    expect(
+      screen.queryByRole('link', { name: /^secrets$/i, hidden: false }),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('project-tree-trigger'))
+
+    // Re-expanding restores visibility.
+    expect(screen.getByRole('link', { name: /^secrets$/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -5,6 +5,9 @@ import React from 'react'
 
 // Mock router and sidebar dependencies
 const mockNavigate = vi.fn()
+// Configurable per-test so we can drive route-based gating (active-state
+// highlighting on the Project tree children).
+let mockPathname = '/'
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -27,11 +30,15 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
       }
       return <a href={href}>{children}</a>
     },
-    useRouter: () => ({ state: { location: { pathname: '/' } }, navigate: mockNavigate }),
+    useRouter: () => ({ state: { location: { pathname: mockPathname } }, navigate: mockNavigate }),
     useNavigate: () => vi.fn(),
   }
 })
 
+// Forward `isActive` as `data-active` so active-state highlighting can be
+// asserted; the real sidebar primitives do the same internally. `asChild`
+// passes through untouched so `<Link>` / button children render without
+// wrapping.
 vi.mock('@/components/ui/sidebar', () => ({
   Sidebar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -49,31 +56,44 @@ vi.mock('@/components/ui/sidebar', () => ({
     asChild,
     isActive,
     ...rest
-  }: React.HTMLAttributes<HTMLElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => {
-    void isActive
-    return asChild ? <>{children}</> : <button {...rest}>{children}</button>
-  },
+  }: React.HTMLAttributes<HTMLElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) =>
+    asChild ? <>{children}</> : (
+      <button data-active={isActive ? 'true' : 'false'} {...rest}>
+        {children}
+      </button>
+    ),
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <li>{children}</li>,
   SidebarMenuSub: ({ children }: { children: React.ReactNode }) => (
     <ul data-testid="sidebar-menu-sub">{children}</ul>
   ),
-  SidebarMenuSubItem: ({ children }: { children: React.ReactNode }) => <li>{children}</li>,
+  SidebarMenuSubItem: ({ children }: { children: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
   SidebarMenuSubButton: ({
     children,
     asChild,
     isActive,
     ...rest
   }: React.HTMLAttributes<HTMLElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => {
-    void isActive
-    return asChild ? <>{children}</> : <a {...rest}>{children}</a>
+    const activeAttr = isActive ? 'true' : 'false'
+    if (asChild) {
+      // Wrap the single child in a span that carries the data-active
+      // attribute so tests can assert the active state without caring how
+      // the child (Link / button / etc.) renders.
+      return <span data-active={activeAttr}>{children}</span>
+    }
+    return (
+      <a data-active={activeAttr} {...rest}>
+        {children}
+      </a>
+    )
   },
   SidebarSeparator: () => <hr />,
 }))
 
-// Flatten Collapsible so CollapsibleContent is always rendered for the
-// expanded-state assertions (the open/closed toggle is radix-driven and
-// portaled in the real app; the component's expand/collapse behavior is
-// exercised in the dedicated behavior suite below via a separate mock).
+// Flatten Collapsible so CollapsibleContent is always rendered. The primitive
+// open/close state is Radix-driven and covered separately by the integration
+// test in -app-sidebar.hover.test.tsx.
 vi.mock('@/components/ui/collapsible', () => ({
   Collapsible: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   CollapsibleTrigger: ({
@@ -91,9 +111,8 @@ vi.mock('@/components/ui/collapsible', () => ({
   ),
 }))
 
-// Flatten Tooltip so the TooltipContent is always in the DOM and its
-// contents can be asserted directly without simulating hover. The real
-// Tooltip portals and is gated on a user interaction.
+// Flatten Tooltip so TooltipContent renders inline; content-level assertions
+// live here, hover/focus wiring lives in the integration test.
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -150,6 +169,7 @@ describe('AppSidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockNavigate.mockReset()
+    mockPathname = '/'
     setDefaults()
   })
 
@@ -216,6 +236,7 @@ describe('AppSidebar', () => {
 describe('AppSidebar — org selected', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockPathname = '/'
     setDefaults()
     ;(useOrg as Mock).mockReturnValue({
       organizations: [{ name: 'my-org', displayName: 'My Org' }],
@@ -265,9 +286,12 @@ describe('AppSidebar — org selected', () => {
 // HOL-604: the project section becomes a collapsible tree labeled "Project"
 // with a tooltip surfacing the display name + slug. Children render inside a
 // SidebarMenuSub in the canonical order: Secrets, Deployments, Templates,
-// Settings. Collapse state is radix-driven and exercised at the primitive
-// level; these tests flatten the Collapsible mock and assert against the
-// rendered children directly.
+// Settings.
+//
+// This suite flattens the Collapsible / Tooltip primitives so content-level
+// assertions (order, routing, active state, tooltip contents) are direct.
+// The real hover + expand/collapse behavior is covered by
+// -app-sidebar.hover.test.tsx which renders with the unmocked primitives.
 describe('AppSidebar — Project tree (HOL-604)', () => {
   function setupProjectSelected() {
     ;(useOrg as Mock).mockReturnValue({
@@ -286,6 +310,7 @@ describe('AppSidebar — Project tree (HOL-604)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockPathname = '/'
     setDefaults()
     setupProjectSelected()
   })
@@ -304,12 +329,15 @@ describe('AppSidebar — Project tree (HOL-604)', () => {
     expect(trigger.textContent).not.toContain('My Project')
   })
 
-  it('renders a tooltip containing the project display name and slug on separate lines', () => {
+  it('renders a tooltip whose first line is the display name and second is the slug', () => {
     render(<AppSidebar />)
     const tooltip = screen.getByTestId('project-tree-tooltip')
-    const lines = Array.from(tooltip.querySelectorAll('div')).map((el) => el.textContent)
-    expect(lines).toContain('My Project')
-    expect(lines).toContain('my-project')
+    // Direct-child divs carry the two lines; nested descendants (if any)
+    // are intentionally excluded to lock in the order.
+    const lineDivs = Array.from(tooltip.children).filter(
+      (el): el is HTMLElement => el.tagName === 'DIV',
+    )
+    expect(lineDivs.map((el) => el.textContent)).toEqual(['My Project', 'my-project'])
   })
 
   it('falls back to the slug for the display-name line when displayName is empty', () => {
@@ -321,12 +349,14 @@ describe('AppSidebar — Project tree (HOL-604)', () => {
     })
     render(<AppSidebar />)
     const tooltip = screen.getByTestId('project-tree-tooltip')
-    // Both lines resolve to the slug when there is no displayName.
-    const lines = Array.from(tooltip.querySelectorAll('div')).map((el) => el.textContent)
-    expect(lines.filter((t) => t === 'my-project').length).toBeGreaterThanOrEqual(2)
+    const lineDivs = Array.from(tooltip.children).filter(
+      (el): el is HTMLElement => el.tagName === 'DIV',
+    )
+    // Both lines collapse to the slug when there is no displayName.
+    expect(lineDivs.map((el) => el.textContent)).toEqual(['my-project', 'my-project'])
   })
 
-  it('renders Secrets as the only child when deploymentsEnabled is false', () => {
+  it('renders only Secrets and Settings (no Deployments/Templates) when deploymentsEnabled is false', () => {
     ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: false }, isPending: false })
     render(<AppSidebar />)
     const sub = screen.getByTestId('sidebar-menu-sub')
@@ -377,5 +407,47 @@ describe('AppSidebar — Project tree (HOL-604)', () => {
     })
     render(<AppSidebar />)
     expect(screen.queryByTestId('project-tree')).not.toBeInTheDocument()
+  })
+
+  // Active-state highlighting: the `isActive` prop on each child is surfaced
+  // on the wrapping <span data-active="..."> by the mock so we can assert
+  // the route-based gate without caring about the internal primitive.
+  describe('active-state highlighting', () => {
+    beforeEach(() => {
+      ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: true }, isPending: false })
+    })
+
+    function activeOf(linkName: RegExp) {
+      const link = screen.getByRole('link', { name: linkName })
+      // The mock wraps the <a> in a <span data-active="..."> when asChild
+      // is used (SidebarMenuSubButton asChild -> Link).
+      return link.parentElement?.getAttribute('data-active')
+    }
+
+    it('marks the Secrets child active when the pathname is /projects/<name>/secrets', () => {
+      mockPathname = '/projects/my-project/secrets'
+      render(<AppSidebar />)
+      expect(activeOf(/^secrets$/i)).toBe('true')
+      expect(activeOf(/^deployments$/i)).toBe('false')
+      expect(activeOf(/^settings$/i)).toBe('false')
+    })
+
+    it('marks the Settings child active when the pathname is /projects/<name>/settings (trailing slash stripped)', () => {
+      mockPathname = '/projects/my-project/settings'
+      render(<AppSidebar />)
+      expect(activeOf(/^settings$/i)).toBe('true')
+      expect(activeOf(/^secrets$/i)).toBe('false')
+    })
+
+    it('marks only the matching child active when the pathname is a deeper sub-route', () => {
+      // Secrets detail page, e.g. /projects/my-project/secrets/foo — the
+      // Secrets child should be active, not the other children.
+      mockPathname = '/projects/my-project/secrets/api-key'
+      render(<AppSidebar />)
+      expect(activeOf(/^secrets$/i)).toBe('true')
+      expect(activeOf(/^deployments$/i)).toBe('false')
+      expect(activeOf(/^templates$/i)).toBe('false')
+      expect(activeOf(/^settings$/i)).toBe('false')
+    })
   })
 })

--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -93,7 +93,7 @@ vi.mock('@/components/ui/sidebar', () => ({
 
 // Flatten Collapsible so CollapsibleContent is always rendered. The primitive
 // open/close state is Radix-driven and covered separately by the integration
-// test in -app-sidebar.hover.test.tsx.
+// test in -app-sidebar.tree.test.tsx.
 vi.mock('@/components/ui/collapsible', () => ({
   Collapsible: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   CollapsibleTrigger: ({
@@ -290,8 +290,9 @@ describe('AppSidebar — org selected', () => {
 //
 // This suite flattens the Collapsible / Tooltip primitives so content-level
 // assertions (order, routing, active state, tooltip contents) are direct.
-// The real hover + expand/collapse behavior is covered by
-// -app-sidebar.hover.test.tsx which renders with the unmocked primitives.
+// The real click-toggle behavior over the asChild prop-merging chain is
+// covered by -app-sidebar.tree.test.tsx which renders with the unmocked
+// primitives.
 describe('AppSidebar — Project tree (HOL-604)', () => {
   function setupProjectSelected() {
     ;(useOrg as Mock).mockReturnValue({

--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -35,17 +35,81 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('@/components/ui/sidebar', () => ({
   Sidebar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SidebarGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarGroup: ({ children, ...rest }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => (
+    <div {...rest}>{children}</div>
+  ),
   SidebarGroupContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarGroupLabel: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="sidebar-group-label">{children}</div>
   ),
   SidebarHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarMenu: ({ children }: { children: React.ReactNode }) => <ul>{children}</ul>,
-  SidebarMenuButton: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) =>
-    asChild ? <>{children}</> : <li>{children}</li>,
+  SidebarMenuButton: ({
+    children,
+    asChild,
+    isActive,
+    ...rest
+  }: React.HTMLAttributes<HTMLElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => {
+    void isActive
+    return asChild ? <>{children}</> : <button {...rest}>{children}</button>
+  },
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <li>{children}</li>,
+  SidebarMenuSub: ({ children }: { children: React.ReactNode }) => (
+    <ul data-testid="sidebar-menu-sub">{children}</ul>
+  ),
+  SidebarMenuSubItem: ({ children }: { children: React.ReactNode }) => <li>{children}</li>,
+  SidebarMenuSubButton: ({
+    children,
+    asChild,
+    isActive,
+    ...rest
+  }: React.HTMLAttributes<HTMLElement> & { children: React.ReactNode; asChild?: boolean; isActive?: boolean }) => {
+    void isActive
+    return asChild ? <>{children}</> : <a {...rest}>{children}</a>
+  },
   SidebarSeparator: () => <hr />,
+}))
+
+// Flatten Collapsible so CollapsibleContent is always rendered for the
+// expanded-state assertions (the open/closed toggle is radix-driven and
+// portaled in the real app; the component's expand/collapse behavior is
+// exercised in the dedicated behavior suite below via a separate mock).
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  CollapsibleTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => (asChild ? <>{children}</> : <button>{children}</button>),
+  CollapsibleContent: ({
+    children,
+    ...rest
+  }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => (
+    <div {...rest}>{children}</div>
+  ),
+}))
+
+// Flatten Tooltip so the TooltipContent is always in the DOM and its
+// contents can be asserted directly without simulating hover. The real
+// Tooltip portals and is gated on a user interaction.
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => (asChild ? <>{children}</> : <span>{children}</span>),
+  TooltipContent: ({
+    children,
+    ...rest
+  }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => (
+    <div {...rest}>{children}</div>
+  ),
 }))
 
 // Stub the workspace menu so AppSidebar tests stay focused on sidebar
@@ -138,7 +202,14 @@ describe('AppSidebar', () => {
   it('does not render project nav links when no project is selected', () => {
     render(<AppSidebar />)
     expect(screen.queryByText('Secrets')).toBeNull()
-    expect(screen.queryByText('Project Settings')).toBeNull()
+    expect(screen.queryByText(/^settings$/i)).toBeNull()
+  })
+
+  // HOL-604: the Project tree itself is hidden when no project is selected.
+  it('does not render the Project tree when no project is selected', () => {
+    render(<AppSidebar />)
+    expect(screen.queryByTestId('project-tree')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('project-tree-trigger')).not.toBeInTheDocument()
   })
 })
 
@@ -191,61 +262,13 @@ describe('AppSidebar — org selected', () => {
   })
 })
 
-describe('AppSidebar — project selected', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setDefaults()
-    ;(useOrg as Mock).mockReturnValue({
-      organizations: [{ name: 'my-org', displayName: 'My Org' }],
-      selectedOrg: 'my-org',
-      setSelectedOrg: vi.fn(),
-      isLoading: false,
-    })
-    ;(useProject as Mock).mockReturnValue({
-      projects: [{ name: 'my-project', displayName: 'My Project' }],
-      selectedProject: 'my-project',
-      setSelectedProject: vi.fn(),
-      isLoading: false,
-    })
-  })
-
-  it('renders Secrets nav link when a project is selected', () => {
-    render(<AppSidebar />)
-    expect(screen.getByText('Secrets')).toBeInTheDocument()
-  })
-
-  it('renders project Settings nav link labeled "Project Settings" when a project is selected', () => {
-    render(<AppSidebar />)
-    expect(screen.getByRole('link', { name: /^project settings$/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /^org settings$/i })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /^settings$/i })).toBeNull()
-  })
-
-  it('project Settings link points to /projects/$projectName/settings', () => {
-    render(<AppSidebar />)
-    const links = screen.getAllByRole('link', { name: /project settings/i })
-    const projectSettingsLink = links.find((l) =>
-      l.getAttribute('href')?.startsWith('/projects/'),
-    )
-    expect(projectSettingsLink?.getAttribute('href')).toBe('/projects/my-project/settings/')
-  })
-
-  it('renders project display name as group label in project nav section', () => {
-    render(<AppSidebar />)
-    const labels = screen.getAllByTestId('sidebar-group-label')
-    const labelTexts = labels.map((l) => l.textContent)
-    expect(labelTexts).toContain('My Project')
-  })
-
-  it('org nav group is also visible when a project is selected', () => {
-    render(<AppSidebar />)
-    const labels = screen.getAllByTestId('sidebar-group-label')
-    const labelTexts = labels.map((l) => l.textContent)
-    expect(labelTexts).toContain('My Org')
-  })
-})
-
-describe('AppSidebar — Templates nav item conditional visibility', () => {
+// HOL-604: the project section becomes a collapsible tree labeled "Project"
+// with a tooltip surfacing the display name + slug. Children render inside a
+// SidebarMenuSub in the canonical order: Secrets, Deployments, Templates,
+// Settings. Collapse state is radix-driven and exercised at the primitive
+// level; these tests flatten the Collapsible mock and assert against the
+// rendered children directly.
+describe('AppSidebar — Project tree (HOL-604)', () => {
   function setupProjectSelected() {
     ;(useOrg as Mock).mockReturnValue({
       organizations: [{ name: 'my-org', displayName: 'My Org' }],
@@ -267,41 +290,92 @@ describe('AppSidebar — Templates nav item conditional visibility', () => {
     setupProjectSelected()
   })
 
-  it('does not show Templates nav when deploymentsEnabled is false', () => {
+  it('renders the Project tree when a project is selected', () => {
+    render(<AppSidebar />)
+    expect(screen.getByTestId('project-tree')).toBeInTheDocument()
+    expect(screen.getByTestId('project-tree-trigger')).toBeInTheDocument()
+  })
+
+  it('uses a static "Project" label instead of the project display name', () => {
+    render(<AppSidebar />)
+    const trigger = screen.getByTestId('project-tree-trigger')
+    expect(trigger.textContent).toContain('Project')
+    // Display name belongs in the tooltip, not the label itself.
+    expect(trigger.textContent).not.toContain('My Project')
+  })
+
+  it('renders a tooltip containing the project display name and slug on separate lines', () => {
+    render(<AppSidebar />)
+    const tooltip = screen.getByTestId('project-tree-tooltip')
+    const lines = Array.from(tooltip.querySelectorAll('div')).map((el) => el.textContent)
+    expect(lines).toContain('My Project')
+    expect(lines).toContain('my-project')
+  })
+
+  it('falls back to the slug for the display-name line when displayName is empty', () => {
+    ;(useProject as Mock).mockReturnValue({
+      projects: [{ name: 'my-project', displayName: '' }],
+      selectedProject: 'my-project',
+      setSelectedProject: vi.fn(),
+      isLoading: false,
+    })
+    render(<AppSidebar />)
+    const tooltip = screen.getByTestId('project-tree-tooltip')
+    // Both lines resolve to the slug when there is no displayName.
+    const lines = Array.from(tooltip.querySelectorAll('div')).map((el) => el.textContent)
+    expect(lines.filter((t) => t === 'my-project').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders Secrets as the only child when deploymentsEnabled is false', () => {
     ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: false }, isPending: false })
     render(<AppSidebar />)
-    expect(screen.queryByRole('link', { name: /^templates$/i })).not.toBeInTheDocument()
+    const sub = screen.getByTestId('sidebar-menu-sub')
+    const labels = Array.from(sub.querySelectorAll('li')).map((li) => li.textContent?.trim())
+    expect(labels).toEqual(['Secrets', 'Settings'])
   })
 
-  it('shows Templates nav when deploymentsEnabled is true', () => {
+  it('renders children in canonical order Secrets, Deployments, Templates, Settings when deploymentsEnabled', () => {
     ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: true }, isPending: false })
     render(<AppSidebar />)
-    expect(screen.getByRole('link', { name: /^templates$/i })).toBeInTheDocument()
+    const sub = screen.getByTestId('sidebar-menu-sub')
+    const labels = Array.from(sub.querySelectorAll('li')).map((li) => li.textContent?.trim())
+    expect(labels).toEqual(['Secrets', 'Deployments', 'Templates', 'Settings'])
   })
 
-  it('Templates link points to /projects/$projectName/templates', () => {
+  it('routes each child link to the existing /projects/$projectName/... URL', () => {
     ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: true }, isPending: false })
     render(<AppSidebar />)
-    const link = screen.getByRole('link', { name: /^templates$/i })
-    expect(link.getAttribute('href')).toBe('/projects/my-project/templates')
+    expect(screen.getByRole('link', { name: /^secrets$/i }).getAttribute('href')).toBe(
+      '/projects/my-project/secrets',
+    )
+    expect(screen.getByRole('link', { name: /^deployments$/i }).getAttribute('href')).toBe(
+      '/projects/my-project/deployments',
+    )
+    expect(screen.getByRole('link', { name: /^templates$/i }).getAttribute('href')).toBe(
+      '/projects/my-project/templates',
+    )
+    // The child Settings link routes to the project-scope settings route;
+    // the org nav still exposes a separate Org Settings link.
+    const settingsLinks = screen.getAllByRole('link', { name: /^settings$/i })
+    expect(settingsLinks).toHaveLength(1)
+    expect(settingsLinks[0].getAttribute('href')).toBe('/projects/my-project/settings/')
   })
 
-  it('does not show Deployments nav when deploymentsEnabled is false', () => {
-    ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: false }, isPending: false })
-    render(<AppSidebar />)
-    expect(screen.queryByRole('link', { name: /^deployments$/i })).not.toBeInTheDocument()
-  })
-
-  it('shows Deployments nav when deploymentsEnabled is true', () => {
+  it('the org nav Org Settings link continues to render alongside the Project Settings child', () => {
     ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: true }, isPending: false })
     render(<AppSidebar />)
-    expect(screen.getByRole('link', { name: /^deployments$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^org settings$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^settings$/i })).toBeInTheDocument()
   })
 
-  it('Deployments link points to /projects/$projectName/deployments', () => {
-    ;(useGetProjectSettings as Mock).mockReturnValue({ data: { deploymentsEnabled: true }, isPending: false })
+  it('does not render the Project tree when selectedProject is cleared', () => {
+    ;(useProject as Mock).mockReturnValue({
+      projects: [{ name: 'my-project', displayName: 'My Project' }],
+      selectedProject: null,
+      setSelectedProject: vi.fn(),
+      isLoading: false,
+    })
     render(<AppSidebar />)
-    const link = screen.getByRole('link', { name: /^deployments$/i })
-    expect(link.getAttribute('href')).toBe('/projects/my-project/deployments')
+    expect(screen.queryByTestId('project-tree')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { Link, useRouter } from '@tanstack/react-router'
 import {
+  ChevronRight,
   KeyRound,
   Folder,
   FolderKanban,
@@ -19,8 +20,22 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarSeparator,
 } from '@/components/ui/sidebar'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { useOrg } from '@/lib/org-context'
 import { useProject } from '@/lib/project-context'
 import { useVersion } from '@/queries/version'
@@ -100,6 +115,13 @@ export function AppSidebar() {
 
   const deploymentsEnabled = projectSettings?.deploymentsEnabled ?? false
 
+  // HOL-604 restructures the project nav into a single collapsible "Project"
+  // tree. Children order is canonical: Secrets, Deployments, Templates,
+  // Settings. Deployments and Templates remain gated on
+  // projectSettings.deploymentsEnabled to preserve the pre-existing feature
+  // flag behavior (covered by the "Templates nav item conditional
+  // visibility" suite). The Project tree itself is rendered only when a
+  // project is selected.
   const projectNavItems: Array<{
     label: string
     to: string
@@ -130,7 +152,7 @@ export function AppSidebar() {
             ]
           : []),
         {
-          label: 'Project Settings',
+          label: 'Settings',
           to: '/projects/$projectName/settings/' as const,
           params: { projectName: selectedProject },
           icon: Settings,
@@ -182,24 +204,60 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
         )}
-        {projectNavItems.length > 0 && (
-          <SidebarGroup>
-            <SidebarGroupLabel>{projectDisplayName}</SidebarGroupLabel>
+        {selectedProject && projectNavItems.length > 0 && (
+          <SidebarGroup data-testid="project-tree">
             <SidebarGroupContent>
               <SidebarMenu>
-                {projectNavItems.map((item) => {
-                  const activePath = `/projects/${item.params.projectName}`
-                  return (
-                    <SidebarMenuItem key={item.label}>
-                      <SidebarMenuButton asChild isActive={pathname.startsWith(activePath)}>
-                        <Link to={item.to} params={item.params}>
-                          <item.icon className="h-4 w-4" />
-                          <span>{item.label}</span>
-                        </Link>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  )
-                })}
+                <Collapsible defaultOpen asChild className="group/collapsible">
+                  <SidebarMenuItem>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <CollapsibleTrigger asChild>
+                          <TooltipTrigger asChild>
+                            <SidebarMenuButton
+                              data-testid="project-tree-trigger"
+                              isActive={pathname.startsWith('/projects/')}
+                            >
+                              <FolderKanban className="h-4 w-4" />
+                              <span>Project</span>
+                              <ChevronRight className="ml-auto h-4 w-4 transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                            </SidebarMenuButton>
+                          </TooltipTrigger>
+                        </CollapsibleTrigger>
+                        <TooltipContent
+                          side="right"
+                          align="start"
+                          data-testid="project-tree-tooltip"
+                        >
+                          <div>{projectDisplayName}</div>
+                          <div>{selectedProject}</div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    <CollapsibleContent data-testid="project-tree-content">
+                      <SidebarMenuSub>
+                        {projectNavItems.map((item) => {
+                          const activePath = (item.to as string)
+                            .replace('$projectName', item.params.projectName)
+                            .replace(/\/$/, '')
+                          return (
+                            <SidebarMenuSubItem key={item.label}>
+                              <SidebarMenuSubButton
+                                asChild
+                                isActive={pathname === activePath || pathname.startsWith(`${activePath}/`)}
+                              >
+                                <Link to={item.to} params={item.params}>
+                                  <item.icon className="h-4 w-4" />
+                                  <span>{item.label}</span>
+                                </Link>
+                              </SidebarMenuSubButton>
+                            </SidebarMenuSubItem>
+                          )
+                        })}
+                      </SidebarMenuSub>
+                    </CollapsibleContent>
+                  </SidebarMenuItem>
+                </Collapsible>
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -204,7 +204,7 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
         )}
-        {selectedProject && projectNavItems.length > 0 && (
+        {projectNavItems.length > 0 && (
           <SidebarGroup data-testid="project-tree">
             <SidebarGroupContent>
               <SidebarMenu>

--- a/frontend/src/components/ui/collapsible.tsx
+++ b/frontend/src/components/ui/collapsible.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+  return (
+    <CollapsiblePrimitive.Content data-slot="collapsible-content" {...props} />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }


### PR DESCRIPTION
## Summary

- Restructures the project nav group in `frontend/src/components/app-sidebar.tsx` into a single collapsible tree labeled **Project**, matching the HOL-553 sidebar refactor plan.
- Adds `frontend/src/components/ui/collapsible.tsx` — a shadcn-style wrapper around the `radix-ui` unified package, mirroring the existing `tooltip` primitive.
- The `Project` label exposes a two-line shadcn `Tooltip` showing the project Display Name and the Name slug, so users can disambiguate projects whose display names collide.
- Children render inside a `SidebarMenuSub` in the canonical order: **Secrets, Deployments, Templates, Settings**. The existing `projectSettings.deploymentsEnabled` gate on Deployments + Templates is preserved.
- Tree is hidden entirely when no project is selected. Existing `/projects/\$projectName/...` URLs are untouched for backwards compatibility.
- Vitest + RTL coverage added in `app-sidebar.test.tsx` for: tree render when project is selected, tree absent when no project is selected, tooltip lines match display name + slug (and fall back to slug when display name is empty), children in canonical order, each child link routes to the correct `/projects/\$projectName/...` URL, and the org nav's `Org Settings` link continues to coexist with the project `Settings` child.

Fixes HOL-604

## Test plan

- [x] `cd frontend && npm test` — 80 files, 1197 tests passing.
- [x] `cd frontend && npm run build` — clean build.
- [ ] Manual: open the app with a project selected, confirm the Project label hover shows display name + slug on two lines and the tree expands/collapses.
- [ ] Manual: clear the selected project (switch org), confirm the Project tree disappears from the sidebar.

Generated with [Claude Code](https://claude.com/claude-code)