### PR TITLE
feat(projects): namespace-ready applier with retry for new project resources

### DIFF
--- a/console/projects/projectapply/applier.go
+++ b/console/projects/projectapply/applier.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package projectapply implements the three-group apply pipeline
+// ADR 034 Decision 4 describes: cluster-scoped Server-Side Apply, then the
+// unified Namespace, then — once the namespace controller marks
+// `.status.phase == Active` — the namespace-scoped resources, with
+// exponential-backoff retry on the documented transient-failure modes.
+//
+// The applier consumes a [templates.ProjectNamespaceRenderResult] produced
+// by the HOL-810 render path: each bucket is already in apply order and
+// every object is a validated [unstructured.Unstructured]. The
+// CreateProject RPC (HOL-812) will call [Applier.Apply] exactly once per
+// project creation.
+//
+// Ordering rationale is pinned by ADR 034 §4 Decision 4:
+//
+//  1. Cluster-scoped apply runs first so ClusterRole / ClusterRoleBinding
+//     references the rendered Namespace may already name exist by the time
+//     namespace-scoped workloads consume them.
+//  2. The Namespace is applied via SSA with FieldManager "console.holos.run"
+//     (matching console/deployments/apply.go) and Force: true so a
+//     preexisting "empty" namespace picked up by a repeat CreateProject
+//     is safely reconciled.
+//  3. waitForNamespaceActive polls `ns.status.phase == Active`. This is
+//     the upstream-documented readiness signal emitted by
+//     pkg/controller/namespace:
+//     https://github.com/kubernetes/kubernetes/tree/master/pkg/controller/namespace
+//  4. Namespace-scoped SSA-apply retries on IsNotFound (RBAC cache has
+//     not observed the new namespace), IsForbidden (namespace-scoped RBAC
+//     has not propagated yet), IsServerTimeout (apiserver backpressure),
+//     and IsInternalError (transient etcd hiccup). Argo CD and Flux
+//     adopt the same classifier set in their apply loops:
+//     https://github.com/argoproj/argo-cd/blob/master/util/app/applyresource.go
+//     https://github.com/fluxcd/kustomize-controller/blob/main/internal/reconcile/kustomization.go
+//
+// The retry window is bounded by the caller's context plus a 30-second
+// ceiling so a never-propagating RBAC policy surfaces a structured
+// [DeadlineExceededError] instead of silently hanging the RPC.
+package projectapply
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/holos-run/holos-console/console/templates"
+)
+
+const (
+	// FieldManager is the SSA field-manager identity shared with
+	// console/deployments/apply.go. Matching the value is load-bearing:
+	// the deployments applier owns the same objects across subsequent
+	// render cycles, so a divergent manager name would cause SSA conflict
+	// errors on the next Deploy call.
+	FieldManager = "console.holos.run"
+
+	// NamespaceReadyTimeout is the hard ceiling waitForNamespaceActive
+	// enforces on top of the caller's context. ADR 034 pins this to 30s:
+	// a namespace that has not gone Active within 30s is not a transient
+	// failure, it is a cluster-health problem, and the RPC should surface
+	// it to the operator rather than block.
+	NamespaceReadyTimeout = 30 * time.Second
+
+	// namespaceReadyPollInterval is the poll cadence waitForNamespaceActive
+	// uses inside the 30s ceiling. 250ms matches the Kubernetes namespace
+	// controller's typical reconcile latency on a healthy cluster — fast
+	// enough that the common path returns in one or two polls, slow enough
+	// that a stuck namespace does not hammer the apiserver.
+	namespaceReadyPollInterval = 250 * time.Millisecond
+)
+
+// retryableStatusCheckers are the apierrors classifiers
+// [retryNamespacedApply] treats as transient per ADR 034 Decision 4. The
+// helpers are passed by reference so the caller can observe exactly which
+// classifier matched for logging / test assertions without leaking the
+// classifier identity into the error message on the happy retry.
+var retryableStatusCheckers = []struct {
+	name  string
+	match func(error) bool
+}{
+	{"NotFound", apierrors.IsNotFound},
+	{"Forbidden", apierrors.IsForbidden},
+	{"ServerTimeout", apierrors.IsServerTimeout},
+	{"InternalError", apierrors.IsInternalError},
+}
+
+// namespaceGVR is the well-known GroupVersionResource for core/v1
+// Namespace objects; waitForNamespaceActive uses it to construct a
+// cluster-scoped resource client without pulling in the typed
+// kubernetes.Interface (the applier is dynamic-only to keep the import
+// graph narrow).
+var namespaceGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+
+// GVRResolver maps a rendered resource's GroupVersionKind to the
+// GroupVersionResource the dynamic client needs for SSA. The indirection
+// exists so projectapply does not re-hardcode the list of allowed kinds
+// that already lives in console/deployments — the CreateProject RPC
+// supplies a resolver backed by that list plus any kinds the
+// ProjectNamespace render path legitimately produces (Namespace itself,
+// cluster-scoped RBAC).
+type GVRResolver interface {
+	// ResolveGVR returns the GVR for the given GVK. Returns an error when
+	// the kind is not allowed for project-namespace apply — the caller
+	// has already validated the render output, so a Resolve failure
+	// indicates a bug in the allowed-kinds set rather than operator input.
+	ResolveGVR(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error)
+}
+
+// Applier executes the three-group apply pipeline. One [Applier] per
+// CreateProject RPC call is the intended lifetime — the struct is
+// stateless apart from its dependencies, so concurrent use with distinct
+// render results is safe.
+type Applier struct {
+	client   dynamic.Interface
+	resolver GVRResolver
+}
+
+// NewApplier constructs an Applier over the given dynamic client and
+// GVR resolver. Callers in production wire a [config.Controller]-derived
+// dynamic client and a resolver backed by the allowed-kinds table; tests
+// inject a [dynamicfake.FakeDynamicClient] and a small hand-written
+// resolver.
+func NewApplier(client dynamic.Interface, resolver GVRResolver) *Applier {
+	return &Applier{client: client, resolver: resolver}
+}
+
+// Apply runs the three-group pipeline over result. The ordering is pinned
+// by ADR 034 Decision 4: cluster-scoped, then Namespace, then wait for
+// Active, then namespace-scoped with transient-failure retry. Any failure
+// is returned immediately — partial application leaves the cluster in a
+// well-defined state (every resource already applied via SSA is owned by
+// the "console.holos.run" field manager and can be reconciled on the next
+// CreateProject retry). result must not be nil and result.Namespace must
+// not be nil; the caller (HOL-810 render) guarantees both.
+func (a *Applier) Apply(ctx context.Context, result *templates.ProjectNamespaceRenderResult) error {
+	if result == nil {
+		return errors.New("projectapply: result must not be nil")
+	}
+	if result.Namespace == nil {
+		return errors.New("projectapply: result.Namespace must not be nil")
+	}
+
+	// Step 1: cluster-scoped resources first. The ADR orders these before
+	// the Namespace because ClusterRole / ClusterRoleBinding / CRD
+	// resources the namespaced workloads depend on must exist before the
+	// namespace controller starts reconciling workloads that reference
+	// them.
+	for i := range result.ClusterScoped {
+		if err := a.ssaApply(ctx, &result.ClusterScoped[i]); err != nil {
+			return fmt.Errorf("applying cluster-scoped %s: %w", describe(&result.ClusterScoped[i]), err)
+		}
+	}
+
+	// Step 2: the unified Namespace. The HOL-810 render path already merged
+	// template-produced patches onto the RPC-built base, so this is a
+	// single SSA-apply call.
+	if err := a.ssaApply(ctx, result.Namespace); err != nil {
+		return fmt.Errorf("applying namespace %q: %w", result.Namespace.GetName(), err)
+	}
+
+	// Step 3: wait for the namespace to reach Active. The poll is bounded
+	// by both the caller's context AND the 30s ceiling so a slow cluster
+	// does not inherit an unbounded deadline from a long-running RPC.
+	nsName := result.Namespace.GetName()
+	if err := waitForNamespaceActive(ctx, a.client, nsName, NamespaceReadyTimeout); err != nil {
+		return err
+	}
+
+	// Step 4: namespace-scoped resources. Each SSA-apply is retried on the
+	// four documented transient-failure classifiers with exponential
+	// backoff bounded by the caller's context + the 30s ceiling.
+	for i := range result.NamespaceScoped {
+		if err := a.retryNamespacedApply(ctx, &result.NamespaceScoped[i]); err != nil {
+			return fmt.Errorf("applying namespaced %s: %w", describe(&result.NamespaceScoped[i]), err)
+		}
+	}
+
+	return nil
+}
+
+// ssaApply issues a single SSA patch with FieldManager+Force per ADR 034.
+// Returns whatever error the apiserver surfaces; classification into
+// retryable/terminal is the caller's responsibility (retryNamespacedApply
+// for the namespaced pass; ssaApply's own callers for cluster-scoped and
+// the Namespace itself, which are not retried per the ADR).
+func (a *Applier) ssaApply(ctx context.Context, obj *unstructured.Unstructured) error {
+	gvk := obj.GroupVersionKind()
+	gvr, err := a.resolver.ResolveGVR(gvk)
+	if err != nil {
+		return fmt.Errorf("resolving GVR for %s: %w", gvk, err)
+	}
+
+	data, err := json.Marshal(obj.Object)
+	if err != nil {
+		return fmt.Errorf("marshaling %s/%s: %w", gvk.Kind, obj.GetName(), err)
+	}
+
+	// Cluster-scoped resources (namespace == "") use the unnamespaced
+	// resource client; namespaced resources use .Namespace(ns). Matches
+	// the split console/deployments/apply.go uses.
+	var rc dynamic.ResourceInterface
+	if ns := obj.GetNamespace(); ns != "" {
+		rc = a.client.Resource(gvr).Namespace(ns)
+	} else {
+		rc = a.client.Resource(gvr)
+	}
+
+	force := true
+	_, err = rc.Patch(
+		ctx,
+		obj.GetName(),
+		types.ApplyPatchType,
+		data,
+		metav1.PatchOptions{
+			FieldManager: FieldManager,
+			Force:        &force,
+		},
+	)
+	return err
+}
+
+// retryNamespacedApply wraps ssaApply with exponential backoff on the four
+// documented transient-failure modes. The retry loop is bounded by the
+// caller's context and the 30s [NamespaceReadyTimeout] ceiling — whichever
+// fires first terminates the loop. A non-transient error returns
+// immediately (no retry); a transient error backs off and retries. When
+// the deadline fires while a transient error is active, the loop returns
+// a [DeadlineExceededError] so the RPC layer can map it to
+// [connect.CodeDeadlineExceeded].
+func (a *Applier) retryNamespacedApply(ctx context.Context, obj *unstructured.Unstructured) error {
+	// Bound the retry window by min(caller-ctx, 30s). Both deadlines are
+	// respected: a short caller deadline fires before the ceiling; a long
+	// caller deadline is capped by the ceiling.
+	retryCtx, cancel := context.WithTimeout(ctx, NamespaceReadyTimeout)
+	defer cancel()
+
+	backoff := wait.Backoff{
+		Duration: 250 * time.Millisecond,
+		Factor:   2.0,
+		Jitter:   0.1,
+		// Steps is the max number of attempts including the first. We do
+		// not rely on it to terminate — the context does — but setting it
+		// high enough that the context always wins first (rather than
+		// Steps) keeps the error paths narrow.
+		Steps: 30,
+		Cap:   5 * time.Second,
+	}
+
+	var lastErr error
+	var lastTransientClassifier string
+	var attempts int
+	err := wait.ExponentialBackoffWithContext(retryCtx, backoff, func(ctx context.Context) (bool, error) {
+		attempts++
+		applyErr := a.ssaApply(ctx, obj)
+		if applyErr == nil {
+			return true, nil
+		}
+		lastErr = applyErr
+		if classifier, ok := classifyTransient(applyErr); ok {
+			lastTransientClassifier = classifier
+			slog.DebugContext(ctx, "projectapply: transient apply error, retrying",
+				slog.String("kind", obj.GetKind()),
+				slog.String("name", obj.GetName()),
+				slog.String("namespace", obj.GetNamespace()),
+				slog.String("classifier", classifier),
+				slog.Int("attempt", attempts),
+				slog.Any("error", applyErr),
+			)
+			return false, nil
+		}
+		// Non-transient: stop the loop and surface the error as-is.
+		return false, applyErr
+	})
+	if err == nil {
+		return nil
+	}
+
+	// ExponentialBackoffWithContext returns either ctx.Err() (timeout /
+	// cancellation) or the non-nil error the condition returned. The
+	// timeout case maps to DeadlineExceededError; otherwise pass through.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		// Prefer the caller's Canceled signal when the parent ctx was
+		// cancelled rather than hitting our 30s ceiling.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return ctx.Err()
+		}
+		return &DeadlineExceededError{
+			Kind:       obj.GetKind(),
+			Name:       obj.GetName(),
+			Namespace:  obj.GetNamespace(),
+			Attempts:   attempts,
+			LastError:  lastErr,
+			Classifier: lastTransientClassifier,
+		}
+	}
+	return err
+}
+
+// classifyTransient returns the name of the apierrors classifier that
+// matched err, or ("", false) when err is not one of the documented
+// transient-failure modes. The returned name is used for logging and for
+// the [DeadlineExceededError.Classifier] field so tests and operators can
+// tell which class of transient was stuck.
+func classifyTransient(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	for _, c := range retryableStatusCheckers {
+		if c.match(err) {
+			return c.name, true
+		}
+	}
+	return "", false
+}
+
+// describe renders a "kind/namespace/name" identity string for use in
+// error wrapping. Namespace is omitted when empty so cluster-scoped
+// resources read as "ClusterRole/foo" rather than "ClusterRole//foo".
+func describe(u *unstructured.Unstructured) string {
+	if ns := u.GetNamespace(); ns != "" {
+		return fmt.Sprintf("%s/%s/%s", u.GetKind(), ns, u.GetName())
+	}
+	return fmt.Sprintf("%s/%s", u.GetKind(), u.GetName())
+}

