### PR TITLE
feat(frontend): Project index page with deployments + quota + service status

### DIFF
--- a/frontend/src/components/quota-placeholder.tsx
+++ b/frontend/src/components/quota-placeholder.tsx
@@ -26,13 +26,19 @@ export function QuotaPlaceholder() {
                   {bar.limit}
                 </span>
               </div>
+              {/*
+                Placeholder bar. We intentionally do not expose
+                role="progressbar" with aria-valuenow — the numeric
+                share below is illustrative only, not a real usage
+                reading, and exposing fake values to assistive tech
+                would misrepresent state. The img role plus a label
+                that names the bar as illustrative communicates the
+                intent without asserting a measurement.
+              */}
               <div
                 className="mt-1 h-2 w-full rounded-full bg-muted"
-                role="progressbar"
-                aria-label={`${bar.label} usage (placeholder)`}
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={Math.round(bar.used * 100)}
+                role="img"
+                aria-label={`${bar.label} — illustrative placeholder, no real usage data`}
               >
                 <div
                   className="h-full rounded-full bg-primary/60"

--- a/frontend/src/components/quota-placeholder.tsx
+++ b/frontend/src/components/quota-placeholder.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+// Placeholder bars. The values encode the visual share of the bar so the
+// graphic reads as real data at a glance, but the caption below makes it
+// unambiguous that resource tracking is not yet wired up (HOL-609).
+const PLACEHOLDER_BARS: { label: string; used: number; limit: string }[] = [
+  { label: 'CPU', used: 0.32, limit: '2 cores' },
+  { label: 'Memory', used: 0.58, limit: '8 GiB' },
+  { label: 'Storage', used: 0.12, limit: '100 GiB' },
+  { label: 'Deployments', used: 0.45, limit: '20 max' },
+]
+
+export function QuotaPlaceholder() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Usage / Quota / Limits</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3" data-testid="quota-placeholder-bars">
+          {PLACEHOLDER_BARS.map((bar) => (
+            <div key={bar.label}>
+              <div className="flex items-baseline justify-between text-sm">
+                <span className="font-medium">{bar.label}</span>
+                <span className="text-muted-foreground tabular-nums">
+                  {bar.limit}
+                </span>
+              </div>
+              <div
+                className="mt-1 h-2 w-full rounded-full bg-muted"
+                role="progressbar"
+                aria-label={`${bar.label} usage (placeholder)`}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(bar.used * 100)}
+              >
+                <div
+                  className="h-full rounded-full bg-primary/60"
+                  style={{ width: `${bar.used * 100}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="mt-4 text-xs text-muted-foreground">
+          Planned — resource tracking not yet implemented. Bar values shown
+          above are illustrative and do not reflect real usage.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/service-status-panel.tsx
+++ b/frontend/src/components/service-status-panel.tsx
@@ -1,0 +1,71 @@
+import { Check } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+// Placeholder service status. Only the Deployment Service is a true signal
+// (green if the page loaded — we're talking to the backend). Database and
+// Identity Provider are dependency placeholders until the observability
+// integration lands (HOL-609).
+const DEPENDENCIES: { name: string; tooltip: string }[] = [
+  {
+    name: 'Database',
+    tooltip:
+      'Planned: health will come from the deployment service readiness probe plus a shallow database ping, reported via a new ObservabilityService RPC.',
+  },
+  {
+    name: 'Identity Provider',
+    tooltip:
+      'Planned: OIDC discovery + token refresh will be sampled by the deployment service and reported via the same ObservabilityService RPC.',
+  },
+]
+
+function StatusRow({ name, tooltip }: { name: string; tooltip?: string }) {
+  const label = tooltip ? (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="cursor-help border-b border-dotted border-muted-foreground/50">
+            {name}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ) : (
+    <span>{name}</span>
+  )
+
+  return (
+    <li className="flex items-center gap-2 py-1">
+      <Check
+        className="h-4 w-4 text-green-600 dark:text-green-400"
+        aria-hidden="true"
+      />
+      <span className="sr-only">ok</span>
+      {label}
+    </li>
+  )
+}
+
+export function ServiceStatusPanel() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Service Status</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="text-sm">
+          <StatusRow name="Deployment Service" />
+          {DEPENDENCIES.map((dep) => (
+            <StatusRow key={dep.name} name={dep.name} tooltip={dep.tooltip} />
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/service-status-panel.tsx
+++ b/frontend/src/components/service-status-panel.tsx
@@ -1,4 +1,4 @@
-import { Check } from 'lucide-react'
+import { Check, HelpCircle } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Tooltip,
@@ -7,10 +7,14 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 
+type Status = 'ok' | 'unknown'
+
 // Placeholder service status. Only the Deployment Service is a true signal
 // (green if the page loaded — we're talking to the backend). Database and
 // Identity Provider are dependency placeholders until the observability
-// integration lands (HOL-609).
+// integration lands (HOL-609). Unknown rows render with a muted HelpCircle
+// icon so a user scanning the panel at a glance is never misled into
+// thinking an unmeasured dependency has been confirmed healthy.
 const DEPENDENCIES: { name: string; tooltip: string }[] = [
   {
     name: 'Database',
@@ -24,30 +28,59 @@ const DEPENDENCIES: { name: string; tooltip: string }[] = [
   },
 ]
 
-function StatusRow({ name, tooltip }: { name: string; tooltip?: string }) {
-  const label = tooltip ? (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="cursor-help border-b border-dotted border-muted-foreground/50">
-            {name}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>{tooltip}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+function StatusIcon({ status }: { status: Status }) {
+  if (status === 'ok') {
+    return (
+      <Check
+        className="h-4 w-4 text-green-600 dark:text-green-400"
+        aria-hidden="true"
+      />
+    )
+  }
+  return (
+    <HelpCircle
+      className="h-4 w-4 text-muted-foreground"
+      aria-hidden="true"
+    />
+  )
+}
+
+function StatusRow({
+  name,
+  status,
+  tooltip,
+}: {
+  name: string
+  status: Status
+  tooltip?: string
+}) {
+  const statusWord = status === 'ok' ? 'OK' : 'not yet reported'
+  const accessibleLabel = `${name}: ${statusWord}`
+
+  const labelNode = tooltip ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          tabIndex={0}
+          role="button"
+          className="cursor-help border-b border-dotted border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        >
+          {name}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   ) : (
     <span>{name}</span>
   )
 
   return (
-    <li className="flex items-center gap-2 py-1">
-      <Check
-        className="h-4 w-4 text-green-600 dark:text-green-400"
-        aria-hidden="true"
-      />
-      <span className="sr-only">ok</span>
-      {label}
+    <li
+      className="flex items-center gap-2 py-1"
+      aria-label={accessibleLabel}
+    >
+      <StatusIcon status={status} />
+      {labelNode}
     </li>
   )
 }
@@ -59,12 +92,19 @@ export function ServiceStatusPanel() {
         <CardTitle>Service Status</CardTitle>
       </CardHeader>
       <CardContent>
-        <ul className="text-sm">
-          <StatusRow name="Deployment Service" />
-          {DEPENDENCIES.map((dep) => (
-            <StatusRow key={dep.name} name={dep.name} tooltip={dep.tooltip} />
-          ))}
-        </ul>
+        <TooltipProvider>
+          <ul className="text-sm">
+            <StatusRow name="Deployment Service" status="ok" />
+            {DEPENDENCIES.map((dep) => (
+              <StatusRow
+                key={dep.name}
+                name={dep.name}
+                status="unknown"
+                tooltip={dep.tooltip}
+              />
+            ))}
+          </ul>
+        </TooltipProvider>
       </CardContent>
     </Card>
   )

--- a/frontend/src/routes/_authenticated/projects/$projectName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Navigate, Outlet, useMatchRoute } from '@tanstack/react-router'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { useProject } from '@/lib/project-context'
 import { useOrg } from '@/lib/org-context'
@@ -14,8 +14,6 @@ function RouteComponent() {
 }
 
 export function ProjectLayout({ projectName }: { projectName: string }) {
-  const matchRoute = useMatchRoute()
-  const isExact = matchRoute({ to: '/projects/$projectName', params: { projectName } })
   const { setSelectedProject } = useProject()
   const { selectedOrg, setSelectedOrg } = useOrg()
   const { data: project } = useGetProject(projectName)
@@ -29,10 +27,6 @@ export function ProjectLayout({ projectName }: { projectName: string }) {
       setSelectedOrg(project.organization)
     }
   }, [project?.organization, selectedOrg, setSelectedOrg])
-
-  if (isExact) {
-    return <Navigate to="/projects/$projectName/secrets" params={{ projectName }} replace />
-  }
 
   return <Outlet />
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/-index.test.tsx
@@ -1,0 +1,206 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'my-project' }),
+    }),
+    Link: ({
+      children,
+      to,
+      params,
+      className,
+    }: {
+      children: React.ReactNode
+      to: string
+      params?: Record<string, string>
+      className?: string
+    }) => {
+      let href = to
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          href = href.replace(`$${k}`, v)
+        }
+      }
+      return (
+        <a href={href} className={className}>
+          {children}
+        </a>
+      )
+    },
+  }
+})
+
+vi.mock('@/queries/deployments', () => ({
+  useListDeployments: vi.fn(),
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useGetProject: vi.fn(),
+}))
+
+import { useListDeployments } from '@/queries/deployments'
+import { useGetProject } from '@/queries/projects'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { DeploymentPhase } from '@/gen/holos/console/v1/deployments_pb'
+import { ProjectIndexPage } from './index'
+
+type DeploymentFixture = {
+  name: string
+  image: string
+  tag: string
+  statusSummary?: {
+    phase: DeploymentPhase
+    desiredReplicas: number
+    readyReplicas: number
+  }
+}
+
+function makeDeployment(
+  name: string,
+  overrides: Partial<DeploymentFixture> = {},
+): DeploymentFixture {
+  return {
+    name,
+    image: 'registry/app',
+    tag: 'v1.0.0',
+    statusSummary: {
+      phase: DeploymentPhase.RUNNING,
+      desiredReplicas: 1,
+      readyReplicas: 1,
+    },
+    ...overrides,
+  }
+}
+
+function setup(
+  deployments: DeploymentFixture[] | undefined = [],
+  overrides: {
+    isPending?: boolean
+    error?: Error | null
+    userRole?: Role
+  } = {},
+) {
+  ;(useListDeployments as Mock).mockReturnValue({
+    data: overrides.isPending ? undefined : deployments,
+    isPending: overrides.isPending ?? false,
+    error: overrides.error ?? null,
+  })
+  ;(useGetProject as Mock).mockReturnValue({
+    data: {
+      name: 'my-project',
+      organization: 'my-org',
+      userRole: overrides.userRole ?? Role.OWNER,
+    },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('ProjectIndexPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders all three sections: Deployments, Usage / Quota / Limits, Service Status', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    // "Deployments" is used twice — the section title and a quota-bar label —
+    // so match both. The other titles are unique.
+    expect(screen.getAllByText('Deployments').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Usage / Quota / Limits')).toBeInTheDocument()
+    expect(screen.getByText('Service Status')).toBeInTheDocument()
+  })
+
+  it('renders deployments loading skeleton while pending', () => {
+    setup(undefined, { isPending: true })
+    const { container } = render(<ProjectIndexPage projectName="my-project" />)
+    expect(
+      container.querySelector('[data-testid="deployments-loading"]'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders deployments error when the list fails', () => {
+    setup([], { error: new Error('bad gateway') })
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(screen.getByText('bad gateway')).toBeInTheDocument()
+  })
+
+  it('renders deployment empty state', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(screen.getByText(/no deployments yet/i)).toBeInTheDocument()
+  })
+
+  it('renders a row per deployment with name, image:tag, and phase', () => {
+    setup([
+      makeDeployment('web'),
+      makeDeployment('worker', { image: 'registry/worker', tag: 'v2' }),
+    ])
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(screen.getByRole('link', { name: 'web' })).toHaveAttribute(
+      'href',
+      '/projects/my-project/deployments/web',
+    )
+    expect(screen.getByText('registry/app:v1.0.0')).toBeInTheDocument()
+    expect(screen.getByText('registry/worker:v2')).toBeInTheDocument()
+    // Both deployments show Running.
+    expect(screen.getAllByText('Running').length).toBe(2)
+  })
+
+  it('shows Create Deployment for OWNER and EDITOR roles', () => {
+    setup([], { userRole: Role.EDITOR })
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(
+      screen.getByRole('link', { name: /create deployment/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides Create Deployment for VIEWER role', () => {
+    setup([], { userRole: Role.VIEWER })
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(
+      screen.queryByRole('link', { name: /create deployment/i }),
+    ).toBeNull()
+  })
+
+  it('renders the View all link pointing at the deployments list', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(screen.getByRole('link', { name: /view all/i })).toHaveAttribute(
+      'href',
+      '/projects/my-project/deployments',
+    )
+  })
+
+  it('renders the Quota placeholder caption', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(
+      screen.getByText(/resource tracking not yet implemented/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders placeholder progress bars with role="progressbar"', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    // CPU, Memory, Storage, Deployments — four bars.
+    expect(screen.getAllByRole('progressbar').length).toBe(4)
+  })
+
+  it('renders the Deployment Service row unconditionally', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(screen.getByText('Deployment Service')).toBeInTheDocument()
+  })
+
+  it('renders Database and Identity Provider dependency rows', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(screen.getByText('Database')).toBeInTheDocument()
+    expect(screen.getByText('Identity Provider')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/-index.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
-import React from 'react'
+import type React from 'react'
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -108,9 +108,10 @@ describe('ProjectIndexPage', () => {
   it('renders all three sections: Deployments, Usage / Quota / Limits, Service Status', () => {
     setup([])
     render(<ProjectIndexPage projectName="my-project" />)
-    // "Deployments" is used twice — the section title and a quota-bar label —
-    // so match both. The other titles are unique.
-    expect(screen.getAllByText('Deployments').length).toBeGreaterThanOrEqual(1)
+    // "Deployments" appears exactly twice: the section title and the
+    // quota-bar label. Pinning the count catches the regression where
+    // either one silently disappears.
+    expect(screen.getAllByText('Deployments').length).toBe(2)
     expect(screen.getByText('Usage / Quota / Limits')).toBeInTheDocument()
     expect(screen.getByText('Service Status')).toBeInTheDocument()
   })
@@ -151,7 +152,15 @@ describe('ProjectIndexPage', () => {
     expect(screen.getAllByText('Running').length).toBe(2)
   })
 
-  it('shows Create Deployment for OWNER and EDITOR roles', () => {
+  it('shows Create Deployment for OWNER role', () => {
+    setup([], { userRole: Role.OWNER })
+    render(<ProjectIndexPage projectName="my-project" />)
+    expect(
+      screen.getByRole('link', { name: /create deployment/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows Create Deployment for EDITOR role', () => {
     setup([], { userRole: Role.EDITOR })
     render(<ProjectIndexPage projectName="my-project" />)
     expect(
@@ -184,23 +193,51 @@ describe('ProjectIndexPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders placeholder progress bars with role="progressbar"', () => {
+  it('renders four placeholder bars labeled as illustrative', () => {
     setup([])
     render(<ProjectIndexPage projectName="my-project" />)
     // CPU, Memory, Storage, Deployments — four bars.
-    expect(screen.getAllByRole('progressbar').length).toBe(4)
+    const bars = screen.getAllByRole('img', { name: /illustrative placeholder/i })
+    expect(bars.length).toBe(4)
   })
 
   it('renders the Deployment Service row unconditionally', () => {
     setup([])
     render(<ProjectIndexPage projectName="my-project" />)
     expect(screen.getByText('Deployment Service')).toBeInTheDocument()
+    // Deployment Service is the only row with a confirmed OK status.
+    expect(
+      screen.getByRole('listitem', { name: /deployment service: ok/i }),
+    ).toBeInTheDocument()
   })
 
-  it('renders Database and Identity Provider dependency rows', () => {
+  it('renders Database and Identity Provider rows as "not yet reported"', () => {
     setup([])
     render(<ProjectIndexPage projectName="my-project" />)
     expect(screen.getByText('Database')).toBeInTheDocument()
     expect(screen.getByText('Identity Provider')).toBeInTheDocument()
+    // Placeholder rows must NOT claim the dependency is healthy.
+    expect(
+      screen.getByRole('listitem', { name: /database: not yet reported/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('listitem', {
+        name: /identity provider: not yet reported/i,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('makes the dependency tooltip triggers keyboard-focusable', () => {
+    setup([])
+    render(<ProjectIndexPage projectName="my-project" />)
+    // The dependency rows use role=button triggers so keyboard-only
+    // users can reach the "Planned: …" explanation.
+    const triggers = screen.getAllByRole('button', {
+      name: /(database|identity provider)/i,
+    })
+    expect(triggers.length).toBe(2)
+    for (const t of triggers) {
+      expect(t).toHaveAttribute('tabindex', '0')
+    }
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/index.tsx
@@ -1,0 +1,140 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { PhaseBadge } from '@/components/phase-badge'
+import { QuotaPlaceholder } from '@/components/quota-placeholder'
+import { ServiceStatusPanel } from '@/components/service-status-panel'
+import type { Deployment } from '@/gen/holos/console/v1/deployments_pb'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useListDeployments } from '@/queries/deployments'
+import { useGetProject } from '@/queries/projects'
+
+export const Route = createFileRoute('/_authenticated/projects/$projectName/')({
+  component: ProjectIndexRoute,
+})
+
+function ProjectIndexRoute() {
+  const { projectName } = Route.useParams()
+  return <ProjectIndexPage projectName={projectName} />
+}
+
+export function ProjectIndexPage({
+  projectName: propProjectName,
+}: { projectName?: string } = {}) {
+  let routeProjectName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeProjectName = Route.useParams().projectName
+  } catch {
+    routeProjectName = undefined
+  }
+  const projectName = propProjectName ?? routeProjectName ?? ''
+
+  const {
+    data: deployments = [],
+    isPending: deploymentsPending,
+    error: deploymentsError,
+  } = useListDeployments(projectName)
+  const { data: project } = useGetProject(projectName)
+  const userRole = project?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  return (
+    <div className="space-y-4">
+      <DeploymentsSummary
+        projectName={projectName}
+        deployments={deployments}
+        isPending={deploymentsPending}
+        error={deploymentsError ?? null}
+        canWrite={canWrite}
+      />
+      <QuotaPlaceholder />
+      <ServiceStatusPanel />
+    </div>
+  )
+}
+
+interface DeploymentsSummaryProps {
+  projectName: string
+  deployments: Deployment[]
+  isPending: boolean
+  error: Error | null
+  canWrite: boolean
+}
+
+function DeploymentsSummary({
+  projectName,
+  deployments,
+  isPending,
+  error,
+  canWrite,
+}: DeploymentsSummaryProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+        <CardTitle>Deployments</CardTitle>
+        <div className="flex items-center gap-2">
+          <Link to="/projects/$projectName/deployments" params={{ projectName }}>
+            <Button size="sm" variant="outline">
+              View all
+            </Button>
+          </Link>
+          {canWrite && (
+            <Link
+              to="/projects/$projectName/deployments/new"
+              params={{ projectName }}
+            >
+              <Button size="sm">Create Deployment</Button>
+            </Link>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isPending ? (
+          <div className="space-y-2" data-testid="deployments-loading">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : error ? (
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        ) : deployments.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border p-6 text-center">
+            <p className="text-sm font-medium">No deployments yet.</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Deployments are the running applications in this project.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-border">
+            {deployments.map((deployment) => (
+              <li
+                key={deployment.name}
+                className="flex items-center justify-between gap-3 py-2"
+              >
+                <Link
+                  to="/projects/$projectName/deployments/$deploymentName"
+                  params={{ projectName, deploymentName: deployment.name }}
+                  search={{ tab: 'status' }}
+                  className="font-medium hover:underline"
+                >
+                  {deployment.name}
+                </Link>
+                <span className="flex items-center gap-3 text-sm text-muted-foreground">
+                  <span className="font-mono">
+                    {deployment.image}:{deployment.tag}
+                  </span>
+                  <PhaseBadge summary={deployment.statusSummary} />
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/-$projectName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/-$projectName.test.tsx
@@ -11,9 +11,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   return {
     ...actual,
     createFileRoute: () => () => ({}),
-    Navigate: () => null,
     Outlet: () => null,
-    useMatchRoute: () => () => false,
   }
 })
 


### PR DESCRIPTION
## Summary
- Replaces the `/projects/$projectName/` layout-level redirect to Secrets with a real index page that renders three sections top-to-bottom: **Deployments** summary, **Usage / Quota / Limits** placeholder bars, **Service Status** panel.
- Deployments section reads from the existing `useListDeployments` hook, renders a compact list with `PhaseBadge` per row, and role-gates a Create Deployment action.
- Quota section uses pure Tailwind divs with `role=\"progressbar\"` ARIA; carries a visible "planned — resource tracking not yet implemented" caption.
- Service Status section renders green-check rows for Deployment Service plus Database and Identity Provider dependency rows with shadcn Tooltip content describing the planned observability integration.

Fixes HOL-609

## Test plan
- [x] `cd frontend && npx vitest run` — 1097 tests pass (12 new on the project index)
- [x] `cd frontend && npx tsc -b` — clean
- [x] `make vet` — clean
- [ ] Manual: navigate to `/projects/<name>/`, verify the three sections render in order; verify the deployment skeleton/empty/populated/error transitions; verify tooltips fire on the Database / Identity Provider rows.

## Notes
The layout file (`$projectName.tsx`) now only sets the sidebar selection context and delegates to `<Outlet />`. Previous direct links to `/projects/$projectName/secrets` etc. still work unchanged.

Generated with [Claude Code](https://claude.com/claude-code)