### PR TITLE
feat(frontend): wire ResourceTypeIcon into Resources index table and breadcrumb

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/resources/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/resources/-index.test.tsx
@@ -110,7 +110,10 @@ describe('ResourcesIndexPage', () => {
     expect(rows).toHaveLength(3)
 
     expect(within(rows[1]).getByText('Folder')).toBeInTheDocument()
+    expect(within(rows[1]).getByTestId('resource-type-icon-folder')).toBeInTheDocument()
+
     expect(within(rows[2]).getByText('Project')).toBeInTheDocument()
+    expect(within(rows[2]).getByTestId('resource-type-icon-project')).toBeInTheDocument()
   })
 
   it('renders clickable path elements with correct hrefs and slug titles', () => {
@@ -122,13 +125,20 @@ describe('ResourcesIndexPage', () => {
     expect(orgLink).toHaveAttribute('href', '/orgs/test-org')
     expect(orgLink).toHaveAttribute('title', 'test-org')
 
-    const folderLink = screen.getByRole('link', { name: 'Team A' })
+    const folderLink = screen.getByRole('link', { name: /Team A/ })
     expect(folderLink).toHaveAttribute('href', '/folders/team-a')
     expect(folderLink).toHaveAttribute('title', 'team-a')
+    // Folder ancestor link shows the folder icon; org root (UNSPECIFIED) does not
+    expect(within(folderLink).getByTestId('resource-type-icon-folder')).toBeInTheDocument()
+    expect(screen.queryByTestId('resource-type-icon-folder')).toBeInTheDocument()
 
     const leafLink = screen.getByRole('link', { name: 'Web App' })
     expect(leafLink).toHaveAttribute('href', '/projects/web')
     expect(leafLink).toHaveAttribute('title', 'web')
+
+    // Org root link should NOT contain any resource-type icon (UNSPECIFIED → null)
+    expect(within(orgLink).queryByTestId('resource-type-icon-folder')).not.toBeInTheDocument()
+    expect(within(orgLink).queryByTestId('resource-type-icon-project')).not.toBeInTheDocument()
   })
 
   it('routes folder leaves to the canonical folder detail URL', () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/resources/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/resources/-index.test.tsx
@@ -130,7 +130,6 @@ describe('ResourcesIndexPage', () => {
     expect(folderLink).toHaveAttribute('title', 'team-a')
     // Folder ancestor link shows the folder icon; org root (UNSPECIFIED) does not
     expect(within(folderLink).getByTestId('resource-type-icon-folder')).toBeInTheDocument()
-    expect(screen.queryByTestId('resource-type-icon-folder')).toBeInTheDocument()
 
     const leafLink = screen.getByRole('link', { name: 'Web App' })
     expect(leafLink).toHaveAttribute('href', '/projects/web')

--- a/frontend/src/routes/_authenticated/orgs/$orgName/resources/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/resources/index.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
+import { ResourceTypeIcon } from '@/components/resource-type-icon'
 import { useListResources } from '@/queries/resources'
 import {
   ResourceType,
@@ -34,10 +35,20 @@ const columnHelper = createColumnHelper<Resource>()
 
 function typeBadge(type: ResourceType) {
   if (type === ResourceType.FOLDER) {
-    return <Badge variant="outline">Folder</Badge>
+    return (
+      <Badge variant="outline" className="inline-flex items-center gap-1.5">
+        <ResourceTypeIcon type={type} className="h-3.5 w-3.5" />
+        Folder
+      </Badge>
+    )
   }
   if (type === ResourceType.PROJECT) {
-    return <Badge variant="outline">Project</Badge>
+    return (
+      <Badge variant="outline" className="inline-flex items-center gap-1.5">
+        <ResourceTypeIcon type={type} className="h-3.5 w-3.5" />
+        Project
+      </Badge>
+    )
   }
   // The server contract forbids UNSPECIFIED entries. Render a destructive
   // badge so the backend bug is visible instead of blending in.
@@ -85,8 +96,9 @@ function PathCell({ resource }: { resource: Resource }) {
                 to="/folders/$folderName"
                 params={{ folderName: element.name }}
                 title={element.name}
-                className="hover:underline text-muted-foreground"
+                className="inline-flex items-center gap-1 hover:underline text-muted-foreground"
               >
+                <ResourceTypeIcon type={element.type} className="h-3.5 w-3.5 opacity-70" />
                 {display}
               </Link>
             )}


### PR DESCRIPTION
## Summary

- Import `ResourceTypeIcon` (added in HOL-782) into the Resources index page
- Update `typeBadge()` to compose the icon inside each `<Badge>` using `inline-flex items-center gap-1.5` with icon sized at `h-3.5 w-3.5` for compact badge fit
- Update `PathCell` to render `ResourceTypeIcon` next to each non-root folder ancestor link; the org root (UNSPECIFIED) renders `null` per the component contract so no empty span leaks
- Extend the "renders a row for each resource with the correct type badge" test to assert `resource-type-icon-folder` and `resource-type-icon-project` testids per row
- Extend the PathCell breadcrumb test to assert folder ancestor link contains the folder icon and org root link does NOT

Fixes HOL-783

## Test plan

- [x] `make test-ui` passes — 1030 tests, 79 files, no regressions
- [x] "renders a row for each resource with the correct type badge" now asserts icon testids
- [x] PathCell test asserts folder ancestor has icon and org root does not
- [x] All existing search, empty state, loading, error, and breadcrumb-link tests pass