### PR TITLE
feat(secretinjector): UpstreamSecret reconciler + ResolvedRefs conditions

### DIFF
--- a/internal/secretinjector/controller/manager.go
+++ b/internal/secretinjector/controller/manager.go
@@ -143,6 +143,20 @@ func NewManager(cfg *rest.Config, opts Options) (*Manager, error) {
 		return nil, fmt.Errorf("controller.NewManager: building manager: %w", err)
 	}
 
+	// Register the secrets-group reconcilers. Each reconciler owns its own
+	// event recorder keyed by controller name so emitted events are
+	// attributable in the cluster event log. M2 lands one reconciler per
+	// kind; HOL-750 registers UpstreamSecret first so the reconciler-
+	// runtime wiring pattern is exercised in the smallest possible surface
+	// area before the Credential and Binding reconcilers land.
+	if err := (&UpstreamSecretReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("upstream-secret-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering UpstreamSecretReconciler: %w", err)
+	}
+
 	return &Manager{mgr: mgr, cacheSyncTimeout: cacheSyncTimeout, logger: logger}, nil
 }
 

--- a/internal/secretinjector/controller/manager_logger_test.go
+++ b/internal/secretinjector/controller/manager_logger_test.go
@@ -33,15 +33,24 @@ import (
 // controller-runtime internals (priorityqueue, cache, leader election) hit
 // the "[controller-runtime] log.SetLogger(...) was never called" code path
 // and dump a stack trace on first use.
+//
+// NewManager now registers the secrets-group reconcilers during
+// construction (HOL-750 onwards). Reconciler registration calls
+// mgr.GetFieldIndexer().IndexField, which primes the informer cache and
+// requires a reachable API server. We pass a bogus rest.Config to keep the
+// test hermetic, so NewManager is expected to fail — the regression guard
+// only requires ctrl.SetLogger to have been invoked before that failure
+// path returns, which is exactly what we assert here.
 func TestNewManager_WiresControllerRuntimeLogger(t *testing.T) {
 	buf := &syncBuffer{}
 	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	logger := slog.New(handler)
 
-	_, err := NewManager(&rest.Config{Host: "http://127.0.0.1:0"}, Options{Logger: logger})
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
+	// NewManager may return an error because the fake rest.Config cannot
+	// reach an API server; the regression under test is not the error but
+	// whether ctrl.SetLogger was called before control returned. We
+	// deliberately ignore the error.
+	_, _ = NewManager(&rest.Config{Host: "http://127.0.0.1:0"}, Options{Logger: logger})
 
 	// Log through controller-runtime's global Logger. If SetLogger was
 	// called correctly, the record flows through our slog handler into buf.

--- a/internal/secretinjector/controller/status.go
+++ b/internal/secretinjector/controller/status.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// mergeCondition stamps the reconciler-observed generation onto cond and
+// merges it into the supplied condition slice via meta.SetStatusCondition.
+// The helper keeps each secrets-group reconciler's Reconcile implementation
+// focused on building conditions rather than bookkeeping ObservedGeneration
+// and LastTransitionTime — both of which are populated by
+// meta.SetStatusCondition for us. Callers pass the object's
+// metadata.generation through generation so the returned conditions carry
+// the same per-condition observedGeneration as the top-level
+// status.observedGeneration written alongside them.
+//
+// This file mirrors internal/controller/status.go for the templates group.
+// ADR 031 forbids cross-imports between the two controller packages; rather
+// than hoist the helper into pkg/, we duplicate the bookkeeping so each
+// binary's controller package owns its own status-write bookkeeping without
+// reaching across the binary boundary.
+func mergeCondition(dst *[]metav1.Condition, generation int64, cond metav1.Condition) {
+	cond.ObservedGeneration = generation
+	meta.SetStatusCondition(dst, cond)
+}
+
+// conditionsEqualIgnoringTransitionTime reports whether the proposed
+// conditions differ from the existing conditions in any field the hot-loop
+// guard cares about: Type, Status, Reason, Message, ObservedGeneration.
+// LastTransitionTime is intentionally ignored — it is set by the API
+// server on every status write, so comparing it would force a write on
+// every reconcile. Order is NOT significant because we key by Type,
+// matching the kubebuilder `+listMapKey=type` marker on each CRD.
+//
+// Mirrors the equivalent helper in internal/controller/status.go. The two
+// groups duplicate this helper so neither package imports the other.
+func conditionsEqualIgnoringTransitionTime(existing, proposed []metav1.Condition) bool {
+	if len(existing) != len(proposed) {
+		return false
+	}
+	ex := make(map[string]metav1.Condition, len(existing))
+	for _, c := range existing {
+		ex[c.Type] = c
+	}
+	for _, pc := range proposed {
+		ec, ok := ex[pc.Type]
+		if !ok {
+			return false
+		}
+		if ec.Status != pc.Status ||
+			ec.Reason != pc.Reason ||
+			ec.Message != pc.Message ||
+			ec.ObservedGeneration != pc.ObservedGeneration {
+			return false
+		}
+	}
+	return true
+}
+
+// aggregateReady returns ConditionTrue iff every component condition in
+// components has Status=True. Used by each secrets-group reconciler to
+// derive the top-level Ready condition from the kind-specific component
+// conditions. The reasonReady / reasonNotReady arguments keep the Ready
+// reason string consistent with the per-kind contract in
+// api/secrets/v1alpha1/conditions.go.
+//
+// Mirrors the equivalent helper in internal/controller/status.go. The Type
+// field on the returned condition is set to the shared ConditionReady
+// string; callers that prefer the kind-scoped alias may overwrite it.
+func aggregateReady(components []metav1.Condition, reasonReady, reasonNotReady, messageReady, messageNotReady string) metav1.Condition {
+	for _, c := range components {
+		if c.Status != metav1.ConditionTrue {
+			return metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonNotReady,
+				Message: messageNotReady,
+			}
+		}
+	}
+	return metav1.Condition{
+		Type:    "Ready",
+		Status:  metav1.ConditionTrue,
+		Reason:  reasonReady,
+		Message: messageReady,
+	}
+}

--- a/internal/secretinjector/controller/upstream_secret_controller.go
+++ b/internal/secretinjector/controller/upstream_secret_controller.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	secretsv1alpha1 "github.com/holos-run/holos-console/api/secrets/v1alpha1"
+)
+
+// upstreamSecretSecretRefNameIndex is the field-indexer key used by the
+// manager to list UpstreamSecrets that reference a given v1.Secret by name.
+// The key mirrors the spec field it tracks so operators and later
+// reconcilers can tell from the name alone what the index keys on. The
+// index is scoped per-namespace because v1alpha1 admission rejects
+// cross-namespace refs on UpstreamSecret.spec.secretRef (HOL-703), which
+// means a (namespace, secretName) pair is a unique O(1) lookup.
+const upstreamSecretSecretRefNameIndex = "spec.secretRef.name"
+
+// UpstreamSecretReconciler reconciles an UpstreamSecret object. The contract
+// mirrors the templates-group reconcilers:
+//
+//  1. Fetch the object; NotFound -> no-op.
+//  2. Build the Accepted / ResolvedRefs component conditions from the
+//     current spec and the resolution of spec.secretRef against a sibling
+//     v1.Secret.
+//  3. Aggregate into Ready.
+//  4. Stamp metadata.generation on every condition plus
+//     status.observedGeneration.
+//  5. Write status ONLY when ObservedGeneration advances or a condition's
+//     (Status, Reason, Message) tuple changes — guards against the classic
+//     hot-loop where Reconcile keeps writing the same status and the API
+//     server keeps firing watch events back at us.
+//
+// RBAC markers for this reconciler live on the package doc comment in
+// rbac.go — controller-gen's rbac generator ignores markers on struct or
+// method doc comments.
+//
+// The reconciler never reads or writes the credential bytes from the
+// referenced v1.Secret: resolution is a Get + key-presence check only. The
+// injector's hot path (HOL-712) does the byte read at request time. This
+// keeps the CR surface free of sensitive material — see
+// api/secrets/v1alpha1/doc.go and ADR 031 "no sensitive values on CRs".
+type UpstreamSecretReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// SetupWithManager registers the reconciler with the supplied manager. In
+// addition to the primary For(&UpstreamSecret{}), it wires:
+//
+//   - A field indexer on UpstreamSecret.spec.secretRef.name so the
+//     Secret watch mapper looks up referencing UpstreamSecrets in O(1)
+//     per namespace.
+//   - A Watch on v1.Secret that re-enqueues the UpstreamSecrets whose
+//     spec.secretRef.name matches the Secret's name in the same
+//     namespace. Cross-namespace churn is ignored because admission
+//     forbids cross-namespace refs and List is already namespace-scoped.
+func (r *UpstreamSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&secretsv1alpha1.UpstreamSecret{},
+		upstreamSecretSecretRefNameIndex,
+		func(obj client.Object) []string {
+			us, ok := obj.(*secretsv1alpha1.UpstreamSecret)
+			if !ok {
+				return nil
+			}
+			if us.Spec.SecretRef.Name == "" {
+				return nil
+			}
+			return []string{us.Spec.SecretRef.Name}
+		},
+	); err != nil {
+		return fmt.Errorf("indexing UpstreamSecret.%s: %w", upstreamSecretSecretRefNameIndex, err)
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&secretsv1alpha1.UpstreamSecret{}).
+		Named("upstream-secret-controller").
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.upstreamSecretsForSecret),
+		).
+		Complete(r)
+}
+
+// Reconcile implements the reconciliation loop for the UpstreamSecret kind.
+// See the type doc for the contract summary.
+func (r *UpstreamSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var us secretsv1alpha1.UpstreamSecret
+	if err := r.Get(ctx, req.NamespacedName, &us); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get UpstreamSecret: %w", err)
+	}
+
+	gen := us.Generation
+
+	accepted := upstreamSecretAcceptedCondition(&us)
+	resolved, err := r.upstreamSecretResolvedRefsCondition(ctx, &us)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("resolving secretRef: %w", err)
+	}
+	components := []metav1.Condition{accepted, resolved}
+
+	proposed := make([]metav1.Condition, 0, len(components)+1)
+	for _, c := range components {
+		c.ObservedGeneration = gen
+		proposed = append(proposed, c)
+	}
+	ready := aggregateReady(components,
+		secretsv1alpha1.UpstreamSecretReasonReady,
+		secretsv1alpha1.UpstreamSecretReasonNotReady,
+		"UpstreamSecret is accepted and the referenced v1.Secret carries the named key.",
+		"UpstreamSecret is not Ready; see component conditions for details.")
+	ready.Type = secretsv1alpha1.UpstreamSecretConditionReady
+	ready.ObservedGeneration = gen
+	proposed = append(proposed, ready)
+
+	target := us.DeepCopy()
+	target.Status.ObservedGeneration = gen
+	newConds := append([]metav1.Condition(nil), us.Status.Conditions...)
+	for _, pc := range proposed {
+		mergeCondition(&newConds, gen, pc)
+	}
+	target.Status.Conditions = newConds
+
+	if us.Status.ObservedGeneration == gen &&
+		conditionsEqualIgnoringTransitionTime(us.Status.Conditions, target.Status.Conditions) {
+		logger.V(1).Info("UpstreamSecret status unchanged; skipping update", "generation", gen)
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.Status().Update(ctx, target); err != nil {
+		if apierrors.IsConflict(err) {
+			// Someone else beat us to a status update. Requeue
+			// immediately: controller-runtime will rate-limit
+			// the retry for us.
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("update UpstreamSecret status: %w", err)
+	}
+	if r.Recorder != nil {
+		if ready.Status == metav1.ConditionTrue {
+			r.Recorder.Eventf(target, "Normal", secretsv1alpha1.UpstreamSecretReasonReady, "UpstreamSecret is Ready")
+		} else {
+			r.Recorder.Eventf(target, "Warning", ready.Reason, "%s", ready.Message)
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// upstreamSecretAcceptedCondition enforces the minimum spec invariants the
+// admission layer does not cover. v1alpha1 admission already rejects the
+// known bad shapes (HOL-703), so on well-formed objects this function
+// always returns Accepted=True. We still populate the InvalidSpec reason
+// path so objects that bypass admission (kubectl --server-side --force,
+// direct etcd writes, etc.) surface their failure on .status rather than
+// silently sailing through Ready=True.
+func upstreamSecretAcceptedCondition(us *secretsv1alpha1.UpstreamSecret) metav1.Condition {
+	if us.Spec.SecretRef.Name == "" {
+		return metav1.Condition{
+			Type:    secretsv1alpha1.UpstreamSecretConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  secretsv1alpha1.UpstreamSecretReasonInvalidSpec,
+			Message: "spec.secretRef.name must not be empty",
+		}
+	}
+	if us.Spec.SecretRef.Key == "" {
+		return metav1.Condition{
+			Type:    secretsv1alpha1.UpstreamSecretConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  secretsv1alpha1.UpstreamSecretReasonInvalidSpec,
+			Message: "spec.secretRef.key must not be empty",
+		}
+	}
+	if us.Spec.Upstream.Host == "" {
+		return metav1.Condition{
+			Type:    secretsv1alpha1.UpstreamSecretConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  secretsv1alpha1.UpstreamSecretReasonInvalidSpec,
+			Message: "spec.upstream.host must not be empty",
+		}
+	}
+	if us.Spec.Upstream.Scheme != "http" && us.Spec.Upstream.Scheme != "https" {
+		return metav1.Condition{
+			Type:    secretsv1alpha1.UpstreamSecretConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  secretsv1alpha1.UpstreamSecretReasonInvalidSpec,
+			Message: fmt.Sprintf("spec.upstream.scheme %q must be \"http\" or \"https\"", us.Spec.Upstream.Scheme),
+		}
+	}
+	if us.Spec.Injection.Header == "" {
+		return metav1.Condition{
+			Type:    secretsv1alpha1.UpstreamSecretConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  secretsv1alpha1.UpstreamSecretReasonInvalidSpec,
+			Message: "spec.injection.header must not be empty",
+		}
+	}
+	return metav1.Condition{
+		Type:    secretsv1alpha1.UpstreamSecretConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  secretsv1alpha1.UpstreamSecretReasonAccepted,
+		Message: "spec passed reconciler validation",
+	}
+}
+
+// upstreamSecretResolvedRefsCondition returns the ResolvedRefs condition
+// derived from the live cluster state of spec.secretRef. The function is
+// bytes-blind: it only asserts the referenced v1.Secret exists in the same
+// namespace as the UpstreamSecret and carries the named key in .data. The
+// actual credential bytes are read by the injector's hot path at request
+// time, not here — per ADR 031's "no sensitive values on CRs" invariant.
+//
+// When the Accepted condition has already flagged the spec as invalid, the
+// secretRef fields we need (Name, Key) may be empty; we short-circuit to
+// preserve a useful reason on ResolvedRefs without chasing a nonsense Get.
+func (r *UpstreamSecretReconciler) upstreamSecretResolvedRefsCondition(ctx context.Context, us *secretsv1alpha1.UpstreamSecret) (metav1.Condition, error) {
+	if us.Spec.SecretRef.Name == "" || us.Spec.SecretRef.Key == "" {
+		return metav1.Condition{
+			Type:    secretsv1alpha1.UpstreamSecretConditionResolvedRefs,
+			Status:  metav1.ConditionFalse,
+			Reason:  secretsv1alpha1.UpstreamSecretReasonSecretNotFound,
+			Message: "spec.secretRef is incomplete; cannot resolve",
+		}, nil
+	}
+
+	var secret corev1.Secret
+	key := types.NamespacedName{Namespace: us.Namespace, Name: us.Spec.SecretRef.Name}
+	if err := r.Get(ctx, key, &secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return metav1.Condition{
+				Type:    secretsv1alpha1.UpstreamSecretConditionResolvedRefs,
+				Status:  metav1.ConditionFalse,
+				Reason:  secretsv1alpha1.UpstreamSecretReasonSecretNotFound,
+				Message: fmt.Sprintf("Secret %s/%s not found", us.Namespace, us.Spec.SecretRef.Name),
+			}, nil
+		}
+		return metav1.Condition{}, fmt.Errorf("get Secret %s: %w", key, err)
+	}
+	if _, ok := secret.Data[us.Spec.SecretRef.Key]; !ok {
+		return metav1.Condition{
+			Type:   secretsv1alpha1.UpstreamSecretConditionResolvedRefs,
+			Status: metav1.ConditionFalse,
+			Reason: secretsv1alpha1.UpstreamSecretReasonSecretKeyMissing,
+			Message: fmt.Sprintf("Secret %s/%s exists but key %q is not set in .data",
+				us.Namespace, us.Spec.SecretRef.Name, us.Spec.SecretRef.Key),
+		}, nil
+	}
+	return metav1.Condition{
+		Type:    secretsv1alpha1.UpstreamSecretConditionResolvedRefs,
+		Status:  metav1.ConditionTrue,
+		Reason:  secretsv1alpha1.UpstreamSecretReasonResolvedRefs,
+		Message: fmt.Sprintf("Secret %s/%s carries key %q", us.Namespace, us.Spec.SecretRef.Name, us.Spec.SecretRef.Key),
+	}, nil
+}
+
+// upstreamSecretsForSecret returns reconcile requests for every
+// UpstreamSecret whose spec.secretRef.name matches the supplied Secret's
+// name, scoped to the same namespace. The mapper powers the v1.Secret
+// watch registered in SetupWithManager so a late-arriving Secret (or a
+// rotated .data payload that only now carries the required key) re-drives
+// the UpstreamSecret reconcile.
+//
+// The field indexer installed in SetupWithManager makes this a single
+// namespace-scoped List by spec.secretRef.name, so cross-namespace Secret
+// churn on the cluster never enqueues reconciles on bystander
+// UpstreamSecrets.
+func (r *UpstreamSecretReconciler) upstreamSecretsForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return nil
+	}
+	var list secretsv1alpha1.UpstreamSecretList
+	if err := r.List(ctx, &list,
+		client.InNamespace(secret.Namespace),
+		client.MatchingFields{upstreamSecretSecretRefNameIndex: secret.Name},
+	); err != nil {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	for _, us := range list.Items {
+		out = append(out, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: us.Namespace,
+				Name:      us.Name,
+			},
+		})
+	}
+	return out
+}

