### PR TITLE
fix(frontend): address HOL-744 style findings from PR #1058 review round 2

### DIFF
--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -19,11 +19,11 @@ export const Route = createFileRoute(
 export function FolderTemplateRedirect() {
   const { folderName, templateName } = Route.useParams()
   const navigate = useNavigate()
-  const { data: folder, error } = useGetFolder(folderName)
+  const { data: folder, isPending, error } = useGetFolder(folderName)
   const orgName = folder?.organization ?? ''
 
   useEffect(() => {
-    if (!orgName) return
+    if (isPending || !orgName) return
     navigate({
       to: '/orgs/$orgName/templates/$namespace/$name',
       params: {

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -33,7 +33,7 @@ export function FolderTemplateRedirect() {
       },
       replace: true,
     })
-  }, [orgName, folderName, templateName, navigate])
+  }, [isPending, orgName, folderName, templateName, navigate])
 
   if (error) {
     return (

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
@@ -8,6 +8,9 @@ import type { Mock } from 'vitest'
 // the frontend references only {namespace, name, display_name} + the CUE body.
 
 // The params vary per case, so the mock defers to a mutable holder.
+// NOTE: This relies on Vitest's default sequential execution within a single
+// file — each it.each case runs serially so mutations to currentParams are
+// isolated between cases. Do not add `concurrent` to this suite.
 let currentParams: { orgName: string; namespace: string; name: string } = {
   orgName: 'test-org',
   namespace: '',

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/index.tsx
@@ -46,6 +46,10 @@ export function OrgTemplatesIndexPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const { data, isLoading, error } = useSearchTemplates({ organization: orgName })
+  // When orgName is empty the query is disabled: isLoading is false and data is
+  // undefined. Treat the disabled state the same as loading so we never render
+  // the "No templates yet" empty state for an org that hasn't resolved yet.
+  const queryDisabled = orgName === ''
   const templates = useMemo(() => data ?? [], [data])
 
   const [globalFilter, setGlobalFilter] = useState('')
@@ -100,7 +104,7 @@ export function OrgTemplatesIndexPage({
     getFilteredRowModel: getFilteredRowModel(),
   })
 
-  if (isLoading) {
+  if (isLoading || queryDisabled) {
     return (
       <Card>
         <CardHeader>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -19,11 +19,11 @@ export const Route = createFileRoute(
 export function ProjectTemplateRedirect() {
   const { projectName, templateName } = Route.useParams()
   const navigate = useNavigate()
-  const { data: project, error } = useGetProject(projectName)
+  const { data: project, isPending, error } = useGetProject(projectName)
   const orgName = project?.organization ?? ''
 
   useEffect(() => {
-    if (!orgName) return
+    if (isPending || !orgName) return
     navigate({
       to: '/orgs/$orgName/templates/$namespace/$name',
       params: {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -33,7 +33,7 @@ export function ProjectTemplateRedirect() {
       },
       replace: true,
     })
-  }, [orgName, projectName, templateName, navigate])
+  }, [isPending, orgName, projectName, templateName, navigate])
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

- Add `isPending` to the `useEffect` navigation guard in the folder-template and project-template redirect shims so the loading gate is explicit: `if (isPending || !orgName) return` instead of the implicit falsy check.
- Add a comment in `-cross-scope.test.tsx` documenting the serial-execution assumption so future maintainers know not to add `concurrent` to the suite.
- Introduce `queryDisabled` in `OrgTemplatesIndexPage` and render the skeleton branch when `orgName === ''`, preventing a false "No templates yet" empty state when the query is disabled.

Fixes HOL-744

## Test plan

- [ ] `make test-ui` passes (1022 tests, 78 files)
- [ ] Navigating to a folder- or project-scoped template URL still redirects correctly to the consolidated editor
- [ ] Templates index page shows skeleton while org is resolving, not empty state