### PR TITLE
docs(proto): amend TemplatePolicyBinding for target_refs wildcards (HOL-769)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -176,6 +176,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -621,7 +622,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.11.0",
@@ -679,6 +681,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -808,6 +811,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -848,6 +852,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1949,6 +1954,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4196,6 +4202,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
       "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -4206,6 +4213,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -4222,6 +4230,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.163.3.tgz",
       "integrity": "sha512-hheBbFVb+PbxtrWp8iy6+TTRTbhx3Pn6hKo8Tv/sWlG89ZMcD1xpQWzx8ukHN9K8YWbh5rdzt4kv6u8X4kB28Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.161.4",
         "@tanstack/react-store": "^0.9.1",
@@ -4470,6 +4479,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4693,6 +4703,7 @@
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4703,6 +4714,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4713,6 +4725,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4776,6 +4789,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -5190,6 +5204,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5510,6 +5525,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6467,6 +6483,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6744,6 +6761,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7350,6 +7368,7 @@
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7799,6 +7818,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -9397,6 +9417,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9406,6 +9427,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9803,6 +9825,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
       "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10511,6 +10534,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10742,6 +10766,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11232,6 +11257,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.d.ts
@@ -63,18 +63,27 @@ export declare type TemplatePolicyBindingTargetRef = Message<"holos.console.v1.T
   kind: TemplatePolicyBindingTargetKind;
 
   /**
-   * name is the target's DNS label slug within project_name.
+   * name is the target's DNS label slug within project_name, or the literal
+   * string "*" to match every resource of this kind within the binding's
+   * reachable scope (i.e., every resource in every project reachable via the
+   * storage-scope ancestor-walk). Duplicate detection treats "*" as a literal
+   * string: two entries with identical (kind, project_name, name="*") triples
+   * are still duplicates and MUST be rejected by handlers (HOL-767 / ADR 029).
    *
    * @generated from field: string name = 2;
    */
   name: string;
 
   /**
-   * project_name is the project that owns the target. Required for
-   * both PROJECT_TEMPLATE and DEPLOYMENT kinds — project-scope
-   * resources are disambiguated by (project_name, name). Left empty
-   * only on zero-valued UNSPECIFIED placeholders, which handlers MUST
-   * reject; UNSPECIFIED is not a legal resting state.
+   * project_name is the project that owns the target, or the literal string
+   * "*" to match targets across every project reachable via the binding's
+   * storage-scope ancestor-walk. Required (non-empty, non-wildcard) for both
+   * PROJECT_TEMPLATE and DEPLOYMENT kinds when naming a specific project;
+   * set to "*" when the intent is to apply the policy to every project in the
+   * binding's reachable scope. Left empty only on zero-valued UNSPECIFIED
+   * placeholders, which handlers MUST reject; UNSPECIFIED is not a legal
+   * resting state. Duplicate detection treats "*" as a literal string (HOL-767
+   * / ADR 029).
    *
    * @generated from field: string project_name = 3;
    */
@@ -139,13 +148,18 @@ export declare type TemplatePolicyBinding = Message<"holos.console.v1.TemplatePo
   policyRef?: LinkedTemplatePolicyRef;
 
   /**
-   * target_refs enumerates every render target the referenced policy
-   * applies to. Order is not significant; duplicates MUST be rejected
-   * by handlers. A "duplicate" is two entries with identical
-   * (kind, project_name, name) triples. Two entries that share
-   * (project_name, name) but differ in kind (e.g., a PROJECT_TEMPLATE
-   * and a DEPLOYMENT with the same slug inside the same project) are
-   * permitted — they name distinct resources.
+   * target_refs enumerates every render target the referenced policy applies
+   * to. Order is not significant; duplicates MUST be rejected by handlers. A
+   * "duplicate" is two entries with identical (kind, project_name, name)
+   * triples — the literal string "*" is treated as a literal value for
+   * duplicate detection purposes. Two entries that share (project_name, name)
+   * but differ in kind (e.g., a PROJECT_TEMPLATE and a DEPLOYMENT with the
+   * same slug inside the same project) are permitted — they name distinct
+   * resources. The literal string "*" is a supported wildcard value on both
+   * `name` and `project_name` fields (HOL-767 / ADR 029 amendment): a
+   * project_name of "*" fans out to every project reachable via the binding's
+   * ancestor-walk; a name of "*" fans out to every resource of the given kind
+   * within the matched project(s).
    *
    * @generated from field: repeated holos.console.v1.TemplatePolicyBindingTargetRef target_refs = 6;
    */
