### PR TITLE
fix(controller): wire controller-runtime logger to slog (HOL-765)

### DIFF
--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -34,6 +34,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -150,6 +151,12 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 	if logger == nil {
 		logger = slog.Default()
 	}
+	// Wire controller-runtime's global logger to slog so internal components
+	// (priorityqueue, cache, leader election) emit through the same pipeline
+	// as the rest of the binary. Without this, controller-runtime prints a
+	// one-shot "log.SetLogger(...) was never called" stack trace on first
+	// use (HOL-765).
+	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
 	cacheSyncTimeout := opts.CacheSyncTimeout
 	if cacheSyncTimeout == 0 {
 		// controller-runtime's default is 2 minutes. We ship a tighter

--- a/internal/secretinjector/controller/manager.go
+++ b/internal/secretinjector/controller/manager.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -109,6 +110,12 @@ func NewManager(cfg *rest.Config, opts Options) (*Manager, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	// Wire controller-runtime's global logger to slog so internal components
+	// (priorityqueue, cache, leader election) emit through the same pipeline
+	// as the rest of the binary. Without this, controller-runtime prints a
+	// one-shot "log.SetLogger(...) was never called" stack trace on first
+	// use (HOL-765).
+	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
 	cacheSyncTimeout := opts.CacheSyncTimeout
 	if cacheSyncTimeout == 0 {
 		// 90s matches the console manager so both binaries roll with the

--- a/internal/secretinjector/controller/manager_logger_test.go
+++ b/internal/secretinjector/controller/manager_logger_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TestNewManager_WiresControllerRuntimeLogger verifies that constructing a
+// Manager also wires controller-runtime's process-global logger. Regression
+// guard for HOL-765: without the SetLogger call inside NewManager,
+// controller-runtime internals (priorityqueue, cache, leader election) hit
+// the "[controller-runtime] log.SetLogger(...) was never called" code path
+// and dump a stack trace on first use.
+func TestNewManager_WiresControllerRuntimeLogger(t *testing.T) {
+	buf := &syncBuffer{}
+	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(handler)
+
+	_, err := NewManager(&rest.Config{Host: "http://127.0.0.1:0"}, Options{Logger: logger})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Log through controller-runtime's global Logger. If SetLogger was
+	// called correctly, the record flows through our slog handler into buf.
+	ctrllog.Log.WithName("test").Info("hol-765-logger-check", "ok", true)
+
+	if out := buf.String(); !strings.Contains(out, "hol-765-logger-check") {
+		t.Fatalf("controller-runtime log did not reach slog handler; buf=%q", out)
+	}
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer so slog writes from
+// controller-runtime's async log sinks don't race with the test goroutine's
+// reads.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}


### PR DESCRIPTION
Assignee: @jeffmccune ([jeff](https://linear.app/holos-run/profiles/jeff))

## Summary

Fixes [HOL-765](https://linear.app/holos-run/issue/HOL-765/fix-logsetlogger-was-never-called-logs-will-not-be-displayed).

controller-runtime's internal components (priorityqueue, cache, leader election) log through `log.Log`, a package-global delegating logger. When `log.SetLogger` has never been called, the first use prints a one-shot `[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed` message with a goroutine stack trace — reproduced on the console binary from `priorityqueue.logState`.

## Changes

- `internal/controller/manager.go`: call `ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))` inside `NewManager` so every controller-runtime record flows through the same slog pipeline the console binary uses.
- `internal/secretinjector/controller/manager.go`: same fix for the secret-injector manager so both binaries stay consistent.
- `internal/secretinjector/controller/manager_logger_test.go`: regression test — constructs a Manager with a slog handler wired to a buffer, emits a record through `ctrllog.Log`, and asserts the buffer received it. Verified to fail without the fix and pass with it.

## Test plan

- [x] `go test ./internal/secretinjector/controller/...` — new unit test passes
- [x] `go test ./...` — full suite green (envtest-based `internal/controller` tests included)
- [x] Negative check — temporarily reverted the fix and confirmed `TestNewManager_WiresControllerRuntimeLogger` fails (empty buffer)
- [x] `go vet ./...` clean

## Acceptance criteria

> Logging is correctly wired up in the controller-runtime.

Met: controller-runtime's package-global logger is now wired to the binary's slog handler on manager construction, so `log.Log` records emit to stderr as structured JSON alongside the rest of the console's log output. The `log.SetLogger(...) was never called` warning will no longer appear.

---
> **Tip:** I will respond to comments that @ mention @cyrus-ai on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->