### PR TITLE
chore(frontend): address style findings from PR #1064 (HOL-612)

### DIFF
--- a/frontend/src/queries/folders.ts
+++ b/frontend/src/queries/folders.ts
@@ -122,3 +122,17 @@ export function useUpdateFolderDefaultSharing(organization: string, name: string
     },
   })
 }
+
+export function useDeleteFolder(organization: string) {
+  const transport = useTransport()
+  const client = useMemo(() => createClient(FolderService, transport), [transport])
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { name: string }) =>
+      client.deleteFolder({ organization, ...params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
+      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
+    },
+  })
+}

--- a/frontend/src/routes/_authenticated/folders/$folderName/-folder-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-folder-detail.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/queries/folders', () => ({
   useListFolders: vi.fn(),
   useUpdateFolderSharing: vi.fn(),
   useUpdateFolderDefaultSharing: vi.fn(),
+  useDeleteFolder: vi.fn(),
 }))
 
 vi.mock('@/queries/organizations', () => ({
@@ -32,7 +33,7 @@ vi.mock('@/queries/organizations', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders, useUpdateFolderSharing, useUpdateFolderDefaultSharing } from '@/queries/folders'
+import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders, useUpdateFolderSharing, useUpdateFolderDefaultSharing, useDeleteFolder } from '@/queries/folders'
 import { useGetOrganization } from '@/queries/organizations'
 import { FolderDetailPage } from '@/routes/_authenticated/folders/$folderName/settings/index'
 
@@ -97,6 +98,10 @@ function setupMocks(overrides: { folder?: Partial<typeof mockFolder>; org?: Part
     isPending: false,
   })
   ;(useUpdateFolderDefaultSharing as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useDeleteFolder as Mock).mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue({}),
     isPending: false,
   })

--- a/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx
@@ -31,7 +31,7 @@ import { Check, Pencil, X, Table2, Braces } from 'lucide-react'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { ViewModeToggle } from '@/components/view-mode-toggle'
 import { RawView } from '@/components/raw-view'
-import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders, useUpdateFolderSharing, useUpdateFolderDefaultSharing } from '@/queries/folders'
+import { useGetFolder, useGetFolderRaw, useUpdateFolder, useListFolders, useUpdateFolderSharing, useUpdateFolderDefaultSharing, useDeleteFolder } from '@/queries/folders'
 import { useGetOrganization } from '@/queries/organizations'
 import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -78,6 +78,7 @@ export function FolderDetailPage({
   const { data: allFolders } = useListFolders(orgName)
   const updateFolderSharing = useUpdateFolderSharing(orgName, folderName)
   const updateFolderDefaultSharing = useUpdateFolderDefaultSharing(orgName, folderName)
+  const deleteFolderMutation = useDeleteFolder(orgName)
 
   // View mode: data or raw
   const [viewMode, setViewMode] = useState<'data' | 'raw'>('data')
@@ -589,8 +590,10 @@ export function FolderDetailPage({
             </Button>
             <Button
               variant="destructive"
+              disabled={deleteFolderMutation.isPending}
               onClick={async () => {
                 try {
+                  await deleteFolderMutation.mutateAsync({ name: folderName })
                   setDeleteOpen(false)
                   navigate?.({
                     to: '/orgs/$orgName/resources',

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/$templateName.tsx
@@ -8,8 +8,8 @@ import { useGetFolder } from '@/queries/folders'
 
 // HOL-607 retired the scope-specific folder-template editor. This route is a
 // redirect shim that resolves the owning organization from the folder record,
-// then navigates to the consolidated editor. Cleanup (HOL-612) may remove it
-// once links settle.
+// then navigates to the consolidated editor. HOL-612 confirmed it must stay —
+// several active pages still link here.
 export const Route = createFileRoute(
   '/_authenticated/folders/$folderName/templates/$templateName',
 )({

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -8,8 +8,8 @@ import { useGetProject } from '@/queries/projects'
 
 // HOL-607 retired the scope-specific project-template editor. This route is a
 // redirect shim that resolves the owning organization from the project record,
-// then navigates to the consolidated editor. Cleanup (HOL-612) may remove it
-// once links settle.
+// then navigates to the consolidated editor. HOL-612 confirmed it must stay —
+// several active pages still link here.
 export const Route = createFileRoute(
   '/_authenticated/projects/$projectName/templates/$templateName',
 )({


### PR DESCRIPTION
## Summary

- Update stale comments on the folder-template and project-template redirect shims: replace the misleading "Cleanup (HOL-612) may remove it once links settle" text with a note that HOL-612 confirmed the shims must stay.
- Add `useDeleteFolder` mutation hook to `frontend/src/queries/folders.ts`, calling `FolderService.deleteFolder`.
- Wire the Delete Folder confirm button in `folders/$folderName/settings/index.tsx` to the new mutation so it actually invokes the delete API before navigating away; button is disabled while the request is in flight and shows a toast on error.
- Update the Vitest test mock for `@/queries/folders` in `-folder-detail.test.tsx` to include `useDeleteFolder`.

Fixes HOL-766

## Test plan

- [x] All 1038 Vitest unit tests pass (`make test-ui`)
- [ ] Manually verify Delete Folder dialog: open folder settings, click Delete Folder, confirm — folder is deleted and page navigates to `/orgs/$orgName/resources`
- [ ] Verify Delete Folder dialog cancel button closes dialog without side effects
- [ ] Verify Delete Folder button is disabled while request is in flight
- [ ] Verify error toast appears when delete API returns an error