### PR TITLE
feat(frontend): unified Template Policies index across scopes

### DIFF
--- a/frontend/src/queries/-templatePolicies.test.ts
+++ b/frontend/src/queries/-templatePolicies.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import type { TemplatePolicy } from '@/gen/holos/console/v1/template_policies_pb.js'
+import { create } from '@bufbuild/protobuf'
+import {
+  TemplatePolicySchema,
+  type TemplatePolicy,
+} from '@/gen/holos/console/v1/template_policies_pb.js'
+import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
 import { aggregateFanOut, type FanOutQueryState } from './templatePolicies'
 
 function policy(name: string, namespace: string): TemplatePolicy {
-  return {
-    $typeName: 'holos.console.v1.TemplatePolicy',
-    name,
-    namespace,
-    displayName: '',
-    description: '',
-    creatorEmail: '',
-    rules: [],
-  } as unknown as TemplatePolicy
+  return create(TemplatePolicySchema, { name, namespace })
 }
 
 function state(
@@ -46,7 +43,7 @@ describe('aggregateFanOut', () => {
   })
 
   it('returns org-scoped policies when only org resolves', () => {
-    const p = policy('org-policy', 'holos-org-test-org')
+    const p = policy('org-policy', namespaceForOrg('test-org'))
     const result = aggregateFanOut<TemplatePolicy>([
       state({ data: [p], fetchStatus: 'idle' }),
     ])
@@ -55,8 +52,8 @@ describe('aggregateFanOut', () => {
   })
 
   it('concatenates org + folder results', () => {
-    const org = policy('org-policy', 'holos-org-test-org')
-    const folder = policy('fld-policy', 'holos-fld-team-alpha')
+    const org = policy('org-policy', namespaceForOrg('test-org'))
+    const folder = policy('fld-policy', namespaceForFolder('team-alpha'))
     const result = aggregateFanOut<TemplatePolicy>([
       state({ data: [org], fetchStatus: 'idle' }),
       state({ data: [folder], fetchStatus: 'idle' }),
@@ -65,7 +62,7 @@ describe('aggregateFanOut', () => {
   })
 
   it('keeps partial data when one query fails', () => {
-    const org = policy('org-policy', 'holos-org-test-org')
+    const org = policy('org-policy', namespaceForOrg('test-org'))
     const err = new Error('folder fetch failed')
     const result = aggregateFanOut<TemplatePolicy>([
       state({ data: [org], fetchStatus: 'idle' }),
@@ -84,7 +81,7 @@ describe('aggregateFanOut', () => {
   })
 
   it('does not report pending when data is already materialized', () => {
-    const p = policy('org-policy', 'holos-org-test-org')
+    const p = policy('org-policy', namespaceForOrg('test-org'))
     const result = aggregateFanOut<TemplatePolicy>([
       state({ data: [p], fetchStatus: 'idle' }),
       state({ isPending: true, fetchStatus: 'fetching' }),

--- a/frontend/src/queries/-templatePolicies.test.ts
+++ b/frontend/src/queries/-templatePolicies.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import type { TemplatePolicy } from '@/gen/holos/console/v1/template_policies_pb.js'
+import { aggregateFanOut, type FanOutQueryState } from './templatePolicies'
+
+function policy(name: string, namespace: string): TemplatePolicy {
+  return {
+    $typeName: 'holos.console.v1.TemplatePolicy',
+    name,
+    namespace,
+    displayName: '',
+    description: '',
+    creatorEmail: '',
+    rules: [],
+  } as unknown as TemplatePolicy
+}
+
+function state(
+  overrides: Partial<FanOutQueryState<TemplatePolicy[]>> = {},
+): FanOutQueryState<TemplatePolicy[]> {
+  return {
+    data: undefined,
+    error: null,
+    isPending: false,
+    fetchStatus: 'idle',
+    ...overrides,
+  }
+}
+
+describe('aggregateFanOut', () => {
+  it('returns empty list when all queries are disabled (idle)', () => {
+    const result = aggregateFanOut<TemplatePolicy>([
+      state({ isPending: true, fetchStatus: 'idle' }),
+      state({ isPending: true, fetchStatus: 'idle' }),
+    ])
+    expect(result.isPending).toBe(false)
+    expect(result.error).toBeNull()
+    expect(result.data).toEqual([])
+  })
+
+  it('reports pending while any active query is still fetching on first load', () => {
+    const result = aggregateFanOut<TemplatePolicy>([
+      state({ isPending: true, fetchStatus: 'fetching' }),
+    ])
+    expect(result.isPending).toBe(true)
+    expect(result.data).toBeUndefined()
+  })
+
+  it('returns org-scoped policies when only org resolves', () => {
+    const p = policy('org-policy', 'holos-org-test-org')
+    const result = aggregateFanOut<TemplatePolicy>([
+      state({ data: [p], fetchStatus: 'idle' }),
+    ])
+    expect(result.isPending).toBe(false)
+    expect(result.data).toEqual([p])
+  })
+
+  it('concatenates org + folder results', () => {
+    const org = policy('org-policy', 'holos-org-test-org')
+    const folder = policy('fld-policy', 'holos-fld-team-alpha')
+    const result = aggregateFanOut<TemplatePolicy>([
+      state({ data: [org], fetchStatus: 'idle' }),
+      state({ data: [folder], fetchStatus: 'idle' }),
+    ])
+    expect(result.data).toEqual([org, folder])
+  })
+
+  it('keeps partial data when one query fails', () => {
+    const org = policy('org-policy', 'holos-org-test-org')
+    const err = new Error('folder fetch failed')
+    const result = aggregateFanOut<TemplatePolicy>([
+      state({ data: [org], fetchStatus: 'idle' }),
+      state({ error: err, fetchStatus: 'idle' }),
+    ])
+    expect(result.error).toBe(err)
+    expect(result.data).toEqual([org])
+  })
+
+  it('wraps non-Error errors into Error', () => {
+    const result = aggregateFanOut<TemplatePolicy>([
+      state({ error: 'string error', fetchStatus: 'idle' }),
+    ])
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toBe('string error')
+  })
+
+  it('does not report pending when data is already materialized', () => {
+    const p = policy('org-policy', 'holos-org-test-org')
+    const result = aggregateFanOut<TemplatePolicy>([
+      state({ data: [p], fetchStatus: 'idle' }),
+      state({ isPending: true, fetchStatus: 'fetching' }),
+    ])
+    expect(result.isPending).toBe(false)
+    expect(result.data).toEqual([p])
+  })
+
+  it('handles empty input as resolved-empty', () => {
+    const result = aggregateFanOut<TemplatePolicy>([])
+    expect(result.isPending).toBe(false)
+    expect(result.error).toBeNull()
+    expect(result.data).toEqual([])
+  })
+})

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -2,7 +2,12 @@ import { useMemo } from 'react'
 import { create } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  useQuery,
+  useQueries,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
 import {
   TemplatePolicyService,
   TemplatePolicySchema,
@@ -13,6 +18,8 @@ import type {
   TemplatePolicyRule,
 } from '@/gen/holos/console/v1/template_policies_pb.js'
 import { useAuth } from '@/lib/auth'
+import { useListFolders } from '@/queries/folders'
+import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
 
 // Re-export generated types/enums used by UI consumers. HOL-600 removed
 // TemplatePolicyTarget from the proto — render-target selection now
@@ -47,6 +54,79 @@ export function useListTemplatePolicies(namespace: string) {
     },
     enabled: isAuthenticated && !!namespace,
   })
+}
+
+// useAllTemplatePoliciesForOrg fans a ListTemplatePolicies call across every
+// namespace reachable from an organization root — the org namespace plus one
+// namespace per folder visible to the caller — and flattens the results into
+// one array. HOL-608 AC requires the unified Template Policies index to show
+// org- and folder-scoped policies together, but TemplatePolicyService has no
+// SearchTemplatePolicies RPC (tracked in HOL-590 as the eventual server-side
+// consolidation). Until that lands this hook is the client-side fan-out.
+//
+// Pending / error semantics deliberately OR across the constituent queries so
+// the page can show a single Skeleton or Alert regardless of which call is
+// still in flight.
+export function useAllTemplatePoliciesForOrg(orgName: string): {
+  data: TemplatePolicy[] | undefined
+  isPending: boolean
+  error: Error | null
+} {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyService, transport),
+    [transport],
+  )
+  const orgNamespace = namespaceForOrg(orgName)
+  const foldersQuery = useListFolders(orgName)
+  const folders = foldersQuery.data ?? []
+
+  const folderQueries = useQueries({
+    queries: folders.map((folder) => ({
+      queryKey: templatePolicyListKey(namespaceForFolder(folder.name)),
+      queryFn: async (): Promise<TemplatePolicy[]> => {
+        const response = await client.listTemplatePolicies({
+          namespace: namespaceForFolder(folder.name),
+        })
+        return response.policies
+      },
+      enabled: isAuthenticated && !!folder.name,
+    })),
+  })
+
+  const orgQuery = useQuery({
+    queryKey: templatePolicyListKey(orgNamespace),
+    queryFn: async () => {
+      const response = await client.listTemplatePolicies({ namespace: orgNamespace })
+      return response.policies
+    },
+    enabled: isAuthenticated && !!orgNamespace,
+  })
+
+  const folderError =
+    folderQueries.find((q) => q.error)?.error ?? null
+  const error = (foldersQuery.error ??
+    orgQuery.error ??
+    folderError) as Error | null
+
+  const isPending =
+    foldersQuery.isPending ||
+    orgQuery.isPending ||
+    folderQueries.some((q) => q.isPending)
+
+  const data = useMemo(() => {
+    if (isPending || error) return undefined
+    const all: TemplatePolicy[] = []
+    if (orgQuery.data) all.push(...orgQuery.data)
+    for (const q of folderQueries) {
+      if (q.data) all.push(...q.data)
+    }
+    return all
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPending, error, orgQuery.data, ...folderQueries.map((q) => q.data)])
+
+  return { data, isPending, error }
 }
 
 // useGetTemplatePolicy fetches a single policy by name within a namespace.

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -56,6 +56,63 @@ export function useListTemplatePolicies(namespace: string) {
   })
 }
 
+// Slice of the TanStack Query result this module cares about. Accepting an
+// interface (vs a union of `useQuery` return types) keeps aggregateFanOut
+// testable without importing TanStack internals and lets the disabled-query
+// case be modeled with `fetchStatus === 'idle'`.
+export interface FanOutQueryState<T> {
+  data: T | undefined
+  error: unknown
+  isPending: boolean
+  fetchStatus: 'fetching' | 'paused' | 'idle'
+}
+
+export interface FanOutAggregate<T> {
+  data: T[] | undefined
+  isPending: boolean
+  error: Error | null
+}
+
+// aggregateFanOut merges org-scope + folder-scope `ListTemplatePolicies`
+// results into a single list view. The rules:
+//
+// - `isPending` reports first-load only — a query counts as "still loading"
+//   when it is pending AND actively fetching. A disabled query
+//   (`fetchStatus === 'idle'`) is treated as resolved-empty so the aggregate
+//   does not lock on an empty org name or unauthenticated user.
+// - `error` is the first non-null error encountered, as an Error. Partial
+//   data is preserved alongside the error so the caller can render rows
+//   from successful queries with an inline warning rather than blanking
+//   the whole grid.
+// - `data` is the concatenated list whenever any query has resolved. It is
+//   only `undefined` while the aggregate is still pending with nothing
+//   materialized yet.
+export function aggregateFanOut(
+  queries: FanOutQueryState<TemplatePolicy[]>[],
+): FanOutAggregate<TemplatePolicy> {
+  const firstLoadPending = queries.some(
+    (q) => q.isPending && q.fetchStatus !== 'idle' && q.data === undefined,
+  )
+  const firstError = queries.find((q) => q.error != null)?.error
+  const error =
+    firstError instanceof Error
+      ? firstError
+      : firstError != null
+        ? new Error(String(firstError))
+        : null
+
+  const hasAnyData = queries.some((q) => q.data !== undefined)
+  if (!hasAnyData && firstLoadPending) {
+    return { data: undefined, isPending: true, error }
+  }
+
+  const data: TemplatePolicy[] = []
+  for (const q of queries) {
+    if (q.data) data.push(...q.data)
+  }
+  return { data, isPending: false, error }
+}
+
 // useAllTemplatePoliciesForOrg fans a ListTemplatePolicies call across every
 // namespace reachable from an organization root — the org namespace plus one
 // namespace per folder visible to the caller — and flattens the results into
@@ -64,14 +121,10 @@ export function useListTemplatePolicies(namespace: string) {
 // SearchTemplatePolicies RPC (tracked in HOL-590 as the eventual server-side
 // consolidation). Until that lands this hook is the client-side fan-out.
 //
-// Pending / error semantics deliberately OR across the constituent queries so
-// the page can show a single Skeleton or Alert regardless of which call is
-// still in flight.
-export function useAllTemplatePoliciesForOrg(orgName: string): {
-  data: TemplatePolicy[] | undefined
-  isPending: boolean
-  error: Error | null
-} {
+// See aggregateFanOut for the exact pending / error semantics.
+export function useAllTemplatePoliciesForOrg(
+  orgName: string,
+): FanOutAggregate<TemplatePolicy> {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(
@@ -98,35 +151,43 @@ export function useAllTemplatePoliciesForOrg(orgName: string): {
   const orgQuery = useQuery({
     queryKey: templatePolicyListKey(orgNamespace),
     queryFn: async () => {
-      const response = await client.listTemplatePolicies({ namespace: orgNamespace })
+      const response = await client.listTemplatePolicies({
+        namespace: orgNamespace,
+      })
       return response.policies
     },
     enabled: isAuthenticated && !!orgNamespace,
   })
 
-  const folderError =
-    folderQueries.find((q) => q.error)?.error ?? null
-  const error = (foldersQuery.error ??
-    orgQuery.error ??
-    folderError) as Error | null
-
-  const isPending =
-    foldersQuery.isPending ||
-    orgQuery.isPending ||
-    folderQueries.some((q) => q.isPending)
-
-  const data = useMemo(() => {
-    if (isPending || error) return undefined
-    const all: TemplatePolicy[] = []
-    if (orgQuery.data) all.push(...orgQuery.data)
-    for (const q of folderQueries) {
-      if (q.data) all.push(...q.data)
+  // Pre-empt the folders-still-loading case: if we never get a folder list
+  // we cannot know whether folder policies exist. Propagate pending in that
+  // specific case to avoid showing an empty grid that is actually partial.
+  if (foldersQuery.isPending && foldersQuery.fetchStatus !== 'idle') {
+    return {
+      data: undefined,
+      isPending: true,
+      error:
+        foldersQuery.error instanceof Error ? foldersQuery.error : null,
     }
-    return all
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPending, error, orgQuery.data, ...folderQueries.map((q) => q.data)])
+  }
+  if (foldersQuery.error instanceof Error) {
+    return { data: undefined, isPending: false, error: foldersQuery.error }
+  }
 
-  return { data, isPending, error }
+  return aggregateFanOut<TemplatePolicy>([
+    {
+      data: orgQuery.data,
+      error: orgQuery.error,
+      isPending: orgQuery.isPending,
+      fetchStatus: orgQuery.fetchStatus,
+    },
+    ...folderQueries.map((q) => ({
+      data: q.data,
+      error: q.error,
+      isPending: q.isPending,
+      fetchStatus: q.fetchStatus,
+    })),
+  ])
 }
 
 // useGetTemplatePolicy fetches a single policy by name within a namespace.

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -87,9 +87,9 @@ export interface FanOutAggregate<T> {
 // - `data` is the concatenated list whenever any query has resolved. It is
 //   only `undefined` while the aggregate is still pending with nothing
 //   materialized yet.
-export function aggregateFanOut(
-  queries: FanOutQueryState<TemplatePolicy[]>[],
-): FanOutAggregate<TemplatePolicy> {
+export function aggregateFanOut<T>(
+  queries: FanOutQueryState<T[]>[],
+): FanOutAggregate<T> {
   const firstLoadPending = queries.some(
     (q) => q.isPending && q.fetchStatus !== 'idle' && q.data === undefined,
   )
@@ -106,12 +106,16 @@ export function aggregateFanOut(
     return { data: undefined, isPending: true, error }
   }
 
-  const data: TemplatePolicy[] = []
+  const data: T[] = []
   for (const q of queries) {
     if (q.data) data.push(...q.data)
   }
   return { data, isPending: false, error }
 }
+
+// Module-level sentinel so the `folders` useMemo fallback preserves reference
+// identity across renders when the folders list is still pending or empty.
+const EMPTY_FOLDERS: readonly { name: string }[] = []
 
 // useAllTemplatePoliciesForOrg fans a ListTemplatePolicies call across every
 // namespace reachable from an organization root — the org namespace plus one
@@ -133,7 +137,10 @@ export function useAllTemplatePoliciesForOrg(
   )
   const orgNamespace = namespaceForOrg(orgName)
   const foldersQuery = useListFolders(orgName)
-  const folders = foldersQuery.data ?? []
+  const folders = useMemo(
+    () => foldersQuery.data ?? EMPTY_FOLDERS,
+    [foldersQuery.data],
+  )
 
   const folderQueries = useQueries({
     queries: folders.map((folder) => ({
@@ -159,22 +166,22 @@ export function useAllTemplatePoliciesForOrg(
     enabled: isAuthenticated && !!orgNamespace,
   })
 
-  // Pre-empt the folders-still-loading case: if we never get a folder list
-  // we cannot know whether folder policies exist. Propagate pending in that
-  // specific case to avoid showing an empty grid that is actually partial.
-  if (foldersQuery.isPending && foldersQuery.fetchStatus !== 'idle') {
-    return {
-      data: undefined,
-      isPending: true,
-      error:
-        foldersQuery.error instanceof Error ? foldersQuery.error : null,
-    }
-  }
-  if (foldersQuery.error instanceof Error) {
-    return { data: undefined, isPending: false, error: foldersQuery.error }
+  // Model the folders-list query as one more input to aggregateFanOut.
+  // When folders are still loading we want the aggregate to report pending
+  // (nothing has materialized yet). When the folders-list errored we want
+  // the caller to see the error alongside any org-scoped policies that did
+  // resolve, rather than blanking the whole grid on a structural failure.
+  // Wrapping the folders query in a FanOutQueryState<TemplatePolicy[]>
+  // (with data always [] on success) gives us both behaviors for free.
+  const foldersAsQuery: FanOutQueryState<TemplatePolicy[]> = {
+    data: foldersQuery.data === undefined ? undefined : [],
+    error: foldersQuery.error,
+    isPending: foldersQuery.isPending,
+    fetchStatus: foldersQuery.fetchStatus,
   }
 
   return aggregateFanOut<TemplatePolicy>([
+    foldersAsQuery,
     {
       data: orgQuery.data,
       error: orgQuery.error,

--- a/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/settings/index.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Check, Pencil, X, Table2, Braces, ChevronRight } from 'lucide-react'
+import { Check, Pencil, X, Table2, Braces } from 'lucide-react'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { ViewModeToggle } from '@/components/view-mode-toggle'
 import { RawView } from '@/components/raw-view'
@@ -451,34 +451,6 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
               onSave={handleSaveDefaultSharing}
               isSaving={updateOrganizationDefaultSharing.isPending}
             />
-
-            {/* Template Policies section */}
-            <div className="space-y-4">
-              <h3 className="text-sm font-medium">Template Policies</h3>
-              <Separator />
-              <p className="text-sm text-muted-foreground">
-                Policies attach templates to projects and deployments in this organization via
-                REQUIRE or EXCLUDE rules with glob patterns.
-              </p>
-              <Link
-                to="/orgs/$orgName/template-policies"
-                params={{ orgName }}
-                aria-label="Organization Template Policies"
-                className="flex items-center justify-between p-3 rounded-md border border-border hover:bg-muted transition-colors"
-              >
-                <span className="text-sm">Manage Organization Template Policies</span>
-                <ChevronRight className="h-4 w-4 text-muted-foreground" />
-              </Link>
-              <Link
-                to="/orgs/$orgName/template-policy-bindings"
-                params={{ orgName }}
-                aria-label="Organization Template Policy Bindings"
-                className="flex items-center justify-between p-3 rounded-md border border-border hover:bg-muted transition-colors"
-              >
-                <span className="text-sm">Manage Organization Template Policy Bindings</span>
-                <ChevronRight className="h-4 w-4 text-muted-foreground" />
-              </Link>
-            </div>
 
             {/* Danger Zone */}
             {isOwner && (

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
@@ -57,6 +57,7 @@ import {
 } from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { namespaceForOrg, namespaceForFolder } from '@/lib/scope-labels'
 import { OrgTemplatePoliciesIndexPage } from './index'
 
 type PolicyFixture = {
@@ -100,8 +101,8 @@ function setup(
   })
 }
 
-const ORG_NS = 'holos-org-test-org'
-const FOLDER_NS = 'holos-fld-team-alpha'
+const ORG_NS = namespaceForOrg('test-org')
+const FOLDER_NS = namespaceForFolder('team-alpha')
 
 describe('OrgTemplatePoliciesIndexPage', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -174,6 +175,21 @@ describe('OrgTemplatePoliciesIndexPage', () => {
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     const link = screen.getByRole('link', { name: 'p-nodn' })
     expect(link).toBeInTheDocument()
+  })
+
+  it('renders a plain span (not a link) for unknown or project-scoped namespaces', () => {
+    // Safety net for stale caches or proto drift: HOL-590 guarantees policies
+    // live only at org or folder scope, but if the server ever surfaces a
+    // project-scoped row we must not forge a link to a 404 page.
+    setup([
+      makePolicy('p-proj', 'holos-prj-billing', 'Project Policy'),
+      makePolicy('p-bad', 'some-other-ns', 'Bad Scope Policy'),
+    ])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.queryByRole('link', { name: 'Project Policy' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Bad Scope Policy' })).toBeNull()
+    expect(screen.getByText('Project Policy')).toBeInTheDocument()
+    expect(screen.getByText('Bad Scope Policy')).toBeInTheDocument()
   })
 
   it('filters by display name', () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
@@ -14,16 +14,27 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
       children,
       to,
       params,
-      ...props
-    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      title,
+      className,
+    }: {
       children: React.ReactNode
-      to?: string
+      to: string
       params?: Record<string, string>
-    }) => (
-      <a href={to} data-params={JSON.stringify(params)} {...props}>
-        {children}
-      </a>
-    ),
+      title?: string
+      className?: string
+    }) => {
+      let href = to
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          href = href.replace(`$${k}`, v)
+        }
+      }
+      return (
+        <a href={href} title={title} className={className}>
+          {children}
+        </a>
+      )
+    },
   }
 })
 
@@ -33,7 +44,7 @@ vi.mock('@/queries/templatePolicies', async () => {
   )
   return {
     ...actual,
-    useListTemplatePolicies: vi.fn(),
+    useAllTemplatePoliciesForOrg: vi.fn(),
   }
 })
 
@@ -41,37 +52,46 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-import { useListTemplatePolicies, TemplatePolicyKind } from '@/queries/templatePolicies'
+import {
+  useAllTemplatePoliciesForOrg,
+} from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { OrgTemplatePoliciesIndexPage } from './index'
 
-function makePolicy(name: string, require = 1, exclude = 0) {
-  const rule = (kind: TemplatePolicyKind) => ({
-    kind,
-    template: { namespace: 'holos-org-test-org', name: 'httproute', versionConstraint: '' },
-    target: { projectPattern: '*', deploymentPattern: '*' },
-  })
+type PolicyFixture = {
+  name: string
+  namespace: string
+  displayName: string
+  description?: string
+  creatorEmail?: string
+  rules: unknown[]
+}
+
+function makePolicy(
+  name: string,
+  namespace: string,
+  displayName = name,
+): PolicyFixture {
   return {
     name,
-    displayName: name,
+    namespace,
+    displayName,
     description: '',
     creatorEmail: '',
-    rules: [
-      ...Array.from({ length: require }, () => rule(TemplatePolicyKind.REQUIRE)),
-      ...Array.from({ length: exclude }, () => rule(TemplatePolicyKind.EXCLUDE)),
-    ],
+    rules: [],
   }
 }
 
 function setup(
+  policies: PolicyFixture[] = [],
   userRole: Role = Role.OWNER,
-  policies: ReturnType<typeof makePolicy>[] = [],
+  overrides: Partial<{ isPending: boolean; error: Error | null }> = {},
 ) {
-  ;(useListTemplatePolicies as Mock).mockReturnValue({
-    data: policies,
-    isPending: false,
-    error: null,
+  ;(useAllTemplatePoliciesForOrg as Mock).mockReturnValue({
+    data: overrides.isPending ? undefined : policies,
+    isPending: overrides.isPending ?? false,
+    error: overrides.error ?? null,
   })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: 'test-org', userRole },
@@ -80,41 +100,145 @@ function setup(
   })
 }
 
+const ORG_NS = 'holos-org-test-org'
+const FOLDER_NS = 'holos-fld-team-alpha'
+
 describe('OrgTemplatePoliciesIndexPage', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('renders populated list with summary counts', () => {
-    setup(Role.OWNER, [makePolicy('p-1', 2, 1)])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.getByText('p-1')).toBeInTheDocument()
-    expect(screen.getByText(/REQUIRE x 2/)).toBeInTheDocument()
-    expect(screen.getByText(/EXCLUDE x 1/)).toBeInTheDocument()
+  it('renders skeleton while loading', () => {
+    setup([], Role.OWNER, { isPending: true })
+    const { container } = render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(container.querySelector('[data-testid="policies-loading"]')).toBeInTheDocument()
   })
 
-  it('renders empty state', () => {
-    setup(Role.OWNER, [])
+  it('renders error alert when the fan-out fails', () => {
+    setup([], Role.OWNER, { error: new Error('bad gateway') })
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByText('bad gateway')).toBeInTheDocument()
+  })
+
+  it('renders empty state when no policies exist', () => {
+    setup([])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(screen.getByText(/no template policies yet/i)).toBeInTheDocument()
   })
 
+  it('renders org-scoped policies only', () => {
+    setup([makePolicy('p-org', ORG_NS, 'Org Policy')])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Org Policy')).toBeInTheDocument()
+    expect(screen.getAllByText(ORG_NS).length).toBeGreaterThan(0)
+    expect(screen.getByText('p-org')).toBeInTheDocument()
+  })
+
+  it('renders folder-scoped policies only', () => {
+    setup([makePolicy('p-folder', FOLDER_NS, 'Folder Policy')])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Folder Policy')).toBeInTheDocument()
+    expect(screen.getAllByText(FOLDER_NS).length).toBeGreaterThan(0)
+  })
+
+  it('renders org and folder policies combined in one grid', () => {
+    setup([
+      makePolicy('p-org', ORG_NS, 'Org Policy'),
+      makePolicy('p-folder', FOLDER_NS, 'Folder Policy'),
+    ])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Org Policy')).toBeInTheDocument()
+    expect(screen.getByText('Folder Policy')).toBeInTheDocument()
+  })
+
+  it('routes org-scoped rows to the org detail page', () => {
+    setup([makePolicy('p-org', ORG_NS, 'Org Policy')])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    const link = screen.getByRole('link', { name: 'Org Policy' })
+    expect(link).toHaveAttribute(
+      'href',
+      '/orgs/test-org/template-policies/p-org',
+    )
+  })
+
+  it('routes folder-scoped rows to the folder detail page', () => {
+    setup([makePolicy('p-folder', FOLDER_NS, 'Folder Policy')])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    const link = screen.getByRole('link', { name: 'Folder Policy' })
+    expect(link).toHaveAttribute(
+      'href',
+      '/folders/team-alpha/template-policies/p-folder',
+    )
+  })
+
+  it('falls back to the name when displayName is empty', () => {
+    setup([makePolicy('p-nodn', ORG_NS, '')])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    const link = screen.getByRole('link', { name: 'p-nodn' })
+    expect(link).toBeInTheDocument()
+  })
+
+  it('filters by display name', () => {
+    setup([
+      makePolicy('p-alpha', ORG_NS, 'Alpha Policy'),
+      makePolicy('p-beta', ORG_NS, 'Beta Policy'),
+    ])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    const search = screen.getByRole('textbox', { name: /search template policies/i })
+    fireEvent.change(search, { target: { value: 'alpha' } })
+    expect(screen.getByText('Alpha Policy')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Policy')).not.toBeInTheDocument()
+  })
+
+  it('filters by namespace', () => {
+    setup([
+      makePolicy('p-org', ORG_NS, 'Org Policy'),
+      makePolicy('p-folder', FOLDER_NS, 'Folder Policy'),
+    ])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    const search = screen.getByRole('textbox', { name: /search template policies/i })
+    fireEvent.change(search, { target: { value: 'fld-team-alpha' } })
+    expect(screen.getByText('Folder Policy')).toBeInTheDocument()
+    expect(screen.queryByText('Org Policy')).not.toBeInTheDocument()
+  })
+
+  it('filters by policy name', () => {
+    setup([
+      makePolicy('reference-grant', ORG_NS, 'ReferenceGrant'),
+      makePolicy('tls-required', ORG_NS, 'Require TLS'),
+    ])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    const search = screen.getByRole('textbox', { name: /search template policies/i })
+    fireEvent.change(search, { target: { value: 'reference' } })
+    expect(screen.getByText('ReferenceGrant')).toBeInTheDocument()
+    expect(screen.queryByText('Require TLS')).not.toBeInTheDocument()
+  })
+
   it('shows Create Policy for OWNER', () => {
-    setup(Role.OWNER, [])
+    setup([])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByRole('link', { name: /create policy/i })).toBeInTheDocument()
+  })
+
+  it('shows Create Policy for EDITOR', () => {
+    setup([], Role.EDITOR)
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(screen.getByRole('link', { name: /create policy/i })).toBeInTheDocument()
   })
 
   it('hides Create Policy for VIEWER', () => {
-    setup(Role.VIEWER, [])
+    setup([], Role.VIEWER)
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(screen.queryByRole('link', { name: /create policy/i })).not.toBeInTheDocument()
   })
 
-  // Regression test for codex review round 1: editors are granted
-  // PERMISSION_TEMPLATE_POLICIES_WRITE by the cascade table and must see the
-  // Create Policy affordance.
-  it('shows Create Policy for EDITOR', () => {
-    setup(Role.EDITOR, [])
+  it('renders each policy row with a distinct Display Name cell', () => {
+    setup([
+      makePolicy('p-org', ORG_NS, 'Org Policy'),
+      makePolicy('p-folder', FOLDER_NS, 'Folder Policy'),
+    ])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.getByRole('link', { name: /create policy/i })).toBeInTheDocument()
+    const table = screen.getByRole('table')
+    const rows = within(table).getAllByRole('row')
+    // 1 header + 2 body rows
+    expect(rows.length).toBe(3)
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
@@ -1,17 +1,33 @@
+import { useMemo, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getFilteredRowModel,
+  flexRender,
+  createColumnHelper,
+} from '@tanstack/react-table'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Separator } from '@/components/ui/separator'
-import { Badge } from '@/components/ui/badge'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
-  useListTemplatePolicies,
-  countRulesByKind,
-} from '@/queries/templatePolicies'
-import { namespaceForOrg } from '@/lib/scope-labels'
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useAllTemplatePoliciesForOrg } from '@/queries/templatePolicies'
+import type { TemplatePolicy } from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
+import {
+  scopeLabelFromNamespace,
+  scopeNameFromNamespace,
+} from '@/lib/scope-labels'
 
 export const Route = createFileRoute(
   '/_authenticated/orgs/$orgName/template-policies/',
@@ -23,6 +39,8 @@ function OrgTemplatePoliciesIndexRoute() {
   const { orgName } = Route.useParams()
   return <OrgTemplatePoliciesIndexPage orgName={orgName} />
 }
+
+const columnHelper = createColumnHelper<TemplatePolicy>()
 
 export function OrgTemplatePoliciesIndexPage({
   orgName: propOrgName,
@@ -36,21 +54,95 @@ export function OrgTemplatePoliciesIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
-  const namespace = namespaceForOrg(orgName)
-  const { data: policies, isPending, error } = useListTemplatePolicies(namespace)
+  const { data: policies, isPending, error } = useAllTemplatePoliciesForOrg(orgName)
   const { data: org } = useGetOrganization(orgName)
 
   const userRole = org?.userRole ?? Role.VIEWER
   // PERMISSION_TEMPLATE_POLICIES_WRITE cascades to editors too.
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
+  const [globalFilter, setGlobalFilter] = useState('')
+
+  const rows = useMemo(() => policies ?? [], [policies])
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor((row) => row.displayName || row.name, {
+        id: 'displayName',
+        header: 'Display Name',
+        cell: ({ row }) => {
+          const p = row.original
+          const label = p.displayName || p.name
+          const scope = scopeLabelFromNamespace(p.namespace)
+          // HOL-590 policies live at org or folder scope only; project scope
+          // has never been reachable for policies.
+          if (scope === 'folder') {
+            const folderName = scopeNameFromNamespace(p.namespace)
+            return (
+              <Link
+                to="/folders/$folderName/template-policies/$policyName"
+                params={{ folderName, policyName: p.name }}
+                title={p.name}
+                className="hover:underline font-medium"
+              >
+                {label}
+              </Link>
+            )
+          }
+          return (
+            <Link
+              to="/orgs/$orgName/template-policies/$policyName"
+              params={{ orgName, policyName: p.name }}
+              title={p.name}
+              className="hover:underline font-medium"
+            >
+              {label}
+            </Link>
+          )
+        },
+      }),
+      columnHelper.accessor('namespace', {
+        header: 'Namespace',
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground font-mono text-sm">
+            {getValue()}
+          </span>
+        ),
+      }),
+      columnHelper.accessor('name', {
+        header: 'Name',
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground font-mono text-sm">
+            {getValue()}
+          </span>
+        ),
+      }),
+    ],
+    [orgName],
+  )
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { globalFilter },
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: 'includesString',
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  })
+
   if (isPending) {
     return (
       <Card>
-        <CardContent className="pt-6 space-y-4">
-          <Skeleton className="h-5 w-48" />
-          <Skeleton className="h-8 w-full" />
-          <Skeleton className="h-8 w-full" />
+        <CardHeader>
+          <CardTitle>Template Policies</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2" data-testid="policies-loading">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     )
@@ -72,7 +164,9 @@ export function OrgTemplatePoliciesIndexPage({
     <Card>
       <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
         <div>
-          <p className="text-sm text-muted-foreground">{orgName} / Template Policies</p>
+          <p className="text-sm text-muted-foreground">
+            {orgName} / Template Policies
+          </p>
           <CardTitle className="mt-1">Template Policies</CardTitle>
         </div>
         {canWrite && (
@@ -81,69 +175,60 @@ export function OrgTemplatePoliciesIndexPage({
           </Link>
         )}
       </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="text-sm text-muted-foreground">
-          Template policies attach templates to projects via REQUIRE or EXCLUDE rules. Rules apply
-          to BOTH project templates and deployments. Policies live only at folder or organization
-          scope — they can never be authored inside a project.
-        </p>
-        <Separator />
-        {policies && policies.length > 0 ? (
-          <ul className="space-y-2" data-testid="policies-list">
-            {policies.map((policy) => {
-              const counts = countRulesByKind(policy)
-              return (
-                <li key={policy.name}>
-                  <Link
-                    to="/orgs/$orgName/template-policies/$policyName"
-                    params={{ orgName, policyName: policy.name }}
-                    className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors border border-border"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-sm font-medium font-mono">{policy.name}</span>
-                        {counts.require > 0 && (
-                          <Badge
-                            variant="outline"
-                            className="text-xs border-green-500/30 text-green-500"
-                          >
-                            REQUIRE x {counts.require}
-                          </Badge>
-                        )}
-                        {counts.exclude > 0 && (
-                          <Badge
-                            variant="outline"
-                            className="text-xs border-amber-500/30 text-amber-500"
-                          >
-                            EXCLUDE x {counts.exclude}
-                          </Badge>
-                        )}
-                      </div>
-                      {policy.description && (
-                        <p className="text-xs text-muted-foreground truncate mt-0.5">
-                          {policy.description}
-                        </p>
-                      )}
-                      {policy.creatorEmail && (
-                        <p className="text-xs text-muted-foreground mt-0.5">
-                          Created by {policy.creatorEmail}
-                        </p>
-                      )}
-                    </div>
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        ) : (
+      <CardContent>
+        {rows.length === 0 ? (
           <div className="rounded-md border border-dashed border-border p-6 text-center">
             <p className="text-sm font-medium">No template policies yet.</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              Policies attach templates to projects through REQUIRE or EXCLUDE rules. Rules apply
-              to both project templates and deployments. Create a policy to enforce a template
-              across every project in this organization.
+              Policies attach templates to projects through REQUIRE or EXCLUDE
+              rules. Rules apply to both project templates and deployments.
+              Policies live only at folder or organization scope.
             </p>
           </div>
+        ) : (
+          <>
+            <div className="mb-3">
+              <Input
+                placeholder="Search policies…"
+                value={globalFilter}
+                onChange={(e) => setGlobalFilter(e.target.value)}
+                className="max-w-sm"
+                aria-label="Search template policies"
+              />
+            </div>
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
@@ -74,14 +74,29 @@ export function OrgTemplatePoliciesIndexPage({
           const p = row.original
           const label = p.displayName || p.name
           const scope = scopeLabelFromNamespace(p.namespace)
-          // HOL-590 policies live at org or folder scope only; project scope
-          // has never been reachable for policies.
+          // HOL-590 guarantees policies live only at org or folder scope.
+          // If the server ever surfaces a project-scoped or unprefixed
+          // namespace (stale cache, proto drift) we render a plain cell
+          // rather than forging a link to a page that will 404.
           if (scope === 'folder') {
             const folderName = scopeNameFromNamespace(p.namespace)
+            if (folderName) {
+              return (
+                <Link
+                  to="/folders/$folderName/template-policies/$policyName"
+                  params={{ folderName, policyName: p.name }}
+                  title={p.name}
+                  className="hover:underline font-medium"
+                >
+                  {label}
+                </Link>
+              )
+            }
+          } else if (scope === 'org') {
             return (
               <Link
-                to="/folders/$folderName/template-policies/$policyName"
-                params={{ folderName, policyName: p.name }}
+                to="/orgs/$orgName/template-policies/$policyName"
+                params={{ orgName, policyName: p.name }}
                 title={p.name}
                 className="hover:underline font-medium"
               >
@@ -90,14 +105,9 @@ export function OrgTemplatePoliciesIndexPage({
             )
           }
           return (
-            <Link
-              to="/orgs/$orgName/template-policies/$policyName"
-              params={{ orgName, policyName: p.name }}
-              title={p.name}
-              className="hover:underline font-medium"
-            >
+            <span className="font-medium" title={p.name}>
               {label}
-            </Link>
+            </span>
           )
         },
       }),


### PR DESCRIPTION
## Summary
- Adds `useAllTemplatePoliciesForOrg` client-side fan-out hook (composes `useListFolders` + per-namespace `useQueries` batch of `ListTemplatePolicies`) so the page can show org + folder policies in one grid without a `SearchTemplatePolicies` RPC (tracked in HOL-590).
- Rewrites `/orgs/$orgName/template-policies/index.tsx` as a TanStack Table with columns Display Name, Namespace, Name + a global filter that matches across all three fields.
- Rows route to the org detail page for org-scoped policies and to the folder detail page for folder-scoped policies, derived from the namespace prefix (`scopeLabelFromNamespace` / `scopeNameFromNamespace`).
- Removes the Template Policies section (both "Manage Template Policies" and "Manage Template Policy Bindings" links) from `/orgs/$orgName/settings/`.

Fixes HOL-608

## Test plan
- [x] `cd frontend && npx vitest run` — 1076 tests pass (15 new, mirroring the HOL-607 table pattern)
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `make vet` — clean
- [ ] Manual: navigate to `/orgs/<org>/template-policies`, verify both org- and folder-scoped policies appear in one grid, exercise search by display name / namespace / name, click both scopes to confirm they route to the correct detail page.

## Notes
The Template Policy Bindings settings link is removed alongside the Template Policies link under the shared heading per AC. Bindings pages remain reachable from the `PolicyBindingsSection` inside policy detail and via direct URLs; if they need a top-level sidebar affordance, that's a follow-up for HOL-612 navigation cleanup.

Generated with [Claude Code](https://claude.com/claude-code)