### PR TITLE
fix(frontend): address review findings from PR #1059

### DIFF
--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -19,6 +19,7 @@ import type {
 } from '@/gen/holos/console/v1/template_policies_pb.js'
 import { useAuth } from '@/lib/auth'
 import { useListFolders } from '@/queries/folders'
+import type { Folder } from '@/gen/holos/console/v1/folders_pb.js'
 import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
 
 // Re-export generated types/enums used by UI consumers. HOL-600 removed
@@ -115,7 +116,7 @@ export function aggregateFanOut<T>(
 
 // Module-level sentinel so the `folders` useMemo fallback preserves reference
 // identity across renders when the folders list is still pending or empty.
-const EMPTY_FOLDERS: readonly { name: string }[] = []
+const EMPTY_FOLDERS: readonly Folder[] = []
 
 // useAllTemplatePoliciesForOrg fans a ListTemplatePolicies call across every
 // namespace reachable from an organization root — the org namespace plus one

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
@@ -113,10 +113,32 @@ describe('OrgTemplatePoliciesIndexPage', () => {
     expect(container.querySelector('[data-testid="policies-loading"]')).toBeInTheDocument()
   })
 
-  it('renders error alert when the fan-out fails', () => {
+  it('renders error alert when the fan-out fails with no data', () => {
     setup([], Role.OWNER, { error: new Error('bad gateway') })
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(screen.getByText('bad gateway')).toBeInTheDocument()
+    // full-page error — table should not be rendered
+    expect(screen.queryByRole('table')).toBeNull()
+  })
+
+  it('renders rows with inline warning banner when partial data and error coexist', () => {
+    ;(useAllTemplatePoliciesForOrg as Mock).mockReturnValue({
+      data: [makePolicy('p-org', namespaceForOrg('test-org'), 'Org Policy')],
+      isPending: false,
+      error: new Error('folders unavailable'),
+    })
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { name: 'test-org', userRole: Role.OWNER },
+      isPending: false,
+      error: null,
+    })
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    // rows must be visible
+    expect(screen.getByText('Org Policy')).toBeInTheDocument()
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    // inline warning banner must be present
+    expect(screen.getByTestId('policies-partial-error')).toBeInTheDocument()
+    expect(screen.getByText('folders unavailable')).toBeInTheDocument()
   })
 
   it('renders empty state when no policies exist', () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
@@ -158,7 +158,10 @@ export function OrgTemplatePoliciesIndexPage({
     )
   }
 
-  if (error) {
+  // When the fan-out has both an error and partial data, fall through to the
+  // full grid so successfully-loaded rows remain visible. The banner below the
+  // CardHeader surfaces the error without blanking the table.
+  if (error && rows.length === 0) {
     return (
       <Card>
         <CardContent className="pt-6">
@@ -186,6 +189,11 @@ export function OrgTemplatePoliciesIndexPage({
         )}
       </CardHeader>
       <CardContent>
+        {error && (
+          <Alert variant="destructive" className="mb-4" data-testid="policies-partial-error">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        )}
         {rows.length === 0 ? (
           <div className="rounded-md border border-dashed border-border p-6 text-center">
             <p className="text-sm font-medium">No template policies yet.</p>


### PR DESCRIPTION
## Summary

- Render partial data + inline warning banner when `useAllTemplatePoliciesForOrg` returns both `data` (rows) and an `error`, rather than blanking the grid with a full-page error Alert
- Type `EMPTY_FOLDERS` sentinel as `readonly Folder[]` (from the Folder proto) instead of the structural `readonly { name: string }[]` shape
- Add test: _renders rows with inline warning banner when partial data and error coexist_
- Rename existing test: _renders error alert when the fan-out fails with no data_ (also adds assertion that the table is not rendered in the full-page error case)

Fixes HOL-745

## Test plan

- [ ] `make test-ui` passes (1023 tests, 18/18 for template-policies index)
- [ ] Navigate to org Template Policies page with all queries healthy — grid renders normally, no banner
- [ ] Simulate a folder-list failure (block network) — partial org-scoped policies remain visible with a destructive alert banner above the table
- [ ] Complete fetch failure with no data — full-page error Alert is shown, no table rendered