--- a/internal/secretinjector/controller/upstream_secret_controller_test.go
+++ b/internal/secretinjector/controller/upstream_secret_controller_test.go
@@ -1,0 +1,434 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	secretsv1alpha1 "github.com/holos-run/holos-console/api/secrets/v1alpha1"
+)
+
+// validUpstreamSecret returns a fully-populated UpstreamSecret pointing at
+// the named sibling Secret. Shared by every positive and negative test case
+// so individual tables only need to mutate the one field under test.
+func validUpstreamSecret(name, namespace, secretName, secretKey string) *secretsv1alpha1.UpstreamSecret {
+	return &secretsv1alpha1.UpstreamSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			Generation: 1,
+		},
+		Spec: secretsv1alpha1.UpstreamSecretSpec{
+			SecretRef: secretsv1alpha1.SecretKeyReference{
+				Name: secretName,
+				Key:  secretKey,
+			},
+			Upstream: secretsv1alpha1.Upstream{
+				Host:   "api.example.com",
+				Scheme: "https",
+			},
+			Injection: secretsv1alpha1.Injection{
+				Header: "Authorization",
+			},
+		},
+	}
+}
+
+// newTestReconciler builds a UpstreamSecretReconciler backed by a fake
+// controller-runtime client seeded with objs and a status subresource
+// registered for UpstreamSecret. A nil Recorder is deliberate — the
+// reconciler must not panic when the event recorder is unset in tests.
+func newTestReconciler(t *testing.T, objs ...client.Object) (*UpstreamSecretReconciler, client.Client) {
+	t.Helper()
+	// Index the fake client on spec.secretRef.name so the
+	// upstreamSecretsForSecret mapper's MatchingFields lookup returns the
+	// right objects. The production cache registers the same index via
+	// mgr.GetFieldIndexer() in SetupWithManager.
+	cli := ctrlfake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&secretsv1alpha1.UpstreamSecret{}).
+		WithIndex(
+			&secretsv1alpha1.UpstreamSecret{},
+			upstreamSecretSecretRefNameIndex,
+			func(obj client.Object) []string {
+				us, ok := obj.(*secretsv1alpha1.UpstreamSecret)
+				if !ok {
+					return nil
+				}
+				if us.Spec.SecretRef.Name == "" {
+					return nil
+				}
+				return []string{us.Spec.SecretRef.Name}
+			},
+		).
+		Build()
+	r := &UpstreamSecretReconciler{
+		Client: cli,
+		Scheme: Scheme,
+	}
+	return r, cli
+}
+
+// TestUpstreamSecret_ResolvedRefs_Outcomes covers the three ResolvedRefs
+// outcomes mandated by HOL-750's acceptance criteria: ResolvedRefs=True
+// when the secret+key exist, ResolvedRefs=False/SecretNotFound when the
+// Secret is absent, ResolvedRefs=False/SecretKeyMissing when the Secret
+// exists but .data does not carry the named key.
+func TestUpstreamSecret_ResolvedRefs_Outcomes(t *testing.T) {
+	const (
+		ns         = "holos-prj-demo"
+		name       = "example"
+		secretName = "creds"
+		secretKey  = "api-key"
+	)
+
+	cases := []struct {
+		name       string
+		secret     *corev1.Secret
+		wantStatus metav1.ConditionStatus
+		wantReason string
+		wantReady  metav1.ConditionStatus
+	}{
+		{
+			name: "ResolvedRefs=True when Secret carries the key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+				Data:       map[string][]byte{secretKey: []byte("s3cret")},
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: secretsv1alpha1.UpstreamSecretReasonResolvedRefs,
+			wantReady:  metav1.ConditionTrue,
+		},
+		{
+			name:       "ResolvedRefs=False/SecretNotFound when Secret is absent",
+			secret:     nil,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: secretsv1alpha1.UpstreamSecretReasonSecretNotFound,
+			wantReady:  metav1.ConditionFalse,
+		},
+		{
+			name: "ResolvedRefs=False/SecretKeyMissing when key is not set",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+				Data:       map[string][]byte{"other-key": []byte("s3cret")},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: secretsv1alpha1.UpstreamSecretReasonSecretKeyMissing,
+			wantReady:  metav1.ConditionFalse,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			us := validUpstreamSecret(name, ns, secretName, secretKey)
+			objs := []client.Object{us}
+			if tc.secret != nil {
+				objs = append(objs, tc.secret)
+			}
+			r, cli := newTestReconciler(t, objs...)
+
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
+			if _, err := r.Reconcile(context.Background(), req); err != nil {
+				t.Fatalf("Reconcile: %v", err)
+			}
+
+			var got secretsv1alpha1.UpstreamSecret
+			if err := cli.Get(context.Background(), req.NamespacedName, &got); err != nil {
+				t.Fatalf("get UpstreamSecret: %v", err)
+			}
+
+			resolved := meta.FindStatusCondition(got.Status.Conditions, secretsv1alpha1.UpstreamSecretConditionResolvedRefs)
+			if resolved == nil {
+				t.Fatalf("ResolvedRefs condition missing; conditions=%+v", got.Status.Conditions)
+			}
+			if resolved.Status != tc.wantStatus {
+				t.Errorf("ResolvedRefs.Status=%s want %s", resolved.Status, tc.wantStatus)
+			}
+			if resolved.Reason != tc.wantReason {
+				t.Errorf("ResolvedRefs.Reason=%s want %s", resolved.Reason, tc.wantReason)
+			}
+			if got.Status.ObservedGeneration != got.Generation {
+				t.Errorf("observedGeneration=%d want %d", got.Status.ObservedGeneration, got.Generation)
+			}
+
+			accepted := meta.FindStatusCondition(got.Status.Conditions, secretsv1alpha1.UpstreamSecretConditionAccepted)
+			if accepted == nil || accepted.Status != metav1.ConditionTrue {
+				t.Errorf("Accepted should be True for well-formed spec; got %+v", accepted)
+			}
+
+			ready := meta.FindStatusCondition(got.Status.Conditions, secretsv1alpha1.UpstreamSecretConditionReady)
+			if ready == nil {
+				t.Fatalf("Ready condition missing; conditions=%+v", got.Status.Conditions)
+			}
+			if ready.Status != tc.wantReady {
+				t.Errorf("Ready.Status=%s want %s", ready.Status, tc.wantReady)
+			}
+			wantReadyReason := secretsv1alpha1.UpstreamSecretReasonReady
+			if tc.wantReady != metav1.ConditionTrue {
+				wantReadyReason = secretsv1alpha1.UpstreamSecretReasonNotReady
+			}
+			if ready.Reason != wantReadyReason {
+				t.Errorf("Ready.Reason=%s want %s", ready.Reason, wantReadyReason)
+			}
+
+			// No sensitive bytes may leak onto the CR — regardless of the
+			// resolved-refs outcome, the Secret data ("s3cret") must
+			// never appear in any condition Message or in the serialised
+			// status. This mirrors the doc.go invariant that ADR 031
+			// elevated to a first-class rule.
+			for _, c := range got.Status.Conditions {
+				if strings.Contains(c.Message, "s3cret") {
+					t.Errorf("condition %s message leaks Secret bytes: %q", c.Type, c.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestUpstreamSecret_HotLoopGuard verifies the reconciler does not re-write
+// status when the generation is unchanged and every condition's (Status,
+// Reason, Message) tuple matches the last observation. HOL-675's hot-loop
+// contract forbids this, and a regression here would cause the API server
+// to fire a watch event for every reconcile, causing it to reconcile
+// again, and so on.
+func TestUpstreamSecret_HotLoopGuard(t *testing.T) {
+	const (
+		ns         = "holos-prj-demo"
+		name       = "stable"
+		secretName = "creds"
+		secretKey  = "api-key"
+	)
+	us := validUpstreamSecret(name, ns, secretName, secretKey)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+		Data:       map[string][]byte{secretKey: []byte("s3cret")},
+	}
+	r, cli := newTestReconciler(t, us, secret)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+
+	var afterFirst secretsv1alpha1.UpstreamSecret
+	if err := cli.Get(context.Background(), req.NamespacedName, &afterFirst); err != nil {
+		t.Fatalf("get after first reconcile: %v", err)
+	}
+	firstRV := afterFirst.ResourceVersion
+	if firstRV == "" {
+		t.Fatalf("resourceVersion empty after first reconcile")
+	}
+
+	// Second reconcile with no spec change must not write status — if it
+	// did, the fake client would bump resourceVersion. This is exactly the
+	// check the envtest suite performs in HOL-753 at the API-server level.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	var afterSecond secretsv1alpha1.UpstreamSecret
+	if err := cli.Get(context.Background(), req.NamespacedName, &afterSecond); err != nil {
+		t.Fatalf("get after second reconcile: %v", err)
+	}
+	if afterSecond.ResourceVersion != firstRV {
+		t.Fatalf("resourceVersion advanced from %q to %q without spec change; hot-loop guard regressed",
+			firstRV, afterSecond.ResourceVersion)
+	}
+}
+
+// TestUpstreamSecret_ObservedGenerationAdvances creates an UpstreamSecret,
+// reconciles, bumps spec.generation (simulated by an Update that changes
+// the injection header), and confirms observedGeneration catches up and
+// the conditions all carry the new generation.
+func TestUpstreamSecret_ObservedGenerationAdvances(t *testing.T) {
+	const (
+		ns         = "holos-prj-demo"
+		name       = "updater"
+		secretName = "creds"
+		secretKey  = "api-key"
+	)
+	us := validUpstreamSecret(name, ns, secretName, secretKey)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+		Data:       map[string][]byte{secretKey: []byte("s3cret")},
+	}
+	r, cli := newTestReconciler(t, us, secret)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+	var read secretsv1alpha1.UpstreamSecret
+	if err := cli.Get(context.Background(), req.NamespacedName, &read); err != nil {
+		t.Fatalf("get after first reconcile: %v", err)
+	}
+	if read.Status.ObservedGeneration != 1 {
+		t.Fatalf("observedGeneration=%d want 1", read.Status.ObservedGeneration)
+	}
+
+	// Mutate the spec and bump generation explicitly. The controller-
+	// runtime fake client does not model the API server's
+	// generation-on-spec-change behavior, so we mirror that by bumping
+	// Generation ourselves. Envtest in HOL-753 exercises the real
+	// generation-advance path end-to-end.
+	read.Spec.Injection.Header = "X-Api-Key"
+	read.Generation = 2
+	if err := cli.Update(context.Background(), &read); err != nil {
+		t.Fatalf("update UpstreamSecret: %v", err)
+	}
+	var bumped secretsv1alpha1.UpstreamSecret
+	if err := cli.Get(context.Background(), req.NamespacedName, &bumped); err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if bumped.Generation <= 1 {
+		t.Fatalf("expected generation to advance past 1; got %d", bumped.Generation)
+	}
+	wantGen := bumped.Generation
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	var final secretsv1alpha1.UpstreamSecret
+	if err := cli.Get(context.Background(), req.NamespacedName, &final); err != nil {
+		t.Fatalf("get after second reconcile: %v", err)
+	}
+	if final.Status.ObservedGeneration != wantGen {
+		t.Fatalf("observedGeneration=%d want %d", final.Status.ObservedGeneration, wantGen)
+	}
+	for _, c := range final.Status.Conditions {
+		if c.ObservedGeneration != wantGen {
+			t.Errorf("condition %s observedGeneration=%d want %d", c.Type, c.ObservedGeneration, wantGen)
+		}
+	}
+}
+
+// TestUpstreamSecret_InvalidSpecReason exercises the Accepted=False path
+// for objects that bypass admission. We zero the secretRef fields directly
+// on an already-created object so the reconciler sees an invalid spec and
+// must surface the InvalidSpec reason on both Accepted and Ready.
+func TestUpstreamSecret_InvalidSpecReason(t *testing.T) {
+	const (
+		ns   = "holos-prj-demo"
+		name = "invalid"
+	)
+	us := &secretsv1alpha1.UpstreamSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  ns,
+			Generation: 1,
+		},
+		Spec: secretsv1alpha1.UpstreamSecretSpec{
+			// secretRef.Name deliberately empty — admission would reject
+			// but our reconciler is belt-and-braces.
+			Upstream: secretsv1alpha1.Upstream{
+				Host:   "api.example.com",
+				Scheme: "https",
+			},
+			Injection: secretsv1alpha1.Injection{
+				Header: "Authorization",
+			},
+		},
+	}
+	r, cli := newTestReconciler(t, us)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var got secretsv1alpha1.UpstreamSecret
+	if err := cli.Get(context.Background(), req.NamespacedName, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	accepted := meta.FindStatusCondition(got.Status.Conditions, secretsv1alpha1.UpstreamSecretConditionAccepted)
+	if accepted == nil || accepted.Status != metav1.ConditionFalse || accepted.Reason != secretsv1alpha1.UpstreamSecretReasonInvalidSpec {
+		t.Fatalf("want Accepted=False/InvalidSpec, got %+v", accepted)
+	}
+	ready := meta.FindStatusCondition(got.Status.Conditions, secretsv1alpha1.UpstreamSecretConditionReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != secretsv1alpha1.UpstreamSecretReasonNotReady {
+		t.Fatalf("want Ready=False/NotReady, got %+v", ready)
+	}
+}
+
+// TestUpstreamSecret_NotFound_ReturnsNoError exercises the cache-miss path:
+// a request for an object that does not exist should return no error and
+// no requeue so controller-runtime does not hot-loop on a deletion.
+func TestUpstreamSecret_NotFound_ReturnsNoError(t *testing.T) {
+	r, _ := newTestReconciler(t)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "x", Name: "missing"}}
+	res, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile on missing: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Fatalf("Reconcile on missing: want no requeue, got %+v", res)
+	}
+}
+
+// TestUpstreamSecret_MapFunc_EnqueuesReferencers covers the v1.Secret
+// watch's mapper: a Secret create/update enqueues exactly the
+// UpstreamSecrets that reference it by (namespace, secretName), and
+// ignores bystander UpstreamSecrets that either reference a different
+// Secret or live in a different namespace.
+func TestUpstreamSecret_MapFunc_EnqueuesReferencers(t *testing.T) {
+	const (
+		nsA        = "holos-prj-a"
+		nsB        = "holos-prj-b"
+		secretName = "creds"
+	)
+
+	target := validUpstreamSecret("refers-to-creds", nsA, secretName, "k")
+	sameSecretDiffNS := validUpstreamSecret("other-ns-same-name", nsB, secretName, "k")
+	otherSecretSameNS := validUpstreamSecret("other-name-same-ns", nsA, "other", "k")
+
+	r, _ := newTestReconciler(t, target, sameSecretDiffNS, otherSecretSameNS)
+
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: nsA}}
+	reqs := r.upstreamSecretsForSecret(context.Background(), secret)
+
+	if len(reqs) != 1 {
+		t.Fatalf("upstreamSecretsForSecret returned %d requests; want exactly 1", len(reqs))
+	}
+	got := reqs[0]
+	want := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: nsA, Name: "refers-to-creds"}}
+	if got != want {
+		t.Fatalf("upstreamSecretsForSecret returned %v; want %v", got, want)
+	}
+}
+
+// TestUpstreamSecret_MapFunc_IgnoresNonSecretObjects asserts the mapper
+// tolerates a non-Secret object gracefully (controller-runtime guarantees
+// the event source emits Secrets, but defense-in-depth against watch
+// misregistration is cheap).
+func TestUpstreamSecret_MapFunc_IgnoresNonSecretObjects(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	reqs := r.upstreamSecretsForSecret(context.Background(), &corev1.ConfigMap{})
+	if len(reqs) != 0 {
+		t.Fatalf("upstreamSecretsForSecret on ConfigMap returned %d requests; want 0", len(reqs))
+	}
+}


