### PR TITLE
feat(templatepolicybindings): accept * in handler validation + envtest coverage

### DIFF
--- a/console/policyresolver/applied_state_envtest_test.go
+++ b/console/policyresolver/applied_state_envtest_test.go
@@ -46,6 +46,13 @@ const (
 	renderStateEnvtestRoundTripPrefix = "rt"
 	renderStateEnvtestAdmissionPrefix = "ad"
 	renderStateEnvtestSelectorPrefix  = "ls"
+	// HOL-772 wildcard cascade prefixes — one per test so the namespace
+	// hierarchy each builds is uniquely named on the shared apiserver.
+	wildcardFolderCascadePrefix      = "wfc"
+	wildcardSiblingFolderPrefix      = "wsf"
+	wildcardProjectScopeCeilingPref  = "wpc"
+	wildcardDeploymentByNamePresent  = "wdp"
+	wildcardDeploymentByNameAbsent   = "wda"
 )
 
 // startRenderStateEnvtest boots a Manager primed with the RenderState
@@ -277,5 +284,491 @@ func TestAppliedRenderStateClient_LabelSelectorLookup(t *testing.T) {
 	if len(projList.Items) != 2 {
 		t.Fatalf("project selector returned %d items, want 2; got %+v",
 			len(projList.Items), projList.Items)
+	}
+}
+
+// startWildcardCascadeEnvtest boots a Manager that primes the
+// TemplatePolicy + TemplatePolicyBinding informers (in addition to the
+// Namespace informer that the cache-backed Manager always carries). The
+// wildcard cascade tests Resolve through a real
+// NewFolderResolverWithBindings wired against the cache-backed client,
+// so a regression that bypasses the cache or short-circuits the
+// ancestor walk surfaces here rather than only in the unit tests.
+func startWildcardCascadeEnvtest(t *testing.T) *crdmgrtesting.Env {
+	t.Helper()
+	return crdmgrtesting.StartManager(t, crdmgrtesting.Options{
+		Scheme: cacheBackedTestScheme(t),
+		InformerObjects: []ctrlclient.Object{
+			&templatesv1alpha1.RenderState{},
+			&templatesv1alpha1.TemplatePolicy{},
+			&templatesv1alpha1.TemplatePolicyBinding{},
+		},
+	})
+}
+
+// waitForBindingCacheVisible polls the cache-backed client until the
+// requested TemplatePolicyBinding is observable. envtest writes go
+// through the apiserver and surface in the informer cache on the next
+// watch event; the tests must not race this propagation because the
+// folderResolver reads through the same cache.
+func waitForBindingCacheVisible(t *testing.T, c ctrlclient.Client, namespace, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var got templatesv1alpha1.TemplatePolicyBinding
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &got); err == nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("binding %s/%s not visible in cache within deadline", namespace, name)
+}
+
+// waitForPolicyCacheVisible mirrors waitForBindingCacheVisible for the
+// TemplatePolicy informer.
+func waitForPolicyCacheVisible(t *testing.T, c ctrlclient.Client, namespace, name string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var got templatesv1alpha1.TemplatePolicy
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &got); err == nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("policy %s/%s not visible in cache within deadline", namespace, name)
+}
+
+// TestFolderResolver_EnvtestWildcardFolderCascade pins HOL-772's
+// folder-scope cascade contract under wildcards. A folder-scope binding
+// with target_refs `[{project: "*", name: "*", kind: PROJECT_TEMPLATE}]`
+// must attach to every project-template render under the folder's
+// projects (cascade reach), and the envtest run uses the production
+// cache-backed client so the test exercises the same code path the
+// running console process does.
+func TestFolderResolver_EnvtestWildcardFolderCascade(t *testing.T) {
+	env := startWildcardCascadeEnvtest(t)
+	if env == nil {
+		return
+	}
+
+	r := baseResolver()
+	prefix := wildcardFolderCascadePrefix
+	orgNs := r.OrgNamespace(prefix + "-acme")
+	folderEngNs := r.FolderNamespace(prefix + "-eng")
+	projectLiliesNs := r.ProjectNamespace(prefix + "-lilies")
+	projectRosesNs := r.ProjectNamespace(prefix + "-roses")
+
+	ensureRenderStateNamespace(t, env.Direct, orgNs, v1alpha2.ResourceTypeOrganization, "")
+	ensureRenderStateNamespace(t, env.Direct, folderEngNs, v1alpha2.ResourceTypeFolder, orgNs)
+	ensureRenderStateNamespace(t, env.Direct, projectLiliesNs, v1alpha2.ResourceTypeProject, folderEngNs)
+	ensureRenderStateNamespace(t, env.Direct, projectRosesNs, v1alpha2.ResourceTypeProject, folderEngNs)
+
+	t.Cleanup(func() {
+		for _, name := range []string{projectLiliesNs, projectRosesNs, folderEngNs, orgNs} {
+			_ = env.Direct.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+		}
+	})
+
+	// Org-scope policy that REQUIRE's an org template the binding targets.
+	orgPolicy := &templatesv1alpha1.TemplatePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "audit", Namespace: orgNs},
+		Spec: templatesv1alpha1.TemplatePolicySpec{
+			Rules: []templatesv1alpha1.TemplatePolicyRule{
+				requireRuleCRD(v1alpha2.TemplateScopeOrganization, prefix+"-acme", "audit-policy"),
+			},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), orgPolicy); err != nil {
+		t.Fatalf("seed org policy: %v", err)
+	}
+
+	// Folder-scope binding with full wildcard {project:*, name:*}
+	// targeting PROJECT_TEMPLATE. By HOL-770 this matches every
+	// project-template render below the folder.
+	wildcardBinding := &templatesv1alpha1.TemplatePolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "wild-cascade", Namespace: folderEngNs},
+		Spec: templatesv1alpha1.TemplatePolicyBindingSpec{
+			PolicyRef: templatesv1alpha1.LinkedTemplatePolicyRef{
+				Namespace: orgNs,
+				Name:      "audit",
+			},
+			TargetRefs: []templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+				Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindProjectTemplate,
+				Name:        WildcardAny,
+				ProjectName: WildcardAny,
+			}},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), wildcardBinding); err != nil {
+		t.Fatalf("seed wildcard binding: %v", err)
+	}
+
+	waitForPolicyCacheVisible(t, env.Client, orgNs, "audit")
+	waitForBindingCacheVisible(t, env.Client, folderEngNs, "wild-cascade")
+
+	walker := &resolver.Walker{
+		Getter:   &resolver.CtrlRuntimeNamespaceGetter{Client: env.Client},
+		Resolver: r,
+	}
+	pl := &cacheBackedPolicyLister{c: env.Client}
+	bl := &cacheBackedBindingLister{c: env.Client}
+	fr := NewFolderResolverWithBindings(pl, walker, r, bl)
+
+	// Both projects under folderEng must observe the audit-policy
+	// injection on a project-template render of any name.
+	for _, projectNs := range []string{projectLiliesNs, projectRosesNs} {
+		for _, targetName := range []string{"web", "api", "anything"} {
+			got, err := fr.Resolve(context.Background(), projectNs, TargetKindProjectTemplate, targetName, nil)
+			if err != nil {
+				t.Fatalf("Resolve(%s, project_template, %s): %v", projectNs, targetName, err)
+			}
+			if names := refNames(got); len(names) != 1 || names[0] != "audit-policy" {
+				t.Errorf("Resolve(%s, project_template, %s) = %v, want [audit-policy]",
+					projectNs, targetName, names)
+			}
+		}
+	}
+
+	// kind never wildcards: a DEPLOYMENT render must NOT match the
+	// PROJECT_TEMPLATE-targeted wildcard binding even though name and
+	// project_name are both "*".
+	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "web", nil)
+	if err != nil {
+		t.Fatalf("Resolve(deployment): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("PROJECT_TEMPLATE wildcard binding leaked into DEPLOYMENT render: got %v, want empty", refNames(got))
+	}
+}
+
+// TestFolderResolver_EnvtestWildcardSiblingFolderIsolation locks down
+// HOL-554 storage isolation under wildcards: a wildcard binding stored
+// under folder A must NOT contribute to renders under sibling folder B.
+// The ancestor walk caps wildcard reach; a regression that flattened
+// the cache would let a folder-scope wildcard cross folders.
+func TestFolderResolver_EnvtestWildcardSiblingFolderIsolation(t *testing.T) {
+	env := startWildcardCascadeEnvtest(t)
+	if env == nil {
+		return
+	}
+
+	r := baseResolver()
+	prefix := wildcardSiblingFolderPrefix
+	orgNs := r.OrgNamespace(prefix + "-acme")
+	folderEngNs := r.FolderNamespace(prefix + "-eng")
+	folderOpsNs := r.FolderNamespace(prefix + "-ops")
+	projectInEngNs := r.ProjectNamespace(prefix + "-eng-app")
+	projectInOpsNs := r.ProjectNamespace(prefix + "-ops-app")
+
+	ensureRenderStateNamespace(t, env.Direct, orgNs, v1alpha2.ResourceTypeOrganization, "")
+	ensureRenderStateNamespace(t, env.Direct, folderEngNs, v1alpha2.ResourceTypeFolder, orgNs)
+	ensureRenderStateNamespace(t, env.Direct, folderOpsNs, v1alpha2.ResourceTypeFolder, orgNs)
+	ensureRenderStateNamespace(t, env.Direct, projectInEngNs, v1alpha2.ResourceTypeProject, folderEngNs)
+	ensureRenderStateNamespace(t, env.Direct, projectInOpsNs, v1alpha2.ResourceTypeProject, folderOpsNs)
+
+	t.Cleanup(func() {
+		for _, name := range []string{projectInEngNs, projectInOpsNs, folderEngNs, folderOpsNs, orgNs} {
+			_ = env.Direct.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+		}
+	})
+
+	// Org-scope policy. Folder-eng-scope binding with full wildcard
+	// targeting PROJECT_TEMPLATE pulls audit-policy into every
+	// project-template render reachable from folder eng.
+	orgPolicy := &templatesv1alpha1.TemplatePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "audit", Namespace: orgNs},
+		Spec: templatesv1alpha1.TemplatePolicySpec{
+			Rules: []templatesv1alpha1.TemplatePolicyRule{
+				requireRuleCRD(v1alpha2.TemplateScopeOrganization, prefix+"-acme", "audit-policy"),
+			},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), orgPolicy); err != nil {
+		t.Fatalf("seed org policy: %v", err)
+	}
+	wildcardBinding := &templatesv1alpha1.TemplatePolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "wild-eng", Namespace: folderEngNs},
+		Spec: templatesv1alpha1.TemplatePolicyBindingSpec{
+			PolicyRef: templatesv1alpha1.LinkedTemplatePolicyRef{Namespace: orgNs, Name: "audit"},
+			TargetRefs: []templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+				Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindProjectTemplate,
+				Name:        WildcardAny,
+				ProjectName: WildcardAny,
+			}},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), wildcardBinding); err != nil {
+		t.Fatalf("seed eng wildcard binding: %v", err)
+	}
+
+	waitForPolicyCacheVisible(t, env.Client, orgNs, "audit")
+	waitForBindingCacheVisible(t, env.Client, folderEngNs, "wild-eng")
+
+	walker := &resolver.Walker{
+		Getter:   &resolver.CtrlRuntimeNamespaceGetter{Client: env.Client},
+		Resolver: r,
+	}
+	pl := &cacheBackedPolicyLister{c: env.Client}
+	bl := &cacheBackedBindingLister{c: env.Client}
+	fr := NewFolderResolverWithBindings(pl, walker, r, bl)
+
+	// Project under folder eng: wildcard binding cascades down.
+	got, err := fr.Resolve(context.Background(), projectInEngNs, TargetKindProjectTemplate, "anything", nil)
+	if err != nil {
+		t.Fatalf("Resolve(eng project): %v", err)
+	}
+	if names := refNames(got); len(names) != 1 || names[0] != "audit-policy" {
+		t.Errorf("Resolve(eng project) = %v, want [audit-policy]", names)
+	}
+
+	// Project under sibling folder ops: ancestor walk does not cross
+	// into folder eng, so the wildcard binding contributes nothing.
+	got, err = fr.Resolve(context.Background(), projectInOpsNs, TargetKindProjectTemplate, "anything", nil)
+	if err != nil {
+		t.Fatalf("Resolve(ops project): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("wildcard binding stored in folder eng leaked into folder ops project: got %v, want empty",
+			refNames(got))
+	}
+}
+
+// TestFolderResolver_EnvtestWildcardProjectScopeCeiling enforces the
+// storage-scope ceiling on a project-stored binding (HOL-554 +
+// HOL-770/772). Today the templatepolicybinding-folder-or-org-only
+// ValidatingAdmissionPolicy rejects every TemplatePolicyBinding stored
+// in a project namespace — so even with name="*" and project_name="*",
+// the binding cannot land in a project namespace at all. This is the
+// admission-layer ceiling on wildcard reach: a wildcard binding cannot
+// be planted inside a project to widen its blast radius beyond the
+// project. (HOL-618 may revisit project-scoped bindings; that ticket
+// will need to update this test alongside any admission relaxation.)
+func TestFolderResolver_EnvtestWildcardProjectScopeCeiling(t *testing.T) {
+	env := crdmgrtesting.StartManager(t, crdmgrtesting.Options{
+		Scheme: cacheBackedTestScheme(t),
+		InformerObjects: []ctrlclient.Object{
+			&templatesv1alpha1.RenderState{},
+			&templatesv1alpha1.TemplatePolicy{},
+			&templatesv1alpha1.TemplatePolicyBinding{},
+		},
+		WaitForAdmissionPolicies: []string{"templatepolicybinding-folder-or-org-only"},
+	})
+	if env == nil {
+		return
+	}
+
+	r := baseResolver()
+	prefix := wildcardProjectScopeCeilingPref
+	orgNs := r.OrgNamespace(prefix + "-acme")
+	folderEngNs := r.FolderNamespace(prefix + "-eng")
+	projectAlphaNs := r.ProjectNamespace(prefix + "-alpha")
+
+	ensureRenderStateNamespace(t, env.Direct, orgNs, v1alpha2.ResourceTypeOrganization, "")
+	ensureRenderStateNamespace(t, env.Direct, folderEngNs, v1alpha2.ResourceTypeFolder, orgNs)
+	ensureRenderStateNamespace(t, env.Direct, projectAlphaNs, v1alpha2.ResourceTypeProject, folderEngNs)
+
+	t.Cleanup(func() {
+		for _, name := range []string{projectAlphaNs, folderEngNs, orgNs} {
+			_ = env.Direct.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+		}
+	})
+
+	projectStoredWildcard := &templatesv1alpha1.TemplatePolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha-wild", Namespace: projectAlphaNs},
+		Spec: templatesv1alpha1.TemplatePolicyBindingSpec{
+			PolicyRef: templatesv1alpha1.LinkedTemplatePolicyRef{Namespace: orgNs, Name: "audit"},
+			TargetRefs: []templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+				Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+				Name:        WildcardAny,
+				ProjectName: WildcardAny,
+			}},
+		},
+	}
+	err := env.Direct.Create(context.Background(), projectStoredWildcard)
+	if err == nil {
+		t.Fatal("expected admission to reject wildcard binding stored in a project namespace")
+	}
+	if !apierrors.IsForbidden(err) && !apierrors.IsInvalid(err) {
+		t.Fatalf("expected Forbidden or Invalid from admission, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), projectAlphaNs) {
+		t.Logf("admission error did not name the project namespace; saw: %v", err)
+	}
+}
+
+// TestFolderResolver_EnvtestWildcardProjectMatchesEveryReachableProject
+// covers the {project: "*", name: "web", kind: DEPLOYMENT} case from
+// HOL-772's AC: a folder-scope binding targets every deployment named
+// "web" across every project reachable from the folder, and contributes
+// zero when the queried target name does not match.
+func TestFolderResolver_EnvtestWildcardProjectMatchesEveryReachableProject(t *testing.T) {
+	env := startWildcardCascadeEnvtest(t)
+	if env == nil {
+		return
+	}
+
+	r := baseResolver()
+	prefix := wildcardDeploymentByNamePresent
+	orgNs := r.OrgNamespace(prefix + "-acme")
+	folderEngNs := r.FolderNamespace(prefix + "-eng")
+	projectOneNs := r.ProjectNamespace(prefix + "-one")
+	projectTwoNs := r.ProjectNamespace(prefix + "-two")
+
+	ensureRenderStateNamespace(t, env.Direct, orgNs, v1alpha2.ResourceTypeOrganization, "")
+	ensureRenderStateNamespace(t, env.Direct, folderEngNs, v1alpha2.ResourceTypeFolder, orgNs)
+	ensureRenderStateNamespace(t, env.Direct, projectOneNs, v1alpha2.ResourceTypeProject, folderEngNs)
+	ensureRenderStateNamespace(t, env.Direct, projectTwoNs, v1alpha2.ResourceTypeProject, folderEngNs)
+
+	t.Cleanup(func() {
+		for _, name := range []string{projectOneNs, projectTwoNs, folderEngNs, orgNs} {
+			_ = env.Direct.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+		}
+	})
+
+	orgPolicy := &templatesv1alpha1.TemplatePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "audit", Namespace: orgNs},
+		Spec: templatesv1alpha1.TemplatePolicySpec{
+			Rules: []templatesv1alpha1.TemplatePolicyRule{
+				requireRuleCRD(v1alpha2.TemplateScopeOrganization, prefix+"-acme", "audit-policy"),
+			},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), orgPolicy); err != nil {
+		t.Fatalf("seed org policy: %v", err)
+	}
+	bindingProjectWildcard := &templatesv1alpha1.TemplatePolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-everywhere", Namespace: folderEngNs},
+		Spec: templatesv1alpha1.TemplatePolicyBindingSpec{
+			PolicyRef: templatesv1alpha1.LinkedTemplatePolicyRef{Namespace: orgNs, Name: "audit"},
+			TargetRefs: []templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+				Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+				Name:        "web",
+				ProjectName: WildcardAny,
+			}},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), bindingProjectWildcard); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+
+	waitForPolicyCacheVisible(t, env.Client, orgNs, "audit")
+	waitForBindingCacheVisible(t, env.Client, folderEngNs, "web-everywhere")
+
+	walker := &resolver.Walker{
+		Getter:   &resolver.CtrlRuntimeNamespaceGetter{Client: env.Client},
+		Resolver: r,
+	}
+	pl := &cacheBackedPolicyLister{c: env.Client}
+	bl := &cacheBackedBindingLister{c: env.Client}
+	fr := NewFolderResolverWithBindings(pl, walker, r, bl)
+
+	// Both projects' "web" deployment match.
+	for _, projectNs := range []string{projectOneNs, projectTwoNs} {
+		got, err := fr.Resolve(context.Background(), projectNs, TargetKindDeployment, "web", nil)
+		if err != nil {
+			t.Fatalf("Resolve(%s, web): %v", projectNs, err)
+		}
+		if names := refNames(got); len(names) != 1 || names[0] != "audit-policy" {
+			t.Errorf("Resolve(%s, web) = %v, want [audit-policy]", projectNs, names)
+		}
+	}
+
+	// A different deployment name does not match.
+	got, err := fr.Resolve(context.Background(), projectOneNs, TargetKindDeployment, "api", nil)
+	if err != nil {
+		t.Fatalf("Resolve(api): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("name=web binding matched deployment 'api': got %v, want empty", refNames(got))
+	}
+}
+
+// TestFolderResolver_EnvtestWildcardProjectZeroMatchesWhenNamesAbsent
+// is the negative companion to the previous test: when no deployment
+// in any reachable project has the target name, Resolve returns the
+// empty set. This is the resolver-side guard that "wildcard project +
+// literal name" still narrows by name — a regression that flattened
+// names on top of projects would surface here.
+func TestFolderResolver_EnvtestWildcardProjectZeroMatchesWhenNamesAbsent(t *testing.T) {
+	env := startWildcardCascadeEnvtest(t)
+	if env == nil {
+		return
+	}
+
+	r := baseResolver()
+	prefix := wildcardDeploymentByNameAbsent
+	orgNs := r.OrgNamespace(prefix + "-acme")
+	folderEngNs := r.FolderNamespace(prefix + "-eng")
+	projectOnlyNs := r.ProjectNamespace(prefix + "-only")
+
+	ensureRenderStateNamespace(t, env.Direct, orgNs, v1alpha2.ResourceTypeOrganization, "")
+	ensureRenderStateNamespace(t, env.Direct, folderEngNs, v1alpha2.ResourceTypeFolder, orgNs)
+	ensureRenderStateNamespace(t, env.Direct, projectOnlyNs, v1alpha2.ResourceTypeProject, folderEngNs)
+
+	t.Cleanup(func() {
+		for _, name := range []string{projectOnlyNs, folderEngNs, orgNs} {
+			_ = env.Direct.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+		}
+	})
+
+	orgPolicy := &templatesv1alpha1.TemplatePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "audit", Namespace: orgNs},
+		Spec: templatesv1alpha1.TemplatePolicySpec{
+			Rules: []templatesv1alpha1.TemplatePolicyRule{
+				requireRuleCRD(v1alpha2.TemplateScopeOrganization, prefix+"-acme", "audit-policy"),
+			},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), orgPolicy); err != nil {
+		t.Fatalf("seed org policy: %v", err)
+	}
+	binding := &templatesv1alpha1.TemplatePolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-only", Namespace: folderEngNs},
+		Spec: templatesv1alpha1.TemplatePolicyBindingSpec{
+			PolicyRef: templatesv1alpha1.LinkedTemplatePolicyRef{Namespace: orgNs, Name: "audit"},
+			TargetRefs: []templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+				Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+				Name:        "web",
+				ProjectName: WildcardAny,
+			}},
+		},
+	}
+	if err := env.Direct.Create(context.Background(), binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+
+	waitForPolicyCacheVisible(t, env.Client, orgNs, "audit")
+	waitForBindingCacheVisible(t, env.Client, folderEngNs, "web-only")
+
+	walker := &resolver.Walker{
+		Getter:   &resolver.CtrlRuntimeNamespaceGetter{Client: env.Client},
+		Resolver: r,
+	}
+	pl := &cacheBackedPolicyLister{c: env.Client}
+	bl := &cacheBackedBindingLister{c: env.Client}
+	fr := NewFolderResolverWithBindings(pl, walker, r, bl)
+
+	// No render target named "web" in this hierarchy means the resolver
+	// is queried for "api" / other names and must return empty.
+	for _, targetName := range []string{"api", "background", "anything"} {
+		got, err := fr.Resolve(context.Background(), projectOnlyNs, TargetKindDeployment, targetName, nil)
+		if err != nil {
+			t.Fatalf("Resolve(%s): %v", targetName, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("Resolve(%s) = %v, want empty (no deployment named 'web' should match the literal-name wildcard-project binding for a different name)",
+				targetName, refNames(got))
+		}
+	}
+
+	// A "web" render in the project DOES match — pinning that the
+	// binding still attaches when the literal name aligns.
+	got, err := fr.Resolve(context.Background(), projectOnlyNs, TargetKindDeployment, "web", nil)
+	if err != nil {
+		t.Fatalf("Resolve(web): %v", err)
+	}
+	if names := refNames(got); len(names) != 1 || names[0] != "audit-policy" {
+		t.Errorf("Resolve(web) = %v, want [audit-policy]", names)
 	}
 }

--- a/console/templatepolicybindings/handler.go
+++ b/console/templatepolicybindings/handler.go
@@ -13,6 +13,7 @@ import (
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/rpc"
@@ -588,12 +589,20 @@ func (h *Handler) validatePolicyRef(ref *consolev1.LinkedTemplatePolicyRef) erro
 }
 
 // validateTargetRefs enforces the invariants common to every target_ref:
-// kind must be set to one of the two legal values, name must be a DNS
-// label, project_name must be present (required for both PROJECT_TEMPLATE
-// and DEPLOYMENT kinds per the proto comment). Duplicate (kind,
+// kind must be set to one of the two legal values; name and project_name
+// must each be either the wildcard sentinel policyresolver.WildcardAny
+// ("*") or a valid DNS label. Empty strings are always rejected — the
+// resolver's nameMatches guard treats the empty target value as no-match
+// for wildcard refs, so storing an empty value would silently make a
+// binding match nothing (see HOL-772 handoff). Duplicate (kind,
 // project_name, name) triples are rejected — two entries with the same
 // triple make the binding semantically ambiguous and most likely signal a
-// UI bug that submitted the same target twice.
+// UI bug that submitted the same target twice. Two rows with
+// {kind, "*", "*"} are therefore still a duplicate of each other.
+//
+// The wildcard short-circuit runs BEFORE dnsLabelRe because
+// dnsLabelRe.MatchString("*") returns false. `kind` is never wildcarded;
+// see ADR 029.
 func validateTargetRefs(refs []*consolev1.TemplatePolicyBindingTargetRef) error {
 	if len(refs) == 0 {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("binding must have at least one target_ref"))
@@ -610,21 +619,11 @@ func validateTargetRefs(refs []*consolev1.TemplatePolicyBindingTargetRef) error 
 			return connect.NewError(connect.CodeInvalidArgument,
 				fmt.Errorf("target_refs[%d]: kind must be PROJECT_TEMPLATE or DEPLOYMENT, got %v", i, ref.GetKind()))
 		}
-		if ref.GetName() == "" {
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("target_refs[%d]: name is required", i))
+		if err := validateTargetRefField(i, "name", ref.GetName()); err != nil {
+			return err
 		}
-		if !dnsLabelRe.MatchString(ref.GetName()) {
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("target_refs[%d]: name must be a valid DNS label, got %q", i, ref.GetName()))
-		}
-		if ref.GetProjectName() == "" {
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("target_refs[%d]: project_name is required", i))
-		}
-		if !dnsLabelRe.MatchString(ref.GetProjectName()) {
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("target_refs[%d]: project_name must be a valid DNS label, got %q", i, ref.GetProjectName()))
+		if err := validateTargetRefField(i, "project_name", ref.GetProjectName()); err != nil {
+			return err
 		}
 		kindStr := targetKindString(ref.GetKind())
 		key := kindStr + "|" + ref.GetProjectName() + "|" + ref.GetName()
