### PR TITLE
feat(frontend): folder-scoped projects index

### DIFF
--- a/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
@@ -157,7 +157,7 @@ describe('FolderIndexPage', () => {
       name: 'View all template policies',
     })
     const projectsLink = screen.getByRole('link', {
-      name: 'View all resources in the organization',
+      name: 'View all projects',
     })
     // Position compareDocumentPosition returns a bitmask where bit 0x04
     // ("following") is set when `other` appears after `this` in the DOM.
@@ -329,9 +329,9 @@ describe('FolderIndexPage', () => {
     render(<FolderIndexPage folderName="payments" />)
     // Each "View all" link carries a section-specific aria-label so
     // the three buttons are distinguishable in a screen-reader link
-    // list. The Projects link additionally signals that the fallback
-    // destination widens scope to the whole org's Resources listing
-    // (HOL-755 will swap this for a folder-scoped projects index).
+    // list. All three now target folder-scoped indexes (HOL-755 added
+    // the folder-scoped projects index so the Projects link no longer
+    // widens scope to the org-wide Resources listing).
     expect(
       screen.getByRole('link', { name: 'View all templates' }),
     ).toHaveAttribute('href', '/folders/payments/templates')
@@ -339,8 +339,8 @@ describe('FolderIndexPage', () => {
       screen.getByRole('link', { name: 'View all template policies' }),
     ).toHaveAttribute('href', '/folders/payments/template-policies')
     expect(
-      screen.getByRole('link', { name: 'View all resources in the organization' }),
-    ).toHaveAttribute('href', '/orgs/test-org/resources')
+      screen.getByRole('link', { name: 'View all projects' }),
+    ).toHaveAttribute('href', '/folders/payments/projects')
   })
 
   it('renders per-section error alerts when a single list query fails', () => {

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -137,7 +137,7 @@ export function FolderIndexPage({
         error={policiesQuery.error as Error | null}
       />
       <ProjectsSection
-        orgName={orgName}
+        folderName={folderName}
         projects={projectsQuery.data}
         isPending={projectsQuery.isPending}
         error={projectsQuery.error as Error | null}
@@ -320,12 +320,12 @@ function TemplatePoliciesSection({
 }
 
 function ProjectsSection({
-  orgName,
+  folderName,
   projects,
   isPending,
   error,
 }: {
-  orgName: string
+  folderName: string
   projects: Project[] | undefined
   isPending: boolean
   error: Error | null
@@ -340,15 +340,10 @@ function ProjectsSection({
       error={error}
       emptyText="No projects in this folder."
       viewAll={
-        // No folder-scoped projects index exists yet (HOL-755); "View all"
-        // falls back to the org-wide Resources listing, which contains both
-        // folders and projects in a single unified table. The aria-label
-        // makes the wider scope explicit so a screen-reader user is not
-        // surprised by it after activating the link.
         <Link
-          to="/orgs/$orgName/resources"
-          params={{ orgName }}
-          aria-label="View all resources in the organization"
+          to="/folders/$folderName/projects"
+          params={{ folderName }}
+          aria-label="View all projects"
         >
           <Button variant="outline" size="sm">
             View all

--- a/frontend/src/routes/_authenticated/folders/$folderName/projects/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/projects/-index.test.tsx
@@ -1,0 +1,205 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { ParentType } from '@/gen/holos/console/v1/folders_pb'
+import { LinkMock } from '@/test/link-mock'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ folderName: 'payments' }),
+    }),
+    Link: LinkMock,
+  }
+})
+
+vi.mock('@/queries/projects', () => ({
+  useListProjectsByParent: vi.fn(),
+}))
+
+vi.mock('@/queries/folders', () => ({
+  useGetFolder: vi.fn(),
+}))
+
+import { useListProjectsByParent } from '@/queries/projects'
+import { useGetFolder } from '@/queries/folders'
+import { FolderProjectsIndexPage } from './index'
+
+type ProjectFixture = {
+  name: string
+  displayName?: string
+  description?: string
+  creatorEmail?: string
+}
+
+const mockFolder = {
+  name: 'payments',
+  displayName: 'Payments Team',
+  organization: 'test-org',
+  creatorEmail: 'admin@example.com',
+}
+
+function setupMocks(
+  projects: ProjectFixture[] | undefined = [],
+  options: {
+    folder?: typeof mockFolder | undefined
+    isPending?: boolean
+    error?: Error | null
+  } = {},
+) {
+  ;(useGetFolder as Mock).mockReturnValue({
+    data: options.folder ?? mockFolder,
+    isPending: false,
+    error: null,
+  })
+  ;(useListProjectsByParent as Mock).mockReturnValue({
+    data: options.isPending ? undefined : projects,
+    isPending: options.isPending ?? false,
+    error: options.error ?? null,
+  })
+}
+
+describe('FolderProjectsIndexPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the breadcrumb and page title', () => {
+    setupMocks([])
+    render(<FolderProjectsIndexPage folderName="payments" />)
+    // The card title is "Projects"; the breadcrumb shows org / Resources /
+    // folder / Projects so a user always has a link back up the hierarchy.
+    const headings = screen.getAllByText('Projects')
+    expect(headings.length).toBeGreaterThan(0)
+    expect(screen.getByRole('link', { name: 'test-org' })).toHaveAttribute(
+      'href',
+      '/orgs/test-org/settings',
+    )
+    expect(screen.getByRole('link', { name: 'Resources' })).toHaveAttribute(
+      'href',
+      '/orgs/test-org/resources',
+    )
+    expect(screen.getByRole('link', { name: 'payments' })).toHaveAttribute(
+      'href',
+      '/folders/payments/settings',
+    )
+  })
+
+  it('renders the empty state when no projects live in the folder', () => {
+    setupMocks([])
+    render(<FolderProjectsIndexPage folderName="payments" />)
+    // The zero-state copy explains where projects come from: projects live
+    // directly under a folder only when their parent is set to that folder.
+    expect(screen.getByText(/no projects in this folder/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/parent is set to this folder/i),
+    ).toBeInTheDocument()
+    // The populated-list <ul> must not exist in the empty state — the
+    // data-testid gives a tight regression pin in case the empty branch is
+    // accidentally dropped.
+    expect(screen.queryByTestId('projects-list')).not.toBeInTheDocument()
+  })
+
+  it('renders a populated list with per-item links into the project scope', () => {
+    setupMocks([
+      {
+        name: 'checkout',
+        displayName: 'Checkout',
+        description: 'Cart and checkout flow',
+        creatorEmail: 'jane@example.com',
+      },
+      { name: 'billing' },
+    ])
+    render(<FolderProjectsIndexPage folderName="payments" />)
+
+    // Each item is a Link whose href targets /projects/$projectName —
+    // navigation from the folder-scoped projects index lands on the
+    // project's own detail page, not a folder-qualified project route
+    // (projects have one canonical detail URL).
+    expect(screen.getByRole('link', { name: /Checkout/ })).toHaveAttribute(
+      'href',
+      '/projects/checkout',
+    )
+    expect(screen.getByRole('link', { name: /billing/ })).toHaveAttribute(
+      'href',
+      '/projects/billing',
+    )
+
+    // displayName renders as the primary label; the slug appears alongside
+    // it when it differs from the display name so two projects with the
+    // same display name can still be disambiguated by their underlying name.
+    expect(screen.getByText('Checkout')).toBeInTheDocument()
+    expect(screen.getByText('checkout')).toBeInTheDocument()
+
+    // Supplementary metadata (description, creator email) renders when
+    // present; projects without those fields (billing) render only the
+    // label.
+    expect(screen.getByText('Cart and checkout flow')).toBeInTheDocument()
+    expect(screen.getByText(/Created by jane@example.com/)).toBeInTheDocument()
+  })
+
+  it('does not duplicate the slug when displayName equals name', () => {
+    // When a project's display name equals its slug, showing both creates
+    // a visually duplicated label. The implementation suppresses the slug
+    // span in that case.
+    setupMocks([
+      { name: 'billing', displayName: 'billing' },
+    ])
+    render(<FolderProjectsIndexPage folderName="payments" />)
+    // Exactly one "billing" text node (inside the link) — no secondary
+    // slug badge.
+    const matches = screen.getAllByText('billing')
+    expect(matches).toHaveLength(1)
+  })
+
+  it('renders a skeleton while the query is pending', () => {
+    setupMocks([], { isPending: true })
+    render(<FolderProjectsIndexPage folderName="payments" />)
+    expect(screen.queryByTestId('projects-list')).not.toBeInTheDocument()
+    expect(screen.queryByText(/no projects in this folder/i)).not.toBeInTheDocument()
+  })
+
+  it('surfaces an error when the list query fails', () => {
+    setupMocks([], { error: new Error('backend unreachable') })
+    render(<FolderProjectsIndexPage folderName="payments" />)
+    expect(screen.getByText('backend unreachable')).toBeInTheDocument()
+  })
+
+  it('queries the RPC with ParentType.FOLDER so results are non-recursive', () => {
+    // The folder index page's Projects summary (HOL-610) and this scoped
+    // index must agree on what "projects in this folder" means: immediate
+    // children only, never grandchildren. Assert the call shape so a
+    // regression to ORGANIZATION or a missing parentName is caught at the
+    // unit-test boundary.
+    setupMocks([])
+    render(<FolderProjectsIndexPage folderName="payments" />)
+    expect(useListProjectsByParent).toHaveBeenCalledWith(
+      'test-org',
+      ParentType.FOLDER,
+      'payments',
+    )
+  })
+
+  it('falls back to an empty org when the folder query has not resolved yet', () => {
+    // The folder is the source of truth for orgName. When useGetFolder is
+    // still resolving the project query must still be made with an empty
+    // organization so the RPC layer's enabled-guard suppresses the call —
+    // no "undefined" slipping into the org field.
+    ;(useGetFolder as Mock).mockReturnValue({
+      data: undefined,
+      isPending: true,
+      error: null,
+    })
+    ;(useListProjectsByParent as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
+    render(<FolderProjectsIndexPage folderName="payments" />)
+    expect(useListProjectsByParent).toHaveBeenCalledWith(
+      '',
+      ParentType.FOLDER,
+      'payments',
+    )
+  })
+})

--- a/frontend/src/routes/_authenticated/folders/$folderName/projects/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/projects/index.tsx
@@ -1,0 +1,147 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import { ParentType } from '@/gen/holos/console/v1/folders_pb'
+import { useListProjectsByParent } from '@/queries/projects'
+import { useGetFolder } from '@/queries/folders'
+
+export const Route = createFileRoute(
+  '/_authenticated/folders/$folderName/projects/',
+)({
+  component: FolderProjectsIndexRoute,
+})
+
+function FolderProjectsIndexRoute() {
+  const { folderName } = Route.useParams()
+  return <FolderProjectsIndexPage folderName={folderName} />
+}
+
+export function FolderProjectsIndexPage({
+  folderName: propFolderName,
+}: { folderName?: string } = {}) {
+  let routeFolderName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeFolderName = Route.useParams().folderName
+  } catch {
+    routeFolderName = undefined
+  }
+  const folderName = propFolderName ?? routeFolderName ?? ''
+
+  const { data: folder } = useGetFolder(folderName)
+  const orgName = folder?.organization ?? ''
+
+  // Reuse the non-recursive parent-scoped query the HOL-610 folder index
+  // already uses for the Projects summary section. The RPC filter returns
+  // only projects whose immediate parent is this folder, never grandchildren.
+  const {
+    data: projects,
+    isPending,
+    error,
+  } = useListProjectsByParent(orgName, ParentType.FOLDER, folderName)
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+              {orgName}
+            </Link>
+            {' / '}
+            <Link to="/orgs/$orgName/resources" params={{ orgName }} className="hover:underline">
+              Resources
+            </Link>
+            {' / '}
+            <Link
+              to="/folders/$folderName/settings"
+              params={{ folderName }}
+              className="hover:underline"
+            >
+              {folderName}
+            </Link>
+            {' / Projects'}
+          </p>
+          <CardTitle className="mt-1">Projects</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Projects whose immediate parent is this folder. Projects nested inside
+          sub-folders appear on their own folder's page.
+        </p>
+        <Separator />
+        {projects && projects.length > 0 ? (
+          <ul className="space-y-2" data-testid="projects-list">
+            {projects.map((project) => (
+              <li key={project.name}>
+                <Link
+                  to="/projects/$projectName"
+                  params={{ projectName: project.name }}
+                  className="flex items-center gap-2 p-3 rounded-md hover:bg-muted transition-colors border border-border"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium">
+                        {project.displayName || project.name}
+                      </span>
+                      {project.displayName && project.displayName !== project.name && (
+                        <span className="text-xs text-muted-foreground font-mono">
+                          {project.name}
+                        </span>
+                      )}
+                    </div>
+                    {project.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">
+                        {project.description}
+                      </p>
+                    )}
+                    {project.creatorEmail && (
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Created by {project.creatorEmail}
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-md border border-dashed border-border p-6 text-center">
+            <p className="text-sm font-medium">No projects in this folder.</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Projects are created from the organization Resources page. Once a
+              project's parent is set to this folder it will appear here.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- Add folder-scoped projects index route at `/folders/$folderName/projects` that lists only direct child projects (via the existing non-recursive `useListProjectsByParent` query).
- Update HOL-610's folder index Projects section to link to the new route and simplify the aria-label from `View all projects in the organization` to `View all projects`.
- Match the existing folder-scoped templates / template-policies route patterns: breadcrumb, loading skeleton, error alert, populated list with per-item links into `/projects/$projectName`, explanatory empty state.

Fixes HOL-755

## Test plan
- [x] `cd frontend && npx vitest run` — 1038 tests pass across 80 files (8 new tests in `projects/-index.test.tsx`; folder `-index.test.tsx` updated for the new aria-label + href).
- [x] `cd frontend && npm run build` — succeeds; `routeTree.gen.ts` includes `/folders/$folderName/projects/`.
- [ ] Manual smoke: navigate from a folder index Projects section "View all" to the new folder-scoped index; confirm only direct-child projects appear and per-row links land on `/projects/$projectName`.