### PR TITLE
fix(frontend): address HOL-746 style review findings from PR #1060

### DIFF
--- a/frontend/src/components/service-status-panel.tsx
+++ b/frontend/src/components/service-status-panel.tsx
@@ -62,7 +62,7 @@ function StatusRow({
       <TooltipTrigger asChild>
         <button
           type="button"
-          className="cursor-help border-b border-dotted border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded bg-transparent p-0 font-inherit text-inherit"
+          className="cursor-help border-b border-dotted border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded bg-transparent p-0"
         >
           {name}
         </button>

--- a/frontend/src/components/service-status-panel.tsx
+++ b/frontend/src/components/service-status-panel.tsx
@@ -60,13 +60,12 @@ function StatusRow({
   const labelNode = tooltip ? (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span
-          tabIndex={0}
-          role="button"
-          className="cursor-help border-b border-dotted border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        <button
+          type="button"
+          className="cursor-help border-b border-dotted border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded bg-transparent p-0 font-inherit text-inherit"
         >
           {name}
-        </span>
+        </button>
       </TooltipTrigger>
       <TooltipContent>{tooltip}</TooltipContent>
     </Tooltip>

--- a/frontend/src/routes/_authenticated/projects/$projectName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/-index.test.tsx
@@ -230,14 +230,15 @@ describe('ProjectIndexPage', () => {
   it('makes the dependency tooltip triggers keyboard-focusable', () => {
     setup([])
     render(<ProjectIndexPage projectName="my-project" />)
-    // The dependency rows use role=button triggers so keyboard-only
-    // users can reach the "Planned: …" explanation.
+    // The dependency rows use native <button> triggers so keyboard-only
+    // users can reach the "Planned: …" explanation without requiring
+    // explicit tabIndex — buttons are focusable by default.
     const triggers = screen.getAllByRole('button', {
       name: /(database|identity provider)/i,
     })
     expect(triggers.length).toBe(2)
     for (const t of triggers) {
-      expect(t).toHaveAttribute('tabindex', '0')
+      expect(t.tagName).toBe('BUTTON')
     }
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/index.tsx
@@ -21,8 +21,6 @@ function ProjectIndexRoute() {
 }
 
 export function ProjectIndexPage({ projectName }: { projectName: string }) {
-  if (!projectName) return null
-
   const {
     data: deployments = [],
     isPending: deploymentsPending,
@@ -31,6 +29,10 @@ export function ProjectIndexPage({ projectName }: { projectName: string }) {
   const { data: project } = useGetProject(projectName)
   const userRole = project?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // projectName is always non-empty under /_authenticated/projects/$projectName/,
+  // but guard defensively so the hooks above can still be called unconditionally.
+  if (!projectName) return null
 
   return (
     <div className="space-y-4">

--- a/frontend/src/routes/_authenticated/projects/$projectName/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/index.tsx
@@ -20,17 +20,8 @@ function ProjectIndexRoute() {
   return <ProjectIndexPage projectName={projectName} />
 }
 
-export function ProjectIndexPage({
-  projectName: propProjectName,
-}: { projectName?: string } = {}) {
-  let routeProjectName: string | undefined
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    routeProjectName = Route.useParams().projectName
-  } catch {
-    routeProjectName = undefined
-  }
-  const projectName = propProjectName ?? routeProjectName ?? ''
+export function ProjectIndexPage({ projectName }: { projectName: string }) {
+  if (!projectName) return null
 
   const {
     data: deployments = [],
@@ -47,7 +38,7 @@ export function ProjectIndexPage({
         projectName={projectName}
         deployments={deployments}
         isPending={deploymentsPending}
-        error={deploymentsError ?? null}
+        error={deploymentsError}
         canWrite={canWrite}
       />
       <QuotaPlaceholder />


### PR DESCRIPTION
## Summary

- Convert tooltip trigger `<span role="button" tabIndex={0}>` to a native `<button type="button">` in `service-status-panel.tsx` for correct keyboard semantics (resolves the `role="button"` semantic stretch and the competing AT naming between `<li aria-label>` and the span trigger)
- Refactor `ProjectIndexPage` to accept `{ projectName: string }` as a pure-props component; `ProjectIndexRoute` remains the sole caller of `Route.useParams()`, removing the `try/catch` dual-entry pattern
- Add a defensive `if (!projectName) return null` guard to prevent an indefinitely-pending query on the empty-string edge case
- Remove the redundant `deploymentsError ?? null` (React Query v5 error is already `Error | null`)
- Update the tooltip focusability test to assert `tagName === 'BUTTON'` rather than an explicit `tabindex` attribute (native buttons are focusable without it)

Fixes HOL-746

## Test plan

- [ ] `make test-ui` passes all 1023 tests
- [ ] Keyboard-navigate to the Service Status panel: Database and Identity Provider rows should be focusable and show tooltips on focus/hover
- [ ] Project index page loads normally via the route