### PR TITLE
feat(templates): delete button + confirmation dialog on consolidated editor

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
@@ -1,11 +1,24 @@
 import { useEffect, useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
-import { useGetTemplate, useUpdateTemplate } from '@/queries/templates'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  useGetTemplate,
+  useUpdateTemplate,
+  useDeleteTemplate,
+} from '@/queries/templates'
 import type { TemplateExample } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
@@ -71,10 +84,13 @@ export function ConsolidatedTemplateEditorPage({
   const namespace = propNamespace ?? routeParams.namespace ?? ''
   const name = propName ?? routeParams.name ?? ''
 
+  const navigate = useNavigate()
   const { data: template, isPending, error } = useGetTemplate(namespace, name)
   const updateMutation = useUpdateTemplate(namespace, name)
+  const deleteMutation = useDeleteTemplate(namespace)
 
   const [cueTemplate, setCueTemplate] = useState('')
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   useEffect(() => {
     if (template?.cueTemplate !== undefined) {
@@ -109,6 +125,21 @@ export function ConsolidatedTemplateEditorPage({
     }
   }
 
+  // Post-success: close the dialog, toast, and navigate to the canonical
+  // org-scope templates index (see HOL-804 AC — do NOT navigate to a
+  // scope-specific list). On error, deleteMutation.error surfaces inline
+  // inside the dialog; we do not double-report via toast.
+  const handleDelete = async () => {
+    try {
+      await deleteMutation.mutateAsync({ name })
+      setDeleteOpen(false)
+      toast.success('Template deleted')
+      navigate({ to: '/orgs/$orgName/templates', params: { orgName } })
+    } catch {
+      /* error surfaced via deleteMutation.error inside the dialog */
+    }
+  }
+
   if (isPending) {
     return (
       <Card>
@@ -138,13 +169,22 @@ export function ConsolidatedTemplateEditorPage({
   return (
     <Card>
       <CardContent className="pt-6 space-y-6">
-        <div>
-          <p className="text-sm text-muted-foreground">
-            {orgName} / Templates / {namespace} / {name}
-          </p>
-          <div className="flex items-center gap-2 mt-1">
-            <h2 className="text-xl font-semibold">{displayName}</h2>
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <p className="text-sm text-muted-foreground">
+              {orgName} / Templates / {namespace} / {name}
+            </p>
+            <div className="flex items-center gap-2 mt-1">
+              <h2 className="text-xl font-semibold">{displayName}</h2>
+            </div>
           </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setDeleteOpen(true)}
+          >
+            Delete
+          </Button>
         </div>
 
         <div className="space-y-4">
@@ -180,6 +220,35 @@ export function ConsolidatedTemplateEditorPage({
           />
         </div>
       </CardContent>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Template</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete template &quot;{namespace}/{name}&quot;?
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteMutation.error && (
+            <Alert variant="destructive">
+              <AlertDescription>{deleteMutation.error.message}</AlertDescription>
+            </Alert>
+          )}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   )
 }

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-$namespace.$name.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-$namespace.$name.test.tsx
@@ -4,6 +4,8 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 
+const mockNavigate = vi.fn()
+
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
   return {
@@ -15,12 +17,14 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
         name: 'web',
       }),
     }),
+    useNavigate: () => mockNavigate,
   }
 })
 
 vi.mock('@/queries/templates', () => ({
   useGetTemplate: vi.fn(),
   useUpdateTemplate: vi.fn(),
+  useDeleteTemplate: vi.fn(),
   useListTemplateExamples: vi.fn(),
   useRenderTemplate: vi.fn().mockReturnValue({
     data: undefined,
@@ -37,7 +41,13 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-import { useGetTemplate, useUpdateTemplate, useListTemplateExamples } from '@/queries/templates'
+import {
+  useGetTemplate,
+  useUpdateTemplate,
+  useDeleteTemplate,
+  useListTemplateExamples,
+} from '@/queries/templates'
+import { toast } from 'sonner'
 import { ConsolidatedTemplateEditorPage } from './$namespace.$name'
 
 const EXAMPLE_HTTPROUTE = {
@@ -83,6 +93,11 @@ function setupMocks(
     mutateAsync: vi.fn().mockResolvedValue({}),
     isPending: false,
   })
+  ;(useDeleteTemplate as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+    error: null,
+  })
   ;(useListTemplateExamples as Mock).mockReturnValue({
     data: examples,
     isPending: false,
@@ -105,6 +120,16 @@ describe('ConsolidatedTemplateEditorPage', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     })
+    ;(useDeleteTemplate as Mock).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+      error: null,
+    })
+    ;(useListTemplateExamples as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
     const { container } = render(<ConsolidatedTemplateEditorPage />)
     // The skeletons render with data-slot="skeleton" (shadcn primitive).
     expect(container.querySelector('[data-slot="skeleton"]')).toBeInTheDocument()
@@ -119,6 +144,16 @@ describe('ConsolidatedTemplateEditorPage', () => {
     ;(useUpdateTemplate as Mock).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
+    })
+    ;(useDeleteTemplate as Mock).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+      error: null,
+    })
+    ;(useListTemplateExamples as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
     })
     render(<ConsolidatedTemplateEditorPage />)
     expect(screen.getByText('template not found')).toBeInTheDocument()
@@ -172,6 +207,11 @@ describe('ConsolidatedTemplateEditorPage', () => {
       error: null,
     })
     ;(useUpdateTemplate as Mock).mockReturnValue({ mutateAsync, isPending: false })
+    ;(useDeleteTemplate as Mock).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+      error: null,
+    })
     ;(useListTemplateExamples as Mock).mockReturnValue({
       data: [EXAMPLE_HTTPROUTE],
       isPending: false,
@@ -253,6 +293,210 @@ describe('ConsolidatedTemplateEditorPage', () => {
         const textarea = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
         expect(textarea.value).toBe(originalCue)
       })
+    })
+  })
+
+  describe('delete flow', () => {
+    it('renders the Delete button in the header row', () => {
+      setupMocks()
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+      // There should be a Delete button visible before the dialog opens.
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+      // useDeleteTemplate should be wired with the same namespace as
+      // useGetTemplate / useUpdateTemplate.
+      expect(useDeleteTemplate).toHaveBeenCalledWith('prj-billing')
+    })
+
+    it('opens the confirmation dialog when Delete is clicked', async () => {
+      setupMocks()
+      const user = userEvent.setup()
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+      expect(
+        screen.getByRole('heading', { name: 'Delete Template' }),
+      ).toBeInTheDocument()
+      // Body names the template as namespace/name.
+      expect(screen.getByText(/prj-billing\/web/)).toBeInTheDocument()
+      // Warning copy.
+      expect(
+        screen.getByText(/cannot be undone/i),
+      ).toBeInTheDocument()
+    })
+
+    it('closes the dialog without mutating when Cancel is clicked', async () => {
+      const deleteMutateAsync = vi.fn()
+      setupMocks()
+      ;(useDeleteTemplate as Mock).mockReturnValue({
+        mutateAsync: deleteMutateAsync,
+        isPending: false,
+        error: null,
+      })
+
+      const user = userEvent.setup()
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }))
+      expect(
+        screen.getByRole('heading', { name: 'Delete Template' }),
+      ).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('heading', { name: 'Delete Template' }),
+        ).not.toBeInTheDocument()
+      })
+      expect(deleteMutateAsync).not.toHaveBeenCalled()
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('calls the delete mutation with the template name on confirm', async () => {
+      const deleteMutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks()
+      ;(useDeleteTemplate as Mock).mockReturnValue({
+        mutateAsync: deleteMutateAsync,
+        isPending: false,
+        error: null,
+      })
+
+      const user = userEvent.setup()
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }))
+      // Confirm inside the dialog — dialog has its own Delete button.
+      const confirmButton = screen
+        .getAllByRole('button', { name: 'Delete' })
+        .find((btn) => btn.closest('[role="dialog"]'))
+      expect(confirmButton).toBeDefined()
+      await user.click(confirmButton!)
+
+      await waitFor(() => {
+        expect(deleteMutateAsync).toHaveBeenCalledWith({ name: 'web' })
+      })
+    })
+
+    it('navigates to the org templates index and toasts on success', async () => {
+      const deleteMutateAsync = vi.fn().mockResolvedValue({})
+      setupMocks()
+      ;(useDeleteTemplate as Mock).mockReturnValue({
+        mutateAsync: deleteMutateAsync,
+        isPending: false,
+        error: null,
+      })
+
+      const user = userEvent.setup()
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }))
+      const confirmButton = screen
+        .getAllByRole('button', { name: 'Delete' })
+        .find((btn) => btn.closest('[role="dialog"]'))
+      await user.click(confirmButton!)
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith({
+          to: '/orgs/$orgName/templates',
+          params: { orgName: 'test-org' },
+        })
+      })
+      expect(toast.success).toHaveBeenCalledWith('Template deleted')
+    })
+
+    it('surfaces an inline error and does not navigate on failure', async () => {
+      const deleteMutateAsync = vi
+        .fn()
+        .mockRejectedValue(new Error('delete forbidden'))
+      setupMocks()
+      ;(useDeleteTemplate as Mock).mockReturnValue({
+        mutateAsync: deleteMutateAsync,
+        isPending: false,
+        error: new Error('delete forbidden'),
+      })
+
+      const user = userEvent.setup()
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }))
+      const confirmButton = screen
+        .getAllByRole('button', { name: 'Delete' })
+        .find((btn) => btn.closest('[role="dialog"]'))
+      await user.click(confirmButton!)
+
+      await waitFor(() => {
+        expect(deleteMutateAsync).toHaveBeenCalledWith({ name: 'web' })
+      })
+
+      // Inline error inside the dialog, no navigation, no success toast.
+      expect(screen.getByText('delete forbidden')).toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: 'Delete Template' }),
+      ).toBeInTheDocument()
+      expect(mockNavigate).not.toHaveBeenCalled()
+      expect(toast.success).not.toHaveBeenCalled()
+    })
+
+    it('shows "Deleting..." and disables the confirm button while pending', async () => {
+      setupMocks()
+      ;(useDeleteTemplate as Mock).mockReturnValue({
+        mutateAsync: vi.fn(),
+        isPending: true,
+        error: null,
+      })
+
+      const user = userEvent.setup()
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+      const deletingButton = await screen.findByRole('button', {
+        name: /deleting/i,
+      })
+      expect(deletingButton).toBeDisabled()
     })
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
@@ -24,12 +24,14 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     createFileRoute: () => () => ({
       useParams: () => currentParams,
     }),
