### PR TITLE
feat(config): add top-level cluster-scoped and namespace-scoped overlays

### DIFF
--- a/config/cluster-scoped/kustomization.yaml
+++ b/config/cluster-scoped/kustomization.yaml
@@ -1,0 +1,13 @@
+# Consolidated cluster-scoped overlay for both holos-console and
+# holos-secret-injector. Installs CRDs, VAPs + VAPBs, and ClusterRoles
+# for templates.holos.run and secrets.holos.run.
+#
+#   kubectl apply -k config/cluster-scoped/
+#
+# Apply config/namespace-scoped/ first so the controller ServiceAccount
+# exists before the ClusterRoleBindings bind it.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../holos-console/cluster-scoped
+- ../secret-injector/cluster-scoped

--- a/config/namespace-scoped/kustomization.yaml
+++ b/config/namespace-scoped/kustomization.yaml
@@ -1,0 +1,12 @@
+# Consolidated namespace-scoped overlay. At M1 only holos-secret-injector
+# ships namespace-local resources (ServiceAccount + narrow Role/RoleBinding
+# in holos-system). Apply BEFORE ../cluster-scoped/ so the SA exists
+# before its ClusterRoleBindings.
+#
+#   kubectl apply -k config/namespace-scoped/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../secret-injector/namespace-scoped
+# Reserved: ../holos-console/namespace-scoped when HOL-670 successors
+# add the console Deployment/Service surface.


### PR DESCRIPTION
## Summary

- Adds `config/cluster-scoped/kustomization.yaml` referencing both `../holos-console/cluster-scoped` and `../secret-injector/cluster-scoped`
- Adds `config/namespace-scoped/kustomization.yaml` referencing `../secret-injector/namespace-scoped` with a reserved comment for future holos-console namespace-scoped resources
- Both files carry header comments explaining apply ordering: namespace-scoped BEFORE cluster-scoped so the `holos-system` ServiceAccount exists before ClusterRoleBindings bind it
- Combined cluster-scoped output: 37 resources (12 console + 25 injector, no duplicates)

Fixes HOL-760

## Test plan

- [x] `kubectl kustomize config/cluster-scoped/` emits 37 resources (12 + 25, no duplicates)
- [x] `kubectl apply --dry-run=client -k config/cluster-scoped/` succeeds
- [x] `kubectl apply --dry-run=client -k config/namespace-scoped/` succeeds
- [ ] Real-cluster smoke test: `scripts/cluster` + `kubectl apply -k config/namespace-scoped/ && kubectl apply -k config/cluster-scoped/` installs all resources (requires live cluster)