### PR TITLE
fix(frontend): address HOL-743 review findings from PR #1057 (Resources index)

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/resources/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/resources/-index.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
-import React from 'react'
+import { LinkMock } from '@/test/link-mock'
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -10,31 +10,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     createFileRoute: () => () => ({
       useParams: () => ({ orgName: 'test-org' }),
     }),
-    Link: ({
-      children,
-      to,
-      params,
-      title,
-      className,
-    }: {
-      children: React.ReactNode
-      to: string
-      params?: Record<string, string>
-      title?: string
-      className?: string
-    }) => {
-      let href = to
-      if (params) {
-        for (const [k, v] of Object.entries(params)) {
-          href = href.replace(`$${k}`, v)
-        }
-      }
-      return (
-        <a href={href} title={title} className={className}>
-          {children}
-        </a>
-      )
-    },
+    Link: LinkMock,
   }
 })
 
@@ -167,11 +143,10 @@ describe('ResourcesIndexPage', () => {
     setupMocks([makeFolder('ops')])
     render(<ResourcesIndexPage />)
 
-    // Leaf link uses the slug since display name is empty.
-    const leafLinks = screen.getAllByRole('link', { name: 'ops' })
-    expect(
-      leafLinks.some((l) => l.getAttribute('href') === '/folders/ops'),
-    ).toBe(true)
+    // When displayName is empty the leaf link uses the slug as its text and
+    // href — assert directly so a regression fails with a clear message.
+    const leafLink = screen.getByRole('link', { name: 'ops', hidden: false })
+    expect(leafLink).toHaveAttribute('href', '/folders/ops')
   })
 
   it('filters rows via the global search input', () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/resources/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/resources/index.tsx
@@ -44,6 +44,18 @@ function typeBadge(type: ResourceType) {
   return <Badge variant="destructive">Unknown</Badge>
 }
 
+// guardOrgName logs a warning and returns a placeholder when the server
+// returns an empty path element name (contract violation). An empty slug
+// would generate broken URLs such as /orgs//folders/… that TanStack Router
+// may 404 or throw on.
+function guardOrgName(name: string): string {
+  if (!name) {
+    console.warn('PathCell: received empty org name in path element; check server contract')
+    return '(unknown)'
+  }
+  return name
+}
+
 // PathCell renders the root→leaf display-name breadcrumb with the leaf
 // (this resource) on the right. The root element (index 0) is the
 // organization; subsequent elements are ancestor folders; the leaf is the
@@ -62,7 +74,7 @@ function PathCell({ resource }: { resource: Resource }) {
             {i === 0 ? (
               <Link
                 to="/orgs/$orgName"
-                params={{ orgName: element.name }}
+                params={{ orgName: guardOrgName(element.name) }}
                 title={element.name}
                 className="hover:underline text-muted-foreground"
               >
@@ -78,6 +90,9 @@ function PathCell({ resource }: { resource: Resource }) {
                 {display}
               </Link>
             )}
+            {/* The `/` separator precedes the next sibling span (or the leaf
+                Link below) and is rendered inside this span so each breadcrumb
+                element is a self-contained flex item: [link /] [link /] [leaf]. */}
             <span className="text-muted-foreground">/</span>
           </span>
         )
@@ -237,12 +252,15 @@ export function ResourcesIndexPage() {
   )
 }
 
+// typeLabel returns the capitalized string used by the type-column accessor.
+// The values are capitalized to agree with typeBadge's rendered text and
+// remove a hidden coupling to case-insensitive globalFilterFn behaviour.
 function typeLabel(type: ResourceType) {
   return type === ResourceType.FOLDER
-    ? 'folder'
+    ? 'Folder'
     : type === ResourceType.PROJECT
-      ? 'project'
-      : 'unknown'
+      ? 'Project'
+      : 'Unknown'
 }
 
 // pathSearchString serializes the row's display-name breadcrumb plus the
@@ -251,7 +269,7 @@ function typeLabel(type: ResourceType) {
 function pathSearchString(resource: Resource): string {
   const crumbs = resource.path.map((p) => p.displayName || p.name)
   crumbs.push(resource.displayName || resource.name)
-  if (resource.name !== (resource.displayName || resource.name)) {
+  if (resource.displayName !== '' && resource.displayName !== resource.name) {
     crumbs.push(resource.name)
   }
   return crumbs.join(' / ')

--- a/frontend/src/test/link-mock.tsx
+++ b/frontend/src/test/link-mock.tsx
@@ -1,0 +1,34 @@
+// linkMock is a test-only TanStack Router Link stub shared across index-page
+// tests. It renders an <a> whose href is the `to` pattern with $param tokens
+// replaced by the corresponding `params` values. All props forwarded by
+// resource / folder / template index pages (title, className, aria-label) are
+// preserved so asserting on them works without per-file duplication.
+import React from 'react'
+
+export function LinkMock({
+  children,
+  to,
+  params,
+  title,
+  className,
+  'aria-label': ariaLabel,
+}: {
+  children: React.ReactNode
+  to: string
+  params?: Record<string, string>
+  title?: string
+  className?: string
+  'aria-label'?: string
+}) {
+  let href = to
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      href = href.replace(`$${k}`, v)
+    }
+  }
+  return (
+    <a href={href} title={title} className={className} aria-label={ariaLabel}>
+      {children}
+    </a>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `guardOrgName()` to `PathCell`: logs a `console.warn` and substitutes `'(unknown)'` when the server returns an empty org-slug, preventing broken URLs like `/orgs//folders/<slug>`
- Add inline comment on the `/` separator in `PathCell.map` explaining the flex-item breadcrumb structure for future readers
- Align `typeLabel()` to return capitalized values (`'Folder'`/`'Project'`/`'Unknown'`) matching `typeBadge`, removing a hidden coupling to case-insensitive `globalFilterFn`
- Simplify `pathSearchString` condition to the equivalent but clearer `resource.displayName !== '' && resource.displayName !== resource.name`
- Tighten slug-fallback test: replace `getAllByRole(...).some(...)` with `getByRole` + `toHaveAttribute` so a regression fails with a useful message
- Extract shared `LinkMock` helper to `frontend/src/test/link-mock.tsx`; update resources test to import from the shared location

Fixes HOL-743

## Test plan

- [x] `make test-ui` passes — 78 test files, 1022 tests green
- [x] Slug-fallback test now uses direct `getByRole` + `toHaveAttribute` assertion
- [x] All existing 9 resource-index tests continue to pass with no logic changes