### PR TITLE
feat(policyresolver): accept `*` in target_refs for name/project_name

### DIFF
--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -363,11 +363,11 @@ type policyKey struct {
 	name      string
 }
 
-// wildcardAny is the literal string used in TemplatePolicyBindingTargetRef
+// WildcardAny is the literal string used in TemplatePolicyBindingTargetRef
 // `name` and `project_name` fields to match every resource of the given kind
-// within the binding's storage-scope ancestor-walk. Defined here so the
-// resolver, the handler validator (HOL-772), and any future UI affordance
-// (HOL-773) reference the same symbol rather than re-spelling "*" inline.
+// within the binding's storage-scope ancestor-walk. Exported so the handler
+// validator (HOL-772) and any future cross-package consumer can reference
+// the same symbol rather than re-spelling "*" inline.
 //
 // The wildcard is *only* recognized on `name` and `project_name`. The `kind`
 // field is never wildcarded — a `kind: DEPLOYMENT` ref never matches a
@@ -377,7 +377,7 @@ type policyKey struct {
 // Wildcard reach is capped by storage scope: a binding stored in folder `F`
 // only sees resources reachable from `F` via the ancestor walk. Wildcards
 // change matching, not evaluation reach (ancestor_bindings.go is unchanged).
-const wildcardAny = "*"
+const WildcardAny = "*"
 
 // bindingAppliesTo reports whether any of a binding's target_refs selects
 // the render target at `(project, targetKind, targetName)`. Match semantics
@@ -432,7 +432,7 @@ func bindingAppliesTo(b *ResolvedBinding, project string, targetKind TargetKind,
 }
 
 // nameMatches returns true when the ref-side value selects the target value.
-// The literal wildcardAny ("*") matches any *non-empty* target value. Exact
+// The literal WildcardAny ("*") matches any *non-empty* target value. Exact
 // string equality covers every other case. Both arguments are compared as-is
 // — no glob, regex, or case folding (ADR 029).
 //
@@ -446,7 +446,7 @@ func bindingAppliesTo(b *ResolvedBinding, project string, targetKind TargetKind,
 // `""` on the binding side (non-empty DNS labels are required), so this
 // branch never rejects a legitimate binding.
 func nameMatches(refValue, targetValue string) bool {
-	if refValue == wildcardAny {
+	if refValue == WildcardAny {
 		return targetValue != ""
 	}
 	return refValue == targetValue

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -432,12 +432,22 @@ func bindingAppliesTo(b *ResolvedBinding, project string, targetKind TargetKind,
 }
 
 // nameMatches returns true when the ref-side value selects the target value.
-// The literal wildcardAny ("*") matches any non-empty target value. Exact
+// The literal wildcardAny ("*") matches any *non-empty* target value. Exact
 // string equality covers every other case. Both arguments are compared as-is
 // — no glob, regex, or case folding (ADR 029).
+//
+// The non-empty requirement is load-bearing: when Resolve cannot derive a
+// project slug from the render-target namespace (e.g., an org- or folder-
+// scope template preview, or a ProjectFromNamespace failure) it passes
+// `project = ""` through here. Allowing `name="*"` / `project_name="*"` to
+// match an empty target would silently inject rules into a render that has
+// no project to attach them to, contradicting the HOL-554 storage-isolation
+// guardrail the resolver is meant to uphold. The handler also never stores
+// `""` on the binding side (non-empty DNS labels are required), so this
+// branch never rejects a legitimate binding.
 func nameMatches(refValue, targetValue string) bool {
 	if refValue == wildcardAny {
-		return true
+		return targetValue != ""
 	}
 	return refValue == targetValue
 }

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -363,19 +363,40 @@ type policyKey struct {
 	name      string
 }
 
+// wildcardAny is the literal string used in TemplatePolicyBindingTargetRef
+// `name` and `project_name` fields to match every resource of the given kind
+// within the binding's storage-scope ancestor-walk. Defined here so the
+// resolver, the handler validator (HOL-772), and any future UI affordance
+// (HOL-773) reference the same symbol rather than re-spelling "*" inline.
+//
+// The wildcard is *only* recognized on `name` and `project_name`. The `kind`
+// field is never wildcarded — a `kind: DEPLOYMENT` ref never matches a
+// `PROJECT_TEMPLATE` target (and vice versa). See ADR 029 (target-refs
+// wildcards) and the proto comments on TemplatePolicyBindingTargetRef.
+//
+// Wildcard reach is capped by storage scope: a binding stored in folder `F`
+// only sees resources reachable from `F` via the ancestor walk. Wildcards
+// change matching, not evaluation reach (ancestor_bindings.go is unchanged).
+const wildcardAny = "*"
+
 // bindingAppliesTo reports whether any of a binding's target_refs selects
 // the render target at `(project, targetKind, targetName)`. Match semantics
-// (AC bullet in HOL-596):
+// (AC bullet in HOL-596, amended by HOL-767 / ADR 029):
 //
 //   - kind=PROJECT_TEMPLATE: matches when the render target is a
-//     project-scope template with the same name AND the binding's
-//     project_name equals the target's project name. The proto contract
-//     (HOL-593) requires project_name on PROJECT_TEMPLATE target refs;
-//     binding handlers reject empty project_name on create/update, so
-//     the match is sound.
-//   - kind=DEPLOYMENT: matches when the render target is a Deployment
-//     with the same name AND the binding's project_name equals the
-//     target's project name.
+//     project-scope template whose name equals tr.name OR tr.name is
+//     the wildcard "*", AND whose project equals tr.project_name OR
+//     tr.project_name is the wildcard "*". The proto contract (HOL-593)
+//     requires project_name on PROJECT_TEMPLATE target refs; binding
+//     handlers reject empty project_name on create/update.
+//   - kind=DEPLOYMENT: same name/project_name semantics as
+//     PROJECT_TEMPLATE.
+//
+// `kind` is never wildcarded. A `kind: DEPLOYMENT` ref never matches a
+// `PROJECT_TEMPLATE` target. The wildcard's reach is bounded by the binding's
+// storage-scope ancestor walk (unchanged in ancestor_bindings.go), so a
+// folder-scope binding with `{project: "*", name: "*"}` only matches
+// resources reachable from that folder.
 //
 // A binding with no target_refs never matches (correctly — an empty target
 // list declares intent to attach zero render targets).
@@ -399,15 +420,26 @@ func bindingAppliesTo(b *ResolvedBinding, project string, targetKind TargetKind,
 		if tr.GetKind() != wantKind {
 			continue
 		}
-		if tr.GetName() != targetName {
+		if !nameMatches(tr.GetName(), targetName) {
 			continue
 		}
-		if tr.GetProjectName() != project {
+		if !nameMatches(tr.GetProjectName(), project) {
 			continue
 		}
 		return true
 	}
 	return false
+}
+
+// nameMatches returns true when the ref-side value selects the target value.
+// The literal wildcardAny ("*") matches any non-empty target value. Exact
+// string equality covers every other case. Both arguments are compared as-is
+// — no glob, regex, or case folding (ADR 029).
+func nameMatches(refValue, targetValue string) bool {
+	if refValue == wildcardAny {
+		return true
+	}
+	return refValue == targetValue
 }
 
 // RefKey is the dedup/comparison key for a LinkedTemplateRef. Exposed so

--- a/console/policyresolver/folder_resolver_bindings_test.go
+++ b/console/policyresolver/folder_resolver_bindings_test.go
@@ -224,7 +224,7 @@ func TestFolderResolver_BindingProjectNameMismatchContributesNothing(t *testing.
 }
 
 // TestBindingAppliesTo_Wildcards exercises every
-// `{name, project_name} × {literal, wildcardAny}` combination across both
+// `{name, project_name} × {literal, WildcardAny}` combination across both
 // PROJECT_TEMPLATE and DEPLOYMENT kinds and asserts:
 //
 //   - literal/literal is a regression guard (exact match).

--- a/console/policyresolver/folder_resolver_bindings_test.go
+++ b/console/policyresolver/folder_resolver_bindings_test.go
@@ -222,3 +222,314 @@ func TestFolderResolver_BindingProjectNameMismatchContributesNothing(t *testing.
 		t.Errorf("expected no refs when binding names a different project, got %v", refNames(got))
 	}
 }
+
+// TestBindingAppliesTo_Wildcards exercises every
+// `{name, project_name} × {literal, wildcardAny}` combination across both
+// PROJECT_TEMPLATE and DEPLOYMENT kinds and asserts:
+//
+//   - literal/literal is a regression guard (exact match).
+//   - name="*" matches any target name within the same project.
+//   - project_name="*" matches any project for the same target name.
+//   - name="*" AND project_name="*" matches every resource of the given kind.
+//   - `kind` is never wildcarded: a DEPLOYMENT ref never matches a
+//     PROJECT_TEMPLATE target and vice-versa.
+//
+// This is a direct unit test of the match function rather than going through
+// Resolve: it keeps the match-logic AC bullets in HOL-770 on a tight feedback
+// loop and surfaces regressions in a single file when either the sentinel or
+// the comparison strategy drifts. The folder cascade behavior is covered
+// separately below.
+func TestBindingAppliesTo_Wildcards(t *testing.T) {
+	type wantMatch struct {
+		project    string
+		targetKind TargetKind
+		targetName string
+		match      bool
+	}
+
+	projectTemplateRef := func(project, name string) *consolev1.TemplatePolicyBindingTargetRef {
+		return &consolev1.TemplatePolicyBindingTargetRef{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+			Name:        name,
+			ProjectName: project,
+		}
+	}
+	deploymentRef := func(project, name string) *consolev1.TemplatePolicyBindingTargetRef {
+		return &consolev1.TemplatePolicyBindingTargetRef{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+			Name:        name,
+			ProjectName: project,
+		}
+	}
+
+	tests := []struct {
+		name  string
+		refs  []*consolev1.TemplatePolicyBindingTargetRef
+		cases []wantMatch
+	}{
+		// --- PROJECT_TEMPLATE kind ---
+		{
+			name: "project_template literal name and project",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{projectTemplateRef("acme-prod", "web")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: true},
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "api", match: false},
+				{project: "other-project", targetKind: TargetKindProjectTemplate, targetName: "web", match: false},
+				// kind mismatch — never matches, even when name+project align.
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: false},
+			},
+		},
+		{
+			name: "project_template wildcard name matches every name in project",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{projectTemplateRef("acme-prod", "*")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: true},
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "api", match: true},
+				{project: "other-project", targetKind: TargetKindProjectTemplate, targetName: "web", match: false},
+				// kind mismatch — never matches.
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: false},
+			},
+		},
+		{
+			name: "project_template wildcard project matches every project with named template",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{projectTemplateRef("*", "web")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: true},
+				{project: "other-project", targetKind: TargetKindProjectTemplate, targetName: "web", match: true},
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "api", match: false},
+				// kind mismatch — never matches.
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: false},
+			},
+		},
+		{
+			name: "project_template wildcard name and project matches every template",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{projectTemplateRef("*", "*")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: true},
+				{project: "other-project", targetKind: TargetKindProjectTemplate, targetName: "api", match: true},
+				// kind mismatch — {*, *} still doesn't bleed across kinds.
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: false},
+				{project: "other-project", targetKind: TargetKindDeployment, targetName: "api", match: false},
+			},
+		},
+		// --- DEPLOYMENT kind ---
+		{
+			name: "deployment literal name and project",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{deploymentRef("acme-prod", "web")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: true},
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "api", match: false},
+				{project: "other-project", targetKind: TargetKindDeployment, targetName: "web", match: false},
+				// kind mismatch — never matches.
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: false},
+			},
+		},
+		{
+			name: "deployment wildcard name matches every deployment in project",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{deploymentRef("acme-prod", "*")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: true},
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "api", match: true},
+				{project: "other-project", targetKind: TargetKindDeployment, targetName: "web", match: false},
+				// kind mismatch — never matches.
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: false},
+			},
+		},
+		{
+			name: "deployment wildcard project matches every project with named deployment",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{deploymentRef("*", "web")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: true},
+				{project: "other-project", targetKind: TargetKindDeployment, targetName: "web", match: true},
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "api", match: false},
+				// kind mismatch — never matches.
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: false},
+			},
+		},
+		{
+			name: "deployment wildcard name and project matches every deployment",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{deploymentRef("*", "*")},
+			cases: []wantMatch{
+				{project: "acme-prod", targetKind: TargetKindDeployment, targetName: "web", match: true},
+				{project: "other-project", targetKind: TargetKindDeployment, targetName: "api", match: true},
+				// kind mismatch — {*, *} still doesn't bleed across kinds.
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: false},
+				{project: "other-project", targetKind: TargetKindProjectTemplate, targetName: "api", match: false},
+			},
+		},
+		// --- Multi-ref: wildcard must not short-circuit a following literal
+		// refusal and vice versa. The first matching ref wins; a wildcard
+		// ref that doesn't match the queried kind must fall through to the
+		// next ref in the slice.
+		{
+			name: "multi-ref deployment wildcard plus project_template literal",
+			refs: []*consolev1.TemplatePolicyBindingTargetRef{
+				deploymentRef("*", "*"),
+				projectTemplateRef("acme-prod", "web"),
+			},
+			cases: []wantMatch{
+				// First ref (deployment wildcard) skipped for PROJECT_TEMPLATE
+				// queries; second ref (literal) matches the named template.
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "web", match: true},
+				// Second ref doesn't match a different name; first ref's
+				// wildcard was the wrong kind — so no match.
+				{project: "acme-prod", targetKind: TargetKindProjectTemplate, targetName: "api", match: false},
+				// First ref (deployment wildcard) matches any deployment.
+				{project: "other-project", targetKind: TargetKindDeployment, targetName: "api", match: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			b := &ResolvedBinding{
+				Name:       "wildcard-test",
+				Namespace:  "holos-org-acme",
+				TargetRefs: tc.refs,
+			}
+			for _, c := range tc.cases {
+				got := bindingAppliesTo(b, c.project, c.targetKind, c.targetName)
+				if got != c.match {
+					t.Errorf("bindingAppliesTo(project=%q, kind=%v, name=%q) = %v, want %v",
+						c.project, c.targetKind, c.targetName, got, c.match)
+				}
+			}
+		})
+	}
+}
+
+// TestBindingAppliesTo_NilAndEmptyRefs asserts the defensive rejects:
+// a nil binding, a binding with no TargetRefs, and a binding whose
+// TargetRefs slice contains a nil entry all degrade to "no match"
+// without panic. The zero-value kind (UNSPECIFIED) never matches
+// either of the two concrete TargetKinds the resolver queries.
+func TestBindingAppliesTo_NilAndEmptyRefs(t *testing.T) {
+	if bindingAppliesTo(nil, "acme-prod", TargetKindDeployment, "web") {
+		t.Error("nil binding must not match")
+	}
+	empty := &ResolvedBinding{Name: "empty", Namespace: "holos-org-acme"}
+	if bindingAppliesTo(empty, "acme-prod", TargetKindDeployment, "web") {
+		t.Error("binding with nil TargetRefs must not match")
+	}
+	withNilEntry := &ResolvedBinding{
+		Name:       "nil-entry",
+		Namespace:  "holos-org-acme",
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{nil},
+	}
+	if bindingAppliesTo(withNilEntry, "acme-prod", TargetKindDeployment, "web") {
+		t.Error("binding with a nil TargetRef entry must not match")
+	}
+	// Zero-value (UNSPECIFIED) kind with wildcard name and project must
+	// still not match either of the two concrete render-target kinds.
+	zeroKind := &ResolvedBinding{
+		Name:      "zero-kind",
+		Namespace: "holos-org-acme",
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_UNSPECIFIED,
+			Name:        "*",
+			ProjectName: "*",
+		}},
+	}
+	if bindingAppliesTo(zeroKind, "acme-prod", TargetKindDeployment, "web") {
+		t.Error("UNSPECIFIED target kind must not match DEPLOYMENT")
+	}
+	if bindingAppliesTo(zeroKind, "acme-prod", TargetKindProjectTemplate, "web") {
+		t.Error("UNSPECIFIED target kind must not match PROJECT_TEMPLATE")
+	}
+}
+
+// TestFolderResolver_WildcardBindingFolderCascade asserts that a binding
+// at folder `team-a` with `{project: "*", name: "*"}` matches resources
+// in projects under team-a (roses) but does NOT escape to projects under
+// a sibling folder (lilies under eng) or to projects directly under the
+// org (orchids).
+//
+// The ancestor walk caps wildcard reach: when resolving for lilies the
+// walk visits lilies → eng → org; the team-a folder is never traversed,
+// so its `{*, *}` binding is never even seen. The wildcard changes
+// *matching* inside the binding's storage scope, not the storage scope
+// itself (HOL-770 AC; ADR 029 "storage scope bounds reach" bullet).
+func TestFolderResolver_WildcardBindingFolderCascade(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	policies := map[string][]templatesv1alpha1.TemplatePolicy{
+		ns["folderTeamA"]: {
+			policyCRD(ns["folderTeamA"], "team-a-audit", []templatesv1alpha1.TemplatePolicyRule{
+				requireRuleCRD(v1alpha2.TemplateScopeFolder, "team-a", "team-a-audit"),
+			}),
+		},
+	}
+	// Binding at team-a folder with full wildcard on both fields for
+	// DEPLOYMENT. Should match any deployment reachable through the
+	// team-a namespace's ancestor walk — i.e., deployments in projects
+	// directly under team-a. Projects under sibling folders or under
+	// org directly never walk through team-a, so they must not see it.
+	bindings := map[string][]templatesv1alpha1.TemplatePolicyBinding{
+		ns["folderTeamA"]: {
+			bindingCRD(ns["folderTeamA"], "team-a-wildcard",
+				folderPolicyRefCRD("team-a", "team-a-audit"),
+				[]templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+					Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+					Name:        "*",
+					ProjectName: "*",
+				}},
+			),
+		},
+	}
+	pl := &policyListerFromClient{items: policies}
+	bl := &bindingListerFromMap{items: bindings}
+	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
+
+	ctx := context.Background()
+
+	// projectRoses is directly under team-a: the wildcard binding MUST
+	// select every deployment in roses.
+	got, err := fr.Resolve(ctx, ns["projectRoses"], TargetKindDeployment, "api", nil)
+	if err != nil {
+		t.Fatalf("Resolve(roses/api): %v", err)
+	}
+	if names := refNames(got); len(names) != 1 || names[0] != "team-a-audit" {
+		t.Errorf("roses/api: expected [team-a-audit], got %v", names)
+	}
+	// Same project, a *different* deployment name — wildcard means both
+	// match; this is the "doesn't accidentally pin to one name" check.
+	got, err = fr.Resolve(ctx, ns["projectRoses"], TargetKindDeployment, "web", nil)
+	if err != nil {
+		t.Fatalf("Resolve(roses/web): %v", err)
+	}
+	if names := refNames(got); len(names) != 1 || names[0] != "team-a-audit" {
+		t.Errorf("roses/web: expected [team-a-audit], got %v", names)
+	}
+
+	// projectLilies is under eng (sibling of team-a): team-a's binding
+	// is NOT on its ancestor chain, so even `{*, *}` must not match.
+	got, err = fr.Resolve(ctx, ns["projectLilies"], TargetKindDeployment, "api", nil)
+	if err != nil {
+		t.Fatalf("Resolve(lilies/api): %v", err)
+	}
+	if names := refNames(got); len(names) != 0 {
+		t.Errorf("lilies/api: sibling-folder wildcard leaked; got %v, want empty", names)
+	}
+
+	// projectOrchids is directly under org (skips eng and team-a
+	// entirely): team-a's binding is not on this chain either.
+	got, err = fr.Resolve(ctx, ns["projectOrchids"], TargetKindDeployment, "api", nil)
+	if err != nil {
+		t.Fatalf("Resolve(orchids/api): %v", err)
+	}
+	if names := refNames(got); len(names) != 0 {
+		t.Errorf("orchids/api: org-sibling wildcard leaked; got %v, want empty", names)
+	}
+
+	// A PROJECT_TEMPLATE render target in roses must NOT be matched by
+	// the DEPLOYMENT `{*, *}` binding — kind is never wildcarded.
+	got, err = fr.Resolve(ctx, ns["projectRoses"], TargetKindProjectTemplate, "any", nil)
+	if err != nil {
+		t.Fatalf("Resolve(roses/project-template): %v", err)
+	}
+	if names := refNames(got); len(names) != 0 {
+		t.Errorf("roses/project-template: DEPLOYMENT {*,*} must not match PROJECT_TEMPLATE; got %v", names)
+	}
+}