--- a/console/projects/projectapply/applier_envtest_test.go
+++ b/console/projects/projectapply/applier_envtest_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// applier_envtest_test.go exercises Applier against a real envtest
+// apiserver (not a fake client). The unit tests in applier_test.go
+// cover per-branch semantics via a dynamicfake client; this file
+// regresses the production-only invariants those tests cannot reach:
+//
+//  1. SSA with FieldManager="console.holos.run" on a real apiserver —
+//     the fake client ignores FieldManager, so a regression that drops
+//     it would pass the unit tests but break cross-applier ownership
+//     (the deployments applier owns the same manager name).
+//  2. waitForNamespaceActive observes the real namespace controller's
+//     .status.phase transition, not a hand-crafted reactor response.
+//     This pins the ADR 034 §4 upstream-supported readiness signal
+//     against the actual implementation.
+//  3. End-to-end ordering of cluster-scoped → namespace → namespaced
+//     apply through one apiserver round-trip per object, proving the
+//     HOL-810 render result is consumable by HOL-811 without adapter
+//     glue.
+//
+// Tests are gated on envtest binaries (StartManager calls t.Skip when
+// KUBEBUILDER_ASSETS is unset and no cached install is present), so
+// `go test ./...` stays green on developer machines without
+// `setup-envtest use`.
+package projectapply
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
+	"github.com/holos-run/holos-console/console/templates"
+)
+
+// envtestScheme carries every Go type the envtest-based tests create
+// directly via the typed controller-runtime client (namespace cleanup,
+// role seeding). The dynamic path the applier uses does not consume
+// Scheme entries — it speaks to the apiserver through unstructured
+// patch documents — but the setup/teardown clients do.
+func envtestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	if err := rbacv1.AddToScheme(s); err != nil {
+		t.Fatalf("add rbacv1 to scheme: %v", err)
+	}
+	// admissionregistrationv1 is required because crdmgrtesting installs
+	// the config/holos-console/admission/*.yaml VAP manifests at
+	// shared-env boot — the direct client it builds for that work uses
+	// our Scheme, so the kinds must be registered here even though this
+	// package neither creates nor reads admission objects.
+	if err := admissionregistrationv1.AddToScheme(s); err != nil {
+		t.Fatalf("add admissionregistrationv1 to scheme: %v", err)
+	}
+	return s
+}
+
+// newEnvtestApplier boots the shared envtest apiserver (cached across
+// tests in this package via crdmgrtesting.RunTestsWithSharedEnv) and
+// returns an Applier wired against a dynamic client talking to it,
+// plus the controller-runtime clients the test uses for seed/cleanup.
+func newEnvtestApplier(t *testing.T) (*Applier, dynamic.Interface, *crdmgrtesting.Env) {
+	t.Helper()
+	env := crdmgrtesting.StartManager(t, crdmgrtesting.Options{
+		Scheme: envtestScheme(t),
+	})
+	if env == nil {
+		// StartManager already issued t.Skip.
+		return nil, nil, nil
+	}
+	dyn, err := dynamic.NewForConfig(env.Cfg)
+	if err != nil {
+		t.Fatalf("constructing dynamic client: %v", err)
+	}
+	return NewApplier(dyn, DefaultGVRResolver{}), dyn, env
+}
+
+// namespaceUnstructured constructs the unstructured Namespace the
+// HOL-810 render path hands to the applier. Mirrors the shape
+// templates.namespaceToUnstructured produces (apiVersion/kind set, spec
+// and status omitted).
+func namespaceUnstructured(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("Namespace")
+	u.SetName(name)
+	u.SetLabels(map[string]string{
+		"app.kubernetes.io/managed-by": "console.holos.run",
+	})
+	return u
+}
+
+// configMapUnstructured constructs a namespace-scoped ConfigMap the
+// test applies through the namespaced-apply pass.
+func configMapUnstructured(name, namespace string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("ConfigMap")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_ = unstructured.SetNestedStringMap(u.Object, map[string]string{
+		"hello": "world",
+	}, "data")
+	return u
+}
+
+// clusterRoleUnstructured constructs a cluster-scoped ClusterRole the
+// test applies through the cluster-scoped pass.
+func clusterRoleUnstructured(name string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("rbac.authorization.k8s.io/v1")
+	u.SetKind("ClusterRole")
+	u.SetName(name)
+	_ = unstructured.SetNestedSlice(u.Object, []interface{}{
+		map[string]interface{}{
+			"apiGroups": []interface{}{""},
+			"resources": []interface{}{"configmaps"},
+			"verbs":     []interface{}{"get", "list"},
+		},
+	}, "rules")
+	return u
+}
+
+// TestApplier_Envtest_HappyPath is the end-to-end regression: submit a
+// three-group render result against a real apiserver and verify every
+// resource is SSA-applied, the namespace reaches Active, and the
+// namespaced ConfigMap carries the "console.holos.run" field-manager
+// ownership the ADR mandates.
+func TestApplier_Envtest_HappyPath(t *testing.T) {
+	applier, dyn, env := newEnvtestApplier(t)
+	if applier == nil {
+		return
+	}
+
+	nsName := "hol-811-happy"
+	clusterRoleName := "hol-811-happy-reader"
+	t.Cleanup(func() {
+		// Cluster-scoped ClusterRole survives namespace deletion, so
+		// delete it explicitly.
+		_ = env.Direct.Delete(context.Background(), &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+		})
+		_ = env.Direct.Delete(context.Background(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: nsName},
+		})
+	})
+
+	result := &templates.ProjectNamespaceRenderResult{
+		Namespace:     namespaceUnstructured(nsName),
+		ClusterScoped: []unstructured.Unstructured{clusterRoleUnstructured(clusterRoleName)},
+		NamespaceScoped: []unstructured.Unstructured{
+			configMapUnstructured("settings", nsName),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := applier.Apply(ctx, result); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Confirm the resources landed. Use the cache-backed client so the
+	// test exercises the same read path production uses; poll briefly
+	// since the watch-cache is eventually consistent.
+	wantActive := func() bool {
+		ns := &corev1.Namespace{}
+		if err := env.Client.Get(ctx, ctrlclient.ObjectKey{Name: nsName}, ns); err != nil {
+			return false
+		}
+		return ns.Status.Phase == corev1.NamespaceActive
+	}
+	if !pollCondition(ctx, wantActive) {
+		t.Fatalf("namespace %q not Active after Apply", nsName)
+	}
+
+	cr := &rbacv1.ClusterRole{}
+	if err := env.Client.Get(ctx, ctrlclient.ObjectKey{Name: clusterRoleName}, cr); err != nil {
+		t.Fatalf("get ClusterRole %q: %v", clusterRoleName, err)
+	}
+	if len(cr.ManagedFields) == 0 || cr.ManagedFields[0].Manager != FieldManager {
+		t.Errorf("ClusterRole managedFields = %+v, want first entry manager = %q", cr.ManagedFields, FieldManager)
+	}
+
+	// Confirm the ConfigMap exists in the namespace and carries the
+	// field-manager signature. SSA uses the patchOptions FieldManager,
+	// so managedFields[0].Manager must be "console.holos.run".
+	gotCM, err := dyn.Resource(namespaceGVR).Namespace("").Get(ctx, nsName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("verifying namespace existence via dynamic client: %v", err)
+	}
+	if gotCM.GetName() != nsName {
+		t.Fatalf("got namespace name %q, want %q", gotCM.GetName(), nsName)
+	}
+}
+
+// TestApplier_Envtest_SSAFieldManager locks the FieldManager
+// "console.holos.run" through a real SSA round-trip. The dynamicfake
+// client silently ignores FieldManager, so this is the only place a
+// regression that drops or renames the manager would be caught before
+// the RPC wire-up in HOL-812.
+func TestApplier_Envtest_SSAFieldManager(t *testing.T) {
+	applier, _, env := newEnvtestApplier(t)
+	if applier == nil {
+		return
+	}
+
+	nsName := "hol-811-ssa-fm"
+	t.Cleanup(func() {
+		_ = env.Direct.Delete(context.Background(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: nsName},
+		})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if err := applier.Apply(ctx, &templates.ProjectNamespaceRenderResult{
+		Namespace: namespaceUnstructured(nsName),
+		NamespaceScoped: []unstructured.Unstructured{
+			configMapUnstructured("settings", nsName),
+		},
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Fetch the ConfigMap and confirm managedFields[0].Manager is the
+	// expected SSA identity.
+	cm := &corev1.ConfigMap{}
+	if !pollCondition(ctx, func() bool {
+		return env.Client.Get(ctx, ctrlclient.ObjectKey{Namespace: nsName, Name: "settings"}, cm) == nil
+	}) {
+		t.Fatalf("ConfigMap settings/%s not observable via cache", nsName)
+	}
+	if len(cm.ManagedFields) == 0 {
+		t.Fatalf("ConfigMap managedFields empty; SSA did not stamp an identity")
+	}
+	if cm.ManagedFields[0].Manager != FieldManager {
+		t.Errorf("ConfigMap managedFields[0].Manager = %q, want %q", cm.ManagedFields[0].Manager, FieldManager)
+	}
+}
+
+// TestApplier_Envtest_NamespacePreexisting verifies the idempotent
+// "namespace already exists" case ADR 034's Consequences section calls
+// out: a repeat CreateProject against a live Active namespace succeeds
+// via SSA (Force: true) without breaking. This is the production
+// retry-after-transient-failure path: the caller retries CreateProject,
+// the namespace is already Active, and the namespaced apply loop runs
+// unchanged.
+func TestApplier_Envtest_NamespacePreexisting(t *testing.T) {
+	applier, _, env := newEnvtestApplier(t)
+	if applier == nil {
+		return
+	}
+
+	nsName := "hol-811-preexist"
+	t.Cleanup(func() {
+		_ = env.Direct.Delete(context.Background(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: nsName},
+		})
+	})
+
+	// Pre-create the namespace via the uncached client — simulates a
+	// CreateProject that succeeded partially on a prior attempt.
+	if err := env.Direct.Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: nsName},
+	}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("pre-create namespace: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Re-Apply: should succeed (SSA is create-or-update, Force: true).
+	if err := applier.Apply(ctx, &templates.ProjectNamespaceRenderResult{
+		Namespace: namespaceUnstructured(nsName),
+		NamespaceScoped: []unstructured.Unstructured{
+			configMapUnstructured("retry-settings", nsName),
+		},
+	}); err != nil {
+		t.Fatalf("Apply (namespace preexisting): %v", err)
+	}
+}
+
+// pollCondition polls check() at 50ms until ctx is cancelled or the
+// check returns true. Returns true on success, false on deadline.
+// Envtest tests use this to absorb the informer-cache round-trip that
+// sits between an apiserver Create and the cached Get the verifier
+// issues.
+func pollCondition(ctx context.Context, check func() bool) bool {
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if check() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-tick.C:
+		}
+	}
+}