@@ -634,6 +633,28 @@ func validateTargetRefs(refs []*consolev1.TemplatePolicyBindingTargetRef) error 
 					i, prev, kindStr, ref.GetProjectName(), ref.GetName()))
 		}
 		seen[key] = i
+	}
+	return nil
+}
+
+// validateTargetRefField enforces the shared name/project_name syntax:
+// the value must be either policyresolver.WildcardAny or a DNS label.
+// Empty strings are rejected unconditionally — the resolver's wildcard
+// match returns false when the target-side value is empty (HOL-770's
+// storage-isolation guardrail), so allowing an empty stored value would
+// silently produce a binding that matches nothing.
+func validateTargetRefField(i int, field, value string) error {
+	if value == "" {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("target_refs[%d]: %s is required", i, field))
+	}
+	if value == policyresolver.WildcardAny {
+		return nil
+	}
+	if !dnsLabelRe.MatchString(value) {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("target_refs[%d]: %s must be a valid DNS label or %q, got %q",
+				i, field, policyresolver.WildcardAny, value))
 	}
 	return nil
 }
@@ -715,6 +736,13 @@ func (h *Handler) validatePolicyRefReachable(
 // from the resolver is converted to CodeInternal; a false return is
 // converted to CodeInvalidArgument with the index and the offending
 // project_name so the UI can highlight the bad row.
+//
+// A target_ref whose project_name is policyresolver.WildcardAny declares
+// "every project reachable from the binding's storage scope" — there is
+// no single project to probe, and the storage-scope ancestor walk already
+// caps the wildcard's reach at render time. The handler skips the
+// existence probe and also bypasses the project-name cache so a literal
+// ref in the same request still reaches ProjectExistsResolver.
 func (h *Handler) validateTargetProjects(
 	ctx context.Context,
 	scope scopeKind,
@@ -732,6 +760,13 @@ func (h *Handler) validateTargetProjects(
 		project := ref.GetProjectName()
 		if project == "" {
 			continue // validateTargetRefs already rejected this
+		}
+		if project == policyresolver.WildcardAny {
+			// Wildcard project_name: nothing to probe, and the cache is
+			// bypassed so a literal ref with the same stored string is
+			// still probed (currently impossible since "*" is not a DNS
+			// label, but the bypass keeps the cache semantically correct).
+			continue
 		}
 		if checked[project] {
 			continue

--- a/console/templatepolicybindings/handler_test.go
+++ b/console/templatepolicybindings/handler_test.go
@@ -16,6 +16,7 @@ import (
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -1182,5 +1183,506 @@ func TestMapK8sError(t *testing.T) {
 				t.Errorf("code=%v want %v (err=%v)", cerr.Code(), tc.want, tc.err)
 			}
 		})
+	}
+}
+
+// TestCreateAcceptsWildcardTargetRefs covers HOL-772: the handler must
+// accept the wildcard sentinel policyresolver.WildcardAny in either or
+// both of target_refs[*].name and target_refs[*].project_name. Every
+// combination of `{literal, *}` on `{name, project_name}` is exercised
+// with both PROJECT_TEMPLATE and DEPLOYMENT kinds so a future regression
+// in validateTargetRefs surfaces as a specific row failure rather than a
+// global one. A wildcard project_name must also succeed even when the
+// wired ProjectExistsResolver would have rejected a literal lookup — the
+// existence probe is supposed to be skipped for wildcard refs.
+func TestCreateAcceptsWildcardTargetRefs(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetRef  *consolev1.TemplatePolicyBindingTargetRef
+		bindingKey string
+	}{
+		{
+			name: "literal name and project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        "api",
+				ProjectName: "payments-web",
+			},
+			bindingKey: "bind-literal-literal",
+		},
+		{
+			name: "wildcard name, literal project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        policyresolver.WildcardAny,
+				ProjectName: "payments-web",
+			},
+			bindingKey: "bind-wild-literal",
+		},
+		{
+			name: "literal name, wildcard project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+				Name:        "web",
+				ProjectName: policyresolver.WildcardAny,
+			},
+			bindingKey: "bind-literal-wild",
+		},
+		{
+			name: "wildcard name and project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+				Name:        policyresolver.WildcardAny,
+				ProjectName: policyresolver.WildcardAny,
+			},
+			bindingKey: "bind-wild-wild",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			h, fakeClient := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+			// ProjectExistsResolver is wired to reject every literal lookup,
+			// so the "wildcard project_name" rows pin that the wildcard
+			// bypasses the probe rather than passing it. Literal rows still
+			// need a reachable project, so seed payments-web.
+			h = h.
+				WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+				WithProjectExistsResolver(&stubProjectResolver{exists: map[string]bool{"payments-web": true}})
+			ctx := authedCtx("owner@example.com", nil)
+
+			folder := newFolderScopeRef("payments")
+			binding := &consolev1.TemplatePolicyBinding{
+				Name:      tc.bindingKey,
+				Namespace: folder,
+				PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+					Namespace: folder,
+					Name:      "local-policy",
+				},
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{tc.targetRef},
+			}
+
+			_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+				Namespace: folder,
+				Binding:   binding,
+			}))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			stored := getBindingCR(t, fakeClient, "holos-fld-payments", tc.bindingKey)
+			if stored == nil {
+				t.Fatal("expected binding to be created")
+			}
+			if len(stored.Spec.TargetRefs) != 1 {
+				t.Fatalf("expected 1 target_ref, got %d", len(stored.Spec.TargetRefs))
+			}
+			if got := stored.Spec.TargetRefs[0].Name; got != tc.targetRef.GetName() {
+				t.Errorf("stored name = %q, want %q", got, tc.targetRef.GetName())
+			}
+			if got := stored.Spec.TargetRefs[0].ProjectName; got != tc.targetRef.GetProjectName() {
+				t.Errorf("stored project_name = %q, want %q", got, tc.targetRef.GetProjectName())
+			}
+		})
+	}
+}
+
+// TestUpdateAcceptsWildcardTargetRefs is the Update-path mirror of
+// TestCreateAcceptsWildcardTargetRefs. Every wildcard combination must
+// round-trip through UpdateTemplatePolicyBinding too, because UI flows
+// that edit an existing binding re-submit the full target_refs list.
+func TestUpdateAcceptsWildcardTargetRefs(t *testing.T) {
+	tests := []struct {
+		name      string
+		targetRef *consolev1.TemplatePolicyBindingTargetRef
+	}{
+		{
+			name: "literal name and project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        "api",
+				ProjectName: "payments-web",
+			},
+		},
+		{
+			name: "wildcard name, literal project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        policyresolver.WildcardAny,
+				ProjectName: "payments-web",
+			},
+		},
+		{
+			name: "literal name, wildcard project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+				Name:        "web",
+				ProjectName: policyresolver.WildcardAny,
+			},
+		},
+		{
+			name: "wildcard name and project_name",
+			targetRef: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+				Name:        policyresolver.WildcardAny,
+				ProjectName: policyresolver.WildcardAny,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			existing := &templatesv1alpha1.TemplatePolicyBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-update-wild",
+					Namespace: "holos-fld-payments",
+					Labels: map[string]string{
+						v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+						v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicyBinding,
+					},
+					Annotations: map[string]string{
+						v1alpha2.AnnotationCreatorEmail: "original@example.com",
+					},
+				},
+				Spec: templatesv1alpha1.TemplatePolicyBindingSpec{
+					DisplayName: "orig",
+					PolicyRef: templatesv1alpha1.LinkedTemplatePolicyRef{
+						Namespace: "holos-fld-payments",
+						Name:      "local-policy",
+					},
+					TargetRefs: []templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+						Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+						Name:        "api",
+						ProjectName: "payments-web",
+					}},
+				},
+			}
+			fakeClient := newFakeCtrlClient(t, existing)
+			r := newTestResolver()
+			k := NewK8sClient(fakeClient, r)
+			h := NewHandler(k, r).
+				WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+				WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{"owner@example.com": "owner"}}).
+				WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+				WithProjectExistsResolver(&stubProjectResolver{exists: map[string]bool{"payments-web": true}})
+			ctx := authedCtx("owner@example.com", nil)
+
+			folder := newFolderScopeRef("payments")
+			inbound := &consolev1.TemplatePolicyBinding{
+				Name:      "bind-update-wild",
+				Namespace: folder,
+				PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+					Namespace: folder,
+					Name:      "local-policy",
+				},
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{tc.targetRef},
+			}
+
+			_, err := h.UpdateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyBindingRequest{
+				Namespace: folder,
+				Binding:   inbound,
+			}))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			stored := getBindingCR(t, fakeClient, "holos-fld-payments", "bind-update-wild")
+			if stored == nil {
+				t.Fatal("expected binding to exist after update")
+			}
+			if len(stored.Spec.TargetRefs) != 1 {
+				t.Fatalf("expected 1 target_ref after update, got %d", len(stored.Spec.TargetRefs))
+			}
+			if got := stored.Spec.TargetRefs[0].Name; got != tc.targetRef.GetName() {
+				t.Errorf("stored name = %q, want %q", got, tc.targetRef.GetName())
+			}
+			if got := stored.Spec.TargetRefs[0].ProjectName; got != tc.targetRef.GetProjectName() {
+				t.Errorf("stored project_name = %q, want %q", got, tc.targetRef.GetProjectName())
+			}
+		})
+	}
+}
+
+// TestCreateRejectsDuplicateWildcardTargetRefs pins the dedup-key
+// invariant: the wildcard sentinel does NOT short-circuit the duplicate
+// detector. Two identical {kind, "*", "*"} rows remain a user error and
+// must be rejected with CodeInvalidArgument, naming target_refs[0] so the
+// UI can highlight the offender.
+func TestCreateRejectsDuplicateWildcardTargetRefs(t *testing.T) {
+	h, fakeClient := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := &consolev1.TemplatePolicyBinding{
+		Name:      "bind-dup-wild",
+		Namespace: folder,
+		PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+			Namespace: folder,
+			Name:      "local-policy",
+		},
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
+			{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        policyresolver.WildcardAny,
+				ProjectName: policyresolver.WildcardAny,
+			},
+			{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        policyresolver.WildcardAny,
+				ProjectName: policyresolver.WildcardAny,
+			},
+		},
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Namespace: folder,
+		Binding:   binding,
+	}))
+	if err == nil {
+		t.Fatal("expected duplicate wildcard target_refs to be rejected")
+	}
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+	}
+	if !containsString(err.Error(), "duplicate of target_refs[0]") {
+		t.Errorf("expected dedup message referencing target_refs[0], got %v", err)
+	}
+
+	if items := listBindings(t, fakeClient, "holos-fld-payments"); len(items) != 0 {
+		t.Errorf("expected no bindings stored on duplicate rejection, got %d", len(items))
+	}
+}
+
+// TestCreateWildcardProjectBypassesProjectExistsResolver pins the second
+// handler contract under HOL-772: when project_name is the wildcard
+// sentinel, validateTargetProjects must skip ProjectExistsResolver. The
+// stub resolver in this test returns false for every literal lookup; the
+// Create must still succeed because the wildcard ref declares "every
+// reachable project" and there is no single slug to probe.
+func TestCreateWildcardProjectBypassesProjectExistsResolver(t *testing.T) {
+	projectStub := &stubProjectResolver{exists: map[string]bool{}}
+	h, fakeClient := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(projectStub)
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := &consolev1.TemplatePolicyBinding{
+		Name:      "bind-wild-project",
+		Namespace: folder,
+		PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+			Namespace: folder,
+			Name:      "local-policy",
+		},
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+			Name:        "web",
+			ProjectName: policyresolver.WildcardAny,
+		}},
+	}
+
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Namespace: folder,
+		Binding:   binding,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if projectStub.calls != 0 {
+		t.Errorf("ProjectExistsResolver should not have been called for wildcard project_name; got %d calls", projectStub.calls)
+	}
+
+	if got := getBindingCR(t, fakeClient, "holos-fld-payments", "bind-wild-project"); got == nil {
+		t.Error("expected wildcard-project binding to be stored")
+	}
+}
+
+// TestCreateWildcardRejectsEmptyStrings guards the handler's empty-value
+// rule: even with wildcard support, empty name / project_name remain
+// invalid. The resolver's nameMatches guard (HOL-770) treats wildcard
+// refs as non-matching when the target value is empty, so allowing an
+// empty stored value would silently produce a binding that matches
+// nothing.
+func TestCreateWildcardRejectsEmptyStrings(t *testing.T) {
+	h, _ := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("owner@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	tests := []struct {
+		name    string
+		ref     *consolev1.TemplatePolicyBindingTargetRef
+		wantMsg string
+	}{
+		{
+			name: "empty name",
+			ref: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        "",
+				ProjectName: "payments-web",
+			},
+			wantMsg: "name is required",
+		},
+		{
+			name: "empty project_name",
+			ref: &consolev1.TemplatePolicyBindingTargetRef{
+				Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_DEPLOYMENT,
+				Name:        "api",
+				ProjectName: "",
+			},
+			wantMsg: "project_name is required",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			binding := &consolev1.TemplatePolicyBinding{
+				Name:      "bind-empty",
+				Namespace: folder,
+				PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+					Namespace: folder,
+					Name:      "local-policy",
+				},
+				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{tc.ref},
+			}
+			_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+				Namespace: folder,
+				Binding:   binding,
+			}))
+			if err == nil {
+				t.Fatal("expected rejection")
+			}
+			if connect.CodeOf(err) != connect.CodeInvalidArgument {
+				t.Errorf("expected CodeInvalidArgument, got %v: %v", connect.CodeOf(err), err)
+			}
+			if !containsString(err.Error(), tc.wantMsg) {
+				t.Errorf("expected error to contain %q, got %v", tc.wantMsg, err)
+			}
+		})
+	}
+}
+
+// TestCreateWildcardTargetRefsRBACDenial re-runs the permission-gate
+// contract from TestCreateRBACDenial against a request whose target_refs
+// are all wildcards. The trust-boundary argument for letting wildcards
+// into storage explicitly depends on h.checkAccess /
+// PermissionTemplatePoliciesWrite still rejecting unauthorized callers
+// — a regression here would turn wildcards into a privilege-escalation
+// gadget.
+func TestCreateWildcardTargetRefsRBACDenial(t *testing.T) {
+	h, fakeClient := newTestHandler(t, map[string]string{}) // no grants
+	h = h.
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("nobody@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	binding := &consolev1.TemplatePolicyBinding{
+		Name:      "bind-wild-denied",
+		Namespace: folder,
+		PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+			Namespace: folder,
+			Name:      "local-policy",
+		},
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+			Name:        policyresolver.WildcardAny,
+			ProjectName: policyresolver.WildcardAny,
+		}},
+	}
+	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
+		Namespace: folder,
+		Binding:   binding,
+	}))
+	if err == nil {
+		t.Fatal("expected permission denied on wildcard target_refs")
+	}
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("expected CodePermissionDenied, got %v: %v", connect.CodeOf(err), err)
+	}
+	if items := listBindings(t, fakeClient, "holos-fld-payments"); len(items) != 0 {
+		t.Errorf("expected no bindings on RBAC denial, got %d", len(items))
+	}
+}
+
+// TestUpdateWildcardTargetRefsRBACDenial mirrors the Create case against
+// the Update path. PermissionTemplatePoliciesWrite gates Update at
+// handler.go:388 today; a caller without the grant must not be able to
+// swap a stored binding's target_refs for a wildcard set.
+func TestUpdateWildcardTargetRefsRBACDenial(t *testing.T) {
+	existing := &templatesv1alpha1.TemplatePolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bind-wild-update-denied",
+			Namespace: "holos-fld-payments",
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeTemplatePolicyBinding,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationCreatorEmail: "original@example.com",
+			},
+		},
+		Spec: templatesv1alpha1.TemplatePolicyBindingSpec{
+			PolicyRef: templatesv1alpha1.LinkedTemplatePolicyRef{
+				Namespace: "holos-fld-payments",
+				Name:      "local-policy",
+			},
+			TargetRefs: []templatesv1alpha1.TemplatePolicyBindingTargetRef{{
+				Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+				Name:        "api",
+				ProjectName: "payments-web",
+			}},
+		},
+	}
+	fakeClient := newFakeCtrlClient(t, existing)
+	r := newTestResolver()
+	k := NewK8sClient(fakeClient, r)
+	h := NewHandler(k, r).
+		WithOrgGrantResolver(&stubOrgGrantResolver{users: map[string]string{}}).
+		WithFolderGrantResolver(&stubFolderGrantResolver{users: map[string]string{}}).
+		WithPolicyExistsResolver(&stubPolicyResolver{exists: true}).
+		WithProjectExistsResolver(&stubProjectResolver{})
+	ctx := authedCtx("nobody@example.com", nil)
+
+	folder := newFolderScopeRef("payments")
+	inbound := &consolev1.TemplatePolicyBinding{
+		Name:      "bind-wild-update-denied",
+		Namespace: folder,
+		PolicyRef: &consolev1.LinkedTemplatePolicyRef{
+			Namespace: folder,
+			Name:      "local-policy",
+		},
+		TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{{
+			Kind:        consolev1.TemplatePolicyBindingTargetKind_TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_TEMPLATE,
+			Name:        policyresolver.WildcardAny,
+			ProjectName: policyresolver.WildcardAny,
+		}},
+	}
+	_, err := h.UpdateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyBindingRequest{
+		Namespace: folder,
+		Binding:   inbound,
+	}))
+	if err == nil {
+		t.Fatal("expected permission denied on wildcard Update")
+	}
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("expected CodePermissionDenied, got %v: %v", connect.CodeOf(err), err)
+	}
+	// Confirm the stored binding was not mutated.
+	stored := getBindingCR(t, fakeClient, "holos-fld-payments", "bind-wild-update-denied")
+	if stored == nil {
+		t.Fatal("expected existing binding to remain")
+	}
+	if len(stored.Spec.TargetRefs) != 1 || stored.Spec.TargetRefs[0].Name != "api" {
+		t.Errorf("stored target_refs mutated on denied update: %+v", stored.Spec.TargetRefs)
 	}
 }


