### PR TITLE
chore(bindings): remove stale "no globs" copy, supersede HOL-649, add ADR-followup hygiene note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,12 @@ The annotation key constants — `AnnotationExternalLinkPrefix`,
 `AnnotationPrimaryURL`, `AnnotationAggregatedLinks`,
 `AnnotationArgoCDLinkPrefix` — live in `api/v1alpha2/annotations.go`.
 
+## ADR Open Questions
+
+When an ADR defers a decision to a later ticket, open a placeholder Linear issue for it, link it from the ADR's "Open Questions" section, and close both the issue and the ADR open question when the work ships. This keeps deferred design questions tracked and prevents prose rot.
+
+Example trail: HOL-664 (ADR-029 open question on wildcards) → HOL-767 (implementation umbrella) → Phases 1–5.
+
 ## Commit Messages
 
 All commit messages must follow this format and include the root-cause analysis for why the issue happened, with citations to sources (for example, deep links to GitHub issues that describe the problem and its cause):

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -434,7 +434,8 @@ func bindingAppliesTo(b *ResolvedBinding, project string, targetKind TargetKind,
 // nameMatches returns true when the ref-side value selects the target value.
 // The literal WildcardAny ("*") matches any *non-empty* target value. Exact
 // string equality covers every other case. Both arguments are compared as-is
-// — no glob, regex, or case folding (ADR 029).
+// — only the single-token wildcard "*" is supported; partial patterns such as
+// "prefix-*" are not (ADR 029).
 //
 // The non-empty requirement is load-bearing: when Resolve cannot derive a
 // project slug from the render-target namespace (e.g., an org- or folder-

--- a/frontend/src/components/template-policies/rule-draft.test.ts
+++ b/frontend/src/components/template-policies/rule-draft.test.ts
@@ -10,15 +10,15 @@ import { TemplatePolicyKind } from '@/queries/templatePolicies'
 import { linkableKey } from '@/queries/templates'
 import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
 
-// HOL-598: The rule draft is no longer a vehicle for glob Target authoring.
+// HOL-598: The rule draft is no longer a vehicle for Target authoring.
 // Attachment is expressed exclusively via TemplatePolicyBinding. These tests
-// pin the new contract: `newEmptyRule()` does not carry glob fields,
-// `ruleDraftToProto` emits a rule with `target` unset, `ruleProtoToDraft`
-// discards any legacy populated Target, and `validateRuleDraft` no longer
-// gates on glob patterns.
+// pin the new contract: `newEmptyRule()` does not carry the legacy
+// `projectPattern`/`deploymentPattern` fields, `ruleDraftToProto` emits a
+// rule with `target` unset, `ruleProtoToDraft` discards any legacy populated
+// Target, and `validateRuleDraft` no longer gates on those legacy fields.
 describe('rule-draft (HOL-598)', () => {
   describe('newEmptyRule', () => {
-    it('returns a draft with no glob pattern fields', () => {
+    it('returns a draft without legacy projectPattern/deploymentPattern fields', () => {
       const draft = newEmptyRule()
       expect(draft).toEqual({
         kind: TemplatePolicyKind.REQUIRE,
@@ -66,7 +66,7 @@ describe('rule-draft (HOL-598)', () => {
   })
 
   describe('ruleProtoToDraft', () => {
-    it('produces a draft with no glob pattern fields even when the proto Target was populated', () => {
+    it('produces a draft without legacy projectPattern/deploymentPattern fields even when the proto Target was populated', () => {
       // Cast through `unknown` so the test stays readable without hand-rolling
       // the `$typeName` brand fields required by protobuf-es Message types.
       const draft = ruleProtoToDraft({
@@ -101,7 +101,7 @@ describe('rule-draft (HOL-598)', () => {
       expect(validateRuleDraft(draft)).toMatch(/template/i)
     })
 
-    it('passes when a template is selected and no glob fields exist', () => {
+    it('passes when a template is selected and no legacy target fields exist', () => {
       const draft: RuleDraft = {
         kind: TemplatePolicyKind.REQUIRE,
         templateKey: linkableKey(namespaceForOrg('acme'), 'httproute'),

--- a/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
@@ -112,7 +112,7 @@ describe('BindingForm', () => {
     stubQueries({})
   })
 
-  it('info box explains the scoped-wildcard model and no longer mentions "no glob patterns"', () => {
+  it('info box explains the scoped-wildcard model and uses updated wildcard copy', () => {
     render(
       <BindingForm
         mode="create"
@@ -127,10 +127,9 @@ describe('BindingForm', () => {
       />,
     )
     const info = screen.getByTestId('binding-form-info')
-    // The HOL-773 info-box rewrite drops the legacy "no glob patterns" copy
-    // entirely — matching it would be a smoke-test that the author forgot
-    // to swap phrasing after Phases 1–3 landed.
-    expect(info.textContent ?? '').not.toMatch(/no glob patterns/i)
+    // The HOL-773 info-box rewrite replaced the pre-wildcard flat-enumeration
+    // copy with language that explains the scoped-wildcard model (HOL-767).
+    expect(info.textContent ?? '').not.toMatch(/every target is named directly/i)
     // New copy mentions wildcard expansion within the binding's storage
     // scope and the kind-never-wildcarded rule.
     expect(info.textContent ?? '').toMatch(/wildcard/i)

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/index.tsx
@@ -109,9 +109,10 @@ export function FolderTemplatePolicyBindingsIndexPage({
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-sm text-muted-foreground">
-          Bindings attach a single TemplatePolicy to an explicit list of project
-          templates and deployments. Every target is named directly — no glob
-          patterns. Bindings live only at folder or organization scope.
+          Bindings attach a single TemplatePolicy to project templates and
+          deployments. Use <code>*</code> in a target row to match every
+          resource of that kind within the binding's storage scope. Bindings
+          live only at folder or organization scope.
         </p>
         <Separator />
         {bindings && bindings.length > 0 ? (

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/index.tsx
@@ -86,9 +86,10 @@ export function OrgTemplatePolicyBindingsIndexPage({
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-sm text-muted-foreground">
-          Bindings attach a single TemplatePolicy to an explicit list of project
-          templates and deployments. Every target is named directly — no glob
-          patterns. Bindings live only at folder or organization scope.
+          Bindings attach a single TemplatePolicy to project templates and
+          deployments. Use <code>*</code> in a target row to match every
+          resource of that kind within the binding's storage scope. Bindings
+          live only at folder or organization scope.
         </p>
         <Separator />
         {bindings && bindings.length > 0 ? (


### PR DESCRIPTION
## Summary

- **Stale copy removed (6 hits):**
  - `frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/index.tsx` — replaced "Every target is named directly — no glob patterns" with wildcard-aware copy
  - `frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/index.tsx` — same
  - `console/policyresolver/folder_resolver.go:437` — replaced "no glob, regex, or case folding" with "only the single-token wildcard '*' is supported; partial patterns such as 'prefix-*' are not"
  - `frontend/src/components/template-policies/rule-draft.test.ts` (3 hits) — updated test descriptions from "no glob pattern fields" to "without legacy projectPattern/deploymentPattern fields"
  - `frontend/src/components/template-policy-bindings/BindingForm.test.tsx` — updated test name and negative assertion to reference flat-enumeration copy instead of "no glob patterns" phrase
- **Proto header status:** Already correct from Phase 1 (HOL-769) — lines 13–17 of `proto/holos/console/v1/template_policy_bindings.proto` describe the `*` wildcard and HOL-767/ADR-029 amendment. No change needed.
- **CONTRIBUTING.md:** Added "ADR Open Questions" section (<10 lines) establishing the HOL-664→HOL-767 trail as the canonical pattern for tracking deferred ADR questions as Linear tickets.
- **HOL-649:** Already in Done state (completed 2026-04-19). Posted a factual comment linking to HOL-767 and explaining the user-facing wildcard UX is live.

## Test Plan

- [ ] `grep -RIn "no glob" . --include="*.go" --include="*.ts" --include="*.tsx" --include="*.md" --include="*.proto"` — only unrelated hits remain (workspace-menu "no global settings route", console.go "no global prefix")
- [ ] `grep -RIn "flat enumeration" .` — no hits
- [ ] `make test` passes — 1061 frontend tests + all Go tests green locally

## References

Closes HOL-774
Part of HOL-767
Supersedes HOL-649