### PR TITLE
feat(frontend): folder index summary page (templates, policies, projects)

### DIFF
--- a/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
@@ -1,9 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
-import React from 'react'
-
-const mockNavigate = vi.fn()
+import type React from 'react'
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -14,264 +12,313 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     }),
     Link: ({
       children,
-      className,
       to,
       params,
+      className,
+      'aria-label': ariaLabel,
     }: {
       children: React.ReactNode
-      className?: string
-      to?: string
+      to: string
       params?: Record<string, string>
-    }) => (
-      <a href={to} data-params={JSON.stringify(params)} className={className}>
-        {children}
-      </a>
-    ),
-    useNavigate: () => mockNavigate,
+      className?: string
+      'aria-label'?: string
+    }) => {
+      let href = to
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          href = href.replace(`$${k}`, v)
+        }
+      }
+      return (
+        <a href={href} className={className} aria-label={ariaLabel}>
+          {children}
+        </a>
+      )
+    },
   }
 })
 
 vi.mock('@/queries/folders', () => ({
   useGetFolder: vi.fn(),
-  useListFolders: vi.fn(),
+}))
+
+vi.mock('@/queries/templates', () => ({
+  useListTemplates: vi.fn(),
+}))
+
+vi.mock('@/queries/templatePolicies', () => ({
+  useListTemplatePolicies: vi.fn(),
 }))
 
 vi.mock('@/queries/projects', () => ({
   useListProjectsByParent: vi.fn(),
 }))
 
-vi.mock('@/queries/organizations', () => ({
-  useGetOrganization: vi.fn(),
+// Stub the console config so namespaceForFolder() produces a stable,
+// predictable namespace without requiring window.__CONSOLE_CONFIG__.
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: () => ({
+    namespacePrefix: 'holos-',
+    organizationPrefix: 'org-',
+    folderPrefix: 'fld-',
+    projectPrefix: 'prj-',
+  }),
 }))
 
-vi.mock('@/components/create-folder-dialog', () => ({
-  CreateFolderDialog: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="create-folder-dialog" /> : null,
-}))
-
-import { useGetFolder, useListFolders } from '@/queries/folders'
+import { useGetFolder } from '@/queries/folders'
+import { useListTemplates } from '@/queries/templates'
+import { useListTemplatePolicies } from '@/queries/templatePolicies'
 import { useListProjectsByParent } from '@/queries/projects'
-import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { namespaceForFolder } from '@/lib/scope-labels'
 import { FolderIndexPage } from './index'
+
+type TemplateFixture = { name: string; displayName?: string; enabled?: boolean }
+type PolicyFixture = { name: string }
+type ProjectFixture = { name: string; displayName?: string }
 
 const mockFolder = {
   name: 'payments',
   displayName: 'Payments Team',
-  description: 'Payment processing projects',
   organization: 'test-org',
   creatorEmail: 'admin@example.com',
-  createdAt: '2025-01-15T10:00:00Z',
   userRole: Role.OWNER,
-  userGrants: [],
-  roleGrants: [],
 }
 
