### PR TITLE
fix(api/secrets): address PR #1053 style findings (HOL-742)

### DIFF
--- a/api/secrets/v1alpha1/credential_types.go
+++ b/api/secrets/v1alpha1/credential_types.go
@@ -254,7 +254,8 @@ type CredentialStatus struct {
 // Status.HashSecretRef and the UpstreamSecret v1.Secret named by
 // Spec.UpstreamSecretRef; this CR carries only the opaque credentialID, the
 // pepper-version counter, phase, conditions, and cross-object references.
-// See the package doc.go "no sensitive values on CRs" invariant.
+// See the package doc.go "no sensitive values on CRs" invariant, ADR 031,
+// and the parent plan (HOL-675) for the full design.
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=cred,categories=holos;secrets

--- a/api/secrets/v1alpha1/secretinjectionpolicybinding_types.go
+++ b/api/secrets/v1alpha1/secretinjectionpolicybinding_types.go
@@ -51,8 +51,14 @@ type PolicyRef struct {
 	Scope PolicyRefScope `json:"scope"`
 
 	// Namespace is the Kubernetes namespace that owns the referenced
-	// SecretInjectionPolicy. Admission additionally verifies that the
-	// namespace's `console.holos.run/resource-type` label matches Scope.
+	// SecretInjectionPolicy. Admission (VAP
+	// `secretinjectionpolicybinding-policyref-same-namespace-or-ancestor`)
+	// accepts this value only when it is one of: (1) the binding's own
+	// namespace, (2) the value of the binding namespace's
+	// `console.holos.run/parent` label (direct parent), or (3) the
+	// synthesized `holos-org-<console.holos.run/organization>` namespace
+	// from the binding namespace's labels (root organization). Scope does
+	// not gate admission — it narrows the reconciler's resolution path.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1

--- a/api/secrets/v1alpha1/upstreamsecret_types.go
+++ b/api/secrets/v1alpha1/upstreamsecret_types.go
@@ -133,7 +133,7 @@ type UpstreamSecretStatus struct {
 // shape. The CR never carries the credential bytes themselves — see the
 // package doc.go "no sensitive values on CRs" invariant. Resolution of the
 // sibling v1.Secret happens on the hot path in the injector (M2), not on
-// reconcile.
+// reconcile. See ADR 031 and the parent plan (HOL-675) for the full design.
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=us,categories=holos;secrets

--- a/config/secret-injector/crd/secrets.holos.run_credentials.yaml
+++ b/config/secret-injector/crd/secrets.holos.run_credentials.yaml
@@ -42,7 +42,8 @@ spec:
           Status.HashSecretRef and the UpstreamSecret v1.Secret named by
           Spec.UpstreamSecretRef; this CR carries only the opaque credentialID, the
           pepper-version counter, phase, conditions, and cross-object references.
-          See the package doc.go "no sensitive values on CRs" invariant.
+          See the package doc.go "no sensitive values on CRs" invariant, ADR 031,
+          and the parent plan (HOL-675) for the full design.
         properties:
           apiVersion:
             description: |-

--- a/config/secret-injector/crd/secrets.holos.run_secretinjectionpolicybindings.yaml
+++ b/config/secret-injector/crd/secrets.holos.run_secretinjectionpolicybindings.yaml
@@ -83,8 +83,14 @@ spec:
                   namespace:
                     description: |-
                       Namespace is the Kubernetes namespace that owns the referenced
-                      SecretInjectionPolicy. Admission additionally verifies that the
-                      namespace's `console.holos.run/resource-type` label matches Scope.
+                      SecretInjectionPolicy. Admission (VAP
+                      `secretinjectionpolicybinding-policyref-same-namespace-or-ancestor`)
+                      accepts this value only when it is one of: (1) the binding's own
+                      namespace, (2) the value of the binding namespace's
+                      `console.holos.run/parent` label (direct parent), or (3) the
+                      synthesized `holos-org-<console.holos.run/organization>` namespace
+                      from the binding namespace's labels (root organization). Scope does
+                      not gate admission — it narrows the reconciler's resolution path.
                     minLength: 1
                     type: string
                   scope:

--- a/config/secret-injector/crd/secrets.holos.run_upstreamsecrets.yaml
+++ b/config/secret-injector/crd/secrets.holos.run_upstreamsecrets.yaml
@@ -39,7 +39,7 @@ spec:
           shape. The CR never carries the credential bytes themselves — see the
           package doc.go "no sensitive values on CRs" invariant. Resolution of the
           sibling v1.Secret happens on the hot path in the injector (M2), not on
-          reconcile.
+          reconcile. See ADR 031 and the parent plan (HOL-675) for the full design.
         properties:
           apiVersion:
             description: |-

--- a/docs/api/secrets.holos.run.md
+++ b/docs/api/secrets.holos.run.md
@@ -107,7 +107,7 @@ that carry tighter RBAC, encryption-at-rest, and KMS integration.
 | --- | --- | --- |
 | `observedGeneration` | `int64` | Most recent `metadata.generation` the reconciler has acted on. |
 | `phase` | `enum { Active, Rotating, Retired, Revoked, Expired }` | Current lifecycle phase. |
-| `credentialID` | `string` (KSUID regex `^[0-9A-Za-z]{27}$`, len 27) | Opaque identifier; **MUST NOT** be or contain the plaintext, a prefix, a last-4, or any substring of the plaintext. |
+| `credentialID` | `string` (KSUID regex `^[0-9A-Za-z]{27}$`, len 27) | Opaque identifier set by the reconciler (M2); **MUST NOT** be or contain the plaintext, a prefix, a last-4, or any substring of the plaintext. |
 | `hashSecretRef` | `*SecretKeyReference` | Pointer; absent until the reconciler materialises the hash `v1.Secret` (M2). Populated the first time `HashMaterialized` transitions to `True`. |
 | `hashSecretRef.name` | `string` (min 1) | `metadata.name` of the sibling `v1.Secret` (same namespace) that stores the argon2id hash + per-credential salt. Owned by the reconciler (M2). |
 | `hashSecretRef.key` | `string` (min 1) | Key inside that `v1.Secret .data`. |


### PR DESCRIPTION
## Summary

- Add direct HOL-675 cite to the kind-level GoDoc on `UpstreamSecret` and `Credential` so all four kinds in `secrets.holos.run/v1alpha1` point readers at the authoritative plan (previously they referenced "the package doc.go invariant" which then cited HOL-675).
- Rewrite `SecretInjectionPolicyBinding.PolicyRef.Namespace` GoDoc to match the actual VAP. The old comment claimed admission verified the namespace's `console.holos.run/resource-type` label matched `Scope`; the real VAP (`secretinjectionpolicybinding-policyref-same-namespace-or-ancestor`) checks namespace equality, the `console.holos.run/parent` label value, or the synthesized `holos-org-<console.holos.run/organization>` namespace.
- Annotate `Credential.status.credentialID` in `docs/api/secrets.holos.run.md` as "set by the reconciler (M2)" to match the other reconciler-owned status fields (hashSecretRef, etc.).
- Regenerated CRDs via `make manifests-secrets`; second run is a no-op (idempotent).

Fixes HOL-742

## Test plan

- [x] `make manifests-secrets` is idempotent (two back-to-back runs produce zero diff).
- [x] `go test ./api/secrets/...` passes.
- [ ] Reviewer: confirm the PolicyRef.Namespace GoDoc accurately reflects the VAP behaviour.
- [ ] Reviewer: confirm the direct HOL-675 cites on the four kind-level GoDocs read consistently.

Generated with [Claude Code](https://claude.com/claude-code)