@@ -433,11 +447,13 @@ export declare const TemplatePolicyBindingTargetKindSchema: GenEnum<TemplatePoli
 
 /**
  * TemplatePolicyBindingService manages TemplatePolicyBinding resources, the
- * explicit, non-glob successor to TemplatePolicy's target-selector rules
- * (ADR 029 / HOL-590). A TemplatePolicyBinding names a single policy and
- * enumerates the project templates and deployments that policy applies to
- * via explicit TemplatePolicyBindingTargetRef entries — no wildcards, no
- * glob semantics. TemplatePolicy continues to declare the REQUIRE/EXCLUDE
+ * explicit successor to TemplatePolicy's target-selector rules (ADR 029 /
+ * HOL-590). A TemplatePolicyBinding names a single policy and enumerates the
+ * project templates and deployments that policy applies to via
+ * TemplatePolicyBindingTargetRef entries. The literal string "*" is supported
+ * as a wildcard on both `name` and `project_name` fields (HOL-767 / ADR 029
+ * amendment), meaning "match every resource of this kind within the binding's
+ * reachable scope." TemplatePolicy continues to declare the REQUIRE/EXCLUDE
  * rules; TemplatePolicyBinding declares the set of targets those rules apply
  * to.
  *

--- a/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.js
+++ b/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.js
@@ -120,11 +120,13 @@ export const TemplatePolicyBindingTargetKind = /*@__PURE__*/
 
 /**
  * TemplatePolicyBindingService manages TemplatePolicyBinding resources, the
- * explicit, non-glob successor to TemplatePolicy's target-selector rules
- * (ADR 029 / HOL-590). A TemplatePolicyBinding names a single policy and
- * enumerates the project templates and deployments that policy applies to
- * via explicit TemplatePolicyBindingTargetRef entries — no wildcards, no
- * glob semantics. TemplatePolicy continues to declare the REQUIRE/EXCLUDE
+ * explicit successor to TemplatePolicy's target-selector rules (ADR 029 /
+ * HOL-590). A TemplatePolicyBinding names a single policy and enumerates the
+ * project templates and deployments that policy applies to via
+ * TemplatePolicyBindingTargetRef entries. The literal string "*" is supported
+ * as a wildcard on both `name` and `project_name` fields (HOL-767 / ADR 029
+ * amendment), meaning "match every resource of this kind within the binding's
+ * reachable scope." TemplatePolicy continues to declare the REQUIRE/EXCLUDE
  * rules; TemplatePolicyBinding declares the set of targets those rules apply
  * to.
  *

--- a/gen/holos/console/v1/template_policy_bindings.pb.go
+++ b/gen/holos/console/v1/template_policy_bindings.pb.go
@@ -154,13 +154,22 @@ type TemplatePolicyBindingTargetRef struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// kind discriminates between PROJECT_TEMPLATE and DEPLOYMENT targets.
 	Kind TemplatePolicyBindingTargetKind `protobuf:"varint,1,opt,name=kind,proto3,enum=holos.console.v1.TemplatePolicyBindingTargetKind" json:"kind,omitempty"`
-	// name is the target's DNS label slug within project_name.
+	// name is the target's DNS label slug within project_name, or the literal
+	// string "*" to match every resource of this kind within the binding's
+	// reachable scope (i.e., every resource in every project reachable via the
+	// storage-scope ancestor-walk). Duplicate detection treats "*" as a literal
+	// string: two entries with identical (kind, project_name, name="*") triples
+	// are still duplicates and MUST be rejected by handlers (HOL-767 / ADR 029).
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	// project_name is the project that owns the target. Required for
-	// both PROJECT_TEMPLATE and DEPLOYMENT kinds — project-scope
-	// resources are disambiguated by (project_name, name). Left empty
-	// only on zero-valued UNSPECIFIED placeholders, which handlers MUST
-	// reject; UNSPECIFIED is not a legal resting state.
+	// project_name is the project that owns the target, or the literal string
+	// "*" to match targets across every project reachable via the binding's
+	// storage-scope ancestor-walk. Required (non-empty, non-wildcard) for both
+	// PROJECT_TEMPLATE and DEPLOYMENT kinds when naming a specific project;
+	// set to "*" when the intent is to apply the policy to every project in the
+	// binding's reachable scope. Left empty only on zero-valued UNSPECIFIED
+	// placeholders, which handlers MUST reject; UNSPECIFIED is not a legal
+	// resting state. Duplicate detection treats "*" as a literal string (HOL-767
+	// / ADR 029).
 	ProjectName   string `protobuf:"bytes,3,opt,name=project_name,json=projectName,proto3" json:"project_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -240,13 +249,18 @@ type TemplatePolicyBinding struct {
 	// binding references exactly one policy; use multiple bindings to
 	// attach multiple policies to overlapping target sets.
 	PolicyRef *LinkedTemplatePolicyRef `protobuf:"bytes,5,opt,name=policy_ref,json=policyRef,proto3" json:"policy_ref,omitempty"`
-	// target_refs enumerates every render target the referenced policy
-	// applies to. Order is not significant; duplicates MUST be rejected
-	// by handlers. A "duplicate" is two entries with identical
-	// (kind, project_name, name) triples. Two entries that share
-	// (project_name, name) but differ in kind (e.g., a PROJECT_TEMPLATE
-	// and a DEPLOYMENT with the same slug inside the same project) are
-	// permitted — they name distinct resources.
+	// target_refs enumerates every render target the referenced policy applies
+	// to. Order is not significant; duplicates MUST be rejected by handlers. A
+	// "duplicate" is two entries with identical (kind, project_name, name)
+	// triples — the literal string "*" is treated as a literal value for
+	// duplicate detection purposes. Two entries that share (project_name, name)
+	// but differ in kind (e.g., a PROJECT_TEMPLATE and a DEPLOYMENT with the
+	// same slug inside the same project) are permitted — they name distinct
+	// resources. The literal string "*" is a supported wildcard value on both
+	// `name` and `project_name` fields (HOL-767 / ADR 029 amendment): a
+	// project_name of "*" fans out to every project reachable via the binding's
+	// ancestor-walk; a name of "*" fans out to every resource of the given kind
+	// within the matched project(s).
 	TargetRefs []*TemplatePolicyBindingTargetRef `protobuf:"bytes,6,rep,name=target_refs,json=targetRefs,proto3" json:"target_refs,omitempty"`
 	// creator_email is the email address of the user who created this
 	// binding. Server-populated from the authenticated caller on Create;

--- a/proto/holos/console/v1/template_policy_bindings.proto
+++ b/proto/holos/console/v1/template_policy_bindings.proto
@@ -7,11 +7,13 @@ import "google/protobuf/timestamp.proto";
 option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;consolev1";
 
 // TemplatePolicyBindingService manages TemplatePolicyBinding resources, the
-// explicit, non-glob successor to TemplatePolicy's target-selector rules
-// (ADR 029 / HOL-590). A TemplatePolicyBinding names a single policy and
-// enumerates the project templates and deployments that policy applies to
-// via explicit TemplatePolicyBindingTargetRef entries — no wildcards, no
-// glob semantics. TemplatePolicy continues to declare the REQUIRE/EXCLUDE
+// explicit successor to TemplatePolicy's target-selector rules (ADR 029 /
+// HOL-590). A TemplatePolicyBinding names a single policy and enumerates the
+// project templates and deployments that policy applies to via
+// TemplatePolicyBindingTargetRef entries. The literal string "*" is supported
+// as a wildcard on both `name` and `project_name` fields (HOL-767 / ADR 029
+// amendment), meaning "match every resource of this kind within the binding's
+// reachable scope." TemplatePolicy continues to declare the REQUIRE/EXCLUDE
 // rules; TemplatePolicyBinding declares the set of targets those rules apply
 // to.
 //
@@ -94,13 +96,22 @@ enum TemplatePolicyBindingTargetKind {
 message TemplatePolicyBindingTargetRef {
   // kind discriminates between PROJECT_TEMPLATE and DEPLOYMENT targets.
   TemplatePolicyBindingTargetKind kind = 1;
-  // name is the target's DNS label slug within project_name.
+  // name is the target's DNS label slug within project_name, or the literal
+  // string "*" to match every resource of this kind within the binding's
+  // reachable scope (i.e., every resource in every project reachable via the
+  // storage-scope ancestor-walk). Duplicate detection treats "*" as a literal
+  // string: two entries with identical (kind, project_name, name="*") triples
+  // are still duplicates and MUST be rejected by handlers (HOL-767 / ADR 029).
   string name = 2;
-  // project_name is the project that owns the target. Required for
-  // both PROJECT_TEMPLATE and DEPLOYMENT kinds — project-scope
-  // resources are disambiguated by (project_name, name). Left empty
-  // only on zero-valued UNSPECIFIED placeholders, which handlers MUST
-  // reject; UNSPECIFIED is not a legal resting state.
+  // project_name is the project that owns the target, or the literal string
+  // "*" to match targets across every project reachable via the binding's
+  // storage-scope ancestor-walk. Required (non-empty, non-wildcard) for both
+  // PROJECT_TEMPLATE and DEPLOYMENT kinds when naming a specific project;
+  // set to "*" when the intent is to apply the policy to every project in the
+  // binding's reachable scope. Left empty only on zero-valued UNSPECIFIED
+  // placeholders, which handlers MUST reject; UNSPECIFIED is not a legal
+  // resting state. Duplicate detection treats "*" as a literal string (HOL-767
+  // / ADR 029).
   string project_name = 3;
 }
 
@@ -126,13 +137,18 @@ message TemplatePolicyBinding {
   // binding references exactly one policy; use multiple bindings to
   // attach multiple policies to overlapping target sets.
   LinkedTemplatePolicyRef policy_ref = 5;
-  // target_refs enumerates every render target the referenced policy
-  // applies to. Order is not significant; duplicates MUST be rejected
-  // by handlers. A "duplicate" is two entries with identical
-  // (kind, project_name, name) triples. Two entries that share
-  // (project_name, name) but differ in kind (e.g., a PROJECT_TEMPLATE
-  // and a DEPLOYMENT with the same slug inside the same project) are
-  // permitted — they name distinct resources.
+  // target_refs enumerates every render target the referenced policy applies
+  // to. Order is not significant; duplicates MUST be rejected by handlers. A
+  // "duplicate" is two entries with identical (kind, project_name, name)
+  // triples — the literal string "*" is treated as a literal value for
+  // duplicate detection purposes. Two entries that share (project_name, name)
+  // but differ in kind (e.g., a PROJECT_TEMPLATE and a DEPLOYMENT with the
+  // same slug inside the same project) are permitted — they name distinct
+  // resources. The literal string "*" is a supported wildcard value on both
+  // `name` and `project_name` fields (HOL-767 / ADR 029 amendment): a
+  // project_name of "*" fans out to every project reachable via the binding's
+  // ancestor-walk; a name of "*" fans out to every resource of the given kind
+  // within the matched project(s).
   repeated TemplatePolicyBindingTargetRef target_refs = 6;
   // creator_email is the email address of the user who created this
   // binding. Server-populated from the authenticated caller on Create;


### PR DESCRIPTION
## Summary

- Removes "no wildcards, no glob semantics" language from the `TemplatePolicyBindingService` proto doc comment
- Updates field comments on `TemplatePolicyBindingTargetRef.name` and `.project_name` to document that the literal string `"*"` is a supported wildcard value meaning "match every resource of this kind within the binding's reachable scope"
- Updates the `target_refs` field comment on `TemplatePolicyBinding` to reference wildcard semantics and clarify that duplicate detection treats `"*"` as a literal string
- Regenerates `gen/holos/console/v1/template_policy_bindings.pb.go`, `frontend/src/gen/holos/console/v1/template_policy_bindings_pb.d.ts`, and `_pb.js` via `make generate`
- No field types, message shapes, wire numbers, or enum values changed

Fixes HOL-769

## Test plan

- [x] `make generate` succeeds without errors
- [x] `make test-go` passes (full Go suite green)
- [x] `make test-ui` passes (78 test files, 1022 tests green)
- [x] Proto field types and wire numbers unchanged (comments-only change)

## Notes

The companion ADR 029 amendment is in a separate PR against `holos-run/holos-console-docs` on the same branch name. Both PRs are part of HOL-769 (Phase 1 of HOL-767).