### PR TITLE
chore(templates): docs sync verification and cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,49 @@ All testing guidance lives in this repo. Read the entries below in order the fir
 - [Smoke Test Contract](https://github.com/holos-run/holos-console-docs/tree/main/demo/smoke-tests) — Smoke-test instructions must use `kubectl` commands for the resources required to observe the feature in the demo environment.
 - [Demo README](https://github.com/holos-run/holos-console-docs/blob/main/demo/README.md) — Forward pointer to the demo setup order, prerequisites, and per-template walkthroughs.
 
+## Example Template Registry
+
+The UI picker on every "New Template" page is backed by a Go registry of built-in CUE drop-in examples. Adding a new example requires **only a single CUE file** — no Go or TypeScript changes.
+
+### Adding a new example (drop-in workflow)
+
+1. Create `console/templates/examples/<name>-<version>.cue` with four top-level fields:
+
+   ```cue
+   displayName: "Human Readable Name (version)"
+   name:        "url-safe-slug-v1"
+   description: "One sentence describing what the template produces."
+
+   cueTemplate: """
+     // CUE template body visible in the editor.
+     // Reference #PlatformInput and #ProjectInput freely — they are
+     // prepended by the renderer at evaluation time.
+     platform: #PlatformInput
+     projectResources: {}
+     """
+   ```
+
+2. Run `make test-go` to confirm the new example compiles against the `v1alpha2` generated schema. The test in `examples_test.go` verifies every registry file.
+
+3. That is all. The ConnectRPC `ListTemplateExamples` handler reads the registry at startup; the picker fetches from that RPC. No Go or TypeScript changes are required unless you also want to seed the example into a namespace via the populate-defaults flow.
+
+### Docs-sync contract
+
+The `holos-console-docs/demo/` directory hosts **demo walkthrough snippets** tied to the CI demo environment (full cluster configs, hard-coded gateway namespaces, etc.). The `console/templates/examples/` registry hosts **generic drop-in starters** intended for new contributors. The two sets are intentionally different — they serve different audiences.
+
+The sync contract is: **both must compile** against the `v1alpha2` generated schema.
+
+`console/templates/examples/docs_sync_test.go` enforces this contract for the pinned copies of docs snippets stored under `console/templates/examples/testdata/docs-snippets/`. When the docs repo updates a snippet, copy the new version into the corresponding `testdata/` subdirectory and run `make test-go` to confirm it still compiles:
+
+```bash
+# Update after a holos-console-docs change:
+cp /path/to/holos-console-docs/demo/httpbin-v1/httpbin-v1.cue \
+    console/templates/examples/testdata/docs-snippets/httpbin-v1/httpbin-v1.cue
+cp /path/to/holos-console-docs/demo/allowed-resources/allowed-resources.cue \
+    console/templates/examples/testdata/docs-snippets/allowed-resources/allowed-resources.cue
+make test-go
+```
+
 ## Binary layout
 
 This repo ships two independent binaries from disjoint source trees per [ADR 031](https://github.com/holos-run/holos-console-docs/blob/main/docs/adrs/031-secret-injector-binary-split.md). The `holos-console` web application owns `cmd/holos-console/`, `api/templates/`, `internal/controller/`, `config/holos-console/{crd,rbac,admission}/`, and `Dockerfile.console`; the `holos-secret-injector` controller owns `cmd/secret-injector/`, `api/secrets/`, `internal/secretinjector/`, `config/secret-injector/{crd,rbac}/`, and `Dockerfile.secret-injector`. Shared infrastructure (`console/`, `frontend/`, `proto/`, `pkg/`) is fair game for either binary. The one hard invariant: **no cross-imports** between `internal/controller` and `internal/secretinjector`. `make check-imports` enforces this locally and in CI; if you find yourself reaching across the boundary, lift the shared code into `pkg/` instead. Secret material never travels through templates CRs — CRs carry metadata and `v1.Secret` refs only (ADR 031's no-sensitive-on-CRs rule).

--- a/console/templates/embed.go
+++ b/console/templates/embed.go
@@ -10,8 +10,7 @@ var DefaultTemplate string
 
 // ExampleHttpbinTemplate is the example go-httpbin project-level deployment
 // template. It produces ServiceAccount, Deployment, and Service resources.
-// Pair with ExampleHttpbinPlatformTemplate (a platform template) to add an
-// HTTPRoute and enforce the closed-struct kind constraint.
+// Used by SeedProjectTemplate to seed the org-creation populate_defaults flow.
 //
 //go:embed example_httpbin.cue
 var ExampleHttpbinTemplate string
@@ -22,12 +21,3 @@ var ExampleHttpbinTemplate string
 //
 //go:embed default_referencegrant.cue
 var DefaultReferenceGrantTemplate string
-
-// ExampleHttpbinPlatformTemplate is the example org-level platform template
-// that provides an HTTPRoute in platformResources and closes
-// projectResources.namespacedResources to Deployment, Service, and
-// ServiceAccount (ADR 016 Decision 9). Pair with ExampleHttpbinTemplate for
-// the project-level template that produces exactly those three kinds.
-//
-//go:embed example_httpbin_platform.cue
-var ExampleHttpbinPlatformTemplate string

--- a/console/templates/examples/docs_sync_test.go
+++ b/console/templates/examples/docs_sync_test.go
@@ -74,7 +74,6 @@ func TestDocsSyncSnippets(t *testing.T) {
 	cueCtx := cuecontext.New()
 
 	for _, path := range cueFiles {
-		path := path // capture for t.Run
 		name := filepath.ToSlash(path)
 		t.Run(name, func(t *testing.T) {
 			src, err := os.ReadFile(path)

--- a/console/templates/examples/docs_sync_test.go
+++ b/console/templates/examples/docs_sync_test.go
@@ -1,0 +1,106 @@
+package examples_test
+
+// docs_sync_test.go verifies that the demo CUE snippets hosted in
+// holos-console-docs/demo/ remain valid against the v1alpha2 generated schema.
+//
+// # Design
+//
+// The registry (console/templates/examples/*.cue) provides generic drop-in
+// starting points for contributors. The docs repo (holos-console-docs/demo/)
+// provides fully-featured walkthrough templates tied to the CI demo
+// environment. The two sets of files serve different roles and are NOT
+// byte-for-byte identical — differing on details like hard-coded gateway
+// namespaces, ReferenceGrant resources, and cluster-specific let bindings.
+//
+// The sync contract is therefore: BOTH must compile cleanly against the
+// v1alpha2 schema. Schema drift in this repo (e.g. renaming a field in
+// api/v1alpha2) must be detected here before the docs snippets silently break.
+//
+// # Maintenance
+//
+// The files under testdata/docs-snippets/ are pinned copies sourced from
+// holos-run/holos-console-docs/demo/. When docs-side snippets change, run:
+//
+//	cp /path/to/holos-console-docs/demo/httpbin-v1/httpbin-v1.cue \
+//	    console/templates/examples/testdata/docs-snippets/httpbin-v1/httpbin-v1.cue
+//	cp /path/to/holos-console-docs/demo/allowed-resources/allowed-resources.cue \
+//	    console/templates/examples/testdata/docs-snippets/allowed-resources/allowed-resources.cue
+//
+// Then run make test-go to confirm the updated snippets still compile.
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+// TestDocsSyncSnippets verifies that the pinned demo CUE snippets from
+// holos-console-docs/demo/ compile cleanly against the v1alpha2 generated
+// schema. This catches schema renames or removals in this repo before they
+// silently invalidate the publicly-hosted docs examples.
+func TestDocsSyncSnippets(t *testing.T) {
+	// testdata/docs-snippets/ mirrors the subset of holos-console-docs/demo/
+	// that corresponds to registry template scenarios.
+	root := filepath.Join("testdata", "docs-snippets")
+
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		t.Fatalf("testdata/docs-snippets/ directory missing — run the copy commands in the test file header to populate it")
+	}
+
+	// Walk all *.cue files under the testdata directory.
+	var cueFiles []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".cue" {
+			cueFiles = append(cueFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+
+	if len(cueFiles) == 0 {
+		t.Fatalf("no *.cue files found under %s — testdata appears empty", root)
+	}
+
+	cueCtx := cuecontext.New()
+
+	for _, path := range cueFiles {
+		path := path // capture for t.Run
+		name := filepath.ToSlash(path)
+		t.Run(name, func(t *testing.T) {
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("reading %s: %v", path, err)
+			}
+
+			// Prepend the generated schema exactly as the renderer does (see
+			// console/templates/defaults.go). Then add stub declarations for
+			// the well-known template variables (platform, input) so that
+			// docs snippets that reference these as free variables — exactly
+			// as they would be injected by the renderer at runtime — compile
+			// without "reference not found" errors. This mirrors the approach
+			// the production renderer takes: it unifies the template body with
+			// a concrete #PlatformInput and #ProjectInput before evaluation.
+			const templateStubs = `
+// Stub declarations injected by the test harness to mirror what the
+// renderer injects at evaluation time.
+platform: #PlatformInput
+input: #ProjectInput
+`
+			fullSrc := v1alpha2.GeneratedSchema + templateStubs + "\n" + string(src)
+			val := cueCtx.CompileString(fullSrc)
+			if err := val.Err(); err != nil {
+				t.Errorf("docs snippet %s failed to compile against v1alpha2 schema: %v", path, err)
+			}
+		})
+	}
+}

--- a/console/templates/examples/testdata/docs-snippets/allowed-resources/allowed-resources.cue
+++ b/console/templates/examples/testdata/docs-snippets/allowed-resources/allowed-resources.cue
@@ -1,0 +1,23 @@
+// a209178-materia / Folders / default / Platform Templates / allowed-resources
+
+// Close projectResources.namespacedResources so that every namespace bucket
+// may only contain Deployment, Service, or ServiceAccount. Using close() with
+// optional fields is the correct CUE pattern: the close() call marks the struct
+// as closed (no additional fields allowed), and the ? marks each listed field
+// as optional (a namespace bucket need not contain all three). Any unlisted
+// Kind key — such as RoleBinding — is a CUE constraint violation at evaluation
+// time, before any Kubernetes API call (ADR 016 Decision 9).
+projectResources: {
+	namespacedResources: close({
+		// constrain the project template to the project namespace
+		(platform.namespace): close({
+			// constrain the project template to these allowed resource kinds
+			Deployment?:     _
+			Service?:        _
+			ServiceAccount?: _
+			ReferenceGrant?: _
+		})
+	})
+	// Disallow project templates from managing cluster scoped resources.
+	clusterResources: close({})
+}

--- a/console/templates/examples/testdata/docs-snippets/httpbin-v1/httpbin-v1.cue
+++ b/console/templates/examples/testdata/docs-snippets/httpbin-v1/httpbin-v1.cue
@@ -1,0 +1,182 @@
+// TODO(HOL-526) use platform.gatewayNamespace instead
+let GATEWAY_NS = "ci-private-apps-gateway"
+let REFERENCE_GRANT_NAME = "\(input.name)-allow-gateway-httproute"
+
+// Default values for the deployment form.
+defaults: #ProjectInput & {
+	name:        "httpbin"
+	image:       "ghcr.io/mccutchen/go-httpbin"
+	tag:         "2.21.0"
+	port:        8080
+	description: "useful to inspect request headers from the perspective of backend services"
+}
+
+// Use generated type definitions from api/v1alpha2 (prepended by renderer).
+// Additional CUE constraints narrow the generated types for this template.
+input: #ProjectInput & {
+	name: =~"^[a-z][a-z0-9-]*$" // DNS label
+	env: [...#EnvVar] | *[]
+	port: >0 & <=65535 | *8080
+}
+platform: #PlatformInput
+
+// _labels are the standard labels required on every resource.
+// app.kubernetes.io/managed-by MUST equal "console.holos.run" or the
+// render will be rejected.
+_labels: {
+	"app.kubernetes.io/name":       input.name
+	"app.kubernetes.io/managed-by": "console.holos.run"
+}
+
+// _annotations are standard annotations applied to every resource.
+// console.holos.run/deployer-email records the identity of the user
+// who last rendered and applied this resource.
+_annotations: {
+	"console.holos.run/deployer-email": platform.claims.email
+}
+
+// _envSpec transforms the env input into Kubernetes container env format.
+_envSpec: [for e in input.env {
+	name: e.name
+	if e.value != _|_ {
+		value: e.value
+	}
+	if e.secretKeyRef != _|_ {
+		valueFrom: secretKeyRef: {
+			name: e.secretKeyRef.name
+			key:  e.secretKeyRef.key
+		}
+	}
+	if e.configMapKeyRef != _|_ {
+		valueFrom: configMapKeyRef: {
+			name: e.configMapKeyRef.name
+			key:  e.configMapKeyRef.key
+		}
+	}
+}]
+
+// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+// Structure: namespaced.<namespace>.<Kind>.<name>
+// The struct path keys must match the corresponding resource metadata fields.
+#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+	kind: Kind
+	metadata: {
+		name:      Name
+		namespace: Namespace
+		...
+	}
+	...
+}
+
+// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+// Structure: cluster.<Kind>.<name>
+// The struct path keys must match the corresponding resource metadata fields.
+#Cluster: [Kind=string]: [Name=string]: {
+	kind: Kind
+	metadata: {
+		name: Name
+		...
+	}
+	...
+}
+
+// projectResources collects all rendered Kubernetes resources.
+// namespacedResources organizes resources that live within a Kubernetes namespace.
+// The struct key path (namespace/Kind/name) must match the resource metadata.
+// clusterResources organizes cluster-scoped resources.
+projectResources: {
+	namespacedResources: #Namespaced & {
+		(platform.namespace): {
+			// ServiceAccount provides a Kubernetes identity for the pods.
+			ServiceAccount: (input.name): {
+				apiVersion: "v1"
+				kind:       "ServiceAccount"
+				metadata: {
+					name:        input.name
+					namespace:   platform.namespace
+					labels:      _labels
+					annotations: _annotations
+				}
+			}
+
+			// Deployment runs the container image.
+			Deployment: (input.name): {
+				apiVersion: "apps/v1"
+				kind:       "Deployment"
+				metadata: {
+					name:        input.name
+					namespace:   platform.namespace
+					labels:      _labels
+					annotations: _annotations
+				}
+				spec: {
+					replicas: 1
+					selector: matchLabels: "app.kubernetes.io/name": input.name
+					template: {
+						metadata: labels: _labels
+						spec: {
+							serviceAccountName: input.name
+							containers: [{
+								name:  input.name
+								image: input.image + ":" + input.tag
+								if len(_envSpec) > 0 {
+									env: _envSpec
+								}
+								ports: [{containerPort: input.port, name: "http"}]
+								if input.command != _|_ {
+									command: input.command
+								}
+								if input.args != _|_ {
+									args: input.args
+								}
+							}]
+						}
+					}
+				}
+			}
+
+			// Service exposes port 80 → container port input.port (named "http").
+			Service: (input.name): {
+				apiVersion: "v1"
+				kind:       "Service"
+				metadata: {
+					name:        input.name
+					namespace:   platform.namespace
+					labels:      _labels
+					annotations: _annotations
+				}
+				spec: {
+					selector: "app.kubernetes.io/name": input.name
+					ports: [{port: 80, targetPort: "http", name: "http"}]
+				}
+			}
+
+			// ReferenceGrant allows HTTPRoute resources in the gateway namespace to
+			// reference Service resources in the project namespace.
+			// This enables platform templates (such as the example HTTPRoute template)
+			// to expose deployments via the gateway.
+			// See: https://gateway-api.sigs.k8s.io/api-types/referencegrant/
+			ReferenceGrant: (REFERENCE_GRANT_NAME): {
+				apiVersion: "gateway.networking.k8s.io/v1beta1"
+				kind:       "ReferenceGrant"
+				metadata: {
+					name:        REFERENCE_GRANT_NAME
+					namespace:   platform.namespace
+					labels:      _labels
+					annotations: _annotations
+				}
+				spec: {
+					from: [{
+						group:     "gateway.networking.k8s.io"
+						kind:      "HTTPRoute"
+						namespace: GATEWAY_NS
+					}]
+					to: [{
+						group: ""
+						kind:  "Service"
+					}]
+				}
+			}
+		}
+	}
+}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-new.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
@@ -33,20 +34,36 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 
 vi.mock('@/queries/templates', () => ({
   useCreateTemplate: vi.fn(),
+  useListTemplateExamples: vi.fn(),
 }))
 
 vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-import { useCreateTemplate } from '@/queries/templates'
+import { useCreateTemplate, useListTemplateExamples } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateOrgTemplatePage } from './new'
 
+const EXAMPLE_HTTPROUTE = {
+  name: 'httproute-v1',
+  displayName: 'HTTPRoute (v1)',
+  description: 'Exposes project services via an HTTPRoute into the org-configured ingress gateway.',
+  cueTemplate: '// httproute CUE\nplatformResources: {}\n',
+}
+
+const EXAMPLE_SECOND = {
+  name: 'allowed-project-resource-kinds-v1',
+  displayName: 'Allowed Project Resource Kinds (v1)',
+  description: 'Closes projectResources.namespacedResources.',
+  cueTemplate: '// allowed CUE\nprojectResources: {}\n',
+}
+
 function setupMocks(
   mutateAsync = vi.fn().mockResolvedValue({}),
   userRole = Role.OWNER,
+  examples: typeof EXAMPLE_HTTPROUTE[] = [EXAMPLE_HTTPROUTE, EXAMPLE_SECOND],
 ) {
   ;(useCreateTemplate as Mock).mockReturnValue({
     mutateAsync,
@@ -55,6 +72,11 @@ function setupMocks(
   })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useListTemplateExamples as Mock).mockReturnValue({
+    data: examples,
     isPending: false,
     error: null,
   })
@@ -199,31 +221,48 @@ describe('CreateOrgTemplatePage', () => {
     expect(screen.getByText('test-org')).toBeInTheDocument()
   })
 
-  describe('Load Example button', () => {
-    it('renders Load Example button', () => {
+  // HOL-800: the inline "Load Example" button and hard-coded CUE body were
+  // replaced by the TemplateExamplePicker (same picker used on folder/project
+  // new-template pages). Verify the transition.
+  describe('example picker', () => {
+    it('renders the Load Example picker trigger', () => {
       render(<CreateOrgTemplatePage orgName="test-org" />)
-      expect(
-        screen.getByRole('button', { name: /load example/i }),
-      ).toBeInTheDocument()
+      // TemplateExamplePicker exposes role=combobox (shadcn Button with role override).
+      expect(screen.getByRole('combobox', { name: /load example/i })).toBeInTheDocument()
     })
 
-    it('clicking Load Example populates all form fields', () => {
+    it('no longer renders a plain hard-coded "Load Example" push button', () => {
       render(<CreateOrgTemplatePage orgName="test-org" />)
-      fireEvent.click(screen.getByRole('button', { name: /load example/i }))
+      // The old inline Load Example button filled a fixed httpbin-platform template.
+      // Now all load-example logic lives in the picker popover — the trigger is
+      // role=combobox, not role=button, so a plain button query returns null.
+      expect(
+        screen.queryByRole('button', { name: /load example/i }),
+      ).toBeNull()
+    })
+
+    it('selecting an example from the picker fills all form fields', async () => {
+      const user = userEvent.setup()
+      render(<CreateOrgTemplatePage orgName="test-org" />)
+
+      // Open the picker.
+      await user.click(screen.getByRole('combobox', { name: /load example/i }))
+
+      // Pick the first example.
+      const item = await screen.findByText(EXAMPLE_HTTPROUTE.displayName)
+      await user.click(item)
+
+      const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement
+      expect(displayNameInput.value).toBe(EXAMPLE_HTTPROUTE.displayName)
 
       const nameInput = screen.getByLabelText(/name slug/i) as HTMLInputElement
-      expect(nameInput.value).toBe('httpbin-platform')
+      expect(nameInput.value).toBe(EXAMPLE_HTTPROUTE.name)
 
-      const displayNameInput = screen.getByLabelText(
-        /display name/i,
-      ) as HTMLInputElement
-      expect(displayNameInput.value).toBe('httpbin Platform')
+      const descriptionInput = screen.getByLabelText(/description/i) as HTMLInputElement
+      expect(descriptionInput.value).toBe(EXAMPLE_HTTPROUTE.description)
 
-      const cueEditor = screen.getByRole('textbox', {
-        name: /cue template/i,
-      }) as HTMLTextAreaElement
-      expect(cueEditor.value).toContain('HTTPRoute')
-      expect(cueEditor.value).toContain('platform.gatewayNamespace')
+      const cueEditor = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
+      expect(cueEditor.value).toBe(EXAMPLE_HTTPROUTE.cueTemplate)
     })
   })
 

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/new.tsx
@@ -11,85 +11,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Info } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplate } from '@/queries/templates'
+import type { TemplateExample } from '@/queries/templates'
 import { namespaceForOrg } from '@/lib/scope-labels'
 import { useGetOrganization } from '@/queries/organizations'
-
-// EXAMPLE_ORG_PLATFORM_TEMPLATE is the example org-level platform template CUE content.
-// It matches console/templates/example_httpbin_platform.cue.
-const EXAMPLE_ORG_PLATFORM_TEMPLATE = `// Org-level platform template — evaluated at organization scope.
-// Any changes here affect every project in the org.
-//
-// This template does two things:
-//  1. Provides an HTTPRoute in platformResources so the gateway routes
-//     traffic to the deployment's Service.
-//  2. Closes projectResources.namespacedResources to Deployment, Service,
-//     and ServiceAccount (ADR 016 Decision 9) so project templates cannot
-//     produce any other resource kind.
-//
-// Pair with console/templates/example_httpbin.cue for the project-level template.
-
-// input and platform are available because platform templates are unified with
-// the deployment template before evaluation (ADR 016 Decision 8).
-input: #ProjectInput & {
-\tport: >0 & <=65535 | *8080
-}
-platform: #PlatformInput
-
-// ── Platform resources (managed by the platform team) ───────────────────────
-
-// platformResources holds resources the platform team manages. The renderer
-// reads these only from organization/folder-level templates — project templates
-// that define platformResources are silently ignored (ADR 016 Decision 8).
-platformResources: {
-\tnamespacedResources: (platform.namespace): {
-\t\t// HTTPRoute exposes the deployment's Service via the gateway.
-\t\t// It routes all traffic from the gateway to the Service named input.name
-\t\t// on port 80 (the Service port, which forwards to containerPort input.port).
-\t\tHTTPRoute: (input.name): {
-\t\t\tapiVersion: "gateway.networking.k8s.io/v1"
-\t\t\tkind:       "HTTPRoute"
-\t\t\tmetadata: {
-\t\t\t\tname:      input.name
-\t\t\t\tnamespace: platform.namespace
-\t\t\t\tlabels: {
-\t\t\t\t\t"app.kubernetes.io/managed-by": "console.holos.run"
-\t\t\t\t\t"app.kubernetes.io/name":       input.name
-\t\t\t\t}
-\t\t\t}
-\t\t\tspec: {
-\t\t\t\tparentRefs: [{
-\t\t\t\t\tgroup:     "gateway.networking.k8s.io"
-\t\t\t\t\tkind:      "Gateway"
-\t\t\t\t\tnamespace: platform.gatewayNamespace
-\t\t\t\t\tname:      "default"
-\t\t\t\t}]
-\t\t\t\trules: [{
-\t\t\t\t\tbackendRefs: [{
-\t\t\t\t\t\tname: input.name
-\t\t\t\t\t\tport: 80
-\t\t\t\t\t}]
-\t\t\t\t}]
-\t\t\t}
-\t\t}
-\t}
-\tclusterResources: {}
-}
-
-// ── Project resource constraints (enforced by the platform team) ─────────────
-
-// Close projectResources.namespacedResources so that every namespace bucket
-// may only contain Deployment, Service, or ServiceAccount. Using close() with
-// optional fields is the correct CUE pattern: the close() call marks the struct
-// as closed (no additional fields allowed), and the ? marks each listed field
-// as optional (a namespace bucket need not contain all three). Any unlisted
-// Kind key — such as RoleBinding — is a CUE constraint violation at evaluation
-// time, before any Kubernetes API call (ADR 016 Decision 9).
-projectResources: namespacedResources: [_]: close({
-\tDeployment?:     _
-\tService?:        _
-\tServiceAccount?: _
-})
-`
+import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
 export const Route = createFileRoute('/_authenticated/orgs/$orgName/templates/new')({
   component: CreateOrgTemplateRoute,
@@ -133,13 +58,11 @@ export function CreateOrgTemplatePage({ orgName: propOrgName }: { orgName?: stri
     setName(slugify(val))
   }
 
-  const handleLoadExample = () => {
-    setName('httpbin-platform')
-    setDisplayName('httpbin Platform')
-    setDescription(
-      'Provides an HTTPRoute for gateway access and constrains project templates to Deployment, Service, and ServiceAccount only.',
-    )
-    setCueTemplate(EXAMPLE_ORG_PLATFORM_TEMPLATE)
+  const handleSelectExample = (example: TemplateExample) => {
+    setDisplayName(example.displayName)
+    setName(example.name)
+    setDescription(example.description)
+    setCueTemplate(example.cueTemplate)
   }
 
   const handleCreate = async () => {
@@ -224,9 +147,10 @@ export function CreateOrgTemplatePage({ orgName: propOrgName }: { orgName?: stri
             <div className="flex items-center justify-between mb-1">
               <Label htmlFor="template-cue-template">CUE Template</Label>
               <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" type="button" onClick={handleLoadExample} disabled={!canWrite}>
-                  Load Example
-                </Button>
+                <TemplateExamplePicker
+                  onSelect={handleSelectExample}
+                  disabled={!canWrite}
+                />
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

- Replaces the inline hard-coded `EXAMPLE_ORG_PLATFORM_TEMPLATE` constant and `handleLoadExample` button on the org new-template page with `TemplateExamplePicker` — matching the folder and project pages (HOL-798, HOL-799)
- Removes the unused `ExampleHttpbinPlatformTemplate` exported var from `console/templates/embed.go` (the underlying `.cue` file is kept as a render-test fixture)
- Adds `console/templates/examples/docs_sync_test.go` with pinned copies of `holos-console-docs/demo/` snippets under `testdata/docs-snippets/`; the test compiles each snippet against the v1alpha2 schema with the same stubs the renderer injects at runtime
- Documents the single-file drop-in workflow and docs-sync refresh procedure in `AGENTS.md` under a new `## Example Template Registry` section

Fixes HOL-800

## Test plan

- [x] `make test-go` — all packages pass including new `TestDocsSyncSnippets`
- [x] `make test-ui` — 1100/1100 Vitest tests pass including updated `orgs/$orgName/templates/-new.test.tsx`
- [x] `TestCueRenderer_HttpbinExample` in `console/deployments` passes (confirms `example_httpbin_platform.cue` fixture still resolves for render tests)