-function makeChildFolder(name: string, displayName: string, creatorEmail = 'admin@example.com') {
-  return {
-    name,
-    displayName,
-    description: '',
-    organization: 'test-org',
-    creatorEmail,
-    createdAt: '2025-02-01T08:00:00Z',
-    userRole: Role.OWNER,
-  }
-}
-
-function makeChildProject(name: string, displayName: string, creatorEmail = 'admin@example.com') {
-  return {
-    name,
-    displayName,
-    description: '',
-    organization: 'test-org',
-    creatorEmail,
-    createdAt: '2025-03-01T12:00:00Z',
-    userRole: Role.OWNER,
-  }
-}
-
-function setupMocks(
-  opts: {
-    folder?: typeof mockFolder
-    childFolders?: ReturnType<typeof makeChildFolder>[]
-    childProjects?: ReturnType<typeof makeChildProject>[]
-    userRole?: Role
-    folderLoading?: boolean
+function setup(
+  overrides: {
+    folder?: typeof mockFolder | undefined
+    folderPending?: boolean
     folderError?: Error | null
-    foldersError?: Error | null
+    templates?: TemplateFixture[]
+    templatesPending?: boolean
+    templatesError?: Error | null
+    policies?: PolicyFixture[]
+    policiesPending?: boolean
+    policiesError?: Error | null
+    projects?: ProjectFixture[]
+    projectsPending?: boolean
     projectsError?: Error | null
   } = {},
 ) {
-  const {
-    folder = mockFolder,
-    childFolders = [],
-    childProjects = [],
-    userRole = Role.OWNER,
-    folderLoading = false,
-    folderError = null,
-    foldersError = null,
-    projectsError = null,
-  } = opts
-
   ;(useGetFolder as Mock).mockReturnValue({
-    data: folderLoading ? undefined : folder,
-    isPending: folderLoading,
-    error: folderError,
+    data: overrides.folderPending ? undefined : overrides.folder ?? mockFolder,
+    isPending: overrides.folderPending ?? false,
+    error: overrides.folderError ?? null,
   })
-  ;(useListFolders as Mock).mockReturnValue({
-    data: foldersError ? undefined : childFolders,
-    isPending: false,
-    error: foldersError,
+  ;(useListTemplates as Mock).mockReturnValue({
+    data: overrides.templatesPending ? undefined : overrides.templates ?? [],
+    isPending: overrides.templatesPending ?? false,
+    error: overrides.templatesError ?? null,
+  })
+  ;(useListTemplatePolicies as Mock).mockReturnValue({
+    data: overrides.policiesPending ? undefined : overrides.policies ?? [],
+    isPending: overrides.policiesPending ?? false,
+    error: overrides.policiesError ?? null,
   })
   ;(useListProjectsByParent as Mock).mockReturnValue({
-    data: projectsError ? undefined : childProjects,
-    isPending: false,
-    error: projectsError,
-  })
-  ;(useGetOrganization as Mock).mockReturnValue({
-    data: { name: 'test-org', userRole },
-    isPending: false,
-    error: null,
+    data: overrides.projectsPending ? undefined : overrides.projects ?? [],
+    isPending: overrides.projectsPending ?? false,
+    error: overrides.projectsError ?? null,
   })
 }
 
 describe('FolderIndexPage', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
+  beforeEach(() => vi.clearAllMocks())
 
-  it('renders loading skeletons while folder is pending', () => {
-    setupMocks({ folderLoading: true })
+  it('renders the folder header with breadcrumb and displayName', () => {
+    setup()
     render(<FolderIndexPage folderName="payments" />)
-    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.getByText('Payments Team')).toBeInTheDocument()
+    // Breadcrumb links back to the org and the folders index.
+    expect(screen.getByRole('link', { name: 'test-org' })).toHaveAttribute(
+      'href',
+      '/orgs/test-org/settings',
+    )
+    expect(screen.getByRole('link', { name: 'Folders' })).toHaveAttribute(
+      'href',
+      '/orgs/test-org/folders',
+    )
   })
 
-  it('renders error alert when folder fetch fails', () => {
-    setupMocks({ folderError: new Error('folder not found') })
+  it('renders all three summary sections in order: Templates, Template Policies, Projects', () => {
+    setup()
+    render(<FolderIndexPage folderName="payments" />)
+    // Section order is established by the order of the per-section "View
+    // all" links, which target stable, section-specific hrefs.
+    const hrefs = screen
+      .getAllByRole('link', { name: 'View all' })
+      .map((a) => a.getAttribute('href'))
+    expect(hrefs).toEqual([
+      '/folders/payments/templates',
+      '/folders/payments/template-policies',
+      '/orgs/test-org/projects',
+    ])
+  })
+
+  it('renders a folder-level error when useGetFolder fails', () => {
+    setup({ folderError: new Error('folder not found') })
     render(<FolderIndexPage folderName="payments" />)
     expect(screen.getByText(/folder not found/i)).toBeInTheDocument()
   })
 
-  it('renders empty state when folder has no children', () => {
-    setupMocks()
-    render(<FolderIndexPage folderName="payments" />)
-    expect(screen.getByText(/no items/i)).toBeInTheDocument()
+  it('renders per-section loading skeletons while queries are pending', () => {
+    setup({
+      templatesPending: true,
+      policiesPending: true,
+      projectsPending: true,
+    })
+    const { container } = render(<FolderIndexPage folderName="payments" />)
+    expect(
+      container.querySelector('[data-testid="templates-loading"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-testid="template-policies-loading"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-testid="projects-loading"]'),
+    ).toBeInTheDocument()
   })
 
-  it('renders data grid with combined folder and project rows', () => {
-    setupMocks({
-      childFolders: [makeChildFolder('billing', 'Billing')],
-      childProjects: [makeChildProject('checkout', 'Checkout')],
+  it('renders per-section empty states when each list is empty', () => {
+    setup()
+    render(<FolderIndexPage folderName="payments" />)
+    expect(
+      screen.getByText(/no templates in this folder/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/no template policies in this folder/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/no projects in this folder/i)).toBeInTheDocument()
+  })
+
+  it('renders templates with a count badge and per-item link', () => {
+    setup({
+      templates: [
+        { name: 'nginx', displayName: 'NGINX', enabled: true },
+        { name: 'redis', enabled: true },
+      ],
     })
     render(<FolderIndexPage folderName="payments" />)
-    expect(screen.getByText('Billing')).toBeInTheDocument()
-    expect(screen.getByText('Checkout')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'NGINX' })).toHaveAttribute(
+      'href',
+      '/folders/payments/templates/nginx',
+    )
+    expect(screen.getByRole('link', { name: 'redis' })).toHaveAttribute(
+      'href',
+      '/folders/payments/templates/redis',
+    )
+    // The badge on the section header exposes the count via aria-label.
+    expect(screen.getByLabelText('2 total')).toBeInTheDocument()
   })
 
-  it('renders type badges for folders and projects', () => {
-    setupMocks({
-      childFolders: [makeChildFolder('billing', 'Billing')],
-      childProjects: [makeChildProject('checkout', 'Checkout')],
+  it('renders a Disabled badge for disabled templates', () => {
+    setup({
+      templates: [{ name: 'legacy', displayName: 'Legacy', enabled: false }],
     })
     render(<FolderIndexPage folderName="payments" />)
-    expect(screen.getByText('Folder')).toBeInTheDocument()
-    expect(screen.getByText('Project')).toBeInTheDocument()
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
   })
 
-  it('search filters rows by display name', () => {
-    setupMocks({
-      childFolders: [makeChildFolder('billing', 'Billing')],
-      childProjects: [makeChildProject('checkout', 'Checkout')],
+  it('caps each section preview at 5 items regardless of list size', () => {
+    const makeTemplates = (n: number): TemplateFixture[] =>
+      Array.from({ length: n }, (_, i) => ({
+        name: `t-${i + 1}`,
+        displayName: `Template ${i + 1}`,
+        enabled: true,
+      }))
+    setup({ templates: makeTemplates(8) })
+    render(<FolderIndexPage folderName="payments" />)
+    // Five rendered links + one "View all" button.
+    expect(
+      screen.getAllByRole('link', { name: /^Template \d+$/ }).length,
+    ).toBe(5)
+    // Count badge still reports the full size.
+    expect(screen.getByLabelText('8 total')).toBeInTheDocument()
+  })
+
+  it('renders template policies with per-item link into the folder scope', () => {
+    setup({ policies: [{ name: 'disallow-privileged' }] })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(
+      screen.getByRole('link', { name: 'disallow-privileged' }),
+    ).toHaveAttribute('href', '/folders/payments/template-policies/disallow-privileged')
+  })
+
+  it('renders projects with displayName fallback and a per-item link', () => {
+    setup({
+      projects: [
+        { name: 'checkout', displayName: 'Checkout' },
+        { name: 'billing' },
+      ],
     })
     render(<FolderIndexPage folderName="payments" />)
-    const searchInput = screen.getByPlaceholderText(/search/i)
-    fireEvent.change(searchInput, { target: { value: 'billing' } })
-    expect(screen.getByText('Billing')).toBeInTheDocument()
-    expect(screen.queryByText('Checkout')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Checkout' })).toHaveAttribute(
+      'href',
+      '/projects/checkout',
+    )
+    expect(screen.getByRole('link', { name: 'billing' })).toHaveAttribute(
+      'href',
+      '/projects/billing',
+    )
   })
 
-  it('clicking a folder row navigates to /folders/$childFolderName', () => {
-    setupMocks({
-      childFolders: [makeChildFolder('billing', 'Billing')],
+  it('renders per-section View all links to the scoped indexes', () => {
+    setup()
+    render(<FolderIndexPage folderName="payments" />)
+    const viewAllLinks = screen.getAllByRole('link', { name: 'View all' })
+    const hrefs = viewAllLinks.map((a) => a.getAttribute('href'))
+    // Template-scope and policy-scope indexes live under /folders/.
+    expect(hrefs).toContain('/folders/payments/templates')
+    expect(hrefs).toContain('/folders/payments/template-policies')
+    // No folder-scoped projects index exists yet; View all for projects
+    // falls back to the org-wide projects page. Revisit when a folder-
+    // scoped projects index lands.
+    expect(hrefs).toContain('/orgs/test-org/projects')
+  })
+
+  it('renders per-section error alerts when a single list query fails', () => {
+    setup({
+      templatesError: new Error('template list failed'),
+      policiesError: new Error('policy list failed'),
+      projectsError: new Error('project list failed'),
     })
     render(<FolderIndexPage folderName="payments" />)
-    const row = screen.getByText('Billing').closest('tr')!
-    fireEvent.click(row)
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/folders/$folderName',
-      params: { folderName: 'billing' },
-    })
+    expect(screen.getByText(/template list failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/policy list failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/project list failed/i)).toBeInTheDocument()
   })
 
-  it('clicking a project row navigates to /projects/$projectName', () => {
-    setupMocks({
-      childProjects: [makeChildProject('checkout', 'Checkout')],
-    })
+  it('calls useListTemplates with the folder namespace, not the folder name', () => {
+    setup()
     render(<FolderIndexPage folderName="payments" />)
-    const row = screen.getByText('Checkout').closest('tr')!
-    fireEvent.click(row)
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/projects/$projectName',
-      params: { projectName: 'checkout' },
-    })
+    expect(useListTemplates).toHaveBeenCalledWith(namespaceForFolder('payments'))
+    expect(useListTemplatePolicies).toHaveBeenCalledWith(
+      namespaceForFolder('payments'),
+    )
   })
 
-  it('settings link points to /folders/$folderName/settings', () => {
-    setupMocks()
+  it('passes ParentType.FOLDER to useListProjectsByParent so the query is non-recursive', async () => {
+    setup()
     render(<FolderIndexPage folderName="payments" />)
-    const settingsLink = screen.getByRole('link', { name: /settings/i })
-    expect(settingsLink).toBeInTheDocument()
-    expect(settingsLink).toHaveAttribute('href', '/folders/$folderName/settings')
+    // Non-recursive semantics come from the query contract: the RPC filters
+    // to children whose immediate parent is this folder. We assert the
+    // call shape here — verifying the contract the page relies on without
+    // re-testing the RPC.
+    const { ParentType } = await import('@/gen/holos/console/v1/folders_pb')
+    expect(useListProjectsByParent).toHaveBeenCalledWith(
+      'test-org',
+      ParentType.FOLDER,
+      'payments',
+    )
   })
 
-  it('shows Create Folder button for OWNER', () => {
-    setupMocks({ userRole: Role.OWNER })
+  it('renders the Settings link in the folder header', () => {
+    setup()
     render(<FolderIndexPage folderName="payments" />)
-    const buttons = screen.getAllByRole('button', { name: /create folder/i })
-    expect(buttons.length).toBeGreaterThanOrEqual(1)
-  })
-
-  it('shows Create Folder button for EDITOR', () => {
-    setupMocks({ userRole: Role.EDITOR })
-    render(<FolderIndexPage folderName="payments" />)
-    const buttons = screen.getAllByRole('button', { name: /create folder/i })
-    expect(buttons.length).toBeGreaterThanOrEqual(1)
-  })
-
-  it('does not show Create Folder button for VIEWER', () => {
-    setupMocks({ userRole: Role.VIEWER })
-    render(<FolderIndexPage folderName="payments" />)
-    expect(screen.queryByRole('button', { name: /create folder/i })).not.toBeInTheDocument()
-  })
-
-  it('clicking Create Folder button opens dialog', () => {
-    setupMocks({
-      userRole: Role.OWNER,
-      childFolders: [makeChildFolder('billing', 'Billing')],
-    })
-    render(<FolderIndexPage folderName="payments" />)
-    fireEvent.click(screen.getByRole('button', { name: /create folder/i }))
-    expect(screen.getByTestId('create-folder-dialog')).toBeInTheDocument()
-  })
-
-  it('renders creator email in the table', () => {
-    setupMocks({
-      childFolders: [makeChildFolder('billing', 'Billing', 'creator@example.com')],
-    })
-    render(<FolderIndexPage folderName="payments" />)
-    expect(screen.getByText('creator@example.com')).toBeInTheDocument()
-  })
-
-  it('renders error alert when child folders fetch fails', () => {
-    setupMocks({ foldersError: new Error('failed to load child folders') })
-    render(<FolderIndexPage folderName="payments" />)
-    expect(screen.getByText(/failed to load child folders/i)).toBeInTheDocument()
-  })
-
-  it('renders error alert when child projects fetch fails', () => {
-    setupMocks({ projectsError: new Error('failed to load child projects') })
-    render(<FolderIndexPage folderName="payments" />)
-    expect(screen.getByText(/failed to load child projects/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute(
+      'href',
+      '/folders/payments/settings',
+    )
   })
 })

--- a/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import type React from 'react'
+import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -144,16 +145,29 @@ describe('FolderIndexPage', () => {
   it('renders all three summary sections in order: Templates, Template Policies, Projects', () => {
     setup()
     render(<FolderIndexPage folderName="payments" />)
-    // Section order is established by the order of the per-section "View
-    // all" links, which target stable, section-specific hrefs.
-    const hrefs = screen
-      .getAllByRole('link', { name: 'View all' })
-      .map((a) => a.getAttribute('href'))
-    expect(hrefs).toEqual([
-      '/folders/payments/templates',
-      '/folders/payments/template-policies',
-      '/orgs/test-org/projects',
-    ])
+    // Section order is established by the document order of the
+    // section-specific "View all" links. Each link carries a distinct
+    // accessible name so a screen-reader user (who jumps between links
+    // via the rotor) can tell which section each belongs to.
+    const templatesLink = screen.getByRole('link', {
+      name: 'View all templates',
+    })
+    const policiesLink = screen.getByRole('link', {
+      name: 'View all template policies',
+    })
+    const projectsLink = screen.getByRole('link', {
+      name: 'View all projects in the organization',
+    })
+    // Position compareDocumentPosition returns a bitmask where bit 0x04
+    // ("following") is set when `other` appears after `this` in the DOM.
+    expect(
+      templatesLink.compareDocumentPosition(policiesLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      policiesLink.compareDocumentPosition(projectsLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
   })
 
   it('renders a folder-level error when useGetFolder fails', () => {
@@ -190,6 +204,37 @@ describe('FolderIndexPage', () => {
       screen.getByText(/no template policies in this folder/i),
     ).toBeInTheDocument()
     expect(screen.getByText(/no projects in this folder/i)).toBeInTheDocument()
+  })
+
+  it('renders the empty state when a list query resolves with undefined data', () => {
+    // Guards against a regression where a resolved-but-shape-less query
+    // (`data: undefined, isPending: false`) slipped through to the
+    // children branch and rendered an empty <ul>. The section card
+    // must treat undefined as empty.
+    ;(useGetFolder as Mock).mockReturnValue({
+      data: mockFolder,
+      isPending: false,
+      error: null,
+    })
+    ;(useListTemplates as Mock).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      error: null,
+    })
+    ;(useListTemplatePolicies as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
+    ;(useListProjectsByParent as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(
+      screen.getByText(/no templates in this folder/i),
+    ).toBeInTheDocument()
   })
 
   it('renders templates with a count badge and per-item link', () => {
@@ -263,18 +308,23 @@ describe('FolderIndexPage', () => {
     )
   })
 
-  it('renders per-section View all links to the scoped indexes', () => {
+  it('renders per-section View all links to the scoped indexes with distinct accessible names', () => {
     setup()
     render(<FolderIndexPage folderName="payments" />)
-    const viewAllLinks = screen.getAllByRole('link', { name: 'View all' })
-    const hrefs = viewAllLinks.map((a) => a.getAttribute('href'))
-    // Template-scope and policy-scope indexes live under /folders/.
-    expect(hrefs).toContain('/folders/payments/templates')
-    expect(hrefs).toContain('/folders/payments/template-policies')
-    // No folder-scoped projects index exists yet; View all for projects
-    // falls back to the org-wide projects page. Revisit when a folder-
-    // scoped projects index lands.
-    expect(hrefs).toContain('/orgs/test-org/projects')
+    // Each "View all" link carries a section-specific aria-label so
+    // the three buttons are distinguishable in a screen-reader link
+    // list. The Projects link additionally signals that the fallback
+    // destination widens scope to the whole org (HOL-755 will swap
+    // this for a folder-scoped projects index).
+    expect(
+      screen.getByRole('link', { name: 'View all templates' }),
+    ).toHaveAttribute('href', '/folders/payments/templates')
+    expect(
+      screen.getByRole('link', { name: 'View all template policies' }),
+    ).toHaveAttribute('href', '/folders/payments/template-policies')
+    expect(
+      screen.getByRole('link', { name: 'View all projects in the organization' }),
+    ).toHaveAttribute('href', '/orgs/test-org/projects')
   })
 
   it('renders per-section error alerts when a single list query fails', () => {
@@ -298,14 +348,13 @@ describe('FolderIndexPage', () => {
     )
   })
 
-  it('passes ParentType.FOLDER to useListProjectsByParent so the query is non-recursive', async () => {
+  it('passes ParentType.FOLDER to useListProjectsByParent so the query is non-recursive', () => {
     setup()
     render(<FolderIndexPage folderName="payments" />)
     // Non-recursive semantics come from the query contract: the RPC filters
     // to children whose immediate parent is this folder. We assert the
     // call shape here — verifying the contract the page relies on without
     // re-testing the RPC.
-    const { ParentType } = await import('@/gen/holos/console/v1/folders_pb')
     expect(useListProjectsByParent).toHaveBeenCalledWith(
       'test-org',
       ParentType.FOLDER,

--- a/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
@@ -221,20 +221,35 @@ describe('FolderIndexPage', () => {
       isPending: false,
       error: null,
     })
+    // Populate the other two sections so any template-item <li>/<ul> or
+    // template-item link rendered by a regression stands out from the
+    // neighbors' legitimately-rendered lists.
     ;(useListTemplatePolicies as Mock).mockReturnValue({
-      data: [],
+      data: [{ name: 'disallow-privileged' }],
       isPending: false,
       error: null,
     })
     ;(useListProjectsByParent as Mock).mockReturnValue({
-      data: [],
+      data: [{ name: 'checkout', displayName: 'Checkout' }],
       isPending: false,
       error: null,
     })
     render(<FolderIndexPage folderName="payments" />)
+    // Zero-state copy renders...
     expect(
       screen.getByText(/no templates in this folder/i),
     ).toBeInTheDocument()
+    // ...and the Templates section surfaces a "0 total" count badge so
+    // the undefined-data path is visually consistent with the zero-
+    // count path — both tell the user there are zero templates.
+    expect(screen.getByLabelText('0 total')).toBeInTheDocument()
+    // ...and no template-item link leaks through. The two neighbor
+    // sections rendered their own items, so "no hrefs into the
+    // templates editor" is a tight regression pin.
+    const templateLinks = screen
+      .queryAllByRole('link')
+      .filter((a) => a.getAttribute('href')?.startsWith('/folders/payments/templates/'))
+    expect(templateLinks).toEqual([])
   })
 
   it('renders templates with a count badge and per-item link', () => {

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -1,35 +1,19 @@
-import { useState, useMemo } from 'react'
-import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
-import {
-  useReactTable,
-  getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
-  flexRender,
-  createColumnHelper,
-  type SortingState,
-} from '@tanstack/react-table'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
-import { ArrowUpDown, ArrowUp, ArrowDown, Plus, Settings } from 'lucide-react'
-import { useGetFolder, useListFolders } from '@/queries/folders'
+import { Badge } from '@/components/ui/badge'
+import { Settings } from 'lucide-react'
+import { useGetFolder } from '@/queries/folders'
+import { useListTemplates } from '@/queries/templates'
+import { useListTemplatePolicies } from '@/queries/templatePolicies'
 import { useListProjectsByParent } from '@/queries/projects'
-import { useGetOrganization } from '@/queries/organizations'
+import { namespaceForFolder } from '@/lib/scope-labels'
 import { ParentType } from '@/gen/holos/console/v1/folders_pb'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { CreateFolderDialog } from '@/components/create-folder-dialog'
+import type { Template } from '@/gen/holos/console/v1/templates_pb'
+import type { TemplatePolicy } from '@/gen/holos/console/v1/template_policies_pb'
+import type { Project } from '@/gen/holos/console/v1/projects_pb'
 
 export const Route = createFileRoute(
   '/_authenticated/folders/$folderName/',
@@ -42,248 +26,83 @@ function FolderIndexRoute() {
   return <FolderIndexPage folderName={folderName} />
 }
 
-/** Unified row type combining child folders and child projects. */
-type FolderChild = {
-  name: string
-  displayName: string
-  type: 'folder' | 'project'
-  createdAt: string
-  creatorEmail: string
-}
+// The summary list caps each section at this many items. Deep browsing
+// happens via the per-section "View all" link.
+const SECTION_PREVIEW_LIMIT = 5
 
-const columnHelper = createColumnHelper<FolderChild>()
-
-export function FolderIndexPage({ folderName: propFolderName }: { folderName?: string } = {}) {
-  let routeParams: { folderName?: string } = {}
+export function FolderIndexPage({
+  folderName: propFolderName,
+}: { folderName?: string } = {}) {
+  let routeFolderName: string | undefined
   try {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    routeParams = Route.useParams()
+    routeFolderName = Route.useParams().folderName
   } catch {
-    routeParams = {}
+    routeFolderName = undefined
   }
-  const folderName = propFolderName ?? routeParams.folderName ?? ''
+  const folderName = propFolderName ?? routeFolderName ?? ''
 
-  let navigate: ReturnType<typeof useNavigate>
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    navigate = useNavigate()
-  } catch {
-    navigate = (() => {}) as unknown as ReturnType<typeof useNavigate>
-  }
-
-  const { data: folder, isPending: folderPending, error: folderError } = useGetFolder(folderName)
+  const {
+    data: folder,
+    isPending: folderPending,
+    error: folderError,
+  } = useGetFolder(folderName)
   const orgName = folder?.organization ?? ''
+  const namespace = namespaceForFolder(folderName)
 
-  const { data: org } = useGetOrganization(orgName)
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  const templatesQuery = useListTemplates(namespace)
+  const policiesQuery = useListTemplatePolicies(namespace)
+  // Projects fan out by parent reference; the RPC filter is non-recursive
+  // by construction — it only returns projects whose immediate parent is
+  // this folder, never grandchildren.
+  const projectsQuery = useListProjectsByParent(
+    orgName,
+    ParentType.FOLDER,
+    folderName,
+  )
 
-  const { data: childFolders, isPending: foldersLoading, error: foldersError } = useListFolders(orgName, ParentType.FOLDER, folderName)
-  const { data: childProjects, isPending: projectsLoading, error: projectsError } = useListProjectsByParent(orgName, ParentType.FOLDER, folderName)
-
-  const [globalFilter, setGlobalFilter] = useState('')
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'displayName', desc: false }])
-  const [createOpen, setCreateOpen] = useState(false)
-
-  const data = useMemo<FolderChild[]>(() => {
-    const items: FolderChild[] = []
-    for (const f of childFolders ?? []) {
-      items.push({
-        name: f.name,
-        displayName: f.displayName || f.name,
-        type: 'folder',
-        createdAt: f.createdAt ?? '',
-        creatorEmail: f.creatorEmail ?? '',
-      })
-    }
-    for (const p of childProjects ?? []) {
-      items.push({
-        name: p.name,
-        displayName: p.displayName || p.name,
-        type: 'project',
-        createdAt: p.createdAt ?? '',
-        creatorEmail: p.creatorEmail ?? '',
-      })
-    }
-    return items
-  }, [childFolders, childProjects])
-
-  const columns = useMemo(() => [
-    columnHelper.accessor('displayName', {
-      header: ({ column }) => {
-        const sorted = column.getIsSorted()
-        return (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="-ml-3 h-8 font-medium"
-            onClick={() => column.toggleSorting(sorted === 'asc')}
-          >
-            Display Name
-            {sorted === 'asc' ? (
-              <ArrowUp className="ml-1 h-3.5 w-3.5" />
-            ) : sorted === 'desc' ? (
-              <ArrowDown className="ml-1 h-3.5 w-3.5" />
-            ) : (
-              <ArrowUpDown className="ml-1 h-3.5 w-3.5 opacity-50" />
-            )}
-          </Button>
-        )
-      },
-      cell: ({ getValue }) => (
-        <span className="font-medium">{getValue()}</span>
-      ),
-    }),
-    columnHelper.accessor('type', {
-      header: 'Type',
-      cell: ({ getValue }) => {
-        const t = getValue()
-        return (
-          <Badge variant="outline">
-            {t === 'folder' ? 'Folder' : 'Project'}
-          </Badge>
-        )
-      },
-    }),
-    columnHelper.accessor('createdAt', {
-      header: ({ column }) => {
-        const sorted = column.getIsSorted()
-        return (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="-ml-3 h-8 font-medium"
-            onClick={() => column.toggleSorting(sorted === 'asc')}
-          >
-            Created
-            {sorted === 'asc' ? (
-              <ArrowUp className="ml-1 h-3.5 w-3.5" />
-            ) : sorted === 'desc' ? (
-              <ArrowDown className="ml-1 h-3.5 w-3.5" />
-            ) : (
-              <ArrowUpDown className="ml-1 h-3.5 w-3.5 opacity-50" />
-            )}
-          </Button>
-        )
-      },
-      cell: ({ getValue }) => {
-        const ts = getValue()
-        if (!ts) return <span className="text-muted-foreground">--</span>
-        try {
-          return (
-            <span className="text-muted-foreground text-sm">
-              {new Intl.DateTimeFormat(undefined, {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              }).format(new Date(ts))}
-            </span>
-          )
-        } catch {
-          return <span className="text-muted-foreground text-sm">{ts}</span>
-        }
-      },
-    }),
-    columnHelper.accessor('creatorEmail', {
-      header: ({ column }) => {
-        const sorted = column.getIsSorted()
-        return (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="-ml-3 h-8 font-medium"
-            onClick={() => column.toggleSorting(sorted === 'asc')}
-          >
-            Creator
-            {sorted === 'asc' ? (
-              <ArrowUp className="ml-1 h-3.5 w-3.5" />
-            ) : sorted === 'desc' ? (
-              <ArrowDown className="ml-1 h-3.5 w-3.5" />
-            ) : (
-              <ArrowUpDown className="ml-1 h-3.5 w-3.5 opacity-50" />
-            )}
-          </Button>
-        )
-      },
-      cell: ({ getValue }) => {
-        const email = getValue()
-        if (!email) return <span className="text-muted-foreground">--</span>
-        return <span className="text-muted-foreground text-sm">{email}</span>
-      },
-    }),
-  ], [])
-
-  const table = useReactTable({
-    data,
-    columns,
-    state: { globalFilter, sorting },
-    onGlobalFilterChange: setGlobalFilter,
-    onSortingChange: setSorting,
-    globalFilterFn: 'includesString',
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-  })
-
-  const handleRowClick = (row: FolderChild) => {
-    if (row.type === 'folder') {
-      navigate({
-        to: '/folders/$folderName',
-        params: { folderName: row.name },
-      })
-    } else {
-      navigate({
-        to: '/projects/$projectName',
-        params: { projectName: row.name },
-      })
-    }
-  }
-
-  const fetchError = folderError ?? foldersError ?? projectsError
-  if (fetchError) {
+  if (folderError) {
     return (
       <Card>
         <CardContent className="pt-6">
           <Alert variant="destructive">
-            <AlertDescription>{fetchError.message}</AlertDescription>
+            <AlertDescription>{folderError.message}</AlertDescription>
           </Alert>
         </CardContent>
       </Card>
     )
   }
 
-  const isLoading = folderPending || foldersLoading || projectsLoading
-
-  if (isLoading) {
+  if (folderPending) {
     return (
-      <Card>
-        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-          <CardTitle>Contents</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-2">
-            {[...Array(3)].map((_, i) => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      <div className="space-y-4">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
     )
   }
 
   const displayName = folder?.displayName || folderName
 
   return (
-    <>
+    <div className="space-y-4">
       <Card>
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
           <div>
             <p className="text-sm text-muted-foreground">
-              <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+              <Link
+                to="/orgs/$orgName/settings"
+                params={{ orgName }}
+                className="hover:underline"
+              >
                 {orgName}
               </Link>
               {' / '}
-              <Link to="/orgs/$orgName/folders" params={{ orgName }} className="hover:underline">
+              <Link
+                to="/orgs/$orgName/folders"
+                params={{ orgName }}
+                className="hover:underline"
+              >
                 Folders
               </Link>
               {' / '}
@@ -291,93 +110,242 @@ export function FolderIndexPage({ folderName: propFolderName }: { folderName?: s
             </p>
             <CardTitle className="mt-1">{displayName}</CardTitle>
           </div>
-          <div className="flex items-center gap-2">
-            <Link
-              to="/folders/$folderName/settings"
-              params={{ folderName }}
-              aria-label="Settings"
-            >
-              <Button variant="outline" size="sm">
-                <Settings className="h-4 w-4 mr-1" />
-                Settings
-              </Button>
-            </Link>
-            {canWrite && (
-              <Button size="sm" onClick={() => setCreateOpen(true)}>
-                <Plus className="h-4 w-4 mr-1" />
-                Create Folder
-              </Button>
-            )}
-          </div>
+          <Link
+            to="/folders/$folderName/settings"
+            params={{ folderName }}
+            aria-label="Settings"
+          >
+            <Button variant="outline" size="sm">
+              <Settings className="h-4 w-4 mr-1" />
+              Settings
+            </Button>
+          </Link>
         </CardHeader>
-        <CardContent>
-          {data.length === 0 ? (
-            <div className="flex flex-col items-center gap-3 py-8 text-center">
-              <p className="text-muted-foreground">No items in this folder yet.</p>
-              {canWrite && (
-                <Button size="sm" onClick={() => setCreateOpen(true)}>
-                  Create Folder
-                </Button>
-              )}
-            </div>
-          ) : (
-            <>
-              <div className="mb-3">
-                <Input
-                  placeholder="Search items..."
-                  value={globalFilter}
-                  onChange={(e) => setGlobalFilter(e.target.value)}
-                  className="max-w-sm"
-                />
-              </div>
-              <Table>
-                <TableHeader>
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => (
-                        <TableHead key={header.id}>
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(header.column.columnDef.header, header.getContext())}
-                        </TableHead>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableHeader>
-                <TableBody>
-                  {table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className="cursor-pointer"
-                      onClick={() => handleRowClick(row.original)}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </>
-          )}
-        </CardContent>
       </Card>
 
-      <CreateFolderDialog
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-        organization={orgName}
-        parentType={ParentType.FOLDER}
-        parentName={folderName}
-        onCreated={(name) => {
-          navigate({
-            to: '/folders/$folderName',
-            params: { folderName: name },
-          })
-        }}
+      <TemplatesSection
+        folderName={folderName}
+        templates={templatesQuery.data}
+        isPending={templatesQuery.isPending}
+        error={templatesQuery.error as Error | null}
       />
-    </>
+      <TemplatePoliciesSection
+        folderName={folderName}
+        policies={policiesQuery.data}
+        isPending={policiesQuery.isPending}
+        error={policiesQuery.error as Error | null}
+      />
+      <ProjectsSection
+        orgName={orgName}
+        projects={projectsQuery.data}
+        isPending={projectsQuery.isPending}
+        error={projectsQuery.error as Error | null}
+      />
+    </div>
+  )
+}
+
+interface SectionCardProps {
+  title: string
+  count: number | undefined
+  isPending: boolean
+  error: Error | null
+  emptyText: string
+  viewAll: React.ReactNode
+  children: React.ReactNode
+}
+
+function SectionCard({
+  title,
+  count,
+  isPending,
+  error,
+  emptyText,
+  viewAll,
+  children,
+}: SectionCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+        <CardTitle className="flex items-center gap-2">
+          {title}
+          {typeof count === 'number' && (
+            <Badge variant="secondary" aria-label={`${count} total`}>
+              {count}
+            </Badge>
+          )}
+        </CardTitle>
+        {viewAll}
+      </CardHeader>
+      <CardContent>
+        {isPending ? (
+          <div className="space-y-2" data-testid={`${title.toLowerCase().replace(/\s+/g, '-')}-loading`}>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full" />
+            ))}
+          </div>
+        ) : error ? (
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        ) : count === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyText}</p>
+        ) : (
+          children
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function TemplatesSection({
+  folderName,
+  templates,
+  isPending,
+  error,
+}: {
+  folderName: string
+  templates: Template[] | undefined
+  isPending: boolean
+  error: Error | null
+}) {
+  const preview = (templates ?? []).slice(0, SECTION_PREVIEW_LIMIT)
+  return (
+    <SectionCard
+      title="Templates"
+      count={templates?.length}
+      isPending={isPending}
+      error={error}
+      emptyText="No templates in this folder."
+      viewAll={
+        <Link
+          to="/folders/$folderName/templates"
+          params={{ folderName }}
+        >
+          <Button variant="outline" size="sm">
+            View all
+          </Button>
+        </Link>
+      }
+    >
+      <ul className="divide-y divide-border">
+        {preview.map((t) => (
+          <li
+            key={t.name}
+            className="flex items-center justify-between gap-3 py-2"
+          >
+            <Link
+              to="/folders/$folderName/templates/$templateName"
+              params={{ folderName, templateName: t.name }}
+              className="font-medium hover:underline"
+            >
+              {t.displayName || t.name}
+            </Link>
+            {!t.enabled && (
+              <Badge variant="outline" className="text-muted-foreground">
+                Disabled
+              </Badge>
+            )}
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
+  )
+}
+
+function TemplatePoliciesSection({
+  folderName,
+  policies,
+  isPending,
+  error,
+}: {
+  folderName: string
+  policies: TemplatePolicy[] | undefined
+  isPending: boolean
+  error: Error | null
+}) {
+  const preview = (policies ?? []).slice(0, SECTION_PREVIEW_LIMIT)
+  return (
+    <SectionCard
+      title="Template Policies"
+      count={policies?.length}
+      isPending={isPending}
+      error={error}
+      emptyText="No template policies in this folder."
+      viewAll={
+        <Link
+          to="/folders/$folderName/template-policies"
+          params={{ folderName }}
+        >
+          <Button variant="outline" size="sm">
+            View all
+          </Button>
+        </Link>
+      }
+    >
+      <ul className="divide-y divide-border">
+        {preview.map((p) => (
+          <li
+            key={p.name}
+            className="flex items-center justify-between gap-3 py-2"
+          >
+            <Link
+              to="/folders/$folderName/template-policies/$policyName"
+              params={{ folderName, policyName: p.name }}
+              className="font-medium hover:underline"
+            >
+              {p.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
+  )
+}
+
+function ProjectsSection({
+  orgName,
+  projects,
+  isPending,
+  error,
+}: {
+  orgName: string
+  projects: Project[] | undefined
+  isPending: boolean
+  error: Error | null
+}) {
+  const preview = (projects ?? []).slice(0, SECTION_PREVIEW_LIMIT)
+  return (
+    <SectionCard
+      title="Projects"
+      count={projects?.length}
+      isPending={isPending}
+      error={error}
+      emptyText="No projects in this folder."
+      viewAll={
+        <Link to="/orgs/$orgName/projects" params={{ orgName }}>
+          <Button variant="outline" size="sm">
+            View all
+          </Button>
+        </Link>
+      }
+    >
+      <ul className="divide-y divide-border">
+        {preview.map((p) => (
+          <li
+            key={p.name}
+            className="flex items-center justify-between gap-3 py-2"
+          >
+            <Link
+              to="/projects/$projectName"
+              params={{ projectName: p.name }}
+              className="font-medium hover:underline"
+            >
+              {p.displayName || p.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
   )
 }

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -169,15 +169,21 @@ function SectionCard({
 }: SectionCardProps) {
   // Treat `undefined` as empty so a resolved-but-shape-less query still
   // surfaces the zero-state copy instead of an empty <ul>.
-  const isEmpty = (count ?? 0) === 0
+  const isEmpty = count === undefined || count === 0
+  // The badge is a count signal; it only makes sense alongside data we
+  // actually fetched. Suppress it during load (we don't know the count
+  // yet) and on error (the count is unknown, not zero). A successful
+  // empty-data query still renders `0` for visual consistency with the
+  // zero-count case.
+  const showCount = !isPending && !error
   return (
     <Card>
       <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
         <CardTitle className="flex items-center gap-2">
           {title}
-          {typeof count === 'number' && (
-            <Badge variant="secondary" aria-label={`${count} total`}>
-              {count}
+          {showCount && (
+            <Badge variant="secondary" aria-label={`${count ?? 0} total`}>
+              {count ?? 0}
             </Badge>
           )}
         </CardTitle>

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -147,16 +148,18 @@ export function FolderIndexPage({
 
 interface SectionCardProps {
   title: string
+  testId: string
   count: number | undefined
   isPending: boolean
   error: Error | null
   emptyText: string
-  viewAll: React.ReactNode
-  children: React.ReactNode
+  viewAll: ReactNode
+  children: ReactNode
 }
 
 function SectionCard({
   title,
+  testId,
   count,
   isPending,
   error,
@@ -164,6 +167,9 @@ function SectionCard({
   viewAll,
   children,
 }: SectionCardProps) {
+  // Treat `undefined` as empty so a resolved-but-shape-less query still
+  // surfaces the zero-state copy instead of an empty <ul>.
+  const isEmpty = (count ?? 0) === 0
   return (
     <Card>
       <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
@@ -179,7 +185,7 @@ function SectionCard({
       </CardHeader>
       <CardContent>
         {isPending ? (
-          <div className="space-y-2" data-testid={`${title.toLowerCase().replace(/\s+/g, '-')}-loading`}>
+          <div className="space-y-2" data-testid={`${testId}-loading`}>
             {Array.from({ length: 3 }).map((_, i) => (
               <Skeleton key={i} className="h-8 w-full" />
             ))}
@@ -188,7 +194,7 @@ function SectionCard({
           <Alert variant="destructive">
             <AlertDescription>{error.message}</AlertDescription>
           </Alert>
-        ) : count === 0 ? (
+        ) : isEmpty ? (
           <p className="text-sm text-muted-foreground">{emptyText}</p>
         ) : (
           children
@@ -213,6 +219,7 @@ function TemplatesSection({
   return (
     <SectionCard
       title="Templates"
+      testId="templates"
       count={templates?.length}
       isPending={isPending}
       error={error}
@@ -221,6 +228,7 @@ function TemplatesSection({
         <Link
           to="/folders/$folderName/templates"
           params={{ folderName }}
+          aria-label="View all templates"
         >
           <Button variant="outline" size="sm">
             View all
@@ -268,6 +276,7 @@ function TemplatePoliciesSection({
   return (
     <SectionCard
       title="Template Policies"
+      testId="template-policies"
       count={policies?.length}
       isPending={isPending}
       error={error}
@@ -276,6 +285,7 @@ function TemplatePoliciesSection({
         <Link
           to="/folders/$folderName/template-policies"
           params={{ folderName }}
+          aria-label="View all template policies"
         >
           <Button variant="outline" size="sm">
             View all
@@ -318,12 +328,21 @@ function ProjectsSection({
   return (
     <SectionCard
       title="Projects"
+      testId="projects"
       count={projects?.length}
       isPending={isPending}
       error={error}
       emptyText="No projects in this folder."
       viewAll={
-        <Link to="/orgs/$orgName/projects" params={{ orgName }}>
+        // No folder-scoped projects index exists yet (HOL-755); "View all"
+        // falls back to the org-wide list. The aria-label makes the
+        // fallback explicit so a screen-reader user is not surprised by
+        // the wider scope after activating the link.
+        <Link
+          to="/orgs/$orgName/projects"
+          params={{ orgName }}
+          aria-label="View all projects in the organization"
+        >
           <Button variant="outline" size="sm">
             View all
           </Button>


### PR DESCRIPTION
## Summary

- Replaces the folder index page's unified child-folders-plus-child-projects data grid with a three-section summary: **Templates**, **Template Policies**, **Projects**.
- Each section renders a count badge, up to five direct-scope items, and a **View all** link into the scoped index.
- Non-recursive by construction: templates and policies are scoped to `namespaceForFolder(folderName)`; projects pass `ParentType.FOLDER` so the RPC filters to immediate children only.
- A shared `<SectionCard>` component normalizes the skeleton / error / empty / populated branches across all three categories.
- Folder header (breadcrumb, display name as `CardTitle`, Settings link) is preserved so existing e2e assertions keep passing.

Fixes HOL-610

## Test plan

- [x] `cd frontend && npx vitest run src/routes/_authenticated/folders/\$folderName/-index.test.tsx` — 15/15 pass
- [x] `cd frontend && npx vitest run` — all 1098 pass
- [x] `cd frontend && npx tsc -b` — clean
- [x] `make vet` — clean
- [ ] CI (unit + lint + e2e)

Generated with [Claude Code](https://claude.com/claude-code)