+    useNavigate: () => vi.fn(),
   }
 })
 
 vi.mock('@/queries/templates', () => ({
   useGetTemplate: vi.fn(),
   useUpdateTemplate: vi.fn(),
+  useDeleteTemplate: vi.fn(),
   useListTemplateExamples: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
   useRenderTemplate: vi.fn().mockReturnValue({
     data: undefined,
@@ -46,7 +48,11 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-import { useGetTemplate, useUpdateTemplate } from '@/queries/templates'
+import {
+  useGetTemplate,
+  useUpdateTemplate,
+  useDeleteTemplate,
+} from '@/queries/templates'
 import { ConsolidatedTemplateEditorPage } from './$namespace.$name'
 
 const cases = [
@@ -80,6 +86,11 @@ describe('ConsolidatedTemplateEditorPage cross-scope equivalence (HOL-607)', () 
       ;(useUpdateTemplate as Mock).mockReturnValue({
         mutateAsync: vi.fn(),
         isPending: false,
+      })
+      ;(useDeleteTemplate as Mock).mockReturnValue({
+        mutateAsync: vi.fn(),
+        isPending: false,
+        error: null,
       })
 
       render(<ConsolidatedTemplateEditorPage />)


### PR DESCRIPTION
## Summary

- Add a destructive Delete button to the consolidated template editor
  (`frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx`),
  placed right-aligned in the page header row.
- Wire the existing `useDeleteTemplate` mutation hook to open a confirmation
  Dialog that names the template `{namespace}/{name}`. On confirm it invokes
  `deleteMutation.mutateAsync({ name })`, shows "Deleting..." while pending,
  toasts "Template deleted", and navigates to `/orgs/$orgName/templates`.
- On failure an Alert inside the dialog surfaces
  `deleteMutation.error.message`; the dialog stays open, no navigation, no
  success toast. One path per failure, matching the secrets-page precedent.
- Extend the existing `-$namespace.$name.test.tsx` with a `delete flow`
  describe block (7 new cases). Patch `-cross-scope.test.tsx` to stub
  `useDeleteTemplate` / `useNavigate` so the HOL-607 cross-scope tests keep
  mounting the component.

Fixes HOL-804

## Test plan

- [ ] `make test-ui` passes (1103 tests, 83 files)
- [ ] `npx tsc --noEmit` clean
- [ ] Scoped `npm run lint` reports no new findings in the changed files
- [ ] Manual: delete flow from org-scope editor lands on
  `/orgs/{orgName}/templates` and shows the success toast
- [ ] Manual: delete failure keeps dialog open and shows inline Alert