--- a/console/policyresolver/folder_resolver_bindings_test.go
+++ b/console/policyresolver/folder_resolver_bindings_test.go
@@ -399,6 +399,71 @@ func TestBindingAppliesTo_Wildcards(t *testing.T) {
 	}
 }
 
+// TestBindingAppliesTo_WildcardRejectsEmptyTargetValue pins the HOL-554
+// storage-isolation guardrail under the new wildcard semantics: when
+// Resolve cannot derive a project slug from the render-target namespace
+// (e.g., ProjectFromNamespace fails and the call site passes `project = ""`
+// through to bindingAppliesTo), a binding whose `project_name` is the
+// wildcard must NOT match the empty target. Same for `name`. Without this
+// guard, a wildcard binding would silently cover render targets that have
+// no project to attach to.
+func TestBindingAppliesTo_WildcardRejectsEmptyTargetValue(t *testing.T) {
+	wildcardBoth := &ResolvedBinding{
+		Name:      "wildcard-both",
+		Namespace: "holos-org-acme",
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+			Name:        "*",
+			ProjectName: "*",
+		}},
+	}
+
+	// Empty project: simulates Resolve's fallback when
+	// ProjectFromNamespace returns an error. A `{*, *}` binding must not
+	// match this "no project" case.
+	if bindingAppliesTo(wildcardBoth, "", TargetKindDeployment, "api") {
+		t.Error("wildcard project_name must not match empty project value (ProjectFromNamespace failure)")
+	}
+	// Empty target name: the handler never stores an empty Name on the
+	// render-target side, but the resolver is called through multiple
+	// layers; belt-and-suspenders check that `name="*"` doesn't match
+	// a caller that forgot to populate targetName either.
+	if bindingAppliesTo(wildcardBoth, "acme-prod", TargetKindDeployment, "") {
+		t.Error("wildcard name must not match empty targetName")
+	}
+	// Both empty: certainly must not match.
+	if bindingAppliesTo(wildcardBoth, "", TargetKindDeployment, "") {
+		t.Error("wildcard must not match both-empty target")
+	}
+
+	// Sanity check: a single-field wildcard still rejects the empty
+	// counterpart on the other axis too.
+	wildcardProjectOnly := &ResolvedBinding{
+		Name:      "wildcard-project",
+		Namespace: "holos-org-acme",
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+			Name:        "web",
+			ProjectName: "*",
+		}},
+	}
+	if bindingAppliesTo(wildcardProjectOnly, "", TargetKindDeployment, "web") {
+		t.Error("wildcard project_name must not match empty project even when name matches literally")
+	}
+	wildcardNameOnly := &ResolvedBinding{
+		Name:      "wildcard-name",
+		Namespace: "holos-org-acme",
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+			Name:        "*",
+			ProjectName: "acme-prod",
+		}},
+	}
+	if bindingAppliesTo(wildcardNameOnly, "acme-prod", TargetKindDeployment, "") {
+		t.Error("wildcard name must not match empty targetName even when project matches literally")
+	}
+}
+
 // TestBindingAppliesTo_NilAndEmptyRefs asserts the defensive rejects:
 // a nil binding, a binding with no TargetRefs, and a binding whose
 // TargetRefs slice contains a nil entry all degrade to "no match"


