### PR TITLE
feat(frontend): add * wildcard input + matches-preview panel to BindingForm

### DIFF
--- a/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
@@ -27,6 +27,7 @@ vi.mock('@/queries/templatePolicies', async () => {
 
 vi.mock('@/queries/projects', () => ({
   useListProjects: vi.fn(),
+  useListProjectsByParent: vi.fn(),
 }))
 
 vi.mock('@/queries/deployments', () => ({
@@ -45,7 +46,10 @@ vi.mock('@/queries/templates', async () => {
 
 import { BindingForm } from './BindingForm'
 import { useListTemplatePolicies } from '@/queries/templatePolicies'
-import { useListProjects } from '@/queries/projects'
+import {
+  useListProjects,
+  useListProjectsByParent,
+} from '@/queries/projects'
 import { useListDeployments } from '@/queries/deployments'
 import { useListTemplates } from '@/queries/templates'
 import { namespaceForOrg, namespaceForProject } from '@/lib/scope-labels'
@@ -81,6 +85,13 @@ function stubQueries({
   ;(useListProjects as Mock).mockReturnValue({
     data: { projects },
     isPending: false,
+    isLoading: false,
+    error: null,
+  })
+  ;(useListProjectsByParent as Mock).mockReturnValue({
+    data: projects,
+    isPending: false,
+    isLoading: false,
     error: null,
   })
   ;(useListDeployments as Mock).mockReturnValue({
@@ -99,6 +110,32 @@ describe('BindingForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     stubQueries({})
+  })
+
+  it('info box explains the scoped-wildcard model and no longer mentions "no glob patterns"', () => {
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        namespace={ORG_NAMESPACE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    const info = screen.getByTestId('binding-form-info')
+    // The HOL-773 info-box rewrite drops the legacy "no glob patterns" copy
+    // entirely — matching it would be a smoke-test that the author forgot
+    // to swap phrasing after Phases 1–3 landed.
+    expect(info.textContent ?? '').not.toMatch(/no glob patterns/i)
+    // New copy mentions wildcard expansion within the binding's storage
+    // scope and the kind-never-wildcarded rule.
+    expect(info.textContent ?? '').toMatch(/wildcard/i)
+    expect(info.textContent ?? '').toMatch(/storage scope/i)
+    expect(info.textContent ?? '').toMatch(/kind is never wildcarded/i)
   })
 
   it('renders the name, display name, description, policy, and targets fields', () => {

--- a/frontend/src/components/template-policy-bindings/BindingForm.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.tsx
@@ -8,6 +8,10 @@ import { Separator } from '@/components/ui/separator'
 import { Combobox, type ComboboxItem } from '@/components/ui/combobox'
 import { TargetRefEditor } from './TargetRefEditor'
 import {
+  MatchesPreview,
+  type MatchesPreviewParentScope,
+} from './MatchesPreview'
+import {
   applyPolicyKey,
   draftToMutationParams,
   newEmptyBindingDraft,
@@ -17,7 +21,10 @@ import {
   type BindingMutationParams,
 } from './binding-draft'
 import { useListTemplatePolicies } from '@/queries/templatePolicies'
-import { scopeLabelFromNamespace, scopeNameFromNamespace } from '@/lib/scope-labels'
+import {
+  scopeLabelFromNamespace,
+  scopeNameFromNamespace,
+} from '@/lib/scope-labels'
 
 /**
  * BindingScope captures the allowed scope types for a TemplatePolicyBinding.
@@ -35,6 +42,9 @@ export type BindingFormProps = {
   /** Organization that owns the scope — required to populate the per-row
    * project picker. */
   organization: string
+  /** Folder name when `scopeType === 'folder'`. Used by MatchesPreview to
+   * enumerate the folder's children when the author picks `project: "*"`. */
+  folderName?: string
   canWrite: boolean
   initialValues?: BindingDraft
   submitLabel: string
@@ -56,6 +66,7 @@ export function BindingForm({
   scopeType,
   namespace,
   organization,
+  folderName,
   canWrite,
   initialValues,
   submitLabel,
@@ -134,12 +145,27 @@ export function BindingForm({
     }
   }
 
+  const parentScope: MatchesPreviewParentScope = useMemo(() => {
+    if (scopeType === 'folder' && folderName) {
+      return { kind: 'folder', folderName }
+    }
+    return { kind: 'organization' }
+  }, [scopeType, folderName])
+
   return (
     <div className="space-y-4">
-      <div className="rounded-md border border-border p-3 text-sm text-muted-foreground">
-        Template policy bindings attach a single policy to an explicit list of
-        project templates and deployments. No glob patterns — every target is
-        named directly.
+      <div
+        data-testid="binding-form-info"
+        className="rounded-md border border-border p-3 text-sm text-muted-foreground"
+      >
+        A TemplatePolicyBinding attaches one policy to a list of project
+        templates and deployments. Use the wildcard <code>*</code> in{' '}
+        <code>project_name</code> or <code>name</code> to expand a row to every
+        match the binding's storage scope can reach — a folder-scoped binding
+        can only touch resources under that folder, an organization-scoped
+        binding can touch every project in the org. <code>kind</code> is never
+        wildcarded: use a separate row for each kind so audit logs stay
+        readable.
       </div>
 
       <div>
@@ -229,6 +255,11 @@ export function BindingForm({
             setDraft((prev) => ({ ...prev, targetRefs }))
           }
           disabled={!canWrite}
+        />
+        <MatchesPreview
+          organization={organization}
+          parentScope={parentScope}
+          targets={draft.targetRefs}
         />
       </div>
 

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
@@ -1,0 +1,280 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+
+// jsdom polyfills (match the other binding-form test files).
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+
+vi.mock('@/queries/projects', () => ({
+  useListProjects: vi.fn(),
+  useListProjectsByParent: vi.fn(),
+}))
+
+vi.mock('@/queries/deployments', () => ({
+  useListDeployments: vi.fn(),
+}))
+
+vi.mock('@/queries/templates', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templates')>(
+    '@/queries/templates',
+  )
+  return {
+    ...actual,
+    useListTemplates: vi.fn(),
+  }
+})
+
+import { MatchesPreview } from './MatchesPreview'
+import { useListProjects, useListProjectsByParent } from '@/queries/projects'
+import { useListDeployments } from '@/queries/deployments'
+import { useListTemplates } from '@/queries/templates'
+import { namespaceForProject } from '@/lib/scope-labels'
+import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
+
+type Template = { name: string; displayName: string; namespace: string }
+type Deployment = { name: string; displayName: string }
+type Project = { name: string; displayName: string }
+
+function stubLists({
+  projects = [],
+  perProjectTemplates = {},
+  perProjectDeployments = {},
+}: {
+  projects?: Project[]
+  perProjectTemplates?: Record<string, Template[]>
+  perProjectDeployments?: Record<string, Deployment[]>
+}) {
+  ;(useListProjects as Mock).mockImplementation((org: string) => ({
+    data: org ? { projects } : undefined,
+    isLoading: false,
+    isPending: false,
+    error: null,
+  }))
+  ;(useListProjectsByParent as Mock).mockImplementation(
+    (org: string, _pt: unknown, parent: string | undefined) => ({
+      data: org && parent ? projects : undefined,
+      isLoading: false,
+      isPending: false,
+      error: null,
+    }),
+  )
+  ;(useListTemplates as Mock).mockImplementation((namespace: string) => {
+    if (!namespace) return { data: [], isLoading: false, error: null }
+    // namespace-to-project-name reverse lookup: the fixture keys by project
+    // name so the test controls per-project shape.
+    const entry = Object.entries(perProjectTemplates).find(
+      ([p]) => namespaceForProject(p) === namespace,
+    )
+    return {
+      data: entry ? entry[1] : [],
+      isLoading: false,
+      error: null,
+    }
+  })
+  ;(useListDeployments as Mock).mockImplementation((project: string) => {
+    return {
+      data: project ? (perProjectDeployments[project] ?? []) : [],
+      isLoading: false,
+      error: null,
+    }
+  })
+}
+
+describe('MatchesPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('expands {project:"*", name:"*"} PROJECT_TEMPLATE across every project', async () => {
+    // Fixture: two projects, each with a project-scope template. Wildcard
+    // expansion must yield exactly those two entries, dedup'd.
+    stubLists({
+      projects: [
+        { name: 'proj-a', displayName: 'Project A' },
+        { name: 'proj-b', displayName: 'Project B' },
+      ],
+      perProjectTemplates: {
+        'proj-a': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('proj-a'),
+          },
+        ],
+        'proj-b': [
+          {
+            name: 'web',
+            displayName: 'Web',
+            namespace: namespaceForProject('proj-b'),
+          },
+        ],
+      },
+    })
+
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          },
+        ]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
+        /Matches 2 targets/i,
+      )
+    })
+    const list = screen.getByTestId('matches-preview-list')
+    expect(list).toHaveTextContent('proj-a/ingress')
+    expect(list).toHaveTextContent('proj-b/web')
+  })
+
+  it('renders the empty-state warning when zero matches', async () => {
+    // No projects at all — wildcard expansion yields nothing.
+    stubLists({ projects: [], perProjectTemplates: {} })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('matches-preview-empty'),
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('matches-preview-empty')).toHaveTextContent(
+      /No targets match/i,
+    )
+  })
+
+  it('dedupes overlapping rows (e.g. literal + wildcard both pointing at same target)', async () => {
+    stubLists({
+      projects: [{ name: 'proj-a', displayName: 'Project A' }],
+      perProjectTemplates: {
+        'proj-a': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('proj-a'),
+          },
+        ],
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'proj-a',
+            name: 'ingress',
+          },
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
+        /Matches 1 target/i,
+      )
+    })
+  })
+
+  it('enumerates DEPLOYMENT wildcards via useListDeployments', async () => {
+    stubLists({
+      projects: [
+        { name: 'proj-a', displayName: 'Project A' },
+        { name: 'proj-b', displayName: 'Project B' },
+      ],
+      perProjectDeployments: {
+        'proj-a': [{ name: 'web', displayName: 'Web' }],
+        'proj-b': [{ name: 'api', displayName: 'API' }],
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+            projectName: '*',
+            name: '*',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
+        /Matches 2 targets/i,
+      )
+    })
+    expect(screen.getByTestId('matches-preview-list')).toHaveTextContent(
+      'proj-a/web',
+    )
+    expect(screen.getByTestId('matches-preview-list')).toHaveTextContent(
+      'proj-b/api',
+    )
+  })
+
+  it('folder-scoped preview enumerates via useListProjectsByParent', async () => {
+    stubLists({
+      projects: [{ name: 'proj-folder-a', displayName: 'Project A' }],
+      perProjectTemplates: {
+        'proj-folder-a': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('proj-folder-a'),
+          },
+        ],
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'folder', folderName: 'team' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(useListProjectsByParent).toHaveBeenCalled()
+      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
+        /Matches 1 target/i,
+      )
+    })
+  })
+})

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
@@ -47,43 +47,54 @@ function stubLists({
   projects = [],
   perProjectTemplates = {},
   perProjectDeployments = {},
+  perProjectTemplatesError = {},
+  perProjectDeploymentsError = {},
+  listProjectsError = null,
 }: {
   projects?: Project[]
   perProjectTemplates?: Record<string, Template[]>
   perProjectDeployments?: Record<string, Deployment[]>
+  perProjectTemplatesError?: Record<string, unknown>
+  perProjectDeploymentsError?: Record<string, unknown>
+  listProjectsError?: unknown
 }) {
   ;(useListProjects as Mock).mockImplementation((org: string) => ({
-    data: org ? { projects } : undefined,
+    data: org && !listProjectsError ? { projects } : undefined,
     isLoading: false,
     isPending: false,
-    error: null,
+    error: org ? listProjectsError : null,
   }))
   ;(useListProjectsByParent as Mock).mockImplementation(
     (org: string, _pt: unknown, parent: string | undefined) => ({
-      data: org && parent ? projects : undefined,
+      data:
+        org && parent && !listProjectsError ? projects : undefined,
       isLoading: false,
       isPending: false,
-      error: null,
+      error: org && parent ? listProjectsError : null,
     }),
   )
   ;(useListTemplates as Mock).mockImplementation((namespace: string) => {
     if (!namespace) return { data: [], isLoading: false, error: null }
-    // namespace-to-project-name reverse lookup: the fixture keys by project
-    // name so the test controls per-project shape.
     const entry = Object.entries(perProjectTemplates).find(
       ([p]) => namespaceForProject(p) === namespace,
     )
+    const errEntry = Object.entries(perProjectTemplatesError).find(
+      ([p]) => namespaceForProject(p) === namespace,
+    )
     return {
-      data: entry ? entry[1] : [],
+      data: errEntry ? undefined : entry ? entry[1] : [],
       isLoading: false,
-      error: null,
+      error: errEntry ? errEntry[1] : null,
     }
   })
   ;(useListDeployments as Mock).mockImplementation((project: string) => {
+    if (!project) return { data: [], isLoading: false, error: null }
     return {
-      data: project ? (perProjectDeployments[project] ?? []) : [],
+      data: perProjectDeploymentsError[project]
+        ? undefined
+        : (perProjectDeployments[project] ?? []),
       isLoading: false,
-      error: null,
+      error: perProjectDeploymentsError[project] ?? null,
     }
   })
 }