### PR DESCRIPTION
## Summary

Phase 3 of HOL-767. Updates the TemplatePolicyBinding handler to accept the wildcard sentinel in `target_refs[].name` and `target_refs[].project_name`, completing the backend gate for wildcard bindings. The resolver (Phase 2, HOL-770) already matches against the wildcard; this PR opens the authoring path.

- `validateTargetRefs` now accepts `policyresolver.WildcardAny` (`\"*\"`) or a DNS label for `name` / `project_name`. The wildcard short-circuit runs BEFORE `dnsLabelRe` because `dnsLabelRe.MatchString(\"*\")` is false. `kind` is never wildcarded; empty strings are still rejected (the resolver's `nameMatches` returns false for an empty target value under a wildcard ref, so an empty stored value would silently match nothing). Dedup key is unchanged — two `{kind, \"*\", \"*\"}` rows are still a duplicate.
- `validateTargetProjects` skips `ProjectExistsResolver` (and bypasses the project-name cache) when the ref's `project_name` is the wildcard. Literal probes are unchanged.
- Validator imports `policyresolver.WildcardAny` rather than hardcoding `\"*\"`, so handler and resolver share one source of truth for the sentinel.
- `PermissionTemplatePoliciesWrite` gate on Create/Update is unchanged; wildcards remain write-gated.

## Test plan

- [x] `console/templatepolicybindings/handler_test.go` — added table-driven Create and Update cases covering all four `{literal, *} × {name, project_name}` combinations; duplicate wildcard rejection; wildcard-project-bypasses-ProjectExistsResolver (deny-all stub still succeeds); empty name / empty project_name still rejected; RBAC denial retained on both Create and Update of wildcard bindings.
- [x] `console/policyresolver/applied_state_envtest_test.go` — added cache-backed cascade tests over a real envtest apiserver:
  - folder-scope `{*, *, PROJECT_TEMPLATE}` attaches to every project-template render under the folder, nothing under a sibling folder
  - admission policy `templatepolicybinding-folder-or-org-only` rejects a wildcard binding stored in a project namespace (HOL-554 ceiling)
  - `{*, \"web\", DEPLOYMENT}` matches every `web` deployment across reachable projects and zero for other names.
- [x] `make test-go` passes locally (race detector on via `CGO_ENABLED=1`).

Closes HOL-772
Part of HOL-767