### PR DESCRIPTION
## Summary

- Phase 2 of HOL-767: teach `console/policyresolver/folder_resolver.go:bindingAppliesTo` to accept the literal string `*` in a `TemplatePolicyBindingTargetRef`'s `name` and `project_name` fields. Extracted the sentinel as package-level `const wildcardAny = "*"` so Phase 3 (HOL-772) and Phase 4 (HOL-773) can reference the same symbol.
- `kind` remains non-wildcarded: a `DEPLOYMENT` ref never matches a `PROJECT_TEMPLATE` target and vice versa. `ancestor_bindings.go` is untouched, so wildcard reach stays capped by the binding's storage-scope ancestor walk.
- New table-driven tests in `folder_resolver_bindings_test.go` cover every `{name, project_name} × {literal, *}` combo for both kinds, defensive rejects (nil binding, nil ref entry, zero-value UNSPECIFIED kind), a multi-ref short-circuit regression, and an end-to-end folder-cascade test that seats a `{*, *}` binding at folder team-a and asserts it matches roses (descendant) while never leaking to lilies (sibling folder) or orchids (under org).

This phase is resolver-only — the binding handler still rejects `*` at admission, so the feature is not yet user-reachable. The handler gate opens in Phase 3 (HOL-772).

Fixes HOL-770

## Test plan

- [x] `go test ./console/policyresolver/...` passes (all new + existing tests green).
- [x] `go vet ./console/policyresolver/...` clean.
- [x] New `TestBindingAppliesTo_Wildcards`, `TestBindingAppliesTo_NilAndEmptyRefs`, and `TestFolderResolver_WildcardBindingFolderCascade` each run green individually.
- [ ] Full `make test-go` run green in CI (local run on main shows pre-existing `console/TestScripts/grpc_reflection` and `.../version` race-detection flakes unrelated to this PR — port-binding conflicts in ephemeral testscripts).