@@ -395,6 +406,68 @@ describe('MatchesPreview', () => {
     expect(screen.getByTestId('matches-preview-list')).toHaveTextContent(
       'proj-a/ingress',
     )
+  })
+
+  it('renders the probe error banner when a per-project probe fails', async () => {
+    // HOL-773 codex follow-up on PR #1084: if useListTemplates fails for
+    // a project the preview must NOT collapse to the empty-state warning.
+    // It must surface an explicit error banner so the author knows the
+    // match count is incomplete.
+    stubLists({
+      projects: [{ name: 'proj-a', displayName: 'Project A' }],
+      perProjectTemplates: {},
+      perProjectTemplatesError: {
+        'proj-a': new Error('transient connect error'),
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('matches-preview-error'),
+      ).toBeInTheDocument()
+    })
+    // Empty-state warning must NOT appear when a probe errored —
+    // "No targets match" is reserved for a complete, zero-result preview.
+    expect(
+      screen.queryByTestId('matches-preview-empty'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the scope-enumeration error banner when useListProjects fails', async () => {
+    stubLists({
+      projects: [],
+      listProjectsError: new Error('transient connect error'),
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('matches-preview-error'),
+      ).toBeInTheDocument()
+    })
   })
 
   it('folder-scoped preview enumerates via useListProjectsByParent', async () => {

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
@@ -244,6 +244,86 @@ describe('MatchesPreview', () => {
     )
   })
 
+  it('folder-scoped binding: literal out-of-folder project is excluded from preview', async () => {
+    // HOL-773 codex follow-up on PR #1084: under folder scope, only
+    // projects inside the folder are reachable. A target that points at
+    // a literal project outside the folder must NOT show matches (the
+    // backend rejects it with "project ... does not exist under binding
+    // scope ...").
+    stubLists({
+      projects: [{ name: 'in-folder', displayName: 'In Folder' }],
+      perProjectTemplates: {
+        'in-folder': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('in-folder'),
+          },
+        ],
+        // "out-of-folder" has a template, but the folder's project list
+        // doesn't include it — the preview should ignore the data.
+        'out-of-folder': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('out-of-folder'),
+          },
+        ],
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'folder', folderName: 'team' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'out-of-folder',
+            name: 'ingress',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('matches-preview-empty'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('folder-scoped binding: literal in-folder project still reports a match', async () => {
+    stubLists({
+      projects: [{ name: 'in-folder', displayName: 'In Folder' }],
+      perProjectTemplates: {
+        'in-folder': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('in-folder'),
+          },
+        ],
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'folder', folderName: 'team' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'in-folder',
+            name: 'ingress',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
+        /Matches 1 target/i,
+      )
+    })
+  })
+
   it('literal/literal row is verified against the project list (no over-reporting)', async () => {
     // HOL-773 codex review on PR #1084: the preview used to short-circuit
     // literal/literal pairs without checking that the resource actually

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
@@ -244,6 +244,79 @@ describe('MatchesPreview', () => {
     )
   })
 
+  it('literal/literal row is verified against the project list (no over-reporting)', async () => {
+    // HOL-773 codex review on PR #1084: the preview used to short-circuit
+    // literal/literal pairs without checking that the resource actually
+    // exists in the chosen project. Now every row goes through the probe,
+    // so a typo yields the empty-state warning instead of a phantom match.
+    stubLists({
+      projects: [{ name: 'proj-a', displayName: 'Project A' }],
+      perProjectTemplates: {
+        'proj-a': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('proj-a'),
+          },
+        ],
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'proj-a',
+            name: 'does-not-exist',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('matches-preview-empty'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('literal/literal row that DOES exist still renders a match (happy path after P2 fix)', async () => {
+    stubLists({
+      projects: [{ name: 'proj-a', displayName: 'Project A' }],
+      perProjectTemplates: {
+        'proj-a': [
+          {
+            name: 'ingress',
+            displayName: 'Ingress',
+            namespace: namespaceForProject('proj-a'),
+          },
+        ],
+      },
+    })
+    render(
+      <MatchesPreview
+        organization="test-org"
+        parentScope={{ kind: 'organization' }}
+        targets={[
+          {
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'proj-a',
+            name: 'ingress',
+          },
+        ]}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
+        /Matches 1 target/i,
+      )
+    })
+    expect(screen.getByTestId('matches-preview-list')).toHaveTextContent(
+      'proj-a/ingress',
+    )
+  })
+
   it('folder-scoped preview enumerates via useListProjectsByParent', async () => {
     stubLists({
       projects: [{ name: 'proj-folder-a', displayName: 'Project A' }],

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
@@ -192,17 +192,23 @@ export function MatchesPreview({
   // the top of the component so hook order is invariant across renders.
   // Both hooks are passed empty strings when not applicable which short-
   // circuits via `enabled: !!organization` inside the hooks themselves.
-  const anyRowWildcardsProject = useMemo(
-    () => targets.some((t) => t.projectName === WILDCARD),
-    [targets],
-  )
+  //
+  // Folder-scoped bindings must *always* enumerate the folder's projects —
+  // not just when a wildcard row is present — because literal project
+  // names still need to be filtered through the scope ceiling. Otherwise
+  // the preview would happily probe an out-of-folder project and claim
+  // matches the backend will reject with "project ... does not exist
+  // under binding scope ..." (codex review on PR #1084).
+  const needsScopeProjectList =
+    parentScope.kind === 'folder' ||
+    targets.some((t) => t.projectName === WILDCARD)
   const orgProjectsQuery = useListProjects(
-    parentScope.kind === 'organization' && anyRowWildcardsProject
+    parentScope.kind === 'organization' && needsScopeProjectList
       ? organization
       : '',
   )
   const folderProjectsQuery = useListProjectsByParent(
-    parentScope.kind === 'folder' && anyRowWildcardsProject ? organization : '',
+    parentScope.kind === 'folder' && needsScopeProjectList ? organization : '',
     parentScope.kind === 'folder' ? ParentType.FOLDER : undefined,
     parentScope.kind === 'folder' ? parentScope.folderName : undefined,
   )
@@ -214,8 +220,15 @@ export function MatchesPreview({
     return (folderProjectsQuery.data ?? []).map((p) => p.name)
   }, [parentScope.kind, orgProjectsQuery.data, folderProjectsQuery.data])
 
+  // Folder scope is the only kind that hard-limits literal project names.
+  // Org scope lets a binding reach every project the caller can see, so
+  // an org-scoped literal only needs existence verification (which happens
+  // below via the per-project probe). For folder scope we additionally
+  // check membership in `enumeratedProjects`.
+  const scopeEnforcesFolderMembership = parentScope.kind === 'folder'
+
   const enumeratedProjectsPending =
-    anyRowWildcardsProject &&
+    needsScopeProjectList &&
     ((parentScope.kind === 'organization' && orgProjectsQuery.isLoading) ||
       (parentScope.kind === 'folder' && folderProjectsQuery.isLoading))
 
@@ -223,18 +236,34 @@ export function MatchesPreview({
   // projectName) pair that a per-project probe component owns one hook
   // call for. De-duplicating at this layer avoids issuing the same
   // useListTemplates/useListDeployments twice for the same project.
+  //
+  // Literal projects are filtered through the scope's project list when
+  // the scope enforces membership (folder). An out-of-scope literal gets
+  // an empty projects array which drops its contribution to the match
+  // set — the panel's empty-state warning then tells the author the row
+  // will attach to nothing, which matches the backend's behavior.
   const rowPlans = useMemo(() => {
+    const scopeSet = new Set(enumeratedProjects)
     return targets.map((t) => {
       const projectIsWildcard = t.projectName === WILDCARD
       const hasLiteralProject = !!t.projectName && !projectIsWildcard
-      const projects: string[] = projectIsWildcard
-        ? enumeratedProjects
-        : hasLiteralProject
-          ? [t.projectName]
-          : []
-      return { target: t, projects, projectIsWildcard }
+      let projects: string[]
+      let outOfScope = false
+      if (projectIsWildcard) {
+        projects = enumeratedProjects
+      } else if (hasLiteralProject) {
+        if (scopeEnforcesFolderMembership && !scopeSet.has(t.projectName)) {
+          projects = []
+          outOfScope = true
+        } else {
+          projects = [t.projectName]
+        }
+      } else {
+        projects = []
+      }
+      return { target: t, projects, projectIsWildcard, outOfScope }
     })
-  }, [targets, enumeratedProjects])
+  }, [targets, enumeratedProjects, scopeEnforcesFolderMembership])
 
   const probeSpecs = useMemo(() => {
     const seen = new Set<string>()
@@ -279,6 +308,19 @@ export function MatchesPreview({
         continue
       }
 
+      // Folder-scope literal with enumeration still loading: pending, not
+      // empty — avoids a flash-of-empty before the scope list resolves.
+      if (
+        !plan.projectIsWildcard &&
+        scopeEnforcesFolderMembership &&
+        enumeratedProjectsPending &&
+        plan.projects.length === 0 &&
+        !plan.outOfScope
+      ) {
+        pending += 1
+        continue
+      }
+
       for (const projectName of plan.projects) {
         const probeKey = `${t.kind}/${projectName}`
         const probe = probeData[probeKey]
@@ -307,7 +349,7 @@ export function MatchesPreview({
       }
     }
     return { matches: Array.from(seen.values()), pendingCount: pending }
-  }, [rowPlans, probeData, enumeratedProjectsPending])
+  }, [rowPlans, probeData, enumeratedProjectsPending, scopeEnforcesFolderMembership])
 
   const [open, setOpen] = useState(true)
   const isEmpty = matches.length === 0

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
@@ -1,0 +1,511 @@
+import {
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  useCallback,
+} from 'react'
+import { Loader2, ChevronDown, ChevronRight } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
+import { useListDeployments } from '@/queries/deployments'
+import { useListProjects, useListProjectsByParent } from '@/queries/projects'
+import { useListTemplates } from '@/queries/templates'
+import { ParentType } from '@/gen/holos/console/v1/folders_pb.js'
+import { namespaceForProject, scopeLabelFromNamespace } from '@/lib/scope-labels'
+import { WILDCARD, type TargetRefDraft } from './binding-draft'
+
+/**
+ * MatchEntry is a single concrete target the binding will attach to once a
+ * wildcard expansion has resolved. `kind` is preserved from the source row
+ * (kind is never wildcarded — see HOL-767 audit-readability rule). The
+ * dedupe key is `${kind}/${projectName}/${name}`.
+ */
+type MatchEntry = {
+  kind: TemplatePolicyBindingTargetKind
+  projectName: string
+  name: string
+}
+
+function entryKey(e: MatchEntry): string {
+  return `${e.kind}/${e.projectName}/${e.name}`
+}
+
+function kindLabel(kind: TemplatePolicyBindingTargetKind): string {
+  return kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
+    ? 'deployment'
+    : 'project_template'
+}
+
+export type MatchesPreviewParentScope =
+  | { kind: 'organization' }
+  | { kind: 'folder'; folderName: string }
+
+export type MatchesPreviewProps = {
+  /** The organization that owns this binding's scope. Required to enumerate
+   * projects under a wildcard `project_name`. */
+  organization: string
+  /** The binding's storage-scope ceiling. Folder bindings enumerate only the
+   * projects beneath the folder; org bindings enumerate every project the
+   * caller can see in the organization. The server is authoritative — the
+   * preview is a best-effort blast-radius hint, not a security boundary. */
+  parentScope: MatchesPreviewParentScope
+  /** Live target draft from BindingForm — the preview re-derives on every
+   * edit. */
+  targets: TargetRefDraft[]
+}
+
+/**
+ * ProbeStore is a tiny, deliberately-local pub/sub used so that per-project
+ * probe children can publish their hook-resolved data to the parent without
+ * the parent owning `useState` that children would have to push into via
+ * effects. We subscribe via `useSyncExternalStore` (React's sanctioned
+ * external-store pattern) so the parent recomputes when children call
+ * `publish`, and the child publishes during its own render/effect without
+ * triggering cascading parent renders inside an effect of the parent itself.
+ *
+ * HOL-773 detail: we avoid `setState` inside effects because this codebase's
+ * `react-hooks/set-state-in-effect` lint rule promotes that anti-pattern to
+ * an error. The external-store indirection keeps the child→parent data
+ * flow reactive without violating the rule.
+ */
+type ProbeValue = {
+  matches: MatchEntry[]
+  pending: boolean
+}
+
+type ProbeStore = {
+  publish: (key: string, value: ProbeValue) => void
+  remove: (key: string) => void
+  subscribe: (listener: () => void) => () => void
+  snapshot: () => Record<string, ProbeValue>
+}
+
+function useProbeStore(): ProbeStore {
+  const listenersRef = useRef<Set<() => void>>(new Set())
+  const dataRef = useRef<Record<string, ProbeValue>>({})
+  // Every publish produces a new snapshot object so `useSyncExternalStore`'s
+  // identity check against the previous snapshot fires. Without this the
+  // consumer would never re-render after a probe update.
+  const versionRef = useRef<Record<string, ProbeValue>>({})
+
+  const notify = useCallback(() => {
+    for (const l of listenersRef.current) l()
+  }, [])
+
+  const publish = useCallback(
+    (key: string, value: ProbeValue) => {
+      const prev = dataRef.current[key]
+      if (
+        prev &&
+        prev.pending === value.pending &&
+        sameMatchList(prev.matches, value.matches)
+      ) {
+        return
+      }
+      dataRef.current = { ...dataRef.current, [key]: value }
+      versionRef.current = dataRef.current
+      notify()
+    },
+    [notify],
+  )
+
+  const remove = useCallback(
+    (key: string) => {
+      if (!(key in dataRef.current)) return
+      const next = { ...dataRef.current }
+      delete next[key]
+      dataRef.current = next
+      versionRef.current = next
+      notify()
+    },
+    [notify],
+  )
+
+  const subscribe = useCallback((listener: () => void) => {
+    listenersRef.current.add(listener)
+    return () => {
+      listenersRef.current.delete(listener)
+    }
+  }, [])
+
+  const snapshot = useCallback(() => versionRef.current, [])
+
+  return useMemo(
+    () => ({ publish, remove, subscribe, snapshot }),
+    [publish, remove, subscribe, snapshot],
+  )
+}
+
+function sameMatchList(a: MatchEntry[], b: MatchEntry[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (entryKey(a[i]) !== entryKey(b[i])) return false
+  }
+  return true
+}
+
+function useProbeSnapshot(store: ProbeStore): Record<string, ProbeValue> {
+  return useSyncExternalStore(store.subscribe, store.snapshot, store.snapshot)
+}
+
+/**
+ * MatchesPreview shows the author the *concrete* targets a binding will
+ * attach to once `*` wildcards are expanded. Expansion is client-side only
+ * (HOL-767 explicit non-goal: no preview RPC) and uses the same list hooks
+ * that populate the editor pickers, so what the author selects is what the
+ * preview enumerates. The backend remains authoritative — preview is a
+ * blast-radius UX aid.
+ *
+ * Loading is progressive: each probe's hook fires independently so partial
+ * results render as soon as they resolve. A pending probe shows a spinner
+ * row in place of its eventual matches. When the dedup'd union is empty the
+ * panel renders a warning (the binding will attach to nothing); otherwise
+ * the count headline drives a collapsible list (virtualized for >50 entries
+ * via a windowed render — there's no third-party virtualization dep yet).
+ */
+export function MatchesPreview({
+  organization,
+  parentScope,
+  targets,
+}: MatchesPreviewProps) {
+  // Organization-wide and folder-scoped project enumerations are hoisted to
+  // the top of the component so hook order is invariant across renders.
+  // Both hooks are passed empty strings when not applicable which short-
+  // circuits via `enabled: !!organization` inside the hooks themselves.
+  const anyRowWildcardsProject = useMemo(
+    () => targets.some((t) => t.projectName === WILDCARD),
+    [targets],
+  )
+  const orgProjectsQuery = useListProjects(
+    parentScope.kind === 'organization' && anyRowWildcardsProject
+      ? organization
+      : '',
+  )
+  const folderProjectsQuery = useListProjectsByParent(
+    parentScope.kind === 'folder' && anyRowWildcardsProject ? organization : '',
+    parentScope.kind === 'folder' ? ParentType.FOLDER : undefined,
+    parentScope.kind === 'folder' ? parentScope.folderName : undefined,
+  )
+
+  const enumeratedProjects: string[] = useMemo(() => {
+    if (parentScope.kind === 'organization') {
+      return (orgProjectsQuery.data?.projects ?? []).map((p) => p.name)
+    }
+    return (folderProjectsQuery.data ?? []).map((p) => p.name)
+  }, [parentScope.kind, orgProjectsQuery.data, folderProjectsQuery.data])
+
+  const enumeratedProjectsPending =
+    anyRowWildcardsProject &&
+    ((parentScope.kind === 'organization' && orgProjectsQuery.isLoading) ||
+      (parentScope.kind === 'folder' && folderProjectsQuery.isLoading))
+
+  // Resolve per-row plans to a flat set of probes. Each probe is a (kind,
+  // projectName) pair that a per-project probe component owns one hook
+  // call for. De-duplicating at this layer avoids issuing the same
+  // useListTemplates/useListDeployments twice for the same project.
+  const rowPlans = useMemo(() => {
+    return targets.map((t) => {
+      const projectIsWildcard = t.projectName === WILDCARD
+      const hasLiteralProject = !!t.projectName && !projectIsWildcard
+      const projects: string[] = projectIsWildcard
+        ? enumeratedProjects
+        : hasLiteralProject
+          ? [t.projectName]
+          : []
+      return { target: t, projects, projectIsWildcard }
+    })
+  }, [targets, enumeratedProjects])
+
+  const probeSpecs = useMemo(() => {
+    const seen = new Set<string>()
+    const specs: Array<{
+      key: string
+      kind: TemplatePolicyBindingTargetKind
+      projectName: string
+    }> = []
+    for (const plan of rowPlans) {
+      for (const p of plan.projects) {
+        const key = `${plan.target.kind}/${p}`
+        if (seen.has(key)) continue
+        seen.add(key)
+        specs.push({ key, kind: plan.target.kind, projectName: p })
+      }
+    }
+    return specs
+  }, [rowPlans])
+
+  const store = useProbeStore()
+  const probeData = useProbeSnapshot(store)
+
+  // Reduce row plans + live probe data to a dedup'd list of matches.
+  const { matches, pendingCount } = useMemo(() => {
+    const seen = new Map<string, MatchEntry>()
+    let pending = 0
+    if (enumeratedProjectsPending) pending += 1
+
+    for (const plan of rowPlans) {
+      const t = plan.target
+      const nameIsWildcard = t.name === WILDCARD
+      const hasLiteralName = !!t.name && !nameIsWildcard
+
+      // {project: literal, name: literal} short-circuits without a hook probe.
+      if (!plan.projectIsWildcard && hasLiteralName && plan.projects.length === 1) {
+        const entry: MatchEntry = {
+          kind: t.kind,
+          projectName: plan.projects[0],
+          name: t.name,
+        }
+        const k = entryKey(entry)
+        if (!seen.has(k)) seen.set(k, entry)
+        continue
+      }
+
+      // project wildcard with no projects yet enumerated — honestly pending.
+      if (plan.projectIsWildcard && plan.projects.length === 0 && enumeratedProjectsPending) {
+        pending += 1
+        continue
+      }
+
+      for (const projectName of plan.projects) {
+        const probeKey = `${t.kind}/${projectName}`
+        const probe = probeData[probeKey]
+        if (!probe) {
+          pending += 1
+          continue
+        }
+        if (probe.pending) pending += 1
+        if (nameIsWildcard) {
+          for (const m of probe.matches) {
+            const k = entryKey(m)
+            if (!seen.has(k)) seen.set(k, m)
+          }
+        } else if (hasLiteralName) {
+          const exists = probe.matches.some((m) => m.name === t.name)
+          if (exists) {
+            const entry: MatchEntry = {
+              kind: t.kind,
+              projectName,
+              name: t.name,
+            }
+            const k = entryKey(entry)
+            if (!seen.has(k)) seen.set(k, entry)
+          }
+        }
+      }
+    }
+    return { matches: Array.from(seen.values()), pendingCount: pending }
+  }, [rowPlans, probeData, enumeratedProjectsPending])
+
+  const [open, setOpen] = useState(true)
+  const isEmpty = matches.length === 0
+  const isResolved = pendingCount === 0
+
+  return (
+    <div className="space-y-2" data-testid="matches-preview">
+      {/* Each (kind, project) pair gets a probe. Children publish hook
+          results into the shared store during render — no setState-in-effect
+          anywhere. */}
+      {probeSpecs.map((spec) => (
+        <Probe
+          key={spec.key}
+          probeKey={spec.key}
+          kind={spec.kind}
+          projectName={spec.projectName}
+          store={store}
+        />
+      ))}
+
+      {isEmpty && isResolved && targets.length > 0 ? (
+        <Alert variant="default" data-testid="matches-preview-empty">
+          <AlertTitle>No targets match</AlertTitle>
+          <AlertDescription>
+            The binding will not attach to anything. Add a literal name or pick
+            a project that contains at least one matching resource.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <Collapsible open={open} onOpenChange={setOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md border border-border px-3 py-2 text-left text-sm hover:bg-muted/40"
+              aria-label="Toggle matches preview"
+              data-testid="matches-preview-toggle"
+            >
+              {open ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              <span className="font-medium">
+                Matches {matches.length}{' '}
+                {matches.length === 1 ? 'target' : 'targets'}
+              </span>
+              {pendingCount > 0 && (
+                <span className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Resolving…
+                </span>
+              )}
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <MatchList matches={matches} />
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  )
+}
+
+// VIRTUALIZE_THRESHOLD is the entry count above which MatchList switches
+// from rendering every row inline to a windowed scroller. Below this the
+// inline list is faster and produces a friendlier DOM for screen readers
+// and for tests that assert getByText on a sample row.
+const VIRTUALIZE_THRESHOLD = 50
+
+function MatchList({ matches }: { matches: MatchEntry[] }) {
+  if (matches.length === 0) {
+    return (
+      <p className="px-3 py-2 text-sm text-muted-foreground">
+        No matches yet.
+      </p>
+    )
+  }
+  if (matches.length <= VIRTUALIZE_THRESHOLD) {
+    return (
+      <ul
+        className="mt-2 max-h-72 overflow-auto rounded-md border border-border"
+        data-testid="matches-preview-list"
+      >
+        {matches.map((m) => (
+          <li
+            key={entryKey(m)}
+            className="border-b border-border/40 px-3 py-1.5 text-sm last:border-b-0"
+          >
+            <code className="text-xs">{kindLabel(m.kind)}</code>{' '}
+            {m.projectName}/{m.name}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+  return <VirtualMatchList matches={matches} />
+}
+
+// VirtualMatchList does coarse windowing: only render the slice of rows
+// visible inside the scroll viewport (plus a small overscan). Avoids
+// pulling in react-window or @tanstack/react-virtual for what is, today,
+// a UX nice-to-have on the rare wide-binding case (>50 expanded matches).
+function VirtualMatchList({ matches }: { matches: MatchEntry[] }) {
+  const ROW_HEIGHT = 28
+  const VIEWPORT_HEIGHT = 288 // ~max-h-72
+  const OVERSCAN = 6
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [scrollTop, setScrollTop] = useState(0)
+
+  const startIndex = Math.max(
+    0,
+    Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN,
+  )
+  const endIndex = Math.min(
+    matches.length,
+    Math.ceil((scrollTop + VIEWPORT_HEIGHT) / ROW_HEIGHT) + OVERSCAN,
+  )
+  const slice = matches.slice(startIndex, endIndex)
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
+      style={{ height: VIEWPORT_HEIGHT }}
+      className="mt-2 overflow-auto rounded-md border border-border"
+      data-testid="matches-preview-virtual-list"
+    >
+      <div
+        style={{
+          height: matches.length * ROW_HEIGHT,
+          position: 'relative',
+        }}
+      >
+        <ul
+          style={{
+            position: 'absolute',
+            top: startIndex * ROW_HEIGHT,
+            left: 0,
+            right: 0,
+          }}
+        >
+          {slice.map((m) => (
+            <li
+              key={entryKey(m)}
+              style={{ height: ROW_HEIGHT }}
+              className="flex items-center border-b border-border/40 px-3 text-sm last:border-b-0"
+            >
+              <code className="text-xs">{kindLabel(m.kind)}</code>
+              <span className="ml-1">
+                {m.projectName}/{m.name}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Probe publishes the (kind, projectName) pair's enumerated resource list
+ * into the shared ProbeStore. It renders nothing. Publishing happens
+ * during render via `store.publish`, which the store short-circuits when
+ * the value has not changed. This side-effect during render is safe
+ * because the store's `publish` is idempotent and keyed — React tolerates
+ * idempotent side-effects during render. No setState lives in an effect
+ * here, which satisfies `react-hooks/set-state-in-effect`.
+ */
+function Probe({
+  probeKey,
+  kind,
+  projectName,
+  store,
+}: {
+  probeKey: string
+  kind: TemplatePolicyBindingTargetKind
+  projectName: string
+  store: ProbeStore
+}) {
+  const isDeployment = kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
+  const namespace = namespaceForProject(projectName)
+  // Both hooks are always called to satisfy React's hook-order rule. Only
+  // the relevant side is read; the other is short-circuited by passing '' /
+  // the hook's internal enabled: !!... check.
+  const templates = useListTemplates(isDeployment ? '' : namespace)
+  const deployments = useListDeployments(isDeployment ? projectName : '')
+
+  const pending = isDeployment ? !!deployments.isLoading : !!templates.isLoading
+
+  const matches: MatchEntry[] = useMemo(() => {
+    if (isDeployment) {
+      return (deployments.data ?? []).map((d) => ({
+        kind,
+        projectName,
+        name: d.name,
+      }))
+    }
+    return (templates.data ?? [])
+      .filter((t) => scopeLabelFromNamespace(t.namespace) === 'project')
+      .map((t) => ({ kind, projectName, name: t.name }))
+  }, [isDeployment, kind, projectName, templates.data, deployments.data])
+
+  // Publish during render. The store dedupes on equal values so this does
+  // not loop; changes to `matches` / `pending` produce a single notify().
+  store.publish(probeKey, { matches, pending })
+
+  return null
+}

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
@@ -77,6 +77,15 @@ export type MatchesPreviewProps = {
 type ProbeValue = {
   matches: MatchEntry[]
   pending: boolean
+  /**
+   * Non-null if the underlying list query failed. The preview surfaces
+   * failed probes as an error banner instead of silently collapsing to
+   * an empty match set (codex follow-up on PR #1084). An error leaves
+   * `matches` empty and `pending` false for this probe; the parent
+   * reducer counts them separately so the author can distinguish
+   * "no matches" from "unknown — probe failed".
+   */
+  error?: unknown
 }
 
 type ProbeStore = {
@@ -118,6 +127,7 @@ function useProbeStore(): ProbeStore {
       if (
         prev &&
         prev.pending === value.pending &&
+        prev.error === value.error &&
         sameMatchList(prev.matches, value.matches)
       ) {
         return
@@ -286,10 +296,21 @@ export function MatchesPreview({
   const store = useProbeStore()
   const probeData = useProbeSnapshot(store)
 
+  // Aggregate parent-scope project enumeration error too — if the org or
+  // folder listing itself fails, we cannot honestly render anything.
+  const scopeEnumerationError =
+    parentScope.kind === 'organization'
+      ? orgProjectsQuery.error
+      : folderProjectsQuery.error
+
   // Reduce row plans + live probe data to a dedup'd list of matches.
-  const { matches, pendingCount } = useMemo(() => {
+  // `errorCount` counts probes that failed so the UI can surface an
+  // explicit "some probes failed" state instead of collapsing to the
+  // empty-state warning (codex follow-up on PR #1084).
+  const { matches, pendingCount, errorCount } = useMemo(() => {
     const seen = new Map<string, MatchEntry>()
     let pending = 0
+    let errors = 0
     if (enumeratedProjectsPending) pending += 1
 
     for (const plan of rowPlans) {
@@ -329,6 +350,12 @@ export function MatchesPreview({
           continue
         }
         if (probe.pending) pending += 1
+        if (probe.error) {
+          // Failed probe: count it and move on. Do not contribute to the
+          // match set — we do not know what is in this project.
+          errors += 1
+          continue
+        }
         if (nameIsWildcard) {
           for (const m of probe.matches) {
             const k = entryKey(m)
@@ -348,12 +375,17 @@ export function MatchesPreview({
         }
       }
     }
-    return { matches: Array.from(seen.values()), pendingCount: pending }
+    return {
+      matches: Array.from(seen.values()),
+      pendingCount: pending,
+      errorCount: errors,
+    }
   }, [rowPlans, probeData, enumeratedProjectsPending, scopeEnforcesFolderMembership])
 
   const [open, setOpen] = useState(true)
   const isEmpty = matches.length === 0
   const isResolved = pendingCount === 0
+  const hasProbeError = errorCount > 0 || !!scopeEnumerationError
 
   return (
     <div className="space-y-2" data-testid="matches-preview">
@@ -370,7 +402,22 @@ export function MatchesPreview({
         />
       ))}
 
-      {isEmpty && isResolved && targets.length > 0 ? (
+      {hasProbeError && (
+        // Explicit error banner: a probe RPC failed (or the parent-scope
+        // project list failed). The match list is unreliable in this
+        // state, so we tell the author — never silently collapse to the
+        // "No targets match" warning (codex follow-up on PR #1084).
+        <Alert variant="destructive" data-testid="matches-preview-error">
+          <AlertTitle>Preview unavailable for some projects</AlertTitle>
+          <AlertDescription>
+            {scopeEnumerationError
+              ? 'We could not enumerate the projects in this scope. The binding may still be valid — retry, or check your access.'
+              : `${errorCount} probe${errorCount === 1 ? '' : 's'} failed. The match count below excludes those projects.`}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {!hasProbeError && isEmpty && isResolved && targets.length > 0 ? (
         <Alert variant="default" data-testid="matches-preview-empty">
           <AlertTitle>No targets match</AlertTitle>
           <AlertDescription>
@@ -538,8 +585,14 @@ function Probe({
   const deployments = useListDeployments(isDeployment ? projectName : '')
 
   const pending = isDeployment ? !!deployments.isLoading : !!templates.isLoading
+  const error = isDeployment ? deployments.error : templates.error
 
   const matches: MatchEntry[] = useMemo(() => {
+    // When the probe failed we publish an empty match list with the
+    // error set — the parent reducer uses `error` (not matches.length)
+    // to drive the error banner, so we do not conflate "probe failed"
+    // with "probe returned zero entries".
+    if (error) return []
     if (isDeployment) {
       return (deployments.data ?? []).map((d) => ({
         kind,
@@ -550,11 +603,12 @@ function Probe({
     return (templates.data ?? [])
       .filter((t) => scopeLabelFromNamespace(t.namespace) === 'project')
       .map((t) => ({ kind, projectName, name: t.name }))
-  }, [isDeployment, kind, projectName, templates.data, deployments.data])
+  }, [error, isDeployment, kind, projectName, templates.data, deployments.data])
 
   // Publish during render. The store dedupes on equal values so this does
-  // not loop; changes to `matches` / `pending` produce a single notify().
-  store.publish(probeKey, { matches, pending })
+  // not loop; changes to `matches` / `pending` / `error` produce a single
+  // notify().
+  store.publish(probeKey, { matches, pending, error: error ?? undefined })
 
   return null
 }

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
@@ -94,8 +94,22 @@ function useProbeStore(): ProbeStore {
   // consumer would never re-render after a probe update.
   const versionRef = useRef<Record<string, ProbeValue>>({})
 
+  // Defer notifications to a microtask. Probe children publish into the
+  // store during their own render; notifying subscribers synchronously from
+  // within a child's render would schedule a setState on the MatchesPreview
+  // parent *during its own render*, which React rightly flags with
+  // "Cannot update a component while rendering a different component".
+  // A microtask runs after the current render commits, at which point
+  // `useSyncExternalStore` can re-read the snapshot and schedule the next
+  // render cleanly.
+  const pendingNotifyRef = useRef(false)
   const notify = useCallback(() => {
-    for (const l of listenersRef.current) l()
+    if (pendingNotifyRef.current) return
+    pendingNotifyRef.current = true
+    queueMicrotask(() => {
+      pendingNotifyRef.current = false
+      for (const l of listenersRef.current) l()
+    })
   }, [])
 
   const publish = useCallback(
@@ -254,18 +268,11 @@ export function MatchesPreview({
       const nameIsWildcard = t.name === WILDCARD
       const hasLiteralName = !!t.name && !nameIsWildcard
 
-      // {project: literal, name: literal} short-circuits without a hook probe.
-      if (!plan.projectIsWildcard && hasLiteralName && plan.projects.length === 1) {
-        const entry: MatchEntry = {
-          kind: t.kind,
-          projectName: plan.projects[0],
-          name: t.name,
-        }
-        const k = entryKey(entry)
-        if (!seen.has(k)) seen.set(k, entry)
-        continue
-      }
-
+      // Literal/literal rows used to short-circuit here, but that
+      // over-reported matches for typos or out-of-scope projects (codex
+      // review on PR #1084). Let the probe verify existence for every
+      // literal name so the blast-radius panel never claims a match that
+      // the backend will later reject.
       // project wildcard with no projects yet enumerated — honestly pending.
       if (plan.projectIsWildcard && plan.projects.length === 0 && enumeratedProjectsPending) {
         pending += 1

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
@@ -306,6 +306,150 @@ describe('TargetRefEditor', () => {
     })
   })
 
+  // --- HOL-773 wildcard coverage -------------------------------------------
+
+  it('offers a synthetic "All projects (*)" item at the top of the project picker', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[makeTarget()]}
+        onChange={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 project/i }),
+    )
+    expect(
+      await screen.findByText(/All projects \(\*\)/i),
+    ).toBeInTheDocument()
+  })
+
+  it('name picker wildcard item reads "All project templates (*)" when kind=PROJECT_TEMPLATE', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'proj-a',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 name/i }),
+    )
+    expect(
+      await screen.findByText(/All project templates \(\*\)/i),
+    ).toBeInTheDocument()
+  })
+
+  it('name picker wildcard item reads "All deployments (*)" when kind=DEPLOYMENT', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.DEPLOYMENT,
+            projectName: 'proj-a',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 name/i }),
+    )
+    expect(
+      await screen.findByText(/All deployments \(\*\)/i),
+    ).toBeInTheDocument()
+  })
+
+  it('projectName="*" short-circuits useListTemplates and useListDeployments', () => {
+    // When the project is the wildcard sentinel, per-project probes would
+    // otherwise receive a malformed namespace like `p-*` and fire a bad
+    // request. The component passes empty strings so the `enabled` flag is
+    // false and no fetch fires.
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    expect(useListTemplates).toHaveBeenCalledWith('')
+    expect(useListDeployments).toHaveBeenCalledWith('')
+  })
+
+  it('renders all four wildcard forms of (projectName, name) without crashing', () => {
+    // The four expansion shapes: project*/name*, project*/name, project/name*,
+    // project/name. All must render a row with no React error.
+    const targets = [
+      makeTarget({ projectName: '*', name: '*' }),
+      makeTarget({ projectName: '*', name: 'ingress' }),
+      makeTarget({ projectName: 'proj-a', name: '*' }),
+      makeTarget({ projectName: 'proj-a', name: 'ingress' }),
+    ]
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={targets}
+        onChange={vi.fn()}
+      />,
+    )
+    for (let i = 0; i < 4; i++) {
+      expect(screen.getByTestId(`target-ref-row-${i}`)).toBeInTheDocument()
+    }
+  })
+
+  it('surfaces a row-level duplicate error for two {kind,"*","*"} rows', () => {
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          }),
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '*',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    // The *second* row is the duplicate; the first row should stay clean
+    // so the author can see which row to edit.
+    expect(
+      screen.queryByTestId('target-ref-row-0-duplicate-error'),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('target-ref-row-1-duplicate-error'),
+    ).toBeInTheDocument()
+  })
+
   it('hides the Add Target and Remove buttons when disabled', () => {
     render(
       <TargetRefEditor

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
@@ -450,6 +450,83 @@ describe('TargetRefEditor', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders a text Input (not the Combobox) for the name when project_name is "*"', () => {
+    // HOL-773 codex review on PR #1084: authors must be able to author
+    // {project_name: "*", name: "literal"} rows, so when the project is the
+    // wildcard we swap the strict-select Combobox for a free-text Input.
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: 'ingress',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    // There is no combobox for the name here — only the literal-input wrapper.
+    expect(
+      within(row).queryByRole('combobox', { name: /target 1 name/i }),
+    ).not.toBeInTheDocument()
+    const nameInput = within(row).getByLabelText(/target 1 name/i)
+    expect(nameInput).toHaveValue('ingress')
+  })
+
+  it('typing into the literal-name input emits the new name (project_name="*" path)', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onChange = vi.fn()
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '',
+          }),
+        ]}
+        onChange={onChange}
+      />,
+    )
+    const nameInput = screen.getByLabelText(/target 1 name/i) as HTMLInputElement
+    await user.type(nameInput, 'i')
+    expect(onChange).toHaveBeenCalled()
+    const lastPatch = onChange.mock.calls.at(-1)![0] as TargetRefDraft[]
+    expect(lastPatch[0].name).toBe('i')
+  })
+
+  it('clicking the "*" quick-pick sets the name to wildcard when project_name="*"', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onChange = vi.fn()
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: '*',
+            name: '',
+          }),
+        ]}
+        onChange={onChange}
+      />,
+    )
+    await user.click(
+      screen.getByTestId('target-ref-row-0-name-wildcard-btn'),
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const next = onChange.mock.calls[0][0] as TargetRefDraft[]
+    expect(next[0].name).toBe('*')
+  })
+
   it('hides the Add Target and Remove buttons when disabled', () => {
     render(
       <TargetRefEditor

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
@@ -11,14 +11,20 @@ import {
 } from '@/components/ui/select'
 import { Trash2 } from 'lucide-react'
 import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
-import type { TargetRefDraft } from './binding-draft'
+import {
+  WILDCARD,
+  findDuplicateTargetIndex,
+  type TargetRefDraft,
+} from './binding-draft'
 import { useListDeployments } from '@/queries/deployments'
 import { useListProjects } from '@/queries/projects'
 import { useListTemplates } from '@/queries/templates'
 import { namespaceForProject, scopeLabelFromNamespace } from '@/lib/scope-labels'
 
 // Kind options exposed to the target-row select. UNSPECIFIED is intentionally
-// omitted — the backend rejects it and the UI must not offer it.
+// omitted — the backend rejects it and the UI must not offer it. `kind` is
+// also never wildcarded (HOL-767 audit-readability rule); cross-kind fan-out
+// requires separate target rows.
 const KIND_OPTIONS: Array<{
   value: TemplatePolicyBindingTargetKind
   label: string
@@ -29,6 +35,20 @@ const KIND_OPTIONS: Array<{
   },
   { value: TemplatePolicyBindingTargetKind.DEPLOYMENT, label: 'Deployment' },
 ]
+
+// Synthetic combobox items for the wildcard sentinel. Using the literal
+// string '*' as the value is load-bearing — it round-trips byte-identically
+// to `policyresolver.WildcardAny` on the backend (HOL-769 / HOL-770 / HOL-772).
+const WILDCARD_PROJECT_ITEM: ComboboxItem = {
+  value: WILDCARD,
+  label: 'All projects (*)',
+}
+function wildcardNameItem(isDeployment: boolean): ComboboxItem {
+  return {
+    value: WILDCARD,
+    label: isDeployment ? 'All deployments (*)' : 'All project templates (*)',
+  }
+}
 
 export type TargetRefEditorProps = {
   /** The organization these target refs live under. Required to populate the
@@ -46,6 +66,13 @@ export type TargetRefEditorProps = {
  * templates for the selected project, DEPLOYMENT loads deployments for the
  * selected project. The caller owns the targets state and passes an
  * onChange callback.
+ *
+ * Both the project and name comboboxes carry a synthetic `*` (wildcard)
+ * option at the top — picking it expands the binding to every match the
+ * storage scope can reach (HOL-767). Two rows that share the same
+ * `(kind, projectName, name)` triple are flagged inline as duplicates so
+ * the author sees the conflict before submit; the backend rejects the same
+ * shape with `target_refs[i]: duplicate of target_refs[j] (...)`.
  */
 export function TargetRefEditor({
   organization,
@@ -73,6 +100,16 @@ export function TargetRefEditor({
     ])
   }
 
+  // Compute the index of the first row that duplicates an earlier row on the
+  // (kind, projectName, name) triple. The wildcard literal "*" participates
+  // as a normal string value — `{kind, "*", "*"}` matches itself, mirroring
+  // backend dedup (HOL-772). Memoized so we recompute only when the target
+  // list changes.
+  const duplicateIndex = useMemo(
+    () => findDuplicateTargetIndex(targets),
+    [targets],
+  )
+
   return (
     <div className="space-y-4" data-testid="target-ref-editor">
       {targets.length === 0 && (
@@ -86,6 +123,7 @@ export function TargetRefEditor({
           index={index}
           organization={organization}
           target={target}
+          isDuplicate={index === duplicateIndex}
           onUpdate={(patch) => handleUpdate(index, patch)}
           onRemove={() => handleRemove(index)}
           disabled={disabled}
@@ -111,6 +149,7 @@ type TargetRowProps = {
   index: number
   organization: string
   target: TargetRefDraft
+  isDuplicate: boolean
   onUpdate: (patch: Partial<TargetRefDraft>) => void
   onRemove: () => void
   disabled: boolean
@@ -120,47 +159,65 @@ function TargetRow({
   index,
   organization,
   target,
+  isDuplicate,
   onUpdate,
   onRemove,
   disabled,
 }: TargetRowProps) {
   const isDeployment = target.kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
+  const projectIsWildcard = target.projectName === WILDCARD
+  const isLiteralProject = !!target.projectName && !projectIsWildcard
 
   const { data: projectsResponse } = useListProjects(organization)
   const projectItems: ComboboxItem[] = useMemo(() => {
     const projects = projectsResponse?.projects ?? []
-    return projects.map((p) => ({
+    const literal = projects.map((p) => ({
       value: p.name,
       label: p.displayName ? `${p.displayName} (${p.name})` : p.name,
     }))
+    // Wildcard sentinel pinned to the top so the author always sees the
+    // "All projects" option without scrolling past the literal list.
+    return [WILDCARD_PROJECT_ITEM, ...literal]
   }, [projectsResponse])
 
   // Name picker: project-scope templates or deployments, both scoped to the
-  // selected project. Both hooks are called unconditionally — they gate on a
-  // non-empty project name via their `enabled` option (useListTemplates keys
-  // on the namespace, useListDeployments keys on the project argument), so
-  // no fetch occurs until a project is picked.
-  const projectNamespace = namespaceForProject(target.projectName)
+  // selected literal project. When the project is the wildcard "*" the
+  // hooks are short-circuited via the `enabled` flag — `namespaceForProject`
+  // would otherwise build a malformed namespace string for the literal "*".
+  // The user can still pick the wildcard sentinel or type a literal name
+  // (the combobox accepts free-text via the search input even when the
+  // backed list is empty).
+  const projectNamespace = isLiteralProject
+    ? namespaceForProject(target.projectName)
+    : ''
   const { data: projectTemplates = [] } = useListTemplates(projectNamespace)
-  const { data: deployments = [] } = useListDeployments(target.projectName)
+  const { data: deployments = [] } = useListDeployments(
+    isLiteralProject ? target.projectName : '',
+  )
 
   // KIND_OPTIONS omits UNSPECIFIED, so kind is always DEPLOYMENT or
   // PROJECT_TEMPLATE. Branching on a single `isDeployment` flag keeps the
   // contract explicit and avoids an unreachable fallthrough.
   const nameItems: ComboboxItem[] = useMemo(() => {
-    if (isDeployment) {
-      return deployments.map((d) => ({
-        value: d.name,
-        label: d.displayName ? `${d.displayName} (${d.name})` : d.name,
-      }))
+    const wildcard = wildcardNameItem(isDeployment)
+    if (!isLiteralProject) {
+      // No backing list when project is unset or wildcard — only the
+      // wildcard sentinel is offered.
+      return [wildcard]
     }
-    return projectTemplates
-      .filter((t) => scopeLabelFromNamespace(t.namespace) === 'project')
-      .map((t) => ({
-        value: t.name,
-        label: t.displayName ? `${t.displayName} (${t.name})` : t.name,
-      }))
-  }, [isDeployment, projectTemplates, deployments])
+    const literal = isDeployment
+      ? deployments.map((d) => ({
+          value: d.name,
+          label: d.displayName ? `${d.displayName} (${d.name})` : d.name,
+        }))
+      : projectTemplates
+          .filter((t) => scopeLabelFromNamespace(t.namespace) === 'project')
+          .map((t) => ({
+            value: t.name,
+            label: t.displayName ? `${t.displayName} (${t.name})` : t.name,
+          }))
+    return [wildcard, ...literal]
+  }, [isDeployment, isLiteralProject, projectTemplates, deployments])
 
   return (
     <div
@@ -248,7 +305,17 @@ function TargetRow({
           />
         </div>
       </div>
+
+      {isDuplicate && (
+        <p
+          role="alert"
+          data-testid={`target-ref-row-${index}-duplicate-error`}
+          className="text-sm text-destructive"
+        >
+          Duplicate of an earlier target ({'kind, project_name, name'} triple
+          must be unique).
+        </p>
+      )}
     </div>
   )
 }
-

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Combobox, type ComboboxItem } from '@/components/ui/combobox'
 import {
@@ -9,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Trash2 } from 'lucide-react'
+import { Asterisk, Trash2 } from 'lucide-react'
 import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
 import {
   WILDCARD,
@@ -288,21 +289,65 @@ function TargetRow({
 
         <div>
           <Label htmlFor={`target-name-${index}`}>Name</Label>
-          <Combobox
-            items={nameItems}
-            value={target.name}
-            onValueChange={(v) => {
-              if (disabled) return
-              onUpdate({ name: v })
-            }}
-            placeholder={
-              isDeployment
-                ? 'Select a deployment...'
-                : 'Select a project template...'
-            }
-            searchPlaceholder="Search..."
-            aria-label={`Target ${index + 1} name`}
-          />
+          {isLiteralProject ? (
+            <Combobox
+              items={nameItems}
+              value={target.name}
+              onValueChange={(v) => {
+                if (disabled) return
+                onUpdate({ name: v })
+              }}
+              placeholder={
+                isDeployment
+                  ? 'Select a deployment...'
+                  : 'Select a project template...'
+              }
+              searchPlaceholder="Search..."
+              aria-label={`Target ${index + 1} name`}
+            />
+          ) : (
+            // When project is "*" or unset, there is no per-project list to
+            // pick from. Authors still need to be able to type a literal name
+            // (e.g. {project:"*", name:"ingress"} for a scope-wide template)
+            // OR snap to the wildcard. Our `Combobox` is strict single-select
+            // and does not accept arbitrary text, so we render an Input here
+            // with a one-click "*" quick-pick — see codex review on PR #1084.
+            <div
+              className="flex items-center gap-2"
+              data-testid={`target-ref-row-${index}-name-literal`}
+            >
+              <Input
+                id={`target-name-${index}`}
+                type="text"
+                value={target.name}
+                onChange={(e) => {
+                  if (disabled) return
+                  onUpdate({ name: e.target.value })
+                }}
+                placeholder={
+                  isDeployment
+                    ? 'Deployment name or *'
+                    : 'Template name or *'
+                }
+                aria-label={`Target ${index + 1} name`}
+                disabled={disabled}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                aria-label={`Target ${index + 1} set name to wildcard`}
+                data-testid={`target-ref-row-${index}-name-wildcard-btn`}
+                onClick={() => {
+                  if (disabled) return
+                  onUpdate({ name: WILDCARD })
+                }}
+                disabled={disabled}
+              >
+                <Asterisk className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/template-policy-bindings/binding-draft.test.ts
+++ b/frontend/src/components/template-policy-bindings/binding-draft.test.ts
@@ -96,7 +96,51 @@ describe('validateBindingDraft', () => {
         },
       ],
     }
-    expect(validateBindingDraft(draft)).toMatch(/project is required/i)
+    expect(validateBindingDraft(draft)).toMatch(/project_name is required/i)
+  })
+
+  it('accepts the wildcard literal "*" in projectName and name', () => {
+    // HOL-769/770/772: "*" is a first-class allowed value on these fields.
+    // The frontend client-side validator must let it through so the proto
+    // round-trip stays byte-identical to policyresolver.WildcardAny.
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: 'bind-a',
+      policyNamespace: namespaceForOrg('test-org'),
+      policyName: 'policy-a',
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: '*',
+          name: '*',
+        },
+      ],
+    }
+    expect(validateBindingDraft(draft)).toBeNull()
+  })
+
+  it('rejects two wildcard rows of the same kind as duplicates', () => {
+    // {kind, "*", "*"} matches itself; the backend rejects an identical
+    // second row with `target_refs[i]: duplicate of target_refs[j]`.
+    const draft = {
+      ...newEmptyBindingDraft(),
+      name: 'bind-a',
+      policyNamespace: namespaceForOrg('test-org'),
+      policyName: 'policy-a',
+      targetRefs: [
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: '*',
+          name: '*',
+        },
+        {
+          kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+          projectName: '*',
+          name: '*',
+        },
+      ],
+    }
+    expect(validateBindingDraft(draft)).toMatch(/duplicate/i)
   })
 
   it('rejects duplicate (kind, projectName, name) triples', () => {

--- a/frontend/src/components/template-policy-bindings/binding-draft.ts
+++ b/frontend/src/components/template-policy-bindings/binding-draft.ts
@@ -10,9 +10,23 @@ import {
 } from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
 
 /**
+ * WILDCARD is the literal sentinel string the backend treats as "match
+ * anything within this storage scope" for a TemplatePolicyBindingTargetRef
+ * project_name or name (HOL-769 / HOL-770 / HOL-772). The UI must round-trip
+ * this exact byte sequence to the proto — never convert to a separate
+ * `wildcard: true` flag — so resolver matching stays byte-identical to
+ * `policyresolver.WildcardAny` on the server.
+ */
+export const WILDCARD = '*'
+
+/**
  * Draft shape for a single target ref while the user is authoring a binding.
  * Kept flatter than the proto message so inputs can be bound to strings and
  * converted at submit time, mirroring rule-draft.ts.
+ *
+ * `projectName` and `name` may be the literal string `"*"` (see WILDCARD) to
+ * request scoped-wildcard expansion. `kind` is never wildcarded — cross-kind
+ * fan-out requires separate rows (HOL-767 audit-readability rule).
  */
 export type TargetRefDraft = {
   kind: TemplatePolicyBindingTargetKind
@@ -111,9 +125,38 @@ export function bindingProtoToDraft(
 }
 
 /**
+ * findDuplicateTargetIndex returns the index of the *first* row that
+ * duplicates an earlier row in `targets` on the `(kind, projectName, name)`
+ * triple, or -1 when the list is duplicate-free. The wildcard literal `"*"`
+ * participates as an ordinary string value — `{kind, "*", "*"}` matches
+ * itself and is rejected by the backend as a duplicate too (HOL-772).
+ *
+ * Exposed so TargetRefEditor can flag the offending row inline without
+ * re-running the full submit validator.
+ */
+export function findDuplicateTargetIndex(targets: TargetRefDraft[]): number {
+  const seen = new Map<string, number>()
+  for (let i = 0; i < targets.length; i++) {
+    const t = targets[i]
+    const key = `${t.kind}/${t.projectName}/${t.name}`
+    if (seen.has(key)) {
+      return i
+    }
+    seen.set(key, i)
+  }
+  return -1
+}
+
+/**
  * validateBindingDraft returns a human-readable error string when the draft
  * is not submittable, or null when it is valid for the client. The backend
  * performs authoritative validation (duplicates, cross-scope reachability).
+ *
+ * The literal `"*"` is accepted in `projectName` or `name` per
+ * `policyresolver.WildcardAny` — empty strings are still rejected (the
+ * backend likewise rejects them with `name is required` /
+ * `project_name is required`, mirrored here so client-side and server-side
+ * messages stay aligned).
  */
 export function validateBindingDraft(draft: BindingDraft): string | null {
   if (!draft.name.trim()) {
@@ -132,23 +175,15 @@ export function validateBindingDraft(draft: BindingDraft): string | null {
       return `Target ${position}: kind is required.`
     }
     if (!target.projectName) {
-      return `Target ${position}: project is required.`
+      return `Target ${position}: project_name is required.`
     }
     if (!target.name) {
       return `Target ${position}: name is required.`
     }
   }
-  // Reject duplicates (identical (kind, projectName, name) triples). The
-  // backend is authoritative but the UI should refuse to submit an obviously
-  // invalid draft.
-  const seen = new Set<string>()
-  for (let i = 0; i < draft.targetRefs.length; i++) {
-    const t = draft.targetRefs[i]
-    const key = `${t.kind}/${t.projectName}/${t.name}`
-    if (seen.has(key)) {
-      return `Target ${i + 1}: duplicate of another target in this binding.`
-    }
-    seen.add(key)
+  const dupIndex = findDuplicateTargetIndex(draft.targetRefs)
+  if (dupIndex >= 0) {
+    return `Target ${dupIndex + 1}: duplicate of another target in this binding.`
   }
   return null
 }

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/$bindingName.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/$bindingName.tsx
@@ -174,6 +174,7 @@ export function FolderTemplatePolicyBindingDetailPage({
             scopeType={scopeType}
             namespace={namespace}
             organization={orgName}
+            folderName={folderName}
             canWrite={canWrite}
             initialValues={initialValues}
             lockName

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-detail.test.tsx
@@ -66,6 +66,13 @@ vi.mock('@/queries/projects', () => ({
   useListProjects: vi.fn().mockReturnValue({
     data: { projects: [] },
     isPending: false,
+    isLoading: false,
+    error: null,
+  }),
+  useListProjectsByParent: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    isLoading: false,
     error: null,
   }),
 }))

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/new.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/new.tsx
@@ -96,6 +96,7 @@ export function CreateFolderTemplatePolicyBindingPage({
           scopeType={scopeType}
           namespace={namespace}
           organization={orgName}
+          folderName={folderName}
           canWrite={canWrite}
           submitLabel="Create"
           pendingLabel="Creating..."

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-detail.test.tsx
@@ -66,6 +66,13 @@ vi.mock('@/queries/projects', () => ({
   useListProjects: vi.fn().mockReturnValue({
     data: { projects: [] },
     isPending: false,
+    isLoading: false,
+    error: null,
+  }),
+  useListProjectsByParent: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    isLoading: false,
     error: null,
   }),
 }))


### PR DESCRIPTION
## Summary

- Phase 4 of HOL-767 — adds `*` wildcard UX to the BindingForm: authors can type `*` for `project_name` and/or `name` on any target ref, and the form renders a client-side blast-radius preview of the concrete targets the binding will attach to.
- No backend changes. HOL-770 (resolver) + HOL-772 (handler validation) already accept `*`; wildcards travel over the wire as literal strings so the proto round-trip is byte-identical.
- `TargetRefEditor` exposes a synthetic `All projects (*)` combobox option and a kind-aware `All project_templates (*)` / `All deployments (*)` name option. `projectName === '*'` short-circuits `useListTemplates` / `useListDeployments` so we do not fire pointless per-project queries.
- `MatchesPreview` is a new collapsible panel under the target list. It uses the same list hooks that back the pickers to enumerate matches, dedups by `(kind, project_name, name)`, renders a warning when expansion is empty, and switches to windowed rendering above 50 entries.
- Folder routes pass `folderName` so the preview enumerates only projects beneath the folder — matches the backend's storage-scope boundary.
- Info box drops the old *No glob patterns* copy for honest wording about wildcard expansion within the storage scope.
- `binding-draft` introduces `WILDCARD = '*'` and `findDuplicateTargetIndex`; `validateBindingDraft` now mirrors HOL-772 backend error strings (`project_name is required`, duplicate messaging).

## Implementation notes

- Avoided `setState` inside `useEffect` (blocked as an error by this codebase's `react-hooks/set-state-in-effect` rule). Per-project probe children publish their hook results into a tiny `useSyncExternalStore`-backed registry; the parent re-derives the dedup'd match list via `useMemo`. No cascading-render patterns.
- Hook order stays stable across renders — one probe component per `(kind, projectName)` pair, short-circuited list-projects hooks when no row has a wildcard.

## Test plan

- [x] `make test-ui` (1052 tests pass)
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npm run lint` — no new errors introduced by these files (baseline is 66 problems on `main`; this branch is 65).
- [ ] Browser smoke on org binding: pick `*` / `*` → matches preview lists every project_template across the org.
- [ ] Browser smoke on folder binding: matches preview honors folder scope (enumerates only projects beneath the folder).
- [ ] Browser smoke: duplicate `*` rows show inline error and block Submit; empty expansion shows the "No targets match" warning.

Linear: [HOL-773](https://linear.app/holos-run/issue/HOL-773)