### PR TITLE
feat(frontend): wire TemplateExamplePicker into project new and org edit pages

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
@@ -6,7 +6,9 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
 import { useGetTemplate, useUpdateTemplate } from '@/queries/templates'
+import type { TemplateExample } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
+import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
 // Platform/project input defaults for the preview pane. The backend injects
 // org-owned values (e.g. gatewayNamespace — HOL-526) at render time regardless
@@ -80,6 +82,18 @@ export function ConsolidatedTemplateEditorPage({
     }
   }, [template?.cueTemplate])
 
+  const handleSelectExample = (example: TemplateExample) => {
+    if (
+      cueTemplate.trim().length > 0 &&
+      !window.confirm(
+        'Replace the current CUE template with the selected example? This cannot be undone until you save.',
+      )
+    ) {
+      return
+    }
+    setCueTemplate(example.cueTemplate)
+  }
+
   const handleSave = async () => {
     try {
       await updateMutation.mutateAsync({
@@ -149,7 +163,10 @@ export function ConsolidatedTemplateEditorPage({
         </div>
 
         <div className="space-y-4">
-          <h3 className="text-sm font-medium">CUE Template</h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium">CUE Template</h3>
+            <TemplateExamplePicker onSelect={handleSelectExample} />
+          </div>
           <Separator />
           <CueTemplateEditor
             cueTemplate={cueTemplate}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-$namespace.$name.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-$namespace.$name.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
@@ -21,6 +21,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('@/queries/templates', () => ({
   useGetTemplate: vi.fn(),
   useUpdateTemplate: vi.fn(),
+  useListTemplateExamples: vi.fn(),
   useRenderTemplate: vi.fn().mockReturnValue({
     data: undefined,
     error: null,
@@ -36,8 +37,22 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-import { useGetTemplate, useUpdateTemplate } from '@/queries/templates'
+import { useGetTemplate, useUpdateTemplate, useListTemplateExamples } from '@/queries/templates'
 import { ConsolidatedTemplateEditorPage } from './$namespace.$name'
+
+const EXAMPLE_HTTPROUTE = {
+  name: 'httproute-v1',
+  displayName: 'HTTPRoute Ingress',
+  description: 'Provides an HTTPRoute for the org-configured ingress gateway.',
+  cueTemplate: '// example CUE\nplatformResources: {}\n',
+}
+
+const EXAMPLE_SECOND = {
+  name: 'configmap-v1',
+  displayName: 'ConfigMap Starter',
+  description: 'A minimal ConfigMap scaffold.',
+  cueTemplate: '// another example\nprojectResources: {}\n',
+}
 
 function setupMocks(
   template: {
@@ -57,6 +72,7 @@ function setupMocks(
     enabled: true,
     linkedTemplates: [],
   },
+  examples: typeof EXAMPLE_HTTPROUTE[] = [EXAMPLE_HTTPROUTE, EXAMPLE_SECOND],
 ) {
   ;(useGetTemplate as Mock).mockReturnValue({
     data: template,
@@ -66,6 +82,11 @@ function setupMocks(
   ;(useUpdateTemplate as Mock).mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue({}),
     isPending: false,
+  })
+  ;(useListTemplateExamples as Mock).mockReturnValue({
+    data: examples,
+    isPending: false,
+    error: null,
   })
 }
 
@@ -151,6 +172,11 @@ describe('ConsolidatedTemplateEditorPage', () => {
       error: null,
     })
     ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync, isPending: false })
+    ;(useListTemplateExamples as Mock).mockReturnValue({
+      data: [EXAMPLE_HTTPROUTE],
+      isPending: false,
+      error: null,
+    })
 
     const user = userEvent.setup()
     render(<ConsolidatedTemplateEditorPage />)
@@ -167,6 +193,66 @@ describe('ConsolidatedTemplateEditorPage', () => {
           enabled: true,
         }),
       )
+    })
+  })
+
+  // HOL-799: TemplateExamplePicker is wired into the consolidated editor so
+  // authors can browse and load examples. Because the editor always starts with
+  // an existing CUE body, selecting an example prompts for confirmation first.
+  describe('TemplateExamplePicker integration', () => {
+    it('renders the Load Example picker trigger', () => {
+      setupMocks()
+      render(<ConsolidatedTemplateEditorPage />)
+      expect(screen.getByRole('combobox', { name: /load example/i })).toBeInTheDocument()
+    })
+
+    it('selecting an example with confirmation replaces the CUE template', async () => {
+      setupMocks({
+        name: 'web',
+        namespace: 'prj-billing',
+        displayName: 'Web Service',
+        cueTemplate: '// original cue body',
+        enabled: true,
+        linkedTemplates: [],
+      })
+      vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+      render(<ConsolidatedTemplateEditorPage />)
+
+      fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+      const item = await screen.findByText(EXAMPLE_HTTPROUTE.displayName)
+      fireEvent.click(item)
+
+      await waitFor(() => {
+        // The CUE editor in CueTemplateEditor renders a textarea. Find it by
+        // its accessible label.
+        const textarea = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
+        expect(textarea.value).toBe(EXAMPLE_HTTPROUTE.cueTemplate)
+      })
+    })
+
+    it('cancelling the confirm dialog leaves the CUE template unchanged', async () => {
+      const originalCue = '// original cue body'
+      setupMocks({
+        name: 'web',
+        namespace: 'prj-billing',
+        displayName: 'Web Service',
+        cueTemplate: originalCue,
+        enabled: true,
+        linkedTemplates: [],
+      })
+      vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+      render(<ConsolidatedTemplateEditorPage />)
+
+      fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+      const item = await screen.findByText(EXAMPLE_HTTPROUTE.displayName)
+      fireEvent.click(item)
+
+      await waitFor(() => {
+        const textarea = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
+        expect(textarea.value).toBe(originalCue)
+      })
     })
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('@/queries/templates', () => ({
   useGetTemplate: vi.fn(),
   useUpdateTemplate: vi.fn(),
+  useListTemplateExamples: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
   useRenderTemplate: vi.fn().mockReturnValue({
     data: undefined,
     error: null,

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/queries/templates', () => ({
   useCreateTemplate: vi.fn(),
   useRenderTemplate: vi.fn(),
   useListLinkableTemplates: vi.fn().mockReturnValue({ data: [], isPending: false }),
+  useListTemplateExamples: vi.fn(),
   linkableKey: (namespace: string | undefined, name: string) =>
     `${namespace ?? ''}/${name}`,
   parseLinkableKey: (key: string) => {
@@ -47,17 +48,32 @@ vi.mock('@/hooks/use-debounced-value', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates } from '@/queries/templates'
+import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates, useListTemplateExamples } from '@/queries/templates'
 import { useGetProject } from '@/queries/projects'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateTemplatePage } from './new'
+
+const EXAMPLE_HTTPBIN = {
+  name: 'httpbin-v1',
+  displayName: 'go-httpbin Deployment',
+  description: 'Deploys go-httpbin with a ServiceAccount, Deployment, and Service.',
+  cueTemplate: '// httpbin CUE\nprojectResources: {}\n',
+}
+
+const EXAMPLE_SECOND = {
+  name: 'minimal-v1',
+  displayName: 'Minimal Starter',
+  description: 'A minimal scaffold for project-scope templates.',
+  cueTemplate: '// minimal CUE\nprojectResources: {namespacedResources: {}}\n',
+}
 
 function setupMocks(
   mutateAsync = vi.fn().mockResolvedValue({}),
   renderData?: { renderedJson?: string },
   renderError?: Error,
   userRole = Role.OWNER,
+  examples: typeof EXAMPLE_HTTPBIN[] = [EXAMPLE_HTTPBIN, EXAMPLE_SECOND],
 ) {
   ;(useCreateTemplate as Mock).mockReturnValue({
     mutateAsync,
@@ -76,6 +92,11 @@ function setupMocks(
   })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: 'test-org', gatewayNamespace: '' },
+    isPending: false,
+    error: null,
+  })
+  ;(useListTemplateExamples as Mock).mockReturnValue({
+    data: examples,
     isPending: false,
     error: null,
   })
@@ -206,7 +227,7 @@ describe('CreateTemplatePage', () => {
     })
   })
 
-  it('shows CUE template has default content', () => {
+  it('shows CUE template has default scaffold content', () => {
     render(<CreateTemplatePage />)
     const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
     expect(cueEditor.value).toContain('projectResources')
@@ -234,28 +255,39 @@ describe('CreateTemplatePage', () => {
     expect(projectInput).not.toContain('namespace:')
   })
 
-  describe('Load httpbin Example button', () => {
-    it('renders Load httpbin Example button', () => {
+  // HOL-799: the inline "Load httpbin Example" button and hard-coded CUE body
+  // were replaced by the reusable TemplateExamplePicker backed by
+  // ListTemplateExamples. The picker is the single source of example content.
+  describe('TemplateExamplePicker integration', () => {
+    it('renders the Load Example picker trigger', () => {
       render(<CreateTemplatePage />)
-      expect(screen.getByRole('button', { name: /load httpbin example/i })).toBeInTheDocument()
+      expect(screen.getByRole('combobox', { name: /load example/i })).toBeInTheDocument()
     })
 
-    it('clicking Load httpbin Example changes the CUE textarea content', () => {
+    it('no longer renders a plain "Load httpbin Example" push button', () => {
       render(<CreateTemplatePage />)
-      const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
-      const initialContent = cueEditor.value
-      fireEvent.click(screen.getByRole('button', { name: /load httpbin example/i }))
-      expect(cueEditor.value).not.toBe(initialContent)
-      expect(cueEditor.value).toContain('go-httpbin')
+      expect(
+        screen.queryByRole('button', { name: /load httpbin example/i }),
+      ).not.toBeInTheDocument()
     })
 
-    it('httpbin example CUE contains ServiceAccount, Deployment, and Service', () => {
+    it('selecting an example populates all four form fields in one action', async () => {
       render(<CreateTemplatePage />)
-      fireEvent.click(screen.getByRole('button', { name: /load httpbin example/i }))
+      fireEvent.click(screen.getByRole('combobox', { name: /load example/i }))
+
+      const item = await screen.findByText(EXAMPLE_HTTPBIN.displayName)
+      fireEvent.click(item)
+
+      await waitFor(() => {
+        const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement
+        expect(displayNameInput.value).toBe(EXAMPLE_HTTPBIN.displayName)
+      })
+      const nameInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
+      expect(nameInput.value).toBe(EXAMPLE_HTTPBIN.name)
+      const descriptionInput = screen.getByLabelText(/description/i) as HTMLInputElement
+      expect(descriptionInput.value).toBe(EXAMPLE_HTTPBIN.description)
       const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
-      expect(cueEditor.value).toContain('ServiceAccount')
-      expect(cueEditor.value).toContain('Deployment')
-      expect(cueEditor.value).toContain('Service')
+      expect(cueEditor.value).toBe(EXAMPLE_HTTPBIN.cueTemplate)
     })
   })
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -8,10 +8,9 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Info } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplate, useRenderTemplate, useListLinkableTemplates, linkableKey, parseLinkableKey } from '@/queries/templates'
+import type { TemplateExample } from '@/queries/templates'
 import { namespaceForProject, scopeLabelFromNamespace } from '@/lib/scope-labels'
 import type { LinkedTemplateRef } from '@/queries/templates'
 import { create } from '@bufbuild/protobuf'
@@ -19,7 +18,11 @@ import { LinkedTemplateRefSchema } from '@/gen/holos/console/v1/policy_state_pb.
 import { useGetProject } from '@/queries/projects'
 import { useGetOrganization } from '@/queries/organizations'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
+import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
+// DEFAULT_CUE_TEMPLATE is the minimal CUE starter shown on an empty create
+// form. It is NOT an example — it is a blank scaffold so users have something
+// to start from before selecting a real example via the picker.
 const DEFAULT_CUE_TEMPLATE = `// Use generated type definitions from api/v1alpha2 (prepended by renderer).
 // Additional CUE constraints narrow the generated types for this template.
 input: #ProjectInput & {
@@ -29,194 +32,10 @@ input: #ProjectInput & {
 }
 platform: #PlatformInput
 
-// _labels are the standard labels required on every resource.
-_labels: {
-  "app.kubernetes.io/name":       input.name
-  "app.kubernetes.io/managed-by": "console.holos.run"
-}
-
-// _annotations are standard annotations applied to every resource.
-_annotations: {
-  "console.holos.run/deployer-email": platform.claims.email
-}
-
-// #Namespaced constrains namespaced resource struct keys to match resource metadata.
-#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
-  kind: Kind
-  metadata: {
-    name:      Name
-    namespace: Namespace
-    ...
-  }
-  ...
-}
-
-// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
-#Cluster: [Kind=string]: [Name=string]: {
-  kind: Kind
-  metadata: {
-    name: Name
-    ...
-  }
-  ...
-}
-
 // projectResources collects all rendered Kubernetes resources.
 projectResources: {
-  namespacedResources: #Namespaced & {
-    (platform.namespace): {
-      Deployment: (input.name): {
-        apiVersion: "apps/v1"
-        kind:       "Deployment"
-        metadata: {
-          name:        input.name
-          namespace:   platform.namespace
-          labels:      _labels
-          annotations: _annotations
-        }
-        spec: {
-          replicas: 1
-          selector: matchLabels: "app.kubernetes.io/name": input.name
-          template: {
-            metadata: labels: _labels
-            spec: containers: [{
-              name:  input.name
-              image: input.image + ":" + input.tag
-              ports: [{containerPort: input.port, name: "http"}]
-            }]
-          }
-        }
-      }
-    }
-  }
-  clusterResources: #Cluster & {}
-}
-`
-
-// EXAMPLE_HTTPBIN_TEMPLATE is the example project-level deployment template CUE content.
-// It matches console/templates/example_httpbin.cue.
-const EXAMPLE_HTTPBIN_TEMPLATE = `// Project-level deployment template for go-httpbin.
-// Produces: ServiceAccount, Deployment, Service.
-// Allowed by the org constraint: Deployment, Service, ServiceAccount.
-//
-// Pair with console/org_templates/example_httpbin_platform.cue to add an
-// HTTPRoute that routes gateway traffic to the Service.
-
-// Use generated type definitions from api/v1alpha2 (prepended by renderer).
-// Additional CUE constraints narrow the generated types for this template.
-input: #ProjectInput & {
-	name:  =~"^[a-z][a-z0-9-]*$" // DNS label
-	image: string | *"ghcr.io/mccutchen/go-httpbin"
-	tag:   string | *"2.21.0"
-	port:  >0 & <=65535 | *8080
-}
-platform: #PlatformInput
-
-// _labels are the standard labels required on every resource.
-// app.kubernetes.io/managed-by MUST equal "console.holos.run" or the
-// render will be rejected.
-_labels: {
-	"app.kubernetes.io/name":       input.name
-	"app.kubernetes.io/managed-by": "console.holos.run"
-}
-
-// _annotations are standard annotations applied to every resource.
-// console.holos.run/deployer-email records the identity of the user
-// who last rendered and applied this resource.
-_annotations: {
-	"console.holos.run/deployer-email": platform.claims.email
-}
-
-// #Namespaced constrains namespaced resource struct keys to match resource metadata.
-// Structure: namespaced.<namespace>.<Kind>.<name>
-// The struct path keys must match the corresponding resource metadata fields.
-#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
-	kind: Kind
-	metadata: {
-		name:      Name
-		namespace: Namespace
-		...
-	}
-	...
-}
-
-// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
-// Structure: cluster.<Kind>.<name>
-// The struct path keys must match the corresponding resource metadata fields.
-#Cluster: [Kind=string]: [Name=string]: {
-	kind: Kind
-	metadata: {
-		name: Name
-		...
-	}
-	...
-}
-
-projectResources: {
-	namespacedResources: #Namespaced & {
-		(platform.namespace): {
-			// ServiceAccount provides a Kubernetes identity for the pods.
-			ServiceAccount: (input.name): {
-				apiVersion: "v1"
-				kind:       "ServiceAccount"
-				metadata: {
-					name:        input.name
-					namespace:   platform.namespace
-					labels:      _labels
-					annotations: _annotations
-				}
-			}
-
-			// Deployment runs the go-httpbin container.
-			// go-httpbin listens on port 8080 by default and needs no special
-			// command or args — the image's default entrypoint works.
-			Deployment: (input.name): {
-				apiVersion: "apps/v1"
-				kind:       "Deployment"
-				metadata: {
-					name:        input.name
-					namespace:   platform.namespace
-					labels:      _labels
-					annotations: _annotations
-				}
-				spec: {
-					replicas: 1
-					selector: matchLabels: "app.kubernetes.io/name": input.name
-					template: {
-						metadata: labels: _labels
-						spec: {
-							serviceAccountName: input.name
-							containers: [{
-								name:  input.name
-								image: input.image + ":" + input.tag
-								ports: [{containerPort: input.port, name: "http"}]
-							}]
-						}
-					}
-				}
-			}
-
-			// Service exposes port 80 → container port input.port (named "http").
-			// The HTTPRoute in the org platform template routes gateway traffic here.
-			Service: (input.name): {
-				apiVersion: "v1"
-				kind:       "Service"
-				metadata: {
-					name:        input.name
-					namespace:   platform.namespace
-					labels:      _labels
-					annotations: _annotations
-				}
-				spec: {
-					selector: "app.kubernetes.io/name": input.name
-					ports: [{port: 80, targetPort: "http", name: "http"}]
-				}
-			}
-		}
-	}
-
-	// clusterResources organizes cluster-scoped resources (none for this template).
-	clusterResources: #Cluster & {}
+  namespacedResources: {}
+  clusterResources: {}
 }
 `
 
@@ -322,8 +141,11 @@ ${gatewayNamespaceLine}\tclaims: {
     previewLinkedTemplates,
   )
 
-  const handleLoadHttpbinExample = () => {
-    setCueTemplate(EXAMPLE_HTTPBIN_TEMPLATE)
+  const handleSelectExample = (example: TemplateExample) => {
+    setDisplayName(example.displayName)
+    setName(example.name)
+    setDescription(example.description)
+    setCueTemplate(example.cueTemplate)
   }
 
   const slugify = (val: string) =>
@@ -412,21 +234,7 @@ ${gatewayNamespaceLine}\tclaims: {
           <div>
             <div className="flex items-center justify-between mb-1">
               <Label htmlFor="template-cue-template">CUE Template</Label>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" type="button" onClick={handleLoadHttpbinExample}>
-                  Load httpbin Example
-                </Button>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Info className="h-4 w-4 text-muted-foreground cursor-default" />
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Deploys go-httpbin with a ServiceAccount, Deployment, and Service as an example.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
+              <TemplateExamplePicker onSelect={handleSelectExample} />
             </div>
             <Textarea
               id="template-cue-template"


### PR DESCRIPTION
## Summary

- On `/projects/{projectName}/templates/new`: replaces the hard-coded `EXAMPLE_HTTPBIN_TEMPLATE` constant and its "Load httpbin Example" push button with `TemplateExamplePicker`. Selecting an example populates Display Name, Name (slug), Description, and CUE Template in one action. The `DEFAULT_CUE_TEMPLATE` is retained as a minimal blank scaffold — the verbose example body is removed.
- On `/orgs/{orgName}/templates/{namespace}.{name}` (consolidated editor): adds `TemplateExamplePicker` next to the "CUE Template" heading. Because the editor opens with an existing CUE body, selecting an example prompts `window.confirm` before overwriting so users cannot accidentally discard edits.
- Tests updated: picker integration tests added to both pages; `useListTemplateExamples` added to the cross-scope test mock to prevent import errors.
- All 1099 tests pass.

Fixes HOL-799

## Test plan

- [ ] `make test-ui` green (83 files / 1099 tests)
- [ ] On project new page: "Load Example" combobox appears; selecting an example populates all four fields
- [ ] On org consolidated editor: "Load Example" combobox appears; selecting with confirm=OK replaces CUE; cancel leaves it unchanged
- [ ] Old "Load httpbin Example" plain button is gone from the project new page