### PR TITLE
feat(frontend): template example picker + folder new-page UI updates

### DIFF
--- a/frontend/src/components/templates/template-example-picker.test.tsx
+++ b/frontend/src/components/templates/template-example-picker.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+vi.mock('@/queries/templates', () => ({
+  useListTemplateExamples: vi.fn(),
+}))
+
+import { useListTemplateExamples } from '@/queries/templates'
+import { TemplateExamplePicker } from './template-example-picker'
+
+const EXAMPLE_HTTPROUTE = {
+  name: 'httproute-v1',
+  displayName: 'HTTPRoute Ingress',
+  description: 'Provides an HTTPRoute for the org-configured ingress gateway.',
+  cueTemplate: '// example CUE\nplatformResources: {}\n',
+}
+
+const EXAMPLE_CONFIGMAP = {
+  name: 'configmap-v1',
+  displayName: 'ConfigMap Starter',
+  description: 'A minimal ConfigMap scaffold for project-scope templates.',
+  cueTemplate: '// another example\nprojectResources: {}\n',
+}
+
+function setHook({
+  data,
+  isPending = false,
+  error = null,
+}: {
+  data?: typeof EXAMPLE_HTTPROUTE[]
+  isPending?: boolean
+  error?: Error | null
+}) {
+  ;(useListTemplateExamples as Mock).mockReturnValue({
+    data,
+    isPending,
+    error,
+  })
+}
+
+describe('TemplateExamplePicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the trigger button with the default label', () => {
+    setHook({ data: [EXAMPLE_HTTPROUTE] })
+    render(<TemplateExamplePicker onSelect={vi.fn()} />)
+    expect(screen.getByRole('combobox', { name: /load example/i })).toBeInTheDocument()
+  })
+
+  it('renders a custom label when provided', () => {
+    setHook({ data: [EXAMPLE_HTTPROUTE] })
+    render(<TemplateExamplePicker onSelect={vi.fn()} label="Pick Starter" />)
+    expect(screen.getByRole('combobox', { name: /pick starter/i })).toBeInTheDocument()
+  })
+
+  it('shows a loading indicator while examples are being fetched', () => {
+    setHook({ data: undefined, isPending: true })
+    render(<TemplateExamplePicker onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+    expect(screen.getByRole('status')).toHaveTextContent(/loading examples/i)
+  })
+
+  it('shows the empty-state message when the server returns no examples', () => {
+    setHook({ data: [] })
+    render(<TemplateExamplePicker onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+    expect(screen.getByText(/no examples found/i)).toBeInTheDocument()
+  })
+
+  it('shows an error message when the hook reports an error', () => {
+    setHook({ data: undefined, error: new Error('boom') })
+    render(<TemplateExamplePicker onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/failed to load examples/i)
+  })
+
+  it('renders each example with its display name and description', () => {
+    setHook({ data: [EXAMPLE_HTTPROUTE, EXAMPLE_CONFIGMAP] })
+    render(<TemplateExamplePicker onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+
+    expect(screen.getByText(EXAMPLE_HTTPROUTE.displayName)).toBeInTheDocument()
+    expect(screen.getByText(EXAMPLE_HTTPROUTE.description)).toBeInTheDocument()
+    expect(screen.getByText(EXAMPLE_CONFIGMAP.displayName)).toBeInTheDocument()
+    expect(screen.getByText(EXAMPLE_CONFIGMAP.description)).toBeInTheDocument()
+  })
+
+  it('invokes onSelect with the full example payload when an item is clicked', async () => {
+    const onSelect = vi.fn()
+    setHook({ data: [EXAMPLE_HTTPROUTE, EXAMPLE_CONFIGMAP] })
+    render(<TemplateExamplePicker onSelect={onSelect} />)
+    fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+
+    const item = await screen.findByText(EXAMPLE_HTTPROUTE.displayName)
+    fireEvent.click(item)
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledTimes(1)
+    })
+    expect(onSelect).toHaveBeenCalledWith(EXAMPLE_HTTPROUTE)
+  })
+
+  it('filters the list when the user types in the search input', async () => {
+    setHook({ data: [EXAMPLE_HTTPROUTE, EXAMPLE_CONFIGMAP] })
+    render(<TemplateExamplePicker onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+
+    // Both items are visible initially.
+    expect(screen.getByText(EXAMPLE_HTTPROUTE.displayName)).toBeInTheDocument()
+    expect(screen.getByText(EXAMPLE_CONFIGMAP.displayName)).toBeInTheDocument()
+
+    const searchInput = screen.getByPlaceholderText(/search examples/i)
+    fireEvent.change(searchInput, { target: { value: 'HTTPRoute' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(EXAMPLE_HTTPROUTE.displayName)).toBeInTheDocument()
+      expect(screen.queryByText(EXAMPLE_CONFIGMAP.displayName)).not.toBeInTheDocument()
+    })
+  })
+
+  it('matches the search input against descriptions as well as display names', async () => {
+    setHook({ data: [EXAMPLE_HTTPROUTE, EXAMPLE_CONFIGMAP] })
+    render(<TemplateExamplePicker onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+
+    const searchInput = screen.getByPlaceholderText(/search examples/i)
+    // "ingress" appears only in the HTTPRoute description.
+    fireEvent.change(searchInput, { target: { value: 'ingress' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(EXAMPLE_HTTPROUTE.displayName)).toBeInTheDocument()
+      expect(screen.queryByText(EXAMPLE_CONFIGMAP.displayName)).not.toBeInTheDocument()
+    })
+  })
+
+  it('disables the trigger when disabled is true', () => {
+    setHook({ data: [EXAMPLE_HTTPROUTE] })
+    render(<TemplateExamplePicker onSelect={vi.fn()} disabled />)
+    expect(screen.getByRole('combobox', { name: /load example/i })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/templates/template-example-picker.tsx
+++ b/frontend/src/components/templates/template-example-picker.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react'
+import { ChevronsUpDownIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { useListTemplateExamples } from '@/queries/templates'
+import type { TemplateExample } from '@/queries/templates'
+
+export interface TemplateExamplePickerProps {
+  /**
+   * Called with the full example payload when the user selects an item.
+   * Consumers are responsible for populating their own form fields
+   * (displayName, name/slug, description, cueTemplate) from the payload in a
+   * single action.
+   */
+  onSelect: (example: TemplateExample) => void
+  /** Trigger button copy. Defaults to "Load Example". */
+  label?: string
+  /** Placeholder shown in the search input. */
+  searchPlaceholder?: string
+  /** Disable the picker (e.g. when the viewer lacks write access). */
+  disabled?: boolean
+  /** Additional class names for the trigger button. */
+  className?: string
+}
+
+/**
+ * TemplateExamplePicker renders a single trigger button that expands into a
+ * searchable list of built-in CUE example templates from the backend
+ * `ListTemplateExamples` RPC. Selecting an example invokes `onSelect` with
+ * the full payload so the parent form can populate Display Name, Name (slug),
+ * Description, and CUE Template in one action.
+ *
+ * Built on the shared `cmdk` Command + shadcn Popover primitives — the same
+ * foundation as `components/ui/combobox.tsx`. The picker renders a two-line
+ * row per example: the `displayName` as the primary label and `description`
+ * as dimmed secondary text. Search matches against both fields.
+ *
+ * Introduced in HOL-798 as part of the HOL-795 example-picker initiative.
+ * The server is the sole source of example content (HOL-796, HOL-797); the
+ * frontend never hard-codes CUE bodies.
+ */
+export function TemplateExamplePicker({
+  onSelect,
+  label = 'Load Example',
+  searchPlaceholder = 'Search examples…',
+  disabled = false,
+  className,
+}: TemplateExamplePickerProps) {
+  const [open, setOpen] = React.useState(false)
+  const { data: examples, isPending, error } = useListTemplateExamples()
+
+  const handleSelect = (example: TemplateExample) => {
+    onSelect(example)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={label}
+          disabled={disabled}
+          className={cn('justify-between gap-2', className)}
+        >
+          <span>{label}</span>
+          <ChevronsUpDownIcon className="h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[22rem] p-0" align="end">
+        <Command
+          // Match against both the display name and description so typing
+          // either a title fragment ("HTTPRoute") or a word from the
+          // description ("ingress") filters the list.
+          filter={(value, search) => {
+            if (!search) return 1
+            return value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0
+          }}
+        >
+          <CommandInput placeholder={searchPlaceholder} aria-label={searchPlaceholder} />
+          <CommandList>
+            {isPending ? (
+              <div
+                role="status"
+                aria-live="polite"
+                className="py-6 text-center text-sm text-muted-foreground"
+              >
+                Loading examples…
+              </div>
+            ) : error ? (
+              <div
+                role="alert"
+                className="py-6 text-center text-sm text-destructive"
+              >
+                Failed to load examples.
+              </div>
+            ) : (
+              <>
+                <CommandEmpty>No examples found.</CommandEmpty>
+                {examples && examples.length > 0 && (
+                  <CommandGroup>
+                    {examples.map((example) => (
+                      <CommandItem
+                        key={example.name}
+                        value={`${example.displayName} ${example.description} ${example.name}`}
+                        onSelect={() => handleSelect(example)}
+                        className="flex flex-col items-start gap-0.5 py-2"
+                      >
+                        <span className="text-sm font-medium">
+                          {example.displayName}
+                        </span>
+                        {example.description && (
+                          <span className="text-xs text-muted-foreground">
+                            {example.description}
+                          </span>
+                        )}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -10,6 +10,7 @@ import {
 import type {
   LinkableTemplate,
   Release,
+  TemplateExample,
   TemplateUpdate,
   TemplateDefaults,
 } from '@/gen/holos/console/v1/templates_pb.js'
@@ -17,7 +18,14 @@ import type { LinkedTemplateRef } from '@/gen/holos/console/v1/policy_state_pb.j
 import { useAuth } from '@/lib/auth'
 
 // Re-export generated types used by consumers.
-export type { LinkableTemplate, LinkedTemplateRef, Release, TemplateUpdate, TemplateDefaults }
+export type {
+  LinkableTemplate,
+  LinkedTemplateRef,
+  Release,
+  TemplateExample,
+  TemplateUpdate,
+  TemplateDefaults,
+}
 
 // linkableKey builds a composite key that uniquely identifies a linkable
 // template across namespaces. HOL-623 reworked the UI to key templates by
@@ -46,6 +54,33 @@ function templateGetKey(namespace: string, name: string) {
 
 function linkableTemplatesKey(namespace: string, includeSelfScope: boolean) {
   return ['templates', 'linkable', namespace, includeSelfScope] as const
+}
+
+function templateExamplesKey() {
+  return ['templates', 'examples'] as const
+}
+
+// useListTemplateExamples fetches the built-in CUE example templates embedded
+// in the server binary (HOL-797). The template example picker UI calls this
+// hook to offer drop-in starting points when creating a new template — the
+// frontend never hard-codes example content.
+//
+// The RPC response is stable across the life of a server binary, so the query
+// is kept long (staleTime: Infinity). Enabled only when the caller is
+// authenticated so we don't fire a request during the pre-auth redirect.
+export function useListTemplateExamples() {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+  return useQuery({
+    queryKey: templateExamplesKey(),
+    queryFn: async () => {
+      const response = await client.listTemplateExamples({})
+      return response.examples
+    },
+    enabled: isAuthenticated,
+    staleTime: Infinity,
+  })
 }
 
 export function useListTemplates(namespace: string) {

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx
@@ -19,22 +19,60 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   }
 })
 
+// Flatten Tooltip so TooltipContent renders inline in jsdom. The hover
+// interaction itself belongs to Radix Tooltip and is not exercised here;
+// this keeps content-level assertions (tooltip copy) reachable via
+// getByText without faking pointer events.
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => (asChild ? <>{children}</> : <span>{children}</span>),
+  TooltipContent: ({
+    children,
+    ...rest
+  }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => (
+    <div {...rest}>{children}</div>
+  ),
+}))
+
 vi.mock('@/queries/templates', () => ({
   useCreateTemplate: vi.fn(),
+  useListTemplateExamples: vi.fn(),
 }))
 
 vi.mock('@/queries/folders', () => ({
   useGetFolder: vi.fn(),
 }))
 
-import { useCreateTemplate } from '@/queries/templates'
+import { useCreateTemplate, useListTemplateExamples } from '@/queries/templates'
 import { useGetFolder } from '@/queries/folders'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateFolderTemplatePage } from './new'
 
+const EXAMPLE_HTTPROUTE = {
+  name: 'httproute-v1',
+  displayName: 'HTTPRoute Ingress',
+  description: 'Provides an HTTPRoute for the org-configured ingress gateway.',
+  cueTemplate: '// example CUE\nplatformResources: {}\n',
+}
+
+const EXAMPLE_SECOND = {
+  name: 'configmap-v1',
+  displayName: 'ConfigMap Starter',
+  description: 'A minimal ConfigMap scaffold for project-scope templates.',
+  cueTemplate: '// another example\nprojectResources: {}\n',
+}
+
 function setupMocks(
   mutateAsync = vi.fn().mockResolvedValue({}),
   userRole = Role.OWNER,
+  examples: typeof EXAMPLE_HTTPROUTE[] = [EXAMPLE_HTTPROUTE, EXAMPLE_SECOND],
 ) {
   ;(useCreateTemplate as Mock).mockReturnValue({
     mutateAsync,
@@ -43,6 +81,11 @@ function setupMocks(
   })
   ;(useGetFolder as Mock).mockReturnValue({
     data: { name: 'test-folder', organization: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useListTemplateExamples as Mock).mockReturnValue({
+    data: examples,
     isPending: false,
     error: null,
   })
@@ -79,11 +122,36 @@ describe('CreateFolderTemplatePage', () => {
     expect(screen.getByRole('textbox', { name: /cue template/i })).toBeInTheDocument()
   })
 
-  it('renders Enabled switch defaulting to unchecked', () => {
+  it('renders Enabled switch defaulting to checked', () => {
     render(<CreateFolderTemplatePage folderName="test-folder" />)
     const toggle = screen.getByRole('switch', { name: /enabled/i })
     expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveAttribute('data-state', 'unchecked')
+    expect(toggle).toHaveAttribute('data-state', 'checked')
+  })
+
+  it('renders Enabled label without the old parenthetical', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    const label = screen.getByText(/^Enabled$/)
+    expect(label).toBeInTheDocument()
+    expect(
+      screen.queryByText(/apply to projects in this folder/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the TemplatePolicyBinding tooltip copy', () => {
+    render(<CreateFolderTemplatePage folderName="test-folder" />)
+    // Use a custom matcher on the <p> element (matched by tagName) so
+    // whitespace from JSX line breaks inside the sentence does not defeat
+    // an exact-text match. The acceptance criterion specifies the tooltip
+    // reads exactly this sentence.
+    const expected =
+      'Unified with resources bound to this Template by Policy when enabled. See TemplatePolicyBinding.'
+    const node = screen.getByText((_content, element) => {
+      if (!element || element.tagName !== 'P') return false
+      const text = element.textContent?.replace(/\s+/g, ' ').trim()
+      return text === expected
+    })
+    expect(node).toBeInTheDocument()
   })
 
   it('renders Create submit button', () => {
@@ -127,7 +195,10 @@ describe('CreateFolderTemplatePage', () => {
           name: 'my-template',
           displayName: 'My Template',
           description: 'A description',
-          enabled: false,
+          // Enabled now defaults to true; the switch is rendered checked on
+          // mount and the mutation carries that value unless the user flips
+          // it off.
+          enabled: true,
         }),
       )
     })
@@ -195,48 +266,60 @@ describe('CreateFolderTemplatePage', () => {
     expect(screen.getByText('test-folder')).toBeInTheDocument()
   })
 
-  describe('Load Example button', () => {
-    it('renders Load Example button', () => {
+  // HOL-798: the inline "Load Example" button and hard-coded CUE body were
+  // replaced by the reusable TemplateExamplePicker backed by
+  // ListTemplateExamples. The picker is the single source of example content
+  // from now on.
+  describe('TemplateExamplePicker integration', () => {
+    it('renders the Load Example picker trigger', () => {
       render(<CreateFolderTemplatePage folderName="test-folder" />)
-      expect(screen.getByRole('button', { name: /load example/i })).toBeInTheDocument()
+      expect(screen.getByRole('combobox', { name: /load example/i })).toBeInTheDocument()
     })
 
-    it('clicking Load Example populates all form fields', () => {
+    it('no longer renders a plain "Load Example" push button', () => {
       render(<CreateFolderTemplatePage folderName="test-folder" />)
-      fireEvent.click(screen.getByRole('button', { name: /load example/i }))
+      // Picker trigger is exposed as role=combobox. A plain role=button with
+      // that accessible name would indicate the old inline button survived.
+      expect(
+        screen.queryByRole('button', { name: /load example/i }),
+      ).not.toBeInTheDocument()
+    })
 
+    it('selecting an example populates all four form fields in one action', async () => {
+      render(<CreateFolderTemplatePage folderName="test-folder" />)
+      fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+
+      const item = await screen.findByText(EXAMPLE_HTTPROUTE.displayName)
+      fireEvent.click(item)
+
+      await waitFor(() => {
+        const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement
+        expect(displayNameInput.value).toBe(EXAMPLE_HTTPROUTE.displayName)
+      })
       const nameInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
-      expect(nameInput.value).toBe('httproute-ingress')
-
-      const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement
-      expect(displayNameInput.value).toBe('HTTPRoute Ingress')
-
+      expect(nameInput.value).toBe(EXAMPLE_HTTPROUTE.name)
       const descriptionInput = screen.getByLabelText(/description/i) as HTMLInputElement
-      expect(descriptionInput.value).toContain('HTTPRoute')
-
+      expect(descriptionInput.value).toBe(EXAMPLE_HTTPROUTE.description)
       const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
-      expect(cueEditor.value).toContain('HTTPRoute')
-      // The example now uses platform.gatewayNamespace (org-configurable)
-      // rather than hard-coding "istio-ingress" — see HOL-526.
-      expect(cueEditor.value).toContain('platform.gatewayNamespace')
-      expect(cueEditor.value).not.toContain('"istio-ingress"')
+      expect(cueEditor.value).toBe(EXAMPLE_HTTPROUTE.cueTemplate)
     })
   })
 
   describe('Enabled switch', () => {
-    it('passes enabled: true when toggle is switched on', async () => {
+    it('passes enabled: false when toggle is switched off', async () => {
       const mutateAsync = vi.fn().mockResolvedValue({})
       setupMocks(mutateAsync)
       render(<CreateFolderTemplatePage folderName="test-folder" />)
 
       fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Template' } })
+      // Toggle starts checked; one click flips it off.
       fireEvent.click(screen.getByRole('switch', { name: /enabled/i }))
       fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
 
       await waitFor(() => {
         expect(mutateAsync).toHaveBeenCalledWith(
           expect.objectContaining({
-            enabled: true,
+            enabled: false,
           }),
         )
       })
@@ -254,6 +337,7 @@ describe('CreateFolderTemplatePage', () => {
       expect(screen.getByRole('textbox', { name: /cue template/i })).toBeDisabled()
       expect(screen.getByRole('switch', { name: /enabled/i })).toBeDisabled()
       expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+      expect(screen.getByRole('combobox', { name: /load example/i })).toBeDisabled()
     })
 
     it('enables form fields for OWNER users', () => {

--- a/frontend/src/routes/_authenticated/folders/$folderName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/templates/new.tsx
@@ -11,51 +11,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Info } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplate } from '@/queries/templates'
+import type { TemplateExample } from '@/queries/templates'
 import { namespaceForFolder } from '@/lib/scope-labels'
 import { useGetFolder } from '@/queries/folders'
-
-// EXAMPLE_FOLDER_PLATFORM_TEMPLATE is the example folder-level platform template CUE content.
-// It provides an HTTPRoute into the org-configured ingress-gateway namespace
-// (platform.gatewayNamespace, set per-org via Settings; falls back to
-// "istio-ingress" when unset). Authors who need a literal pin should use the
-// same value the org is configured with — see HOL-526.
-const EXAMPLE_FOLDER_PLATFORM_TEMPLATE = `// Folder-level platform template — HTTPRoute for the org-configured ingress gateway.
-// Applied to projects within this folder hierarchy. The HTTPRoute lands in
-// platform.gatewayNamespace, which the backend resolves from the org's
-// console.holos.run/gateway-namespace annotation. Configure it on the org's
-// Settings page (see HOL-526).
-platformResources: {
-    namespacedResources: (platform.gatewayNamespace): {
-        HTTPRoute: (input.name): {
-            apiVersion: "gateway.networking.k8s.io/v1"
-            kind:       "HTTPRoute"
-            metadata: {
-                name:      input.name
-                namespace: platform.gatewayNamespace
-                labels: {
-                    "app.kubernetes.io/managed-by": "console.holos.run"
-                    "app.kubernetes.io/name":       input.name
-                }
-            }
-            spec: {
-                parentRefs: [{
-                    group:     "gateway.networking.k8s.io"
-                    kind:      "Gateway"
-                    namespace: platform.gatewayNamespace
-                    name:      "default"
-                }]
-                rules: [{
-                    backendRefs: [{
-                        name: input.name
-                        port: 80
-                    }]
-                }]
-            }
-        }
-    }
-    clusterResources: {}
-}
-`
+import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
 export const Route = createFileRoute('/_authenticated/folders/$folderName/templates/new')({
   component: CreateFolderTemplateRoute,
@@ -89,7 +48,10 @@ export function CreateFolderTemplatePage({ folderName: propFolderName }: { folde
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [cueTemplate, setCueTemplate] = useState('')
-  const [enabled, setEnabled] = useState(false)
+  // The Enabled toggle defaults to true so a newly created folder-scope
+  // template is live immediately. Authors who want a dry-run entry can flip
+  // it off before submitting. See HOL-789 AC 5.
+  const [enabled, setEnabled] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const slugify = (val: string) =>
@@ -100,13 +62,11 @@ export function CreateFolderTemplatePage({ folderName: propFolderName }: { folde
     setName(slugify(val))
   }
 
-  const handleLoadExample = () => {
-    setName('httproute-ingress')
-    setDisplayName('HTTPRoute Ingress')
-    setDescription(
-      'Provides an HTTPRoute for the org-configured ingress gateway, routing traffic to project services.',
-    )
-    setCueTemplate(EXAMPLE_FOLDER_PLATFORM_TEMPLATE)
+  const handleSelectExample = (example: TemplateExample) => {
+    setDisplayName(example.displayName)
+    setName(example.name)
+    setDescription(example.description)
+    setCueTemplate(example.cueTemplate)
   }
 
   const handleCreate = async () => {
@@ -206,25 +166,10 @@ export function CreateFolderTemplatePage({ folderName: propFolderName }: { folde
           <div>
             <div className="flex items-center justify-between mb-1">
               <Label htmlFor="template-cue-template">CUE Template</Label>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" type="button" onClick={handleLoadExample} disabled={!canWrite}>
-                  Load Example
-                </Button>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Info className="h-4 w-4 text-muted-foreground cursor-default" />
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>
-                        Platform templates are unified with project deployment templates at render
-                        time via CUE. This example provides an HTTPRoute for the org-configured
-                        ingress gateway (platform.gatewayNamespace).
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
+              <TemplateExamplePicker
+                onSelect={handleSelectExample}
+                disabled={!canWrite}
+              />
             </div>
             <Textarea
               id="template-cue-template"
@@ -245,8 +190,24 @@ export function CreateFolderTemplatePage({ folderName: propFolderName }: { folde
               disabled={!canWrite}
             />
             <Label htmlFor="template-enabled" className="text-sm cursor-pointer">
-              Enabled (apply to projects in this folder)
+              Enabled
             </Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info
+                    aria-label="Enabled tooltip"
+                    className="h-4 w-4 text-muted-foreground cursor-default"
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    Unified with resources bound to this Template by Policy when enabled. See
+                    TemplatePolicyBinding.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
           {error && (
             <Alert variant="destructive">


### PR DESCRIPTION
## Summary

- Add reusable `TemplateExamplePicker` component (`frontend/src/components/templates/template-example-picker.tsx`) that renders a single `role=combobox` trigger expanding to a searchable list of built-in CUE example templates, backed by the new `ListTemplateExamples` RPC. Each row shows `displayName` as primary text and `description` as dimmed secondary; search matches against both fields.
- Add `useListTemplateExamples()` hook in `frontend/src/queries/templates.ts` (`staleTime: Infinity` — the registry is server-binary-scoped).
- Integrate the picker on `/folders/{folderName}/templates/new`, replacing the old hand-rolled "Load Example" button and the inline `EXAMPLE_FOLDER_PLATFORM_TEMPLATE` constant. Selecting an example populates Display Name, Name (slug), Description, and CUE Template in one action.
- Apply HOL-789 AC 5 copy changes on the same page: Enabled toggle defaults to `true`, label reads exactly `Enabled`, adjacent tooltip reads exactly `Unified with resources bound to this Template by Policy when enabled. See TemplatePolicyBinding.`
- New focused component test file `template-example-picker.test.tsx` (10 tests). Existing `-new.test.tsx` rewritten to mock `useListTemplateExamples`, assert picker presence, full-field population, new Enabled default, tooltip copy, and absence of the retired parenthetical.

Fixes HOL-798

## Test plan

- [x] `cd frontend && npx vitest run src/components/templates/template-example-picker.test.tsx` — 10 tests pass
- [x] `cd frontend && npx vitest run 'src/routes/_authenticated/folders/$folderName/templates/-new.test.tsx'` — 24 tests pass
- [x] `make test-ui` — 82 test files, 1074 tests pass
- [x] `cd frontend && npx tsc --noEmit` — exit 0
- [x] `cd frontend && npm run lint` — no new findings in modified/added files
- [ ] Manually verify the picker opens, filters on "HTTPRoute" and on "ingress" (description-only match), and populating the form fields works end-to-end against `make run`.

## Follow-up

- HOL-799 applies the same picker + Enabled copy to the project-scope new page and the org-scope create/edit flows (out of scope for this PR).