### PR TITLE
feat(frontend): add org-scope Create Template flow at /orgs/$orgName/templates

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-index.test.tsx
@@ -42,7 +42,13 @@ vi.mock('@/queries/templates', () => ({
   useSearchTemplates: vi.fn(),
 }))
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 import { useSearchTemplates } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { OrgTemplatesIndexPage } from './index'
 
 type Template = {
@@ -51,10 +57,15 @@ type Template = {
   displayName: string
 }
 
-function setup(templates: Template[] = []) {
+function setup(templates: Template[] = [], userRole: Role = Role.OWNER) {
   ;(useSearchTemplates as Mock).mockReturnValue({
     data: templates,
     isLoading: false,
+    error: null,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
     error: null,
   })
 }
@@ -62,6 +73,11 @@ function setup(templates: Template[] = []) {
 describe('OrgTemplatesIndexPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(useGetOrganization as Mock).mockReturnValue({
+      data: { name: 'test-org', userRole: Role.OWNER },
+      isPending: false,
+      error: null,
+    })
   })
 
   it('renders loading skeletons while the query is pending', () => {
@@ -167,6 +183,37 @@ describe('OrgTemplatesIndexPage', () => {
     const rows = screen.getAllByRole('row')
     expect(rows).toHaveLength(2)
     expect(within(rows[1]).getByText('Web Service')).toBeInTheDocument()
+  })
+
+  it('renders the Create Template button for org OWNERs', () => {
+    setup([], Role.OWNER)
+    render(<OrgTemplatesIndexPage />)
+    const link = screen.getByRole('link', { name: /create template/i })
+    expect(link).toHaveAttribute('href', '/orgs/test-org/templates/new')
+  })
+
+  it('hides the Create Template button for non-OWNER users', () => {
+    setup([], Role.VIEWER)
+    render(<OrgTemplatesIndexPage />)
+    expect(
+      screen.queryByRole('link', { name: /create template/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('empty state prompts OWNERs to create a template', () => {
+    setup([], Role.OWNER)
+    render(<OrgTemplatesIndexPage />)
+    expect(
+      screen.getByText(/no templates yet\. create one to get started/i),
+    ).toBeInTheDocument()
+  })
+
+  it('empty state directs non-OWNERs to ask an owner', () => {
+    setup([], Role.VIEWER)
+    render(<OrgTemplatesIndexPage />)
+    expect(
+      screen.getByText(/ask an organization owner to create one/i),
+    ).toBeInTheDocument()
   })
 
   it('filters rows by slug name', () => {

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-new.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org' }),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({
+      children,
+      className,
+      to,
+      params,
+    }: {
+      children: React.ReactNode
+      className?: string
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/queries/templates', () => ({
+  useCreateTemplate: vi.fn(),
+}))
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+import { useCreateTemplate } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateOrgTemplatePage } from './new'
+
+function setupMocks(
+  mutateAsync = vi.fn().mockResolvedValue({}),
+  userRole = Role.OWNER,
+) {
+  ;(useCreateTemplate as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+    reset: vi.fn(),
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('CreateOrgTemplatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page heading', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByText(/create platform template/i)).toBeInTheDocument()
+  })
+
+  it('renders Display Name field', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+  })
+
+  it('renders Name (slug) field', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByLabelText(/name slug/i)).toBeInTheDocument()
+  })
+
+  it('renders Description field', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders CUE Template textarea', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(
+      screen.getByRole('textbox', { name: /cue template/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders Enabled switch defaulting to unchecked', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    const toggle = screen.getByRole('switch', { name: /enabled/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders Create submit button', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(
+      screen.getByRole('button', { name: /^create$/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a Cancel link back to the templates list', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByRole('link', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('auto-derives slug from display name', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    const displayNameInput = screen.getByLabelText(/display name/i)
+    fireEvent.change(displayNameInput, { target: { value: 'My Web App' } })
+    const slugInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
+    expect(slugInput.value).toBe('my-web-app')
+  })
+
+  it('shows validation error when name is empty', async () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => {
+      expect(
+        screen.getByText(/template name is required/i),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('calls createMutation with form values on submit', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(mutateAsync)
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'My Template' },
+    })
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: 'A description' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'my-template',
+          displayName: 'My Template',
+          description: 'A description',
+          enabled: false,
+        }),
+      )
+    })
+  })
+
+  it('navigates to the consolidated editor after successful creation', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(mutateAsync)
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'My Template' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '/orgs/$orgName/templates/$namespace/$name',
+          params: expect.objectContaining({
+            orgName: 'test-org',
+            name: 'my-template',
+          }),
+        }),
+      )
+    })
+  })
+
+  it('shows error message when creation fails', async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(new Error('server error'))
+    setupMocks(mutateAsync)
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'My Template' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/server error/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders breadcrumb navigation', () => {
+    render(<CreateOrgTemplatePage orgName="test-org" />)
+    expect(screen.getByText('Templates')).toBeInTheDocument()
+    expect(screen.getByText('test-org')).toBeInTheDocument()
+  })
+
+  describe('Load Example button', () => {
+    it('renders Load Example button', () => {
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+      expect(
+        screen.getByRole('button', { name: /load example/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('clicking Load Example populates all form fields', () => {
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+      fireEvent.click(screen.getByRole('button', { name: /load example/i }))
+
+      const nameInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
+      expect(nameInput.value).toBe('httpbin-platform')
+
+      const displayNameInput = screen.getByLabelText(
+        /display name/i,
+      ) as HTMLInputElement
+      expect(displayNameInput.value).toBe('httpbin Platform')
+
+      const cueEditor = screen.getByRole('textbox', {
+        name: /cue template/i,
+      }) as HTMLTextAreaElement
+      expect(cueEditor.value).toContain('HTTPRoute')
+      expect(cueEditor.value).toContain('platform.gatewayNamespace')
+    })
+  })
+
+  describe('permissions', () => {
+    it('disables form fields for non-OWNER users', () => {
+      setupMocks(vi.fn().mockResolvedValue({}), Role.VIEWER)
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+
+      expect(screen.getByLabelText(/display name/i)).toBeDisabled()
+      expect(screen.getByLabelText(/name slug/i)).toBeDisabled()
+      expect(screen.getByLabelText(/description/i)).toBeDisabled()
+      expect(
+        screen.getByRole('textbox', { name: /cue template/i }),
+      ).toBeDisabled()
+      expect(screen.getByRole('switch', { name: /enabled/i })).toBeDisabled()
+      expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+    })
+
+    it('enables form fields for OWNER users', () => {
+      setupMocks(vi.fn().mockResolvedValue({}), Role.OWNER)
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+
+      expect(screen.getByLabelText(/display name/i)).not.toBeDisabled()
+      expect(screen.getByLabelText(/name slug/i)).not.toBeDisabled()
+      expect(screen.getByLabelText(/description/i)).not.toBeDisabled()
+      expect(
+        screen.getByRole('textbox', { name: /cue template/i }),
+      ).not.toBeDisabled()
+      expect(
+        screen.getByRole('button', { name: /^create$/i }),
+      ).not.toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/index.tsx
@@ -7,6 +7,7 @@ import {
   flexRender,
   createColumnHelper,
 } from '@tanstack/react-table'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -19,7 +20,9 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useSearchTemplates } from '@/queries/templates'
+import { useGetOrganization } from '@/queries/organizations'
 import type { Template } from '@/gen/holos/console/v1/templates_pb'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/templates/')({
@@ -46,11 +49,15 @@ export function OrgTemplatesIndexPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const { data, isLoading, error } = useSearchTemplates({ organization: orgName })
+  const { data: org } = useGetOrganization(orgName)
   // When orgName is empty the query is disabled: isLoading is false and data is
   // undefined. Treat the disabled state the same as loading so we never render
   // the "No templates yet" empty state for an org that hasn't resolved yet.
   const queryDisabled = orgName === ''
   const templates = useMemo(() => data ?? [], [data])
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER
 
   const [globalFilter, setGlobalFilter] = useState('')
 
@@ -135,15 +142,22 @@ export function OrgTemplatesIndexPage({
 
   return (
     <Card>
-      <CardHeader>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
         <CardTitle>Templates</CardTitle>
+        {canWrite && (
+          <Link to="/orgs/$orgName/templates/new" params={{ orgName }}>
+            <Button size="sm">Create Template</Button>
+          </Link>
+        )}
       </CardHeader>
       <CardContent>
         {templates.length === 0 ? (
           <div className="flex flex-col items-center gap-3 py-8 text-center">
             <p className="text-muted-foreground">
-              No templates yet. Create one from an organization, folder, or
-              project scope.
+              No templates yet.
+              {canWrite
+                ? ' Create one to get started.'
+                : ' Ask an organization owner to create one.'}
             </p>
           </div>
         ) : (

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/new.tsx
@@ -1,0 +1,290 @@
+import { useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Info } from 'lucide-react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplate } from '@/queries/templates'
+import { namespaceForOrg } from '@/lib/scope-labels'
+import { useGetOrganization } from '@/queries/organizations'
+
+// EXAMPLE_ORG_PLATFORM_TEMPLATE is the example org-level platform template CUE content.
+// It matches console/templates/example_httpbin_platform.cue.
+const EXAMPLE_ORG_PLATFORM_TEMPLATE = `// Org-level platform template — evaluated at organization scope.
+// Any changes here affect every project in the org.
+//
+// This template does two things:
+//  1. Provides an HTTPRoute in platformResources so the gateway routes
+//     traffic to the deployment's Service.
+//  2. Closes projectResources.namespacedResources to Deployment, Service,
+//     and ServiceAccount (ADR 016 Decision 9) so project templates cannot
+//     produce any other resource kind.
+//
+// Pair with console/templates/example_httpbin.cue for the project-level template.
+
+// input and platform are available because platform templates are unified with
+// the deployment template before evaluation (ADR 016 Decision 8).
+input: #ProjectInput & {
+\tport: >0 & <=65535 | *8080
+}
+platform: #PlatformInput
+
+// ── Platform resources (managed by the platform team) ───────────────────────
+
+// platformResources holds resources the platform team manages. The renderer
+// reads these only from organization/folder-level templates — project templates
+// that define platformResources are silently ignored (ADR 016 Decision 8).
+platformResources: {
+\tnamespacedResources: (platform.namespace): {
+\t\t// HTTPRoute exposes the deployment's Service via the gateway.
+\t\t// It routes all traffic from the gateway to the Service named input.name
+\t\t// on port 80 (the Service port, which forwards to containerPort input.port).
+\t\tHTTPRoute: (input.name): {
+\t\t\tapiVersion: "gateway.networking.k8s.io/v1"
+\t\t\tkind:       "HTTPRoute"
+\t\t\tmetadata: {
+\t\t\t\tname:      input.name
+\t\t\t\tnamespace: platform.namespace
+\t\t\t\tlabels: {
+\t\t\t\t\t"app.kubernetes.io/managed-by": "console.holos.run"
+\t\t\t\t\t"app.kubernetes.io/name":       input.name
+\t\t\t\t}
+\t\t\t}
+\t\t\tspec: {
+\t\t\t\tparentRefs: [{
+\t\t\t\t\tgroup:     "gateway.networking.k8s.io"
+\t\t\t\t\tkind:      "Gateway"
+\t\t\t\t\tnamespace: platform.gatewayNamespace
+\t\t\t\t\tname:      "default"
+\t\t\t\t}]
+\t\t\t\trules: [{
+\t\t\t\t\tbackendRefs: [{
+\t\t\t\t\t\tname: input.name
+\t\t\t\t\t\tport: 80
+\t\t\t\t\t}]
+\t\t\t\t}]
+\t\t\t}
+\t\t}
+\t}
+\tclusterResources: {}
+}
+
+// ── Project resource constraints (enforced by the platform team) ─────────────
+
+// Close projectResources.namespacedResources so that every namespace bucket
+// may only contain Deployment, Service, or ServiceAccount. Using close() with
+// optional fields is the correct CUE pattern: the close() call marks the struct
+// as closed (no additional fields allowed), and the ? marks each listed field
+// as optional (a namespace bucket need not contain all three). Any unlisted
+// Kind key — such as RoleBinding — is a CUE constraint violation at evaluation
+// time, before any Kubernetes API call (ADR 016 Decision 9).
+projectResources: namespacedResources: [_]: close({
+\tDeployment?:     _
+\tService?:        _
+\tServiceAccount?: _
+})
+`
+
+export const Route = createFileRoute('/_authenticated/orgs/$orgName/templates/new')({
+  component: CreateOrgTemplateRoute,
+})
+
+function CreateOrgTemplateRoute() {
+  const { orgName } = Route.useParams()
+  return <CreateOrgTemplatePage orgName={orgName} />
+}
+
+export function CreateOrgTemplatePage({ orgName: propOrgName }: { orgName?: string } = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const navigate = useNavigate()
+  const namespace = namespaceForOrg(orgName)
+  const createMutation = useCreateTemplate(namespace)
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER
+
+  const [displayName, setDisplayName] = useState('')
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [cueTemplate, setCueTemplate] = useState('')
+  const [enabled, setEnabled] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const slugify = (val: string) =>
+    val.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+
+  const handleDisplayNameChange = (val: string) => {
+    setDisplayName(val)
+    setName(slugify(val))
+  }
+
+  const handleLoadExample = () => {
+    setName('httpbin-platform')
+    setDisplayName('httpbin Platform')
+    setDescription(
+      'Provides an HTTPRoute for gateway access and constrains project templates to Deployment, Service, and ServiceAccount only.',
+    )
+    setCueTemplate(EXAMPLE_ORG_PLATFORM_TEMPLATE)
+  }
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      setError('Template name is required')
+      return
+    }
+    setError(null)
+    try {
+      await createMutation.mutateAsync({
+        name: name.trim(),
+        displayName: displayName.trim(),
+        description: description.trim(),
+        cueTemplate,
+        enabled,
+      })
+      await navigate({
+        to: '/orgs/$orgName/templates/$namespace/$name',
+        params: { orgName, namespace, name: name.trim() },
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link to="/orgs/$orgName/settings" params={{ orgName }} className="hover:underline">
+              {orgName}
+            </Link>
+            {' / '}
+            <Link to="/orgs/$orgName/templates" params={{ orgName }} className="hover:underline">
+              Templates
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">Create Platform Template</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="template-display-name">Display Name</Label>
+            <Input
+              id="template-display-name"
+              aria-label="Display Name"
+              autoFocus
+              value={displayName}
+              onChange={(e) => handleDisplayNameChange(e.target.value)}
+              placeholder="My Template"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <Label>Name (slug)</Label>
+            <Input
+              aria-label="Name slug"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-template"
+              disabled={!canWrite}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Auto-derived from display name. Lowercase alphanumeric and hyphens only.
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="template-description">Description</Label>
+            <Input
+              id="template-description"
+              aria-label="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this template produce?"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <Label htmlFor="template-cue-template">CUE Template</Label>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" type="button" onClick={handleLoadExample} disabled={!canWrite}>
+                  Load Example
+                </Button>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info className="h-4 w-4 text-muted-foreground cursor-default" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>
+                        Platform templates are unified with project deployment templates at render
+                        time via CUE. This example constrains project resources to safe kinds and
+                        provides an HTTPRoute for external access.
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            </div>
+            <Textarea
+              id="template-cue-template"
+              aria-label="CUE Template"
+              value={cueTemplate}
+              onChange={(e) => setCueTemplate(e.target.value)}
+              rows={20}
+              className="font-mono text-sm field-sizing-normal max-h-[600px] overflow-y-auto"
+              disabled={!canWrite}
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="template-enabled"
+              aria-label="Enabled"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+              disabled={!canWrite}
+            />
+            <Label htmlFor="template-enabled" className="text-sm cursor-pointer">
+              Enabled (apply to projects in this organization)
+            </Label>
+          </div>
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <div className="flex items-center gap-3 pt-2">
+            <Button onClick={handleCreate} disabled={createMutation.isPending || !canWrite}>
+              {createMutation.isPending ? 'Creating...' : 'Create'}
+            </Button>
+            <Link
+              to="/orgs/$orgName/templates"
+              params={{ orgName }}
+            >
+              <Button variant="ghost" type="button" aria-label="Cancel">
+                Cancel
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
Assignee: @jeffmccune ([Jeff McCune](https://linear.app/holos-run/profiles/jeff))

## Summary

Closes [HOL-792](https://linear.app/holos-run/issue/HOL-792/no-create-template-at-orgsholostemplates). The unified Templates index at `/orgs/$orgName/templates` (introduced in HOL-607) had no create affordance after `4f43440` retired the legacy `/orgs/$orgName/settings/org-templates/new` page. Org OWNERs could no longer create an org-scope platform template through the UI.

This PR closes that gap symmetrically with the existing folder/project create flows:

- Adds `frontend/src/routes/_authenticated/orgs/$orgName/templates/new.tsx`, a create form mirroring the folder-scope pattern. Uses `namespaceForOrg(orgName)` + `useCreateTemplate`, permission-gated on `org.userRole === OWNER`, redirects to the consolidated editor `/orgs/$orgName/templates/$namespace/$name` on success.
- Adds a **Create Template** button on the org Templates index (`CardHeader`), visible only to OWNERs.
- Rewrites the empty-state copy: OWNERs see *"Create one to get started"*; non-OWNERs see *"Ask an organization owner to create one"* instead of the stale dead-end reference.
- Covers the flow with unit tests for `new.tsx` (fields, permissions, validation, mutation payload, success navigation) and extends `-index.test.tsx` with button-visibility and empty-state assertions for OWNER vs VIEWER.

## Scope

This is option (1) — the minimal symmetric fix matching the existing folder/project pattern. Consolidation into a single shared `TemplateCreateForm` (option 2, possibly related to HOL-790) is tracked as follow-up [HOL-816](https://linear.app/holos-run/issue/HOL-816).

## Testing performed

- `cd frontend && npm test -- --run` → 82 test files, 1083 tests pass
- `cd frontend && ./node_modules/.bin/tsc -b` → clean
- `cd frontend && ./node_modules/.bin/eslint 'src/routes/_authenticated/orgs/$orgName/templates/'` → clean
- UI smoke-test with a running dev server was not performed in-session (Chrome extension unavailable). Recommended: click **Create Template** at `/orgs/holos/templates`, submit a template, verify redirect to the consolidated editor.

## Test plan

- [ ] As org OWNER: button visible at `/orgs/$orgName/templates`, opens `/orgs/$orgName/templates/new`, form creates a template, redirects to the consolidated editor.
- [ ] As org VIEWER: no button; empty state reads *"Ask an organization owner to create one"*.
- [ ] Form fields disabled for VIEWER; enabled for OWNER.
- [ ] Load Example populates all fields with the httpbin platform template CUE.
- [ ] Cancel link returns to `/orgs/$orgName/templates`.

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->