### PR TITLE
feat(templates): add example template registry with two embedded examples

### DIFF
--- a/console/templates/examples/allowed-project-resource-kinds-v1.cue
+++ b/console/templates/examples/allowed-project-resource-kinds-v1.cue
@@ -1,0 +1,32 @@
+// Allowed project resource kinds — folder/org-level platform template.
+// Closes projectResources.namespacedResources to Deployment, Service, and
+// ServiceAccount (ADR 016 Decision 9). Drop this into a folder's or org's
+// template set to enforce the kind constraint across all projects in scope.
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "Allowed Project Resource Kinds (v1)"
+name:        "allowed-project-resource-kinds-v1"
+description: "Closes projectResources.namespacedResources to Deployment, Service, and ServiceAccount (ADR 016 Decision 9)."
+
+cueTemplate: """
+	// platform is available because platform templates are unified with the
+	// deployment template before evaluation (ADR 016 Decision 8).
+	platform: #PlatformInput
+
+	// Close projectResources.namespacedResources so that every namespace bucket
+	// may only contain Deployment, Service, or ServiceAccount. Using close() with
+	// optional fields is the correct CUE pattern: the close() call marks the struct
+	// as closed (no additional fields allowed), and the ? marks each listed field
+	// as optional (a namespace bucket need not contain all three). Any unlisted
+	// Kind key — such as RoleBinding — is a CUE constraint violation at evaluation
+	// time, before any Kubernetes API call (ADR 016 Decision 9).
+	projectResources: namespacedResources: [_]: close({
+		Deployment?:     _
+		Service?:        _
+		ServiceAccount?: _
+	})
+	"""

--- a/console/templates/examples/examples.go
+++ b/console/templates/examples/examples.go
@@ -1,0 +1,109 @@
+// Package examples provides a registry of built-in CUE example templates that
+// the UI can offer as drop-in starting points when creating a new template.
+//
+// Each example is a single CUE file that declares its own display metadata
+// (displayName, name, description) and the template body (cueTemplate) as
+// top-level fields. The outer CUE file is valid CUE; the template body is kept
+// as a multi-line string so it can reference #PlatformInput, #ProjectInput,
+// etc. without those types needing to be in scope in this file.
+//
+// Adding a new example requires only dropping a new *.cue file in this
+// directory — no Go changes are needed.
+package examples
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+// Example holds the parsed metadata and template body for a single example.
+type Example struct {
+	// DisplayName is the human-readable name shown in the UI picker.
+	DisplayName string
+	// Name is the URL-safe slug identifier (e.g. "httproute-v1").
+	Name string
+	// Description is a short sentence describing what the example does.
+	Description string
+	// CueTemplate is the full CUE source the user will see in the editor.
+	CueTemplate string
+}
+
+//go:embed *.cue
+var examplesFS embed.FS
+
+// Examples loads and returns all example templates embedded in this package.
+// Each *.cue file in the directory is parsed and returned as an Example. The
+// order of the returned list is deterministic (lexicographic file name order).
+func Examples() ([]Example, error) {
+	cueCtx := cuecontext.New()
+
+	entries, err := fs.ReadDir(examplesFS, ".")
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded examples directory: %w", err)
+	}
+
+	var list []Example
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+
+		src, err := fs.ReadFile(examplesFS, name)
+		if err != nil {
+			return nil, fmt.Errorf("reading embedded example %s: %w", name, err)
+		}
+
+		ex, err := parseExample(cueCtx, name, string(src))
+		if err != nil {
+			return nil, fmt.Errorf("parsing example %s: %w", name, err)
+		}
+		list = append(list, ex)
+	}
+
+	return list, nil
+}
+
+// parseExample compiles a single CUE example file and extracts its metadata
+// fields. The v1alpha2 generated schema is prepended so that the template body
+// string field can mention schema types without breaking the outer file.
+func parseExample(cueCtx *cue.Context, filename, src string) (Example, error) {
+	// Prepend the generated schema exactly as the renderer does (see defaults.go).
+	fullSrc := v1alpha2.GeneratedSchema + "\n" + src
+	val := cueCtx.CompileString(fullSrc, cue.Filename(filename))
+	if err := val.Err(); err != nil {
+		return Example{}, fmt.Errorf("compiling CUE: %w", err)
+	}
+
+	ex := Example{}
+	for _, f := range []struct {
+		path string
+		dest *string
+	}{
+		{"displayName", &ex.DisplayName},
+		{"name", &ex.Name},
+		{"description", &ex.Description},
+		{"cueTemplate", &ex.CueTemplate},
+	} {
+		v := val.LookupPath(cue.ParsePath(f.path))
+		if !v.Exists() {
+			return Example{}, fmt.Errorf("missing required field %q", f.path)
+		}
+		if err := v.Err(); err != nil {
+			return Example{}, fmt.Errorf("evaluating field %q: %w", f.path, err)
+		}
+		s, err := v.String()
+		if err != nil {
+			return Example{}, fmt.Errorf("reading field %q as string: %w", f.path, err)
+		}
+		*f.dest = s
+	}
+
+	return ex, nil
+}