### PR DESCRIPTION
## Summary

- Land the `UpstreamSecretReconciler` under `internal/secretinjector/controller/` with the Gateway-API-style `Accepted` / `ResolvedRefs` / `Ready` condition triple from `api/secrets/v1alpha1/conditions.go`.
- Add `internal/secretinjector/controller/status.go` — the hot-loop guard + `aggregateReady` helper mirroring `internal/controller/status.go`. The two controller packages duplicate the helper so neither imports the other, per ADR 031's disjoint-tree invariant.
- Register the reconciler in `internal/secretinjector/controller/manager.go` alongside the existing manager construction. Wire a field indexer on `spec.secretRef.name` so a `v1.Secret` watch mapper enqueues referencing UpstreamSecrets in O(1) per namespace.
- Table-driven unit tests via `sigs.k8s.io/controller-runtime/pkg/client/fake` cover all three ResolvedRefs outcomes, the hot-loop guard (resourceVersion steady on idempotent reconcile), observedGeneration advance, InvalidSpec admission-bypass handling, and the map-function referencer selection. Envtest coverage lands in HOL-753.
- The sibling `v1.Secret` is resolved by Get + key-presence only — the credential bytes never flow through the reconciler, in line with ADR 031's "no sensitive values on CRs" rule. A test asserts no condition message leaks Secret bytes.

Fixes HOL-750

## Test plan

- [x] `CGO_ENABLED=1 go test -race ./internal/secretinjector/... ./api/secrets/...` green
- [x] `make manifests-secrets` emits zero diff (RBAC markers from HOL-675 remain authoritative)
- [x] `make check-imports` green (ADR 031 disjoint-tree invariant holds)
- [x] `go vet ./...` green
- [ ] CI green across all matrix jobs