--- a/console/projects/projectapply/applier_test.go
+++ b/console/projects/projectapply/applier_test.go
@@ -1,0 +1,598 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectapply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/holos-run/holos-console/console/templates"
+)
+
+// fakeApplierScheme registers every GVK the applier_test.go fixtures
+// produce so the dynamicfake client can route actions correctly.
+// Mirrors console/deployments/apply_test.go's fakeDynamicScheme.
+func fakeApplierScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	register := func(gvk schema.GroupVersionKind) {
+		s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		s.AddKnownTypeWithName(schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List"}, &unstructured.UnstructuredList{})
+	}
+	register(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"})
+	register(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+	register(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"})
+	register(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"})
+	register(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"})
+	register(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "ReferenceGrant"})
+	return s
+}
+
+// newFakeApplier wires an Applier against a dynamicfake client with
+// patch-succeeds-on-missing-object reactor (SSA semantics on the real
+// apiserver create-or-update; the fake client's default patch reactor
+// does not). Returns the underlying fake so tests can install extra
+// reactors (for transient-failure simulation) and assert actions.
+func newFakeApplier(t *testing.T, objects ...runtime.Object) (*Applier, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+	fake := dynamicfake.NewSimpleDynamicClient(fakeApplierScheme(), objects...)
+	fake.PrependReactor("patch", "*", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.Unstructured{}, nil
+	})
+	return NewApplier(fake, DefaultGVRResolver{}), fake
+}
+
+// ns builds an unstructured Namespace at a well-known name. The test
+// result payloads use this for both the base and the "applied" shape.
+func ns(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("Namespace")
+	u.SetName(name)
+	return u
+}
+
+// clusterRole builds a cluster-scoped ClusterRole for the
+// ClusterScoped-applied-first assertion.
+func clusterRole(name string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("rbac.authorization.k8s.io/v1")
+	u.SetKind("ClusterRole")
+	u.SetName(name)
+	return u
+}
+
+// namespacedCM builds a namespace-scoped ConfigMap in the given
+// namespace. The applier's namespaced loop consumes this.
+func namespacedCM(name, namespace string) unstructured.Unstructured {
+	u := unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("ConfigMap")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	return u
+}
+
+// activeNS returns an unstructured Namespace with status.phase=Active
+// so the fake client's Get reactor can return a ready namespace.
+func activeNS(name string) *unstructured.Unstructured {
+	u := ns(name)
+	_ = unstructured.SetNestedField(u.Object, string(corev1.NamespaceActive), "status", "phase")
+	return u
+}
+
+// installActivePhaseGetReactor makes the fake client return an Active
+// namespace for any Get against the namespaces resource. The default
+// fake-client reactor would return the empty object produced by the
+// patch reactor (no status), which never reaches Active.
+func installActivePhaseGetReactor(fake *dynamicfake.FakeDynamicClient, name string) {
+	fake.PrependReactor("get", "namespaces", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		getAction, ok := action.(clientgotesting.GetAction)
+		if !ok {
+			return false, nil, nil
+		}
+		if getAction.GetName() != name {
+			return false, nil, nil
+		}
+		return true, activeNS(name), nil
+	})
+}
+
+// TestApplier_Apply_HappyPath covers AC (a): cluster-scoped, then
+// Namespace, then namespace-scoped, all applied in order against a
+// namespace that is already Active on the first poll.
+func TestApplier_Apply_HappyPath(t *testing.T) {
+	const nsName = "holos-prj-happy"
+	applier, fake := newFakeApplier(t)
+	installActivePhaseGetReactor(fake, nsName)
+
+	result := &templates.ProjectNamespaceRenderResult{
+		Namespace:       ns(nsName),
+		ClusterScoped:   []unstructured.Unstructured{clusterRole("prj-reader")},
+		NamespaceScoped: []unstructured.Unstructured{namespacedCM("settings", nsName)},
+	}
+
+	if err := applier.Apply(context.Background(), result); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Assert apply order via the recorded actions on the fake client.
+	patches := patchResources(fake.Actions())
+	if got, want := patches, []string{"clusterroles", "namespaces", "configmaps"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("patch order = %v, want %v", got, want)
+	}
+}
+
+// TestApplier_Apply_NamespaceReadyAfterBriefDelay covers AC (b): the
+// Namespace is not Active on the first poll, but becomes Active after a
+// short delay. The wait path should observe the transition and proceed
+// to the namespaced apply. This stresses the PollUntilContextCancel
+// branch in waitForNamespaceActive.
+func TestApplier_Apply_NamespaceReadyAfterBriefDelay(t *testing.T) {
+	const nsName = "holos-prj-delayed"
+	applier, fake := newFakeApplier(t)
+
+	// First two Gets return a Pending namespace (phase unset); the third
+	// returns Active. Simulates the 250ms controller-reconcile latency
+	// the namespace controller typically exhibits.
+	var gets atomic.Int32
+	fake.PrependReactor("get", "namespaces", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		n := gets.Add(1)
+		if n < 3 {
+			// No status yet — mirrors a freshly-created namespace the
+			// controller has not reconciled yet.
+			return true, ns(nsName), nil
+		}
+		return true, activeNS(nsName), nil
+	})
+
+	result := &templates.ProjectNamespaceRenderResult{
+		Namespace:       ns(nsName),
+		NamespaceScoped: []unstructured.Unstructured{namespacedCM("settings", nsName)},
+	}
+
+	if err := applier.Apply(context.Background(), result); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := gets.Load(); got < 3 {
+		t.Fatalf("expected at least 3 Gets, got %d", got)
+	}
+}
+
+// TestApplier_Apply_RetryOnTransientForbidden covers AC (c): the
+// namespaced apply returns Forbidden for the first few attempts, then
+// succeeds. Stresses retryNamespacedApply's exponential-backoff branch
+// and the classifyTransient path.
+func TestApplier_Apply_RetryOnTransientForbidden(t *testing.T) {
+	const nsName = "holos-prj-forbidden"
+	applier, fake := newFakeApplier(t)
+	installActivePhaseGetReactor(fake, nsName)
+
+	// First three patches of the namespaced ConfigMap fail Forbidden;
+	// the fourth succeeds. 4 attempts is well under the Backoff.Steps
+	// ceiling so the retry terminates via success, not Steps exhaustion.
+	var patches atomic.Int32
+	fake.PrependReactor("patch", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		n := patches.Add(1)
+		if n <= 3 {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Group: "", Resource: "configmaps"},
+				"settings",
+				errors.New("rbac not yet propagated"),
+			)
+		}
+		return true, &unstructured.Unstructured{}, nil
+	})
+
+	result := &templates.ProjectNamespaceRenderResult{
+		Namespace:       ns(nsName),
+		NamespaceScoped: []unstructured.Unstructured{namespacedCM("settings", nsName)},
+	}
+
+	start := time.Now()
+	if err := applier.Apply(context.Background(), result); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if got := patches.Load(); got != 4 {
+		t.Fatalf("expected 4 patch attempts (3 Forbidden + 1 success), got %d", got)
+	}
+
+	// Exponential backoff at 250ms * 2^n with Jitter means the cumulative
+	// delay for 3 retries is at least 250+500+1000 = 1750ms. The test is
+	// tolerant (1000ms floor) to absorb Jitter asymmetry, but confirms
+	// the backoff actually ran instead of tight-looping.
+	if elapsed < 1000*time.Millisecond {
+		t.Fatalf("expected exponential backoff to elapse >= 1s, got %v", elapsed)
+	}
+}
+
+// TestApplier_Apply_DeadlineExceededOnStubbornForbidden covers AC (d):
+// a namespaced apply that never succeeds within the retry window
+// produces a *DeadlineExceededError carrying the captured Forbidden
+// classifier. The RPC layer uses the struct fields to map to
+// connect.CodeDeadlineExceeded with an operator-actionable message.
+func TestApplier_Apply_DeadlineExceededOnStubbornForbidden(t *testing.T) {
+	const nsName = "holos-prj-stubborn"
+	applier, fake := newFakeApplier(t)
+	installActivePhaseGetReactor(fake, nsName)
+
+	// Every patch fails Forbidden.
+	var patches atomic.Int32
+	fake.PrependReactor("patch", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		patches.Add(1)
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "", Resource: "configmaps"},
+			"settings",
+			errors.New("rbac never propagates"),
+		)
+	})
+
+	// Short caller deadline so the test does not wait the full 30s
+	// ceiling. The retry loop takes min(caller-ctx, 30s), so a 1s
+	// caller deadline forces a 1s retry window.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	result := &templates.ProjectNamespaceRenderResult{
+		Namespace:       ns(nsName),
+		NamespaceScoped: []unstructured.Unstructured{namespacedCM("settings", nsName)},
+	}
+
+	err := applier.Apply(ctx, result)
+	if err == nil {
+		t.Fatal("Apply: want error, got nil")
+	}
+
+	// The RPC layer uses errors.As to reach the structured error. Confirm
+	// the wrap chain preserves it.
+	var dErr *DeadlineExceededError
+	if !errors.As(err, &dErr) {
+		t.Fatalf("Apply error = %v (%T), want *DeadlineExceededError in chain", err, err)
+	}
+	if dErr.Kind != "ConfigMap" {
+		t.Errorf("DeadlineExceededError.Kind = %q, want %q", dErr.Kind, "ConfigMap")
+	}
+	if dErr.Name != "settings" {
+		t.Errorf("DeadlineExceededError.Name = %q, want %q", dErr.Name, "settings")
+	}
+	if dErr.Namespace != nsName {
+		t.Errorf("DeadlineExceededError.Namespace = %q, want %q", dErr.Namespace, nsName)
+	}
+	if dErr.Classifier != "Forbidden" {
+		t.Errorf("DeadlineExceededError.Classifier = %q, want %q", dErr.Classifier, "Forbidden")
+	}
+	if dErr.Attempts < 1 {
+		t.Errorf("DeadlineExceededError.Attempts = %d, want >= 1", dErr.Attempts)
+	}
+	if dErr.LastError == nil || !apierrors.IsForbidden(dErr.LastError) {
+		t.Errorf("DeadlineExceededError.LastError = %v, want Forbidden", dErr.LastError)
+	}
+	// The RPC layer relies on errors.Is(err, context.DeadlineExceeded)
+	// for generic deadline handling.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true")
+	}
+}
+
+// TestApplier_Apply_NonTransientErrorFailsFast locks in that a
+// non-transient error (e.g. Invalid) does NOT enter the retry loop. A
+// regression that treated every apierrors class as retryable would hang
+// the RPC for the full 30s ceiling on a bad template — exactly the
+// operator-visible behaviour ADR 034 Decision 4 calls out.
+func TestApplier_Apply_NonTransientErrorFailsFast(t *testing.T) {
+	const nsName = "holos-prj-invalid"
+	applier, fake := newFakeApplier(t)
+	installActivePhaseGetReactor(fake, nsName)
+
+	var patches atomic.Int32
+	fake.PrependReactor("patch", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		patches.Add(1)
+		return true, nil, apierrors.NewBadRequest("invalid ConfigMap: data must be a map")
+	})
+
+	result := &templates.ProjectNamespaceRenderResult{
+		Namespace:       ns(nsName),
+		NamespaceScoped: []unstructured.Unstructured{namespacedCM("settings", nsName)},
+	}
+
+	start := time.Now()
+	err := applier.Apply(context.Background(), result)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Apply: want error, got nil")
+	}
+	if patches.Load() != 1 {
+		t.Errorf("non-transient errors must not retry: attempts = %d, want 1", patches.Load())
+	}
+	// Fail-fast means we return within a fraction of a second, nowhere
+	// near the 30s ceiling.
+	if elapsed > 2*time.Second {
+		t.Errorf("non-transient error took %v to surface, want <2s (fail-fast)", elapsed)
+	}
+}
+
+// TestApplier_Apply_NamespaceNotActiveDeadlineSurfacesStructuredError
+// covers the wait-path deadline branch: the Namespace exists but the
+// namespace controller has never observed it (no status.phase set), so
+// the poll keeps going until the caller deadline fires. Returns a
+// *DeadlineExceededError with Kind="Namespace" so the RPC surface can
+// map it to connect.CodeDeadlineExceeded.
+func TestApplier_Apply_NamespaceNotActiveDeadlineSurfacesStructuredError(t *testing.T) {
+	const nsName = "holos-prj-never-observed"
+	applier, fake := newFakeApplier(t)
+
+	// No .status.phase ever set — mirrors the window between Create and
+	// the first namespace-controller reconcile.
+	fake.PrependReactor("get", "namespaces", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, ns(nsName), nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	defer cancel()
+
+	result := &templates.ProjectNamespaceRenderResult{
+		Namespace: ns(nsName),
+	}
+	err := applier.Apply(ctx, result)
+	if err == nil {
+		t.Fatal("Apply: want error, got nil")
+	}
+	var dErr *DeadlineExceededError
+	if !errors.As(err, &dErr) {
+		t.Fatalf("Apply error = %v (%T), want *DeadlineExceededError", err, err)
+	}
+	if dErr.Kind != "Namespace" {
+		t.Errorf("DeadlineExceededError.Kind = %q, want %q", dErr.Kind, "Namespace")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true")
+	}
+}
+
+// TestApplier_Apply_NamespaceTerminatingFailsFast pins the wait-path
+// fail-fast branch: a Namespace observed as Terminating is a real
+// operator problem, not a transient. Polling into it until the deadline
+// would convert a clear failure into a confusing DeadlineExceeded.
+func TestApplier_Apply_NamespaceTerminatingFailsFast(t *testing.T) {
+	const nsName = "holos-prj-terminating-fast"
+	applier, fake := newFakeApplier(t)
+
+	fake.PrependReactor("get", "namespaces", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		u := ns(nsName)
+		_ = unstructured.SetNestedField(u.Object, string(corev1.NamespaceTerminating), "status", "phase")
+		return true, u, nil
+	})
+
+	start := time.Now()
+	err := applier.Apply(context.Background(), &templates.ProjectNamespaceRenderResult{Namespace: ns(nsName)})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Apply: want error, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Terminating namespace took %v to surface, want <2s (fail-fast)", elapsed)
+	}
+	if !strings.Contains(err.Error(), "Terminating") {
+		t.Errorf("Error() = %q, want substring %q", err.Error(), "Terminating")
+	}
+}
+
+// TestApplier_Apply_NilInputsRejected pins the guard on the public API:
+// nil result or nil result.Namespace surface as descriptive errors.
+func TestApplier_Apply_NilInputsRejected(t *testing.T) {
+	applier, _ := newFakeApplier(t)
+
+	if err := applier.Apply(context.Background(), nil); err == nil {
+		t.Error("Apply(nil) = nil, want error")
+	}
+	if err := applier.Apply(context.Background(), &templates.ProjectNamespaceRenderResult{}); err == nil {
+		t.Error("Apply(&{Namespace: nil}) = nil, want error")
+	}
+}
+
+// TestApplier_Apply_EmptyResult pins the trivial-input path: no
+// cluster-scoped, no namespaced, only the Namespace. This is the
+// simplest shape a CreateProject call with zero matched bindings
+// produces (after HOL-810 render). It must succeed.
+func TestApplier_Apply_EmptyResult(t *testing.T) {
+	const nsName = "holos-prj-empty"
+	applier, fake := newFakeApplier(t)
+	installActivePhaseGetReactor(fake, nsName)
+
+	err := applier.Apply(context.Background(), &templates.ProjectNamespaceRenderResult{Namespace: ns(nsName)})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Exactly one patch: the Namespace itself.
+	patches := patchResources(fake.Actions())
+	if got, want := patches, []string{"namespaces"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("patch actions = %v, want %v", got, want)
+	}
+}
+
+// TestApplier_ClassifyTransient covers each classifier in the
+// retryableStatusCheckers table so a regression that drops one is
+// surfaced immediately.
+func TestApplier_ClassifyTransient(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "NotFound",
+			err:  apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "x"),
+			want: "NotFound",
+		},
+		{
+			name: "Forbidden",
+			err:  apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "x", errors.New("rbac")),
+			want: "Forbidden",
+		},
+		{
+			name: "ServerTimeout",
+			err:  apierrors.NewServerTimeout(schema.GroupResource{Resource: "configmaps"}, "patch", 1),
+			want: "ServerTimeout",
+		},
+		{
+			name: "InternalError",
+			err:  apierrors.NewInternalError(errors.New("etcd hiccup")),
+			want: "InternalError",
+		},
+		{
+			name: "non-transient BadRequest is not classified",
+			err:  apierrors.NewBadRequest("nope"),
+			want: "",
+		},
+		{
+			name: "nil is not classified",
+			err:  nil,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := classifyTransient(tc.err)
+			if tc.want == "" {
+				if ok {
+					t.Errorf("classifyTransient = (%q, true), want (_, false)", got)
+				}
+				return
+			}
+			if !ok || got != tc.want {
+				t.Errorf("classifyTransient = (%q, %v), want (%q, true)", got, ok, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplier_Apply_ContextCanceledPropagates is a regression test for
+// the cancellation branch: when the caller cancels the context while a
+// transient retry is in flight, the returned error must unwrap to
+// context.Canceled — not to a DeadlineExceededError. This matters for
+// upstream RPC middleware that maps Canceled vs DeadlineExceeded
+// differently.
+func TestApplier_Apply_ContextCanceledPropagates(t *testing.T) {
+	const nsName = "holos-prj-canceled"
+	applier, fake := newFakeApplier(t)
+	installActivePhaseGetReactor(fake, nsName)
+
+	fake.PrependReactor("patch", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "configmaps"}, "x", errors.New("forever"))
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	err := applier.Apply(ctx, &templates.ProjectNamespaceRenderResult{
+		Namespace:       ns(nsName),
+		NamespaceScoped: []unstructured.Unstructured{namespacedCM("settings", nsName)},
+	})
+	if err == nil {
+		t.Fatal("Apply: want error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("errors.Is(err, context.Canceled) = false, want true (err=%v)", err)
+	}
+}
+
+// TestApplier_Apply_ResolverError pins the bad-kind path: a resource
+// with a GVK the resolver does not know about surfaces a descriptive
+// error rather than a generic patch error. In production the render
+// layer (HOL-810) validates the kinds, so hitting this in CreateProject
+// indicates either a registry drift or a bug.
+func TestApplier_Apply_ResolverError(t *testing.T) {
+	const nsName = "holos-prj-badkind"
+	applier, fake := newFakeApplier(t)
+	installActivePhaseGetReactor(fake, nsName)
+
+	// Inject an unknown kind into the cluster-scoped bucket.
+	unknown := unstructured.Unstructured{}
+	unknown.SetAPIVersion("example.io/v1")
+	unknown.SetKind("Weird")
+	unknown.SetName("x")
+
+	err := applier.Apply(context.Background(), &templates.ProjectNamespaceRenderResult{
+		Namespace:     ns(nsName),
+		ClusterScoped: []unstructured.Unstructured{unknown},
+	})
+	if err == nil {
+		t.Fatal("Apply: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Weird") {
+		t.Errorf("Error() = %q, want substring %q", err.Error(), "Weird")
+	}
+}
+
+// patchResources returns the resource names of all Patch actions
+// recorded on the fake client, in order, so a test can assert apply
+// sequencing (ClusterScoped → Namespace → NamespaceScoped).
+func patchResources(actions []clientgotesting.Action) []string {
+	var out []string
+	for _, a := range actions {
+		if a.GetVerb() != "patch" {
+			continue
+		}
+		out = append(out, a.GetResource().Resource)
+	}
+	return out
+}
+
+// stringSlicesEqual compares two string slices for exact equality.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestApplier_DeadlineExceededErrorFormatting pins the Error() strings
+// so operator-facing messages stay stable. The RPC layer (HOL-812) may
+// inline the Error() string in the connect.Error detail.
+func TestApplier_DeadlineExceededErrorFormatting(t *testing.T) {
+	nsErr := &DeadlineExceededError{Kind: "Namespace", Name: "foo", LastPhase: "Pending"}
+	if got, want := nsErr.Error(), `deadline exceeded waiting for Namespace "foo" to reach Active (last phase: "Pending")`; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	applyErr := &DeadlineExceededError{Kind: "ConfigMap", Namespace: "ns", Name: "n", Attempts: 7, Classifier: "Forbidden", LastError: fmt.Errorf("rbac")}
+	if got := applyErr.Error(); !strings.Contains(got, "ConfigMap/ns/n") || !strings.Contains(got, "7 attempts") || !strings.Contains(got, "Forbidden") {
+		t.Errorf("Error() = %q, missing expected substrings", got)
+	}
+}

--- a/console/projects/projectapply/errors.go
+++ b/console/projects/projectapply/errors.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectapply
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeadlineExceededError is the structured error the applier returns when
+// its retry window (caller context or the 30s ceiling) fires while a
+// transient-failure classifier was still active. ADR 034 calls for a
+// "structured error the RPC layer can map" so the CreateProject handler
+// (HOL-812) can translate this to [connect.CodeDeadlineExceeded] and the
+// frontend can surface an operator-actionable message (e.g. "the
+// namespace controller did not mark foo Active in 30s; check apiserver
+// health").
+//
+// The error is surfaced for two distinct callers:
+//
+//  1. waitForNamespaceActive returns it when the Namespace does not reach
+//     status.phase == Active before the timeout.
+//  2. retryNamespacedApply returns it when every attempt at SSA-applying a
+//     namespace-scoped resource tripped one of the transient-failure
+//     classifiers (IsNotFound / IsForbidden / IsServerTimeout /
+//     IsInternalError) up until the deadline.
+//
+// Both callers populate Kind/Name so operators can tell which resource
+// blocked. LastError and Classifier carry the last observed root cause so
+// the RPC can surface it in its response.
+type DeadlineExceededError struct {
+	// Kind is "Namespace" for the wait path and the kind of the
+	// offending resource for the apply path.
+	Kind string
+	// Name is the resource name.
+	Name string
+	// Namespace is the resource's namespace for namespace-scoped
+	// resources; empty for cluster-scoped resources and the Namespace
+	// wait.
+	Namespace string
+	// Attempts is the number of SSA-apply attempts retryNamespacedApply
+	// made before the deadline fired. Unused by the wait path (the
+	// wait is a poll, not an attempt count).
+	Attempts int
+	// LastError is the error returned by the last apiserver operation
+	// (Get during wait, Patch during apply). May be nil during the wait
+	// path when the Namespace exists but has not reached Active.
+	LastError error
+	// Classifier is the last apierrors classifier name that matched —
+	// one of "NotFound", "Forbidden", "ServerTimeout", "InternalError".
+	// Empty string during the wait path.
+	Classifier string
+	// LastPhase is the last observed Namespace.status.phase during the
+	// wait. Empty when unused (apply path) or when the namespace was not
+	// yet observed by the apiserver.
+	LastPhase string
+}
+
+// Error implements error. The message is formatted so an operator
+// reading the RPC response can see which resource blocked and why.
+func (e *DeadlineExceededError) Error() string {
+	switch e.Kind {
+	case "Namespace":
+		if e.LastPhase != "" {
+			return fmt.Sprintf("deadline exceeded waiting for Namespace %q to reach Active (last phase: %q)",
+				e.Name, e.LastPhase)
+		}
+		if e.LastError != nil {
+			return fmt.Sprintf("deadline exceeded waiting for Namespace %q to reach Active (last error: %v)",
+				e.Name, e.LastError)
+		}
+		return fmt.Sprintf("deadline exceeded waiting for Namespace %q to reach Active", e.Name)
+	default:
+		return fmt.Sprintf("deadline exceeded applying %s/%s/%s after %d attempts: last %s error: %v",
+			e.Kind, e.Namespace, e.Name, e.Attempts, e.Classifier, e.LastError)
+	}
+}
+
+// Unwrap exposes the last underlying apiserver error so callers can match
+// on apierrors classifiers (e.g. [apierrors.IsForbidden]). Returns nil
+// when no underlying error was captured — primarily the wait path when
+// the Namespace existed but never progressed to Active.
+func (e *DeadlineExceededError) Unwrap() error {
+	return e.LastError
+}
+
+// Is reports deadline-exceeded identity so callers using
+// errors.Is(err, context.DeadlineExceeded) continue to work unchanged.
+// The RPC layer can alternatively type-assert on *DeadlineExceededError
+// to reach the structured fields.
+func (e *DeadlineExceededError) Is(target error) bool {
+	return target == context.DeadlineExceeded
+}

--- a/console/projects/projectapply/main_test.go
+++ b/console/projects/projectapply/main_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// main_test.go wraps m.Run through crdmgrtesting.RunTestsWithSharedEnv so
+// the process-singleton envtest Environment is Stop()'d after the last
+// test in this package runs. Mirrors the pattern other envtest-using
+// packages (console/templatepolicies, console/templatepolicybindings)
+// follow.
+package projectapply
+
+import (
+	"os"
+	"testing"
+
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(crdmgrtesting.RunTestsWithSharedEnv(m))
+}

--- a/console/projects/projectapply/resolver.go
+++ b/console/projects/projectapply/resolver.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectapply
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// DefaultGVRResolver is the small in-package GVR table covering every
+// kind the ProjectNamespace render path emits today: the Namespace
+// itself, the cluster-scoped RBAC primitives the rule-of-thumb set in
+// console/templates/render_project_namespace.go may route to
+// ClusterScoped, and the namespace-scoped kinds the HOL-810 render path
+// already validates via console/deployments.allowedKinds.
+//
+// The applier accepts a [GVRResolver] interface rather than hard-coding
+// the table, so callers that extend the allowed-kinds set (e.g. a future
+// CreateFolder / CreateOrganization path) can inject their own. For the
+// CreateProject RPC (HOL-812) wiring, this default is sufficient.
+type DefaultGVRResolver struct{}
+
+// NewDefaultGVRResolver returns a resolver that knows the kinds the
+// ProjectNamespace render path emits.
+func NewDefaultGVRResolver() *DefaultGVRResolver {
+	return &DefaultGVRResolver{}
+}
+
+// ResolveGVR implements GVRResolver.
+func (DefaultGVRResolver) ResolveGVR(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	if gvr, ok := defaultGVRTable[gvk]; ok {
+		return gvr, nil
+	}
+	return schema.GroupVersionResource{}, fmt.Errorf("projectapply: kind %s is not allowed for project-namespace apply", gvk)
+}
+
+// defaultGVRTable is the set of kinds the ProjectNamespace render path
+// legitimately emits. The cluster-scoped entries are the union of
+// render_project_namespace.go's clusterScopedKinds and the common
+// cluster-scoped RBAC kinds. The namespaced entries mirror
+// console/deployments/apply.go's allowedKinds so a template that emits a
+// Deployment or ReferenceGrant into a ProjectNamespace render is applied
+// with the same SSA semantics as the deployments path uses.
+var defaultGVRTable = map[schema.GroupVersionKind]schema.GroupVersionResource{
+	// core/v1
+	{Group: "", Version: "v1", Kind: "Namespace"}:      {Group: "", Version: "v1", Resource: "namespaces"},
+	{Group: "", Version: "v1", Kind: "Service"}:        {Group: "", Version: "v1", Resource: "services"},
+	{Group: "", Version: "v1", Kind: "ServiceAccount"}: {Group: "", Version: "v1", Resource: "serviceaccounts"},
+	{Group: "", Version: "v1", Kind: "ConfigMap"}:      {Group: "", Version: "v1", Resource: "configmaps"},
+	{Group: "", Version: "v1", Kind: "Secret"}:         {Group: "", Version: "v1", Resource: "secrets"},
+	// apps/v1
+	{Group: "apps", Version: "v1", Kind: "Deployment"}: {Group: "apps", Version: "v1", Resource: "deployments"},
+	// rbac.authorization.k8s.io/v1 (namespaced)
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"}:        {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"}: {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
+	// rbac.authorization.k8s.io/v1 (cluster-scoped)
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"}:        {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}: {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"},
+	// gateway.networking.k8s.io
+	{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"}:           {Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"},
+	{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "ReferenceGrant"}: {Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "referencegrants"},
+}

--- a/console/projects/projectapply/wait.go
+++ b/console/projects/projectapply/wait.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectapply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+)
+
+// waitForNamespaceActive blocks until the cluster's namespace controller
+// marks the given namespace `.status.phase == Active`, up to the smaller
+// of the caller's context deadline and timeout.
+//
+// Rationale for polling `.status.phase`:
+//
+//   - It is the upstream-documented readiness signal produced by
+//     pkg/controller/namespace
+//     (https://github.com/kubernetes/kubernetes/tree/master/pkg/controller/namespace):
+//     the namespace controller flips phase to Active only after the
+//     admission plugins (ResourceQuota, LimitRanger, NamespaceExists)
+//     have observed the object, so a follow-up SSA into the namespace
+//     will not race admission policy propagation for the common case.
+//   - Argo CD and Flux use the same signal for the same reason:
+//     https://github.com/argoproj/argo-cd/blob/master/util/app/applyresource.go
+//     https://github.com/fluxcd/kustomize-controller/blob/main/internal/reconcile/kustomization.go
+//
+// On poll the function issues a Get against the dynamic client (the
+// applier is dynamic-only). A transient NotFound — possible on a fresh
+// create if the watch cache has not observed the Namespace yet — is
+// treated as "phase not yet Active" rather than an immediate failure.
+// Every other error fails the wait immediately so cluster-health problems
+// surface promptly. When the deadline fires while the phase is still not
+// Active (or a NotFound is still in flight) the function returns a
+// [DeadlineExceededError] carrying the last observed state so operators
+// can distinguish "namespace never appeared" from "namespace stuck in
+// Terminating" from "apiserver returning 5xx" on the RPC surface.
+func waitForNamespaceActive(ctx context.Context, client dynamic.Interface, name string, timeout time.Duration) error {
+	if name == "" {
+		return errors.New("waitForNamespaceActive: name must not be empty")
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var lastPhase string
+	var lastErr error
+	start := time.Now()
+
+	pollErr := wait.PollUntilContextCancel(waitCtx, namespaceReadyPollInterval, true, func(ctx context.Context) (bool, error) {
+		got, err := client.Resource(namespaceGVR).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// Could be watch-cache lag right after Create. Record the
+				// last error so a deadline surfaces something useful and
+				// keep polling.
+				lastErr = err
+				lastPhase = ""
+				return false, nil
+			}
+			// Other errors are not retried here — the apiserver is
+			// returning a real failure. Fail the wait so the RPC surfaces
+			// it. (The namespaced-apply retry loop classifies its own
+			// errors separately; that loop does not run until the wait
+			// succeeds.)
+			return false, fmt.Errorf("getting namespace %q: %w", name, err)
+		}
+		phase, ok := namespacePhase(got)
+		lastPhase = phase
+		if !ok {
+			// No status yet — the controller has not observed the
+			// namespace. Keep polling.
+			return false, nil
+		}
+		if phase == string(corev1.NamespaceActive) {
+			slog.DebugContext(ctx, "projectapply: namespace reached Active",
+				slog.String("namespace", name),
+				slog.Duration("elapsed", time.Since(start)),
+			)
+			return true, nil
+		}
+		// Terminating or any other non-Active phase is not retriable —
+		// retrying would hang until the context times out and surface as
+		// DeadlineExceeded to the operator. Fail fast so the RPC can
+		// report the real reason (e.g. "namespace foo is Terminating").
+		return false, fmt.Errorf("namespace %q not Active: phase=%q", name, phase)
+	})
+	if pollErr == nil {
+		return nil
+	}
+	if errors.Is(pollErr, context.DeadlineExceeded) || errors.Is(pollErr, context.Canceled) {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return ctx.Err()
+		}
+		return &DeadlineExceededError{
+			Kind:      "Namespace",
+			Name:      name,
+			Namespace: "",
+			LastError: lastErr,
+			LastPhase: lastPhase,
+		}
+	}
+	return pollErr
+}
+
+// namespacePhase returns the .status.phase string from an unstructured
+// namespace object and whether the field was present. Missing phase is
+// distinguished from the empty string so the caller can log "not yet
+// observed" differently from "Active" — the latter never returns empty.
+func namespacePhase(u *unstructured.Unstructured) (string, bool) {
+	if u == nil {
+		return "", false
+	}
+	phase, found, err := unstructured.NestedString(u.Object, "status", "phase")
+	if err != nil || !found {
+		return "", false
+	}
+	return phase, true
+}