--- a/console/templates/examples/examples_test.go
+++ b/console/templates/examples/examples_test.go
@@ -1,0 +1,73 @@
+package examples_test
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/templates/examples"
+)
+
+// TestExamples verifies the example registry loads both built-in examples and
+// that each example satisfies the structural and compilation requirements.
+func TestExamples(t *testing.T) {
+	list, err := examples.Examples()
+	if err != nil {
+		t.Fatalf("Examples() error: %v", err)
+	}
+
+	// There must be exactly two examples.
+	if got, want := len(list), 2; got != want {
+		t.Fatalf("Examples() returned %d examples, want %d", got, want)
+	}
+
+	// Index by name for deterministic lookup.
+	byName := make(map[string]examples.Example, len(list))
+	for _, ex := range list {
+		byName[ex.Name] = ex
+	}
+
+	wantNames := []string{"httproute-v1", "allowed-project-resource-kinds-v1"}
+	for _, name := range wantNames {
+		ex, ok := byName[name]
+		if !ok {
+			t.Errorf("example %q not found in registry", name)
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			testExample(t, ex)
+		})
+	}
+}
+
+// testExample runs all per-example assertions.
+func testExample(t *testing.T, ex examples.Example) {
+	t.Helper()
+
+	// All metadata fields must be non-empty.
+	if ex.DisplayName == "" {
+		t.Error("DisplayName is empty")
+	}
+	if ex.Name == "" {
+		t.Error("Name is empty")
+	}
+	if ex.Description == "" {
+		t.Error("Description is empty")
+	}
+	if ex.CueTemplate == "" {
+		t.Error("CueTemplate is empty")
+	}
+
+	// The cueTemplate body must compile against the v1alpha2 generated schema.
+	// This catches the HOL-789 class of non-concrete-value regressions before
+	// the renderer ever sees the template.
+	t.Run("cueTemplate_compiles", func(t *testing.T) {
+		cueCtx := cuecontext.New()
+		fullSrc := v1alpha2.GeneratedSchema + "\n" + ex.CueTemplate
+		val := cueCtx.CompileString(fullSrc)
+		if err := val.Err(); err != nil {
+			t.Errorf("cueTemplate failed to compile against v1alpha2 schema: %v", err)
+		}
+	})
+}

--- a/console/templates/examples/httproute-v1.cue
+++ b/console/templates/examples/httproute-v1.cue
@@ -1,0 +1,58 @@
+// HTTPRoute platform example — folder-level platform template.
+// Drop this into a folder's template set to expose every project in the folder
+// via an HTTPRoute into the org-configured ingress gateway.
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "HTTPRoute (v1)"
+name:        "httproute-v1"
+description: "Exposes project services via an HTTPRoute into the org-configured ingress gateway."
+
+cueTemplate: """
+	// input and platform are available because platform templates are unified with
+	// the deployment template before evaluation (ADR 016 Decision 8).
+	input: #ProjectInput & {
+		port: >0 & <=65535 | *8080
+	}
+	platform: #PlatformInput
+
+	// platformResources holds resources the platform team manages. The renderer
+	// reads these only from organization/folder-level templates — project templates
+	// that define platformResources are silently ignored (ADR 016 Decision 8).
+	platformResources: {
+		namespacedResources: (platform.gatewayNamespace): {
+			// HTTPRoute routes traffic from the gateway to the project Service on port 80.
+			HTTPRoute: (input.name): {
+				apiVersion: "gateway.networking.k8s.io/v1"
+				kind:       "HTTPRoute"
+				metadata: {
+					name:      input.name
+					namespace: platform.gatewayNamespace
+					labels: {
+						"app.kubernetes.io/managed-by": "console.holos.run"
+						"app.kubernetes.io/name":       input.name
+					}
+				}
+				spec: {
+					parentRefs: [{
+						group:     "gateway.networking.k8s.io"
+						kind:      "Gateway"
+						namespace: platform.gatewayNamespace
+						name:      "default"
+					}]
+					rules: [{
+						backendRefs: [{
+							name:      input.name
+							namespace: platform.namespace
+							port:      80
+						}]
+					}]
+				}
+			}
+		}
+		clusterResources: {}
+	}
+	"""


### PR DESCRIPTION
## Summary
- Add `console/templates/examples/` package with an `embed.FS`-backed registry
- Each CUE file declares `displayName`, `name`, `description`, `cueTemplate` as top-level fields
- `Examples()` iterates the embedded FS, parses each CUE file with the v1alpha2 schema prepended, and returns the structured list
- Two starter examples: `httproute-v1` (HTTPRoute platform template using `platform.gatewayNamespace`) and `allowed-project-resource-kinds-v1` (closed-struct kind constraint)
- Table-driven test asserts count, non-empty fields, and that each `cueTemplate` compiles against v1alpha2 schema

Fixes HOL-796

## Test plan
- [ ] `make test-go` passes (new `console/templates/examples` package: all tests green)
- [ ] `Examples()` returns exactly 2 examples
- [ ] Each example has non-empty `displayName`, `name`, `description`, `cueTemplate`
- [ ] Each `cueTemplate` compiles against the v1alpha2 generated schema without error
- [ ] `httproute-v1` uses `platform.gatewayNamespace` (not `platform.namespace`) for the HTTPRoute namespace and parentRef
- [ ] `allowed-project-resource-kinds-v1` uses `close({...})` pattern with optional fields for Deployment, Service, ServiceAccount