### PR TITLE
chore(scripts,ci): migrate kind-up and CI to consolidated kustomize overlays

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,15 +90,17 @@ jobs:
       # The controller-runtime manager embedded in holos-console (HOL-620) starts
       # informers over templates.holos.run/v1alpha1 at boot. The manager fails
       # its initial cache sync — and the console treats that as fatal — when
-      # the target cluster does not have the CRDs installed. Apply the CRDs,
-      # admission policies, and RBAC here, in the same order scripts/kind-up
-      # uses for local clusters (ADR 030). Order matters: CRDs first so the
-      # ValidatingAdmissionPolicies can reference templates.holos.run kinds.
-      - name: Install holos-console CRDs, admission policies, and RBAC
+      # the target cluster does not have the CRDs installed. Apply the
+      # consolidated namespace-scoped and cluster-scoped overlays here, in the
+      # same order scripts/kind-up uses for local clusters (ADR 030). Order
+      # matters: namespace-scoped resources (ServiceAccounts in holos-system)
+      # must exist before the cluster-scoped ClusterRoleBindings bind them,
+      # and the cluster-scoped overlay installs the CRDs before the
+      # ValidatingAdmissionPolicies reference them.
+      - name: Install holos-console and secret-injector manifests
         run: |
-          kubectl apply -k config/holos-console/crd/
-          kubectl apply -k config/holos-console/admission/
-          kubectl apply -k config/holos-console/rbac/
+          kubectl apply -k config/namespace-scoped/
+          kubectl apply -k config/cluster-scoped/
 
       - name: Install Playwright browsers
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,13 @@ jobs:
       # ValidatingAdmissionPolicies reference them.
       - name: Install holos-console and secret-injector manifests
         run: |
+          # The namespace-scoped overlay installs the holos-secret-injector
+          # ServiceAccount in holos-system. Kustomize overlays do not declare
+          # the Namespace itself (M1 deferral; see
+          # config/secret-injector/namespace-scoped/README.md), so create it
+          # idempotently before applying so CI bootstraps cleanly on a fresh
+          # k3s cluster.
+          kubectl create namespace holos-system --dry-run=client -o yaml | kubectl apply -f -
           kubectl apply -k config/namespace-scoped/
           kubectl apply -k config/cluster-scoped/
 

--- a/scripts/kind-up
+++ b/scripts/kind-up
@@ -5,20 +5,22 @@
 #
 # Apply order (locked in ADR 030):
 #   1. DNS + k3d cluster + mkcert root CA
-#   2. kubectl apply -k config/holos-console/crd/
-#   3. kubectl apply -k config/holos-console/admission/
-#   4. kubectl apply -k config/holos-console/rbac/
-#   5. holos-console deployment rollout
+#   2. kubectl apply -k config/namespace-scoped/
+#   3. kubectl apply -k config/cluster-scoped/
+#   4. holos-console deployment rollout
 #
-# The ordering matters: CRDs must exist before admission policies reference
-# them; admission policies must exist before the first policy/binding is
-# created; RBAC must exist before the console pod starts (reconcilers need
-# list/watch permissions at manager startup).
+# The ordering matters: namespace-scoped resources (including the controller
+# ServiceAccounts in holos-system) must exist before the cluster-scoped
+# ClusterRoleBindings bind them. The cluster-scoped overlay installs CRDs,
+# ValidatingAdmissionPolicies, and ClusterRoles for both templates.holos.run
+# and secrets.holos.run; CRDs are installed before any policy/binding that
+# references them, and RBAC is in place before the console pod starts
+# (reconcilers need list/watch permissions at manager startup).
 #
 # The rolling deployment step is intentionally a hook (HOLOS_CONSOLE_ROLLOUT).
 # The container image lifecycle lives in the user's own workflow — this script
-# only guarantees the CRD / admission / RBAC surface is installed before that
-# hook runs.
+# only guarantees the namespace-scoped and cluster-scoped manifests are
+# installed before that hook runs.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -33,10 +35,9 @@ echo ">>> (2/5) scripts/local-k3d"
 echo ">>> (3/5) scripts/local-ca"
 ./scripts/local-ca
 
-echo ">>> (4/5) kubectl apply CRDs, admission policies, RBAC"
-kubectl apply -k "${REPO_ROOT}/config/holos-console/crd/"
-kubectl apply -k "${REPO_ROOT}/config/holos-console/admission/"
-kubectl apply -k "${REPO_ROOT}/config/holos-console/rbac/"
+echo ">>> (4/5) kubectl apply namespace-scoped then cluster-scoped overlays"
+kubectl apply -k "${REPO_ROOT}/config/namespace-scoped/"
+kubectl apply -k "${REPO_ROOT}/config/cluster-scoped/"
 
 echo ">>> (5/5) roll holos-console deployment"
 if [[ -n "${HOLOS_CONSOLE_ROLLOUT:-}" ]]; then

--- a/scripts/kind-up
+++ b/scripts/kind-up
@@ -36,6 +36,12 @@ echo ">>> (3/5) scripts/local-ca"
 ./scripts/local-ca
 
 echo ">>> (4/5) kubectl apply namespace-scoped then cluster-scoped overlays"
+# The namespace-scoped overlay installs the holos-secret-injector
+# ServiceAccount + Role + RoleBinding in holos-system. Kustomize overlays
+# do not declare the Namespace itself (M1 deferral; see
+# config/secret-injector/namespace-scoped/README.md), so create it first
+# server-side and idempotently so a fresh k3d cluster bootstraps cleanly.
+kubectl create namespace holos-system --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -k "${REPO_ROOT}/config/namespace-scoped/"
 kubectl apply -k "${REPO_ROOT}/config/cluster-scoped/"
 


### PR DESCRIPTION
## Summary

- Replace the three-step `kubectl apply -k config/holos-console/{crd,admission,rbac}/` bootstrap in `scripts/kind-up` and `.github/workflows/ci.yaml` with a two-step `kubectl apply -k config/namespace-scoped/` + `kubectl apply -k config/cluster-scoped/` flow against the consolidated overlays from HOL-760.
- Preserve ServiceAccount-first ordering: the namespace-scoped overlay installs the `holos-secret-injector` SA in `holos-system` before the cluster-scoped overlay binds it via ClusterRoleBindings, and the cluster-scoped overlay installs CRDs before the ValidatingAdmissionPolicies that reference them.
- Update the header comment block in `scripts/kind-up` and the explanatory comment in `.github/workflows/ci.yaml` to describe the new two-step apply while retaining the ADR 030 ordering rationale.

Fixes HOL-761

## Test plan

- [x] `kubectl kustomize config/namespace-scoped/` builds cleanly (3 resources: SA, Role, RoleBinding in `holos-system`).
- [x] `kubectl kustomize config/cluster-scoped/` builds cleanly (9 CRDs, 12 VAPs, 12 VAPBs, 3 ClusterRoles, 1 ClusterRoleBinding).
- [ ] CI workflow run passes the `Install holos-console and secret-injector manifests` step (watch logs for successful kustomize build over both overlays).
- [ ] Local smoke test: `make cluster && scripts/kind-up && make run` produces a working controller manager.