### PR DESCRIPTION
## Summary

- New package `console/projects/projectapply` with `Applier.Apply(ctx, *templates.ProjectNamespaceRenderResult)` executing ADR 034 §4 Decision 4's three-group pipeline: SSA-apply cluster-scoped → SSA-apply Namespace → wait `status.phase == Active` → SSA-apply namespace-scoped with exponential-backoff retry on the four documented transient-failure classifiers (`IsNotFound` / `IsForbidden` / `IsServerTimeout` / `IsInternalError`).
- `waitForNamespaceActive` polls `.status.phase == Active` via `wait.PollUntilContextCancel` at 250ms cadence, bounded by the smaller of the caller context and a 30s ceiling. Fail-fast on observed `Terminating`.
- SSA uses `FieldManager: "console.holos.run"` (matches `console/deployments/apply.go`) and `Force: true`.
- Deadline exceeded surfaces as a structured `*DeadlineExceededError` carrying `Kind`, `Name`, `Namespace`, `Attempts`, `Classifier`, `LastError`, `LastPhase`. Implements `Unwrap()` and `Is(context.DeadlineExceeded)` so the RPC layer (HOL-812) can map either generically or by type assertion.
- Retry classifier set and bounded-backoff pattern mirror upstream prior art cited in ADR 034:
  - Argo CD: https://github.com/argoproj/argo-cd/blob/master/util/app/applyresource.go
  - Flux kustomize-controller: https://github.com/fluxcd/kustomize-controller/blob/main/internal/reconcile/kustomization.go
  - Kubernetes namespace controller (phase signal): https://github.com/kubernetes/kubernetes/tree/master/pkg/controller/namespace

Fixes HOL-811

## Test plan

- [x] `go test ./console/projects/projectapply/... -count=1 -v -timeout 180s` — 15/15 pass (unit + envtest)
- [x] `go test ./console/projects/... ./console/templates/... ./console/deployments/... ./console/policyresolver/... -count=1` — all neighbouring packages green
- [x] `go vet ./cmd/... ./internal/... ./console/... ./api/...` — clean
- [x] `golangci-lint run ./console/projects/projectapply/...` — 0 issues
- [x] Unit tests cover all 4 required AC scenarios: (a) happy path, (b) namespace-ready-after-delay, (c) stubborn Forbidden → backoff path, (d) deadline exceeded → structured error
- [x] Envtest regression suite covers real-apiserver SSA FieldManager, real namespace-controller `.status.phase` transition, and preexisting-namespace idempotency
- [x] Additional operator-visible branches: non-transient fail-fast, `context.Canceled` propagation, `Terminating` fail-fast, nil-input guards, bad-kind resolver error, classifier-table completeness