### PR TITLE
feat(secretinjector): pluggable KDF interface + argon2id default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,12 @@ require (
 	github.com/dexidp/dex v0.0.0-20251209162832-8ab38ebb7920
 	github.com/fullstorydev/grpcurl v1.9.3
 	github.com/go-jose/go-jose/v4 v4.1.3
+	github.com/go-logr/logr v1.4.3
+	github.com/google/go-cmp v0.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rogpeppe/go-internal v1.14.1
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/crypto v0.48.0
 	golang.org/x/net v0.50.0
 	google.golang.org/protobuf v1.36.11
 	k8s.io/api v0.35.0
@@ -88,7 +91,6 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
 	github.com/go-chi/chi/v5 v5.2.3 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.12 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -99,7 +101,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -173,7 +174,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect

--- a/internal/secretinjector/crypto/argon2id.go
+++ b/internal/secretinjector/crypto/argon2id.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// Argon2idDefault is the pinned default parameter set for the argon2id
+// KDF binding. The values track the OWASP Password Storage Cheat Sheet
+// argon2id recommendation "m=19456, t=2, p=1" (19 MiB, two passes, one
+// lane) with a 32-byte output per RFC 9106 §4. See
+// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+// for the current guidance.
+//
+// The values are pinned in code rather than read from a config file so a
+// silent parameter change is loud: bumping any field is a reviewable
+// diff, and an envelope written with the old values cannot verify against
+// the new values (see [ErrParamMismatch]), which forces a re-hash at
+// next login.
+//
+// Memory is expressed in KiB to match [argon2.IDKey]'s API. 19456 KiB =
+// 19 MiB.
+var Argon2idDefault = Params{
+	Time:        2,
+	Memory:      19456,
+	Parallelism: 1,
+	KeyLength:   32,
+}
+
+// Argon2id is the default non-FIPS [KDF] binding. The zero value is
+// ready to use: all configuration lives in [Params], and the caller
+// routes params either via [Argon2id.DefaultParams] or by passing an
+// explicit [Params] into [Argon2id.Hash].
+type Argon2id struct{}
+
+// ID reports the stable algorithm identifier argon2id writes into
+// [Envelope.KDF].
+func (Argon2id) ID() KDFID { return KDFArgon2id }
+
+// DefaultParams returns [Argon2idDefault]. Callers are free to override
+// for migrations (for example, to re-hash at higher cost), but the
+// default is what the reconciler uses on the hot path.
+func (Argon2id) DefaultParams() Params { return Argon2idDefault }
+
+// Hash derives an encoded-hash [Envelope] via [argon2.IDKey]. Inputs are
+// validated up front so an empty pepper or empty plaintext fails loudly
+// rather than deriving a useless hash.
+//
+// Hash concatenates the pepper to the plaintext before feeding the
+// combined buffer into [argon2.IDKey]. The pepper is NOT folded into the
+// salt so a future pepper rotation can re-hash without regenerating the
+// per-credential salt. See HOL-749 for the pepper rotation story.
+//
+// The returned envelope carries the effective [Params] so [Verify] can
+// reject parameter drift.
+func (a Argon2id) Hash(plaintext, salt, pepper []byte, pepperVersion string, params Params) (Envelope, error) {
+	if err := validateInputs(plaintext, salt, pepper); err != nil {
+		return Envelope{}, err
+	}
+	if pepperVersion == "" {
+		return Envelope{}, ErrEmptyPepperVersion
+	}
+	if err := validateArgon2idParams(params); err != nil {
+		return Envelope{}, err
+	}
+	peppered := append([]byte{}, plaintext...)
+	peppered = append(peppered, pepper...)
+	hash := argon2.IDKey(peppered, salt, params.Time, params.Memory, params.Parallelism, params.KeyLength)
+	// Copy salt so later mutation of the caller's slice cannot corrupt
+	// the envelope. The hash is freshly allocated by argon2.IDKey so no
+	// defensive copy is needed on that field.
+	saltCopy := append([]byte(nil), salt...)
+	return Envelope{
+		SchemaVersion: EnvelopeSchemaVersion,
+		KDF:           KDFArgon2id,
+		KDFParams:     params,
+		PepperVersion: pepperVersion,
+		Salt:          saltCopy,
+		Hash:          hash,
+	}, nil
+}
+
+// Verify re-derives the hash from plaintext + envelope.Salt + pepper
+// under envelope.KDFParams and compares to envelope.Hash in constant
+// time. Verify rejects a KDF-identifier mismatch, a schema-version
+// mismatch, and a [Params] drift before touching the primitive — the
+// goal is that a silent parameter bump is impossible to verify against.
+func (a Argon2id) Verify(plaintext, pepper []byte, envelope Envelope) error {
+	if envelope.SchemaVersion != EnvelopeSchemaVersion {
+		return fmt.Errorf("%w: got %d, want %d", ErrUnknownSchemaVersion, envelope.SchemaVersion, EnvelopeSchemaVersion)
+	}
+	if envelope.KDF != KDFArgon2id {
+		return fmt.Errorf("%w: envelope KDF %q, verifier %q", ErrKDFMismatch, envelope.KDF, KDFArgon2id)
+	}
+	if err := validateInputs(plaintext, envelope.Salt, pepper); err != nil {
+		return err
+	}
+	if err := validateArgon2idParams(envelope.KDFParams); err != nil {
+		return err
+	}
+	peppered := append([]byte{}, plaintext...)
+	peppered = append(peppered, pepper...)
+	candidate := argon2.IDKey(
+		peppered,
+		envelope.Salt,
+		envelope.KDFParams.Time,
+		envelope.KDFParams.Memory,
+		envelope.KDFParams.Parallelism,
+		envelope.KDFParams.KeyLength,
+	)
+	if !CompareHash(candidate, envelope.Hash) {
+		return ErrHashMismatch
+	}
+	return nil
+}
+
+// VerifyWithParams is the strict verification entry point the reconciler
+// uses when it has a caller-expected [Params] and wants to refuse to
+// verify against an envelope whose stored params drifted. The helper
+// compares [Envelope.KDFParams] to want before delegating to
+// [Argon2id.Verify] so a silent parameter change cannot pass.
+func (a Argon2id) VerifyWithParams(plaintext, pepper []byte, envelope Envelope, want Params) error {
+	if !paramsEqual(envelope.KDFParams, want) {
+		return fmt.Errorf("%w", ErrParamMismatch)
+	}
+	return a.Verify(plaintext, pepper, envelope)
+}
+
+// validateArgon2idParams rejects params the argon2id primitive cannot
+// operate with. The golang.org/x/crypto/argon2 API panics on
+// parallelism=0, so we fail loudly with a structured error instead.
+func validateArgon2idParams(p Params) error {
+	if p.Time == 0 {
+		return fmt.Errorf("%w: argon2id requires Time >= 1", ErrInvalidParams)
+	}
+	if p.Memory == 0 {
+		return fmt.Errorf("%w: argon2id requires Memory >= 1 (KiB)", ErrInvalidParams)
+	}
+	if p.Parallelism == 0 {
+		return fmt.Errorf("%w: argon2id requires Parallelism >= 1", ErrInvalidParams)
+	}
+	if p.KeyLength == 0 {
+		return fmt.Errorf("%w: argon2id requires KeyLength >= 1", ErrInvalidParams)
+	}
+	return nil
+}

--- a/internal/secretinjector/crypto/argon2id.go
+++ b/internal/secretinjector/crypto/argon2id.go
@@ -90,11 +90,32 @@ func (a Argon2id) Hash(plaintext, salt, pepper []byte, pepperVersion string, par
 	return Envelope{
 		SchemaVersion: EnvelopeSchemaVersion,
 		KDF:           KDFArgon2id,
-		KDFParams:     params,
+		// Normalize params before stamping: zero out the PBKDF2-only
+		// Iterations field so a caller that accidentally passed a
+		// non-zero Iterations (for example, a params struct shared
+		// with a PBKDF2 call site) cannot poison the envelope with a
+		// field argon2id ignores. Combined with
+		// argon2idParamsEqual's relevant-fields-only comparison on
+		// Verify, this makes the argon2id envelope strictly describe
+		// the argon2id cost and nothing else.
+		KDFParams:     normalizeArgon2idParams(params),
 		PepperVersion: pepperVersion,
 		Salt:          saltCopy,
 		Hash:          hash,
 	}, nil
+}
+
+// normalizeArgon2idParams returns a [Params] that carries only the four
+// fields argon2id consumes. Other fields (currently just the PBKDF2
+// Iterations counter) are zeroed so the envelope is a faithful
+// description of the argon2id cost actually paid.
+func normalizeArgon2idParams(p Params) Params {
+	return Params{
+		Time:        p.Time,
+		Memory:      p.Memory,
+		Parallelism: p.Parallelism,
+		KeyLength:   p.KeyLength,
+	}
 }
 
 // Verify re-derives the hash from plaintext + envelope.Salt + pepper
@@ -115,7 +136,7 @@ func (a Argon2id) Verify(plaintext, pepper []byte, envelope Envelope, wantParams
 	if envelope.KDF != KDFArgon2id {
 		return fmt.Errorf("%w: envelope KDF %q, verifier %q", ErrKDFMismatch, envelope.KDF, KDFArgon2id)
 	}
-	if !paramsEqual(envelope.KDFParams, wantParams) {
+	if !argon2idParamsEqual(envelope.KDFParams, wantParams) {
 		return ErrParamMismatch
 	}
 	if err := validateInputs(plaintext, envelope.Salt, pepper); err != nil {

--- a/internal/secretinjector/crypto/argon2id.go
+++ b/internal/secretinjector/crypto/argon2id.go
@@ -100,14 +100,23 @@ func (a Argon2id) Hash(plaintext, salt, pepper []byte, pepperVersion string, par
 // Verify re-derives the hash from plaintext + envelope.Salt + pepper
 // under envelope.KDFParams and compares to envelope.Hash in constant
 // time. Verify rejects a KDF-identifier mismatch, a schema-version
-// mismatch, and a [Params] drift before touching the primitive — the
-// goal is that a silent parameter bump is impossible to verify against.
-func (a Argon2id) Verify(plaintext, pepper []byte, envelope Envelope) error {
+// mismatch, and a [Params] drift (envelope.KDFParams != wantParams)
+// before touching the primitive — the goal is that a silent parameter
+// bump is impossible to verify against from the pluggable seam alone.
+//
+// To re-hash an envelope that was stored under old parameters during a
+// cost-bump migration, the caller invokes [Argon2id.Hash] with the new
+// Params and writes the new envelope verbatim to v1.Secret.data["hash"].
+// Verify never silently accepts drift.
+func (a Argon2id) Verify(plaintext, pepper []byte, envelope Envelope, wantParams Params) error {
 	if envelope.SchemaVersion != EnvelopeSchemaVersion {
 		return fmt.Errorf("%w: got %d, want %d", ErrUnknownSchemaVersion, envelope.SchemaVersion, EnvelopeSchemaVersion)
 	}
 	if envelope.KDF != KDFArgon2id {
 		return fmt.Errorf("%w: envelope KDF %q, verifier %q", ErrKDFMismatch, envelope.KDF, KDFArgon2id)
+	}
+	if !paramsEqual(envelope.KDFParams, wantParams) {
+		return ErrParamMismatch
 	}
 	if err := validateInputs(plaintext, envelope.Salt, pepper); err != nil {
 		return err
@@ -129,18 +138,6 @@ func (a Argon2id) Verify(plaintext, pepper []byte, envelope Envelope) error {
 		return ErrHashMismatch
 	}
 	return nil
-}
-
-// VerifyWithParams is the strict verification entry point the reconciler
-// uses when it has a caller-expected [Params] and wants to refuse to
-// verify against an envelope whose stored params drifted. The helper
-// compares [Envelope.KDFParams] to want before delegating to
-// [Argon2id.Verify] so a silent parameter change cannot pass.
-func (a Argon2id) VerifyWithParams(plaintext, pepper []byte, envelope Envelope, want Params) error {
-	if !paramsEqual(envelope.KDFParams, want) {
-		return fmt.Errorf("%w", ErrParamMismatch)
-	}
-	return a.Verify(plaintext, pepper, envelope)
 }
 
 // validateArgon2idParams rejects params the argon2id primitive cannot

--- a/internal/secretinjector/crypto/default_nofips.go
+++ b/internal/secretinjector/crypto/default_nofips.go
@@ -1,0 +1,31 @@
+//go:build !fips
+
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+// Default returns the non-FIPS default [KDF] used by every reconciler in a
+// default build. The return type is the interface so a caller cannot
+// accidentally rely on a concrete type that changes when the -fips build
+// variant swaps the binding. This file is excluded from -fips builds by
+// the !fips build tag above; the -fips override lives under the fips tag
+// in pbkdf2.go so an -fips build that forgets to land the override fails
+// loudly at link time on a missing Default symbol rather than silently
+// reverting to argon2id.
+func Default() KDF {
+	return Argon2id{}
+}

--- a/internal/secretinjector/crypto/default_nofips_test.go
+++ b/internal/secretinjector/crypto/default_nofips_test.go
@@ -1,0 +1,40 @@
+//go:build !fips
+
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestDefaultBindsArgon2id pins the package-level [Default] contract: the
+// non-FIPS build wires the argon2id implementation, not any future
+// primitive. This test lives under the !fips tag (matching
+// default_nofips.go) so the -fips build variant's own test of its own
+// [Default] binding does not collide here.
+func TestDefaultBindsArgon2id(t *testing.T) {
+	k := Default()
+	if k.ID() != KDFArgon2id {
+		t.Fatalf("Default().ID() = %q, want %q", k.ID(), KDFArgon2id)
+	}
+	if diff := cmp.Diff(Argon2idDefault, k.DefaultParams()); diff != "" {
+		t.Fatalf("Default().DefaultParams() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/secretinjector/crypto/doc.go
+++ b/internal/secretinjector/crypto/doc.go
@@ -25,12 +25,21 @@ limitations under the License.
 //
 // [KDF] is a small interface with two methods: [KDF.Hash] derives an
 // encoded-hash [Envelope] from (plaintext, salt, pepper, params), and
-// [KDF.Verify] checks an envelope against a candidate plaintext in constant
-// time. The default non-FIPS build binds [Argon2id] via [Default] and is the
-// only implementation M2 ships. A future -fips build variant will bind a
-// PBKDF2-HMAC-SHA512 implementation into pbkdf2.go without touching
-// reconciler code — reconcilers depend on the interface, not the concrete
-// type.
+// [KDF.Verify] checks an envelope against a candidate plaintext under
+// caller-supplied wantParams in constant time. The default non-FIPS
+// build binds [Argon2id] via [Default] (defined in default_nofips.go
+// behind the !fips build tag) and is the only implementation M2 ships.
+// A future -fips build variant will bind a PBKDF2-HMAC-SHA512
+// implementation into pbkdf2.go and supply its own [Default] under the
+// fips tag — reconcilers depend on the interface, not the concrete type.
+// An -fips build that forgets to land the override fails at link time on
+// the missing [Default] symbol rather than silently reverting to argon2id.
+//
+// [KDF.Verify] enforces parameter-drift rejection on the interface path
+// itself: if envelope.KDFParams differ from wantParams, Verify returns
+// [ErrParamMismatch] before touching the primitive. Drift is never
+// silently accepted — migrating a cost bump requires an explicit re-hash
+// via [KDF.Hash] with the new Params.
 //
 // # Pepper discipline
 //

--- a/internal/secretinjector/crypto/doc.go
+++ b/internal/secretinjector/crypto/doc.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package crypto hosts the pluggable key-derivation function (KDF) seam used
+// by the holos-secret-injector control plane to turn a plaintext credential
+// plus salt plus pepper into an encoded-hash envelope the Credential
+// reconciler (HOL-751) writes to the data["hash"] key of a sibling
+// v1.Secret. See docs/adrs/031-secret-injection-service.md §3 for the
+// architecture.
+//
+// # Pluggability contract
+//
+// [KDF] is a small interface with two methods: [KDF.Hash] derives an
+// encoded-hash [Envelope] from (plaintext, salt, pepper, params), and
+// [KDF.Verify] checks an envelope against a candidate plaintext in constant
+// time. The default non-FIPS build binds [Argon2id] via [Default] and is the
+// only implementation M2 ships. A future -fips build variant will bind a
+// PBKDF2-HMAC-SHA512 implementation into pbkdf2.go without touching
+// reconciler code — reconcilers depend on the interface, not the concrete
+// type.
+//
+// # Pepper discipline
+//
+// Pepper is passed in by the caller on every Hash / Verify call. This
+// package MUST NOT read the pepper from a file, a ConfigMap, a Secret, an
+// environment variable, or any other side channel — that is the pepper
+// bootstrap reconciler's job (HOL-749). Callers that pass a nil-or-empty
+// pepper receive [ErrNilPepper]; the KDF refuses to operate without one so a
+// forgotten pepper lookup is loud rather than silent.
+//
+// # Logging invariants
+//
+// Implementations in this package MUST NOT log plaintext, the pepper, the
+// salt, or the derived hash, not even at debug verbosity. Error messages
+// MUST NOT embed any of the four. [Envelope] is marshal-only: it does not
+// implement [fmt.Stringer] or [fmt.GoStringer], so a stray %v / %+v print
+// cannot smuggle the bytes into an operator log. The encoded envelope
+// bytes live exclusively on the wire between [KDF.Hash] and the sibling
+// v1.Secret — no CR, no event, no log.
+//
+// # Envelope versioning
+//
+// [Envelope] carries an integer [Envelope.SchemaVersion] so a future KDF row
+// (for example, an argon2id v2 default or a PBKDF2-HMAC-SHA512 fallback row)
+// can be read unambiguously by an older binary. M2 ships
+// [EnvelopeSchemaVersion] = 1; bump it in the same commit that introduces a
+// new on-wire shape and extend the decoder to tolerate both.
+package crypto

--- a/internal/secretinjector/crypto/kdf.go
+++ b/internal/secretinjector/crypto/kdf.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// KDFID identifies a key-derivation algorithm by a stable string. The
+// string travels on the wire inside [Envelope.KDF] so a verifier can route
+// to the matching implementation years after the bytes were written. Values
+// MUST be lowercase ASCII so case differences cannot split a single
+// algorithm into two routing buckets.
+type KDFID string
+
+const (
+	// KDFArgon2id identifies the default argon2id binding from argon2id.go.
+	KDFArgon2id KDFID = "argon2id"
+	// KDFPBKDF2HMACSHA512 identifies the -fips build variant's PBKDF2
+	// binding that will land under pbkdf2.go. The placeholder file keeps
+	// the constant reserved so verifier tables can route on the string
+	// before the primitive ships.
+	KDFPBKDF2HMACSHA512 KDFID = "pbkdf2-hmac-sha512"
+)
+
+// EnvelopeSchemaVersion is the on-wire schema version that every Envelope
+// written by this package stamps into [Envelope.SchemaVersion]. Bump this
+// constant in the same commit that introduces a new on-wire shape and
+// extend the decoder to tolerate both versions. M2 ships version 1.
+const EnvelopeSchemaVersion = 1
+
+// Params pins the KDF cost parameters for a single Hash / Verify call. The
+// fields are a superset across every KDF implementation this package hosts
+// so a single [Params] value can be plumbed through the reconciler and
+// dispatched to any [KDF] without type-switching. Each implementation
+// documents which fields it reads and validates the rest away as ignored.
+//
+// The field set is deliberately flat and JSON-round-trippable: [Envelope]
+// stores the effective [Params] so a verifier reconstructs the exact
+// settings used to derive the hash without consulting a side channel.
+type Params struct {
+	// Time is the argon2id pass count (RFC 9106 §4 `t`). Ignored by
+	// PBKDF2-HMAC-SHA512.
+	Time uint32 `json:"time,omitempty"`
+	// Memory is the argon2id memory cost in KiB (RFC 9106 §4 `m`). Ignored
+	// by PBKDF2-HMAC-SHA512.
+	Memory uint32 `json:"memory,omitempty"`
+	// Parallelism is the argon2id lane count (RFC 9106 §4 `p`). Ignored
+	// by PBKDF2-HMAC-SHA512.
+	Parallelism uint8 `json:"parallelism,omitempty"`
+	// KeyLength is the derived-hash length in bytes. All bindings honor
+	// this field. argon2id's RFC 9106 recommendation is 32.
+	KeyLength uint32 `json:"keyLength,omitempty"`
+	// Iterations is the PBKDF2 iteration count. Ignored by argon2id. The
+	// field is present so an -fips binary's PBKDF2 binding can use the
+	// same [Params] struct.
+	Iterations uint32 `json:"iterations,omitempty"`
+}
+
+// Envelope is the self-describing record the Credential reconciler (HOL-751)
+// will write verbatim to the data["hash"] key of a sibling v1.Secret. The
+// shape is deliberately marshal-only: Envelope has no String method, no
+// GoString method, and no logging helpers so a stray %v can never leak the
+// hash bytes into an operator log. The envelope is the ONLY legitimate
+// carrier of hash material out of this package — callers that reach into
+// the fields directly are violating the contract.
+//
+// The struct ships a [Envelope.SchemaVersion] so a future KDF row can be
+// read unambiguously by an older verifier: the decoder rejects an unknown
+// schema version rather than silently mis-parsing a v2 envelope as v1.
+type Envelope struct {
+	// SchemaVersion pins the on-wire shape. Always equal to
+	// [EnvelopeSchemaVersion] when written by this package.
+	SchemaVersion int `json:"schemaVersion"`
+	// KDF identifies the algorithm that derived [Envelope.Hash]. The
+	// verifier routes on this field.
+	KDF KDFID `json:"kdf"`
+	// KDFParams are the cost parameters used to derive [Envelope.Hash].
+	// Verify MUST compare these against the caller-supplied [Params] and
+	// refuse to verify on drift — a silent parameter change would be a
+	// security regression.
+	KDFParams Params `json:"kdfParams"`
+	// PepperVersion identifies the pepper row used to derive
+	// [Envelope.Hash]. The Credential reconciler uses this to route to
+	// the matching pepper bytes when multiple pepper versions coexist
+	// during a rotation (HOL-749).
+	PepperVersion string `json:"pepperVersion"`
+	// Salt is the per-credential random salt. The verifier feeds it back
+	// into the KDF on Verify.
+	Salt []byte `json:"salt"`
+	// Hash is the derived-hash output. Compared in constant time on
+	// Verify via [CompareHash].
+	Hash []byte `json:"hash"`
+}
+
+// KDF is the pluggability seam. The default non-FIPS build binds
+// [Argon2id]; the -fips build variant will bind a PBKDF2-HMAC-SHA512
+// implementation under pbkdf2.go. Reconcilers depend on the interface only.
+//
+// Implementations MUST:
+//
+//   - Refuse to operate when plaintext, salt, or pepper is nil or empty
+//     (see [ErrEmptyPlaintext], [ErrEmptySalt], [ErrNilPepper]). The KDF
+//     refuses rather than defaulting so a forgotten pepper lookup fails
+//     loudly.
+//   - Stamp [Envelope.KDFParams] with the effective parameters used so a
+//     later Verify can reject parameter drift via [ErrParamMismatch].
+//   - Compare hashes in constant time on Verify (see [CompareHash]) to
+//     deny timing side channels.
+//   - Never log plaintext, pepper, salt, or hash bytes — not even at
+//     debug verbosity. Error messages MUST NOT embed any of the four.
+type KDF interface {
+	// ID returns the stable algorithm identifier this KDF writes into
+	// [Envelope.KDF]. Verifiers route on the identifier.
+	ID() KDFID
+
+	// DefaultParams returns the pinned cost parameters this KDF uses
+	// when the caller does not override. Pinned values are documented on
+	// the concrete implementation (for argon2id, see [Argon2idDefault]).
+	DefaultParams() Params
+
+	// Hash derives an encoded-hash [Envelope] from plaintext + salt +
+	// pepper under params. pepperVersion is stamped verbatim onto
+	// [Envelope.PepperVersion] so Verify can route to the matching
+	// pepper bytes on future calls.
+	Hash(plaintext, salt, pepper []byte, pepperVersion string, params Params) (Envelope, error)
+
+	// Verify checks that plaintext + salt + pepper under params derives
+	// the hash bytes in envelope. Verify returns nil on match,
+	// [ErrHashMismatch] on a constant-time mismatch, or one of the
+	// validation errors when the inputs are unusable.
+	Verify(plaintext, pepper []byte, envelope Envelope) error
+}
+
+// Default returns the non-FIPS default KDF used by every reconciler. The
+// return type is the interface so a caller cannot accidentally rely on a
+// concrete type that changes when the -fips build variant swaps the
+// binding. A -fips build override lands alongside the PBKDF2 primitive in
+// pbkdf2.go.
+func Default() KDF {
+	return Argon2id{}
+}
+
+// Errors returned by this package. They are sentinel values so callers can
+// match with [errors.Is] without string parsing.
+var (
+	// ErrNilPepper is returned when a KDF is invoked with a nil or empty
+	// pepper. The KDF refuses to fall back to an unpeppered hash so a
+	// missing pepper bootstrap is loud rather than silent.
+	ErrNilPepper = errors.New("crypto: pepper must be non-empty")
+	// ErrEmptyPlaintext is returned when a KDF is invoked with a nil or
+	// empty plaintext.
+	ErrEmptyPlaintext = errors.New("crypto: plaintext must be non-empty")
+	// ErrEmptySalt is returned when a KDF is invoked with a nil or empty
+	// salt.
+	ErrEmptySalt = errors.New("crypto: salt must be non-empty")
+	// ErrEmptyPepperVersion is returned by Hash when the caller does not
+	// supply a pepper version string. A pepper version is required so a
+	// verifier can route to the right pepper bytes after rotation.
+	ErrEmptyPepperVersion = errors.New("crypto: pepper version must be non-empty")
+	// ErrKDFMismatch is returned by Verify when the envelope's KDF
+	// identifier does not match the receiver's [KDF.ID].
+	ErrKDFMismatch = errors.New("crypto: envelope KDF does not match verifier")
+	// ErrParamMismatch is returned by Verify when the envelope's stored
+	// [Params] differ from the caller-supplied [Params]. A silent
+	// parameter change would be a security regression; the KDF refuses
+	// to verify on drift.
+	ErrParamMismatch = errors.New("crypto: envelope params differ from verifier params")
+	// ErrUnknownSchemaVersion is returned by Verify when the envelope's
+	// [Envelope.SchemaVersion] is not recognized. A future schema row
+	// extends the decoder in lock-step with the producer.
+	ErrUnknownSchemaVersion = errors.New("crypto: envelope schema version is not recognized")
+	// ErrHashMismatch is returned by Verify on a constant-time hash
+	// mismatch. The error does NOT embed the hash bytes.
+	ErrHashMismatch = errors.New("crypto: hash mismatch")
+	// ErrInvalidParams is returned by Hash / Verify when a [Params] field
+	// that the concrete KDF relies on is zero or otherwise nonsensical.
+	ErrInvalidParams = errors.New("crypto: invalid params for KDF")
+)
+
+// CompareHash reports whether a and b are equal in time that does not
+// depend on their contents. Callers use the helper to avoid a timing side
+// channel where a byte-wise short-circuit comparator leaks hash prefix
+// length through wall-clock time.
+//
+// The function is a thin wrapper around [subtle.ConstantTimeCompare] so
+// the intent is legible at the call site and the package under review
+// does not have a free-floating import of crypto/subtle scattered across
+// files. When lengths differ, CompareHash returns false in constant time
+// relative to min(len(a), len(b)).
+func CompareHash(a, b []byte) bool {
+	return subtle.ConstantTimeCompare(a, b) == 1
+}
+
+// MarshalEnvelope serializes e into the canonical JSON shape the
+// Credential reconciler writes to v1.Secret.data["hash"]. The output is
+// deterministic for a given envelope because [json.Marshal] iterates
+// struct fields in declaration order and byte slices encode as base64.
+// Callers MUST feed the returned bytes verbatim to v1.Secret; mutating
+// the bytes breaks Verify.
+func MarshalEnvelope(e Envelope) ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// UnmarshalEnvelope is the inverse of [MarshalEnvelope]. The decoder
+// rejects an envelope whose schema version is outside the set of versions
+// this binary understands, so a future envelope shape does not silently
+// parse as a v1 record.
+func UnmarshalEnvelope(data []byte, e *Envelope) error {
+	if e == nil {
+		return fmt.Errorf("crypto: UnmarshalEnvelope destination is nil")
+	}
+	if err := json.Unmarshal(data, e); err != nil {
+		return fmt.Errorf("crypto: unmarshal envelope: %w", err)
+	}
+	if e.SchemaVersion != EnvelopeSchemaVersion {
+		return fmt.Errorf("%w: got %d, want %d", ErrUnknownSchemaVersion, e.SchemaVersion, EnvelopeSchemaVersion)
+	}
+	return nil
+}
+
+// paramsEqual reports whether two [Params] values are equal across every
+// field the verifier cares about. Used by concrete KDF Verify
+// implementations to flag parameter drift before attempting a compare.
+// The helper lives here rather than on [Params] so the equality check is
+// owned by the package that defines the sentinel errors.
+func paramsEqual(a, b Params) bool {
+	return a.Time == b.Time &&
+		a.Memory == b.Memory &&
+		a.Parallelism == b.Parallelism &&
+		a.KeyLength == b.KeyLength &&
+		a.Iterations == b.Iterations
+}
+
+// validateInputs enforces the non-empty-input invariants shared by every
+// KDF binding. Concrete implementations call this before invoking the
+// primitive so a missing pepper fails loudly instead of deriving an
+// unpeppered hash.
+func validateInputs(plaintext, salt, pepper []byte) error {
+	if len(plaintext) == 0 {
+		return ErrEmptyPlaintext
+	}
+	if len(salt) == 0 {
+		return ErrEmptySalt
+	}
+	if len(pepper) == 0 {
+		return ErrNilPepper
+	}
+	return nil
+}

--- a/internal/secretinjector/crypto/kdf.go
+++ b/internal/secretinjector/crypto/kdf.go
@@ -111,8 +111,9 @@ type Envelope struct {
 }
 
 // KDF is the pluggability seam. The default non-FIPS build binds
-// [Argon2id]; the -fips build variant will bind a PBKDF2-HMAC-SHA512
-// implementation under pbkdf2.go. Reconcilers depend on the interface only.
+// [Argon2id] via [Default]; the -fips build variant will bind a
+// PBKDF2-HMAC-SHA512 implementation by swapping [Default] in a
+// build-tagged file. Reconcilers depend on the interface only.
 //
 // Implementations MUST:
 //
@@ -120,8 +121,13 @@ type Envelope struct {
 //     (see [ErrEmptyPlaintext], [ErrEmptySalt], [ErrNilPepper]). The KDF
 //     refuses rather than defaulting so a forgotten pepper lookup fails
 //     loudly.
-//   - Stamp [Envelope.KDFParams] with the effective parameters used so a
-//     later Verify can reject parameter drift via [ErrParamMismatch].
+//   - Stamp [Envelope.KDFParams] with the effective parameters used so
+//     the caller can observe what cost they paid, and so Verify can
+//     reject parameter drift via [ErrParamMismatch].
+//   - Reject a Verify call whose caller-supplied wantParams differ from
+//     [Envelope.KDFParams], before touching the primitive. A silent
+//     parameter bump would be a security regression; the interface
+//     denies this path.
 //   - Compare hashes in constant time on Verify (see [CompareHash]) to
 //     deny timing side channels.
 //   - Never log plaintext, pepper, salt, or hash bytes — not even at
@@ -142,20 +148,19 @@ type KDF interface {
 	// pepper bytes on future calls.
 	Hash(plaintext, salt, pepper []byte, pepperVersion string, params Params) (Envelope, error)
 
-	// Verify checks that plaintext + salt + pepper under params derives
-	// the hash bytes in envelope. Verify returns nil on match,
-	// [ErrHashMismatch] on a constant-time mismatch, or one of the
-	// validation errors when the inputs are unusable.
-	Verify(plaintext, pepper []byte, envelope Envelope) error
-}
-
-// Default returns the non-FIPS default KDF used by every reconciler. The
-// return type is the interface so a caller cannot accidentally rely on a
-// concrete type that changes when the -fips build variant swaps the
-// binding. A -fips build override lands alongside the PBKDF2 primitive in
-// pbkdf2.go.
-func Default() KDF {
-	return Argon2id{}
+	// Verify checks that plaintext + envelope.Salt + pepper derives
+	// envelope.Hash under wantParams. The method MUST reject an
+	// envelope whose [Envelope.KDFParams] differ from wantParams with
+	// [ErrParamMismatch] before touching the primitive: drift rejection
+	// is part of the interface contract, not a concrete-only extra. To
+	// re-hash an old-parameter envelope during a migration, a caller
+	// invokes Hash with the new params and writes the new envelope;
+	// Verify is never permissive about cost.
+	//
+	// Returns nil on match, [ErrHashMismatch] on a constant-time
+	// mismatch, or one of the validation errors when the inputs are
+	// unusable.
+	Verify(plaintext, pepper []byte, envelope Envelope, wantParams Params) error
 }
 
 // Errors returned by this package. They are sentinel values so callers can

--- a/internal/secretinjector/crypto/kdf.go
+++ b/internal/secretinjector/crypto/kdf.go
@@ -241,17 +241,20 @@ func UnmarshalEnvelope(data []byte, e *Envelope) error {
 	return nil
 }
 
-// paramsEqual reports whether two [Params] values are equal across every
-// field the verifier cares about. Used by concrete KDF Verify
-// implementations to flag parameter drift before attempting a compare.
-// The helper lives here rather than on [Params] so the equality check is
-// owned by the package that defines the sentinel errors.
-func paramsEqual(a, b Params) bool {
+// argon2idParamsEqual reports whether two [Params] values agree on every
+// field argon2id actually feeds into [argon2.IDKey] — Time, Memory,
+// Parallelism, KeyLength. The PBKDF2-only Iterations field is
+// deliberately excluded because argon2id does not consume it; including
+// it would fail a verify whenever a caller changed an unrelated field
+// (for example, after a migration to a binary with a different default
+// Iterations value). Each KDF owns its own equality check so a future
+// row (PBKDF2 under the -fips tag) can pick its own set of significant
+// fields without cross-field coupling.
+func argon2idParamsEqual(a, b Params) bool {
 	return a.Time == b.Time &&
 		a.Memory == b.Memory &&
 		a.Parallelism == b.Parallelism &&
-		a.KeyLength == b.KeyLength &&
-		a.Iterations == b.Iterations
+		a.KeyLength == b.KeyLength
 }
 
 // validateInputs enforces the non-empty-input invariants shared by every

--- a/internal/secretinjector/crypto/kdf_test.go
+++ b/internal/secretinjector/crypto/kdf_test.go
@@ -92,15 +92,15 @@ func TestArgon2idHashDeterministic(t *testing.T) {
 }
 
 // TestArgon2idRoundTrip covers the contract the Credential reconciler
-// relies on: Hash → Verify returns nil, the envelope round-trips through
-// JSON, and a re-hash with identical inputs produces identical bytes.
+// relies on: Hash → Verify returns nil under matching wantParams, and a
+// re-hash with identical inputs produces identical bytes.
 func TestArgon2idRoundTrip(t *testing.T) {
 	k := Argon2id{}
 	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
 	if err != nil {
 		t.Fatalf("Hash: %v", err)
 	}
-	if err := k.Verify(fixturePlaintext, fixturePepper, env); err != nil {
+	if err := k.Verify(fixturePlaintext, fixturePepper, env, Argon2idDefault); err != nil {
 		t.Fatalf("Verify against matching plaintext: unexpected error %v", err)
 	}
 	// Re-hashing with identical inputs produces identical bytes (argon2id
@@ -125,7 +125,7 @@ func TestArgon2idVerifyRejectsWrongPlaintext(t *testing.T) {
 	}
 	wrong := append([]byte{}, fixturePlaintext...)
 	wrong[0] ^= 0x01
-	err = k.Verify(wrong, fixturePepper, env)
+	err = k.Verify(wrong, fixturePepper, env, Argon2idDefault)
 	if !errors.Is(err, ErrHashMismatch) {
 		t.Fatalf("Verify(wrong plaintext): got %v, want ErrHashMismatch", err)
 	}
@@ -143,7 +143,7 @@ func TestArgon2idVerifyRejectsWrongPepper(t *testing.T) {
 	}
 	wrongPepper := append([]byte{}, fixturePepper...)
 	wrongPepper[0] ^= 0x01
-	err = k.Verify(fixturePlaintext, wrongPepper, env)
+	err = k.Verify(fixturePlaintext, wrongPepper, env, Argon2idDefault)
 	if !errors.Is(err, ErrHashMismatch) {
 		t.Fatalf("Verify(wrong pepper): got %v, want ErrHashMismatch", err)
 	}
@@ -167,7 +167,7 @@ func TestArgon2idNilPepperRejection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Hash (setup): %v", err)
 	}
-	if err := k.Verify(fixturePlaintext, nil, env); !errors.Is(err, ErrNilPepper) {
+	if err := k.Verify(fixturePlaintext, nil, env, Argon2idDefault); !errors.Is(err, ErrNilPepper) {
 		t.Errorf("Verify(nil pepper): got %v, want ErrNilPepper", err)
 	}
 }
@@ -231,9 +231,9 @@ func TestArgon2idParamsValidation(t *testing.T) {
 // TestArgon2idParamDriftRejection is the security-critical case cited in
 // the HOL-748 acceptance criteria: a hash encoded at time=2 must NOT
 // verify under a verifier that insists on time=3 (or any other mutated
-// field). The Verify helper alone is permissive because it reads the
-// params back out of the envelope, so the ticket specifically wants the
-// strict variant to reject drift.
+// field). Drift rejection is part of the [KDF.Verify] contract on the
+// interface itself, so the reconciler's pluggable-seam call site cannot
+// silently accept a parameter bump.
 func TestArgon2idParamDriftRejection(t *testing.T) {
 	k := Argon2id{}
 	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
@@ -263,11 +263,29 @@ func TestArgon2idParamDriftRejection(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := k.VerifyWithParams(fixturePlaintext, fixturePepper, env, tc.want)
+			err := k.Verify(fixturePlaintext, fixturePepper, env, tc.want)
 			if !errors.Is(err, ErrParamMismatch) {
-				t.Fatalf("VerifyWithParams: got %v, want ErrParamMismatch", err)
+				t.Fatalf("Verify: got %v, want ErrParamMismatch", err)
 			}
 		})
+	}
+}
+
+// TestArgon2idParamDriftRejectionViaInterface is the reviewer-requested
+// cousin: the reconciler's call site only has a [KDF] interface, so drift
+// rejection must be reachable without a concrete-type assertion. This
+// test holds Verify through the interface and confirms ErrParamMismatch
+// still surfaces.
+func TestArgon2idParamDriftRejectionViaInterface(t *testing.T) {
+	var kdf KDF = Argon2id{}
+	env, err := kdf.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash (via interface): %v", err)
+	}
+	bumped := Argon2idDefault
+	bumped.Time++
+	if err := kdf.Verify(fixturePlaintext, fixturePepper, env, bumped); !errors.Is(err, ErrParamMismatch) {
+		t.Fatalf("Verify via KDF interface: got %v, want ErrParamMismatch", err)
 	}
 }
 
@@ -284,7 +302,7 @@ func TestArgon2idVerifyRejectsForeignKDF(t *testing.T) {
 		Salt:          fixtureSalt,
 		Hash:          bytes.Repeat([]byte{0}, int(Argon2idDefault.KeyLength)),
 	}
-	err := Argon2id{}.Verify(fixturePlaintext, fixturePepper, env)
+	err := Argon2id{}.Verify(fixturePlaintext, fixturePepper, env, Argon2idDefault)
 	if !errors.Is(err, ErrKDFMismatch) {
 		t.Fatalf("Verify(foreign KDF): got %v, want ErrKDFMismatch", err)
 	}
@@ -299,7 +317,7 @@ func TestArgon2idVerifyRejectsUnknownSchemaVersion(t *testing.T) {
 		t.Fatalf("Hash: %v", err)
 	}
 	env.SchemaVersion = EnvelopeSchemaVersion + 1
-	err = Argon2id{}.Verify(fixturePlaintext, fixturePepper, env)
+	err = Argon2id{}.Verify(fixturePlaintext, fixturePepper, env, Argon2idDefault)
 	if !errors.Is(err, ErrUnknownSchemaVersion) {
 		t.Fatalf("Verify(unknown schema): got %v, want ErrUnknownSchemaVersion", err)
 	}
@@ -326,7 +344,7 @@ func TestEnvelopeJSONRoundTrip(t *testing.T) {
 	}
 	// The round-tripped envelope must still verify.
 	k := Argon2id{}
-	if err := k.Verify(fixturePlaintext, fixturePepper, decoded); err != nil {
+	if err := k.Verify(fixturePlaintext, fixturePepper, decoded, Argon2idDefault); err != nil {
 		t.Fatalf("Verify(round-tripped envelope): unexpected error %v", err)
 	}
 }
@@ -406,7 +424,8 @@ func TestCompareHashConstantTimeSemantics(t *testing.T) {
 // TestDefaultBindsArgon2id pins the package-level [Default] contract: the
 // non-FIPS build wires the argon2id implementation, not any future
 // primitive. The -fips build variant overrides this in its own
-// build-tagged file.
+// build-tagged file, so this test lives under the implicit !fips tag
+// (default_nofips.go).
 func TestDefaultBindsArgon2id(t *testing.T) {
 	k := Default()
 	if k.ID() != KDFArgon2id {
@@ -444,7 +463,7 @@ func TestHashDoesNotAliasCallerSalt(t *testing.T) {
 	}
 	// Verify still works because the envelope has its own salt copy.
 	k := Argon2id{}
-	if err := k.Verify(fixturePlaintext, fixturePepper, env); err != nil {
+	if err := k.Verify(fixturePlaintext, fixturePepper, env, Argon2idDefault); err != nil {
 		t.Fatalf("Verify after caller salt mutation: unexpected error %v", err)
 	}
 }

--- a/internal/secretinjector/crypto/kdf_test.go
+++ b/internal/secretinjector/crypto/kdf_test.go
@@ -289,6 +289,41 @@ func TestArgon2idParamDriftRejectionViaInterface(t *testing.T) {
 	}
 }
 
+// TestArgon2idIgnoresPBKDF2OnlyIterationsField pins the contract that
+// argon2id compares only the four argon2id-relevant fields (Time,
+// Memory, Parallelism, KeyLength) on Verify. A caller that passes a
+// non-zero [Params.Iterations] (meaningless to argon2id; owned by the
+// future PBKDF2 binding) must not cause Verify to fail — the envelope
+// normalizes it to zero on Hash, and the drift check ignores it on
+// Verify. A regression here would surface as spurious login failures
+// after a cross-binary migration.
+func TestArgon2idIgnoresPBKDF2OnlyIterationsField(t *testing.T) {
+	k := Argon2id{}
+	paramsWithIterations := Argon2idDefault
+	paramsWithIterations.Iterations = 600_000 // PBKDF2-style value the caller fat-fingered in
+	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, paramsWithIterations)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	// Envelope must have normalized Iterations to zero so the
+	// on-disk record is a faithful description of the argon2id cost
+	// actually paid.
+	if env.KDFParams.Iterations != 0 {
+		t.Errorf("envelope KDFParams.Iterations = %d, want 0 (normalized)", env.KDFParams.Iterations)
+	}
+	// Verify under the original params (with the ignored Iterations
+	// field) must succeed — argon2id does not feed Iterations into
+	// argon2.IDKey, so drift on that field is not drift.
+	if err := k.Verify(fixturePlaintext, fixturePepper, env, paramsWithIterations); err != nil {
+		t.Errorf("Verify with PBKDF2-only Iterations field: got %v, want nil", err)
+	}
+	// Verify under the normalized want (Iterations=0) must also
+	// succeed — both shapes are valid inputs for the argon2id path.
+	if err := k.Verify(fixturePlaintext, fixturePepper, env, Argon2idDefault); err != nil {
+		t.Errorf("Verify with normalized params: got %v, want nil", err)
+	}
+}
+
 // TestArgon2idVerifyRejectsForeignKDF covers the routing table: an
 // envelope produced by some future KDF must not be silently verified by
 // the argon2id binding. We forge an envelope with a mismatching KDF
@@ -418,21 +453,6 @@ func TestCompareHashConstantTimeSemantics(t *testing.T) {
 				t.Fatalf("CompareHash(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
 			}
 		})
-	}
-}
-
-// TestDefaultBindsArgon2id pins the package-level [Default] contract: the
-// non-FIPS build wires the argon2id implementation, not any future
-// primitive. The -fips build variant overrides this in its own
-// build-tagged file, so this test lives under the implicit !fips tag
-// (default_nofips.go).
-func TestDefaultBindsArgon2id(t *testing.T) {
-	k := Default()
-	if k.ID() != KDFArgon2id {
-		t.Fatalf("Default().ID() = %q, want %q", k.ID(), KDFArgon2id)
-	}
-	if diff := cmp.Diff(Argon2idDefault, k.DefaultParams()); diff != "" {
-		t.Fatalf("Default().DefaultParams() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/secretinjector/crypto/kdf_test.go
+++ b/internal/secretinjector/crypto/kdf_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/crypto/argon2"
+)
+
+// These fixtures are deterministic so a silent argon2id parameter change
+// or a silent pepper concatenation change surfaces as a diff in the
+// expected-hash fixture below. Do not regenerate them lightly; a change
+// here means every previously-written hash in a running cluster stops
+// verifying.
+var (
+	fixturePlaintext     = []byte("correct horse battery staple")
+	fixtureSalt          = []byte("fixed-16-byte-slt")
+	fixturePepper        = []byte("pepper-bytes-v1-abcdef0123456789")
+	fixturePepperVersion = "v1"
+)
+
+// fixtureExpectedHash re-derives the expected bytes with argon2.IDKey
+// under [Argon2idDefault] so the test below fails loudly if either
+//
+//  1. [Argon2id.Hash] changes how it stitches plaintext + pepper, or
+//  2. [Argon2idDefault] is silently bumped.
+//
+// The helper lives in the test file so production code cannot use it by
+// accident; reaching argon2.IDKey directly from a reconciler would bypass
+// the [KDF] seam.
+func fixtureExpectedHash(t *testing.T) []byte {
+	t.Helper()
+	peppered := append([]byte{}, fixturePlaintext...)
+	peppered = append(peppered, fixturePepper...)
+	return argon2.IDKey(
+		peppered,
+		fixtureSalt,
+		Argon2idDefault.Time,
+		Argon2idDefault.Memory,
+		Argon2idDefault.Parallelism,
+		Argon2idDefault.KeyLength,
+	)
+}
+
+// TestArgon2idHashDeterministic pins the hash output under the default
+// parameters. A parameter bump or a code path that silently stops
+// including the pepper would move the bytes and fail this test.
+func TestArgon2idHashDeterministic(t *testing.T) {
+	want := fixtureExpectedHash(t)
+	env, err := Argon2id{}.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: unexpected error: %v", err)
+	}
+	if env.SchemaVersion != EnvelopeSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", env.SchemaVersion, EnvelopeSchemaVersion)
+	}
+	if env.KDF != KDFArgon2id {
+		t.Errorf("KDF = %q, want %q", env.KDF, KDFArgon2id)
+	}
+	if env.PepperVersion != fixturePepperVersion {
+		t.Errorf("PepperVersion = %q, want %q", env.PepperVersion, fixturePepperVersion)
+	}
+	if diff := cmp.Diff(Argon2idDefault, env.KDFParams); diff != "" {
+		t.Errorf("KDFParams mismatch (-want +got):\n%s", diff)
+	}
+	if !bytes.Equal(env.Salt, fixtureSalt) {
+		t.Errorf("Salt mismatch: got %x, want %x", env.Salt, fixtureSalt)
+	}
+	if !bytes.Equal(env.Hash, want) {
+		t.Errorf("Hash mismatch:\n got  %s\n want %s", hex.EncodeToString(env.Hash), hex.EncodeToString(want))
+	}
+}
+
+// TestArgon2idRoundTrip covers the contract the Credential reconciler
+// relies on: Hash → Verify returns nil, the envelope round-trips through
+// JSON, and a re-hash with identical inputs produces identical bytes.
+func TestArgon2idRoundTrip(t *testing.T) {
+	k := Argon2id{}
+	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if err := k.Verify(fixturePlaintext, fixturePepper, env); err != nil {
+		t.Fatalf("Verify against matching plaintext: unexpected error %v", err)
+	}
+	// Re-hashing with identical inputs produces identical bytes (argon2id
+	// is deterministic under fixed params + salt).
+	env2, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash (second call): %v", err)
+	}
+	if !bytes.Equal(env.Hash, env2.Hash) {
+		t.Fatalf("argon2id not deterministic under fixed inputs:\n first  %x\n second %x", env.Hash, env2.Hash)
+	}
+}
+
+// TestArgon2idVerifyRejectsWrongPlaintext is the happy-path mismatch: a
+// candidate plaintext that differs by a single byte must fail verify,
+// and the error must be [ErrHashMismatch] so a caller can switch on it.
+func TestArgon2idVerifyRejectsWrongPlaintext(t *testing.T) {
+	k := Argon2id{}
+	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	wrong := append([]byte{}, fixturePlaintext...)
+	wrong[0] ^= 0x01
+	err = k.Verify(wrong, fixturePepper, env)
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("Verify(wrong plaintext): got %v, want ErrHashMismatch", err)
+	}
+}
+
+// TestArgon2idVerifyRejectsWrongPepper is the pepper-discipline mirror:
+// the same plaintext with a different pepper MUST NOT verify. This
+// catches a regression where a future refactor silently drops the pepper
+// from the input concatenation.
+func TestArgon2idVerifyRejectsWrongPepper(t *testing.T) {
+	k := Argon2id{}
+	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	wrongPepper := append([]byte{}, fixturePepper...)
+	wrongPepper[0] ^= 0x01
+	err = k.Verify(fixturePlaintext, wrongPepper, env)
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("Verify(wrong pepper): got %v, want ErrHashMismatch", err)
+	}
+}
+
+// TestArgon2idNilPepperRejection enforces the "pepper is required" rule
+// from the package doc. Hash and Verify both refuse to operate rather
+// than silently producing an unpeppered hash.
+func TestArgon2idNilPepperRejection(t *testing.T) {
+	k := Argon2id{}
+	// Hash with nil pepper.
+	if _, err := k.Hash(fixturePlaintext, fixtureSalt, nil, fixturePepperVersion, Argon2idDefault); !errors.Is(err, ErrNilPepper) {
+		t.Errorf("Hash(nil pepper): got %v, want ErrNilPepper", err)
+	}
+	// Hash with empty-but-non-nil pepper.
+	if _, err := k.Hash(fixturePlaintext, fixtureSalt, []byte{}, fixturePepperVersion, Argon2idDefault); !errors.Is(err, ErrNilPepper) {
+		t.Errorf("Hash(empty pepper): got %v, want ErrNilPepper", err)
+	}
+	// Verify with nil pepper against a previously-valid envelope.
+	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash (setup): %v", err)
+	}
+	if err := k.Verify(fixturePlaintext, nil, env); !errors.Is(err, ErrNilPepper) {
+		t.Errorf("Verify(nil pepper): got %v, want ErrNilPepper", err)
+	}
+}
+
+// TestArgon2idEmptyInputs mirrors TestArgon2idNilPepperRejection for
+// plaintext and salt, per the three-input non-empty contract.
+func TestArgon2idEmptyInputs(t *testing.T) {
+	k := Argon2id{}
+	tests := []struct {
+		name      string
+		plaintext []byte
+		salt      []byte
+		want      error
+	}{
+		{name: "empty plaintext", plaintext: nil, salt: fixtureSalt, want: ErrEmptyPlaintext},
+		{name: "empty salt", plaintext: fixturePlaintext, salt: nil, want: ErrEmptySalt},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := k.Hash(tc.plaintext, tc.salt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Hash: got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestArgon2idEmptyPepperVersion enforces the "pepper version required on
+// Hash" rule: without a version string a verifier cannot route to the
+// right pepper after a rotation.
+func TestArgon2idEmptyPepperVersion(t *testing.T) {
+	_, err := Argon2id{}.Hash(fixturePlaintext, fixtureSalt, fixturePepper, "", Argon2idDefault)
+	if !errors.Is(err, ErrEmptyPepperVersion) {
+		t.Fatalf("Hash(empty pepper version): got %v, want ErrEmptyPepperVersion", err)
+	}
+}
+
+// TestArgon2idParamsValidation exercises the four zero-field guards so a
+// caller that fat-fingers [Params] gets a structured error instead of a
+// panic from the underlying argon2 primitive.
+func TestArgon2idParamsValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		params Params
+	}{
+		{name: "Time=0", params: Params{Time: 0, Memory: 19456, Parallelism: 1, KeyLength: 32}},
+		{name: "Memory=0", params: Params{Time: 2, Memory: 0, Parallelism: 1, KeyLength: 32}},
+		{name: "Parallelism=0", params: Params{Time: 2, Memory: 19456, Parallelism: 0, KeyLength: 32}},
+		{name: "KeyLength=0", params: Params{Time: 2, Memory: 19456, Parallelism: 1, KeyLength: 0}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Argon2id{}.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, tc.params)
+			if !errors.Is(err, ErrInvalidParams) {
+				t.Fatalf("Hash(%s): got %v, want ErrInvalidParams", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestArgon2idParamDriftRejection is the security-critical case cited in
+// the HOL-748 acceptance criteria: a hash encoded at time=2 must NOT
+// verify under a verifier that insists on time=3 (or any other mutated
+// field). The Verify helper alone is permissive because it reads the
+// params back out of the envelope, so the ticket specifically wants the
+// strict variant to reject drift.
+func TestArgon2idParamDriftRejection(t *testing.T) {
+	k := Argon2id{}
+	env, err := k.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	tests := []struct {
+		name string
+		want Params
+	}{
+		{
+			name: "drift on Time",
+			want: Params{Time: Argon2idDefault.Time + 1, Memory: Argon2idDefault.Memory, Parallelism: Argon2idDefault.Parallelism, KeyLength: Argon2idDefault.KeyLength},
+		},
+		{
+			name: "drift on Memory",
+			want: Params{Time: Argon2idDefault.Time, Memory: Argon2idDefault.Memory * 2, Parallelism: Argon2idDefault.Parallelism, KeyLength: Argon2idDefault.KeyLength},
+		},
+		{
+			name: "drift on Parallelism",
+			want: Params{Time: Argon2idDefault.Time, Memory: Argon2idDefault.Memory, Parallelism: Argon2idDefault.Parallelism + 1, KeyLength: Argon2idDefault.KeyLength},
+		},
+		{
+			name: "drift on KeyLength",
+			want: Params{Time: Argon2idDefault.Time, Memory: Argon2idDefault.Memory, Parallelism: Argon2idDefault.Parallelism, KeyLength: Argon2idDefault.KeyLength + 16},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := k.VerifyWithParams(fixturePlaintext, fixturePepper, env, tc.want)
+			if !errors.Is(err, ErrParamMismatch) {
+				t.Fatalf("VerifyWithParams: got %v, want ErrParamMismatch", err)
+			}
+		})
+	}
+}
+
+// TestArgon2idVerifyRejectsForeignKDF covers the routing table: an
+// envelope produced by some future KDF must not be silently verified by
+// the argon2id binding. We forge an envelope with a mismatching KDF
+// identifier and confirm the error path.
+func TestArgon2idVerifyRejectsForeignKDF(t *testing.T) {
+	env := Envelope{
+		SchemaVersion: EnvelopeSchemaVersion,
+		KDF:           KDFPBKDF2HMACSHA512,
+		KDFParams:     Argon2idDefault,
+		PepperVersion: fixturePepperVersion,
+		Salt:          fixtureSalt,
+		Hash:          bytes.Repeat([]byte{0}, int(Argon2idDefault.KeyLength)),
+	}
+	err := Argon2id{}.Verify(fixturePlaintext, fixturePepper, env)
+	if !errors.Is(err, ErrKDFMismatch) {
+		t.Fatalf("Verify(foreign KDF): got %v, want ErrKDFMismatch", err)
+	}
+}
+
+// TestArgon2idVerifyRejectsUnknownSchemaVersion guarantees that a future
+// v2 envelope will not silently verify against a v1 decoder; the
+// reconciler will surface the structured error to operators.
+func TestArgon2idVerifyRejectsUnknownSchemaVersion(t *testing.T) {
+	env, err := Argon2id{}.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	env.SchemaVersion = EnvelopeSchemaVersion + 1
+	err = Argon2id{}.Verify(fixturePlaintext, fixturePepper, env)
+	if !errors.Is(err, ErrUnknownSchemaVersion) {
+		t.Fatalf("Verify(unknown schema): got %v, want ErrUnknownSchemaVersion", err)
+	}
+}
+
+// TestEnvelopeJSONRoundTrip covers the on-wire contract: the canonical
+// Marshal / Unmarshal round-trip preserves every field so a reconciler
+// write + read produces byte-identical content.
+func TestEnvelopeJSONRoundTrip(t *testing.T) {
+	original, err := Argon2id{}.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	encoded, err := MarshalEnvelope(original)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	var decoded Envelope
+	if err := UnmarshalEnvelope(encoded, &decoded); err != nil {
+		t.Fatalf("UnmarshalEnvelope: %v", err)
+	}
+	if diff := cmp.Diff(original, decoded); diff != "" {
+		t.Fatalf("Envelope round-trip mismatch (-want +got):\n%s", diff)
+	}
+	// The round-tripped envelope must still verify.
+	k := Argon2id{}
+	if err := k.Verify(fixturePlaintext, fixturePepper, decoded); err != nil {
+		t.Fatalf("Verify(round-tripped envelope): unexpected error %v", err)
+	}
+}
+
+// TestEnvelopeJSONShape pins the JSON field names so a downstream
+// operator script or a future parser in a sibling binary can rely on the
+// exact keys. A rename is a breaking wire change and should fail this
+// test.
+func TestEnvelopeJSONShape(t *testing.T) {
+	env, err := Argon2id{}.Hash(fixturePlaintext, fixtureSalt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	encoded, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(encoded, &m); err != nil {
+		t.Fatalf("re-unmarshal to map: %v", err)
+	}
+	for _, k := range []string{"schemaVersion", "kdf", "kdfParams", "pepperVersion", "salt", "hash"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("envelope JSON missing required key %q; have %v", k, m)
+		}
+	}
+	paramsAny, ok := m["kdfParams"].(map[string]any)
+	if !ok {
+		t.Fatalf("kdfParams is not a JSON object: %T", m["kdfParams"])
+	}
+	for _, k := range []string{"time", "memory", "parallelism", "keyLength"} {
+		if _, ok := paramsAny[k]; !ok {
+			t.Errorf("kdfParams JSON missing key %q; have %v", k, paramsAny)
+		}
+	}
+}
+
+// TestEnvelopeUnmarshalRejectsUnknownSchema covers the decoder gate: a
+// stray v99 envelope on disk must fail to unmarshal rather than silently
+// parse as v1 with the new fields stripped.
+func TestEnvelopeUnmarshalRejectsUnknownSchema(t *testing.T) {
+	bogus := []byte(`{"schemaVersion":99,"kdf":"argon2id","kdfParams":{"time":2,"memory":19456,"parallelism":1,"keyLength":32},"pepperVersion":"v1","salt":"c2FsdA==","hash":"aGFzaA=="}`)
+	var decoded Envelope
+	err := UnmarshalEnvelope(bogus, &decoded)
+	if !errors.Is(err, ErrUnknownSchemaVersion) {
+		t.Fatalf("UnmarshalEnvelope: got %v, want ErrUnknownSchemaVersion", err)
+	}
+}
+
+// TestCompareHashConstantTimeSemantics is a sanity check that the
+// [CompareHash] wrapper behaves like the crypto/subtle primitive it
+// delegates to: equal byte slices return true, unequal slices or length
+// mismatches return false. The constant-time property itself is owned by
+// the stdlib and is not retested here.
+func TestCompareHashConstantTimeSemantics(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []byte
+		b    []byte
+		want bool
+	}{
+		{name: "equal", a: []byte("abc"), b: []byte("abc"), want: true},
+		{name: "differ single byte", a: []byte("abc"), b: []byte("abd"), want: false},
+		{name: "length differs", a: []byte("abc"), b: []byte("abcd"), want: false},
+		{name: "both empty", a: nil, b: nil, want: true},
+		{name: "one empty", a: nil, b: []byte("abc"), want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CompareHash(tc.a, tc.b); got != tc.want {
+				t.Fatalf("CompareHash(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultBindsArgon2id pins the package-level [Default] contract: the
+// non-FIPS build wires the argon2id implementation, not any future
+// primitive. The -fips build variant overrides this in its own
+// build-tagged file.
+func TestDefaultBindsArgon2id(t *testing.T) {
+	k := Default()
+	if k.ID() != KDFArgon2id {
+		t.Fatalf("Default().ID() = %q, want %q", k.ID(), KDFArgon2id)
+	}
+	if diff := cmp.Diff(Argon2idDefault, k.DefaultParams()); diff != "" {
+		t.Fatalf("Default().DefaultParams() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestUnmarshalEnvelopeNilDestination protects against a caller that
+// forgets to allocate. A nil destination returns a structured error
+// rather than panicking.
+func TestUnmarshalEnvelopeNilDestination(t *testing.T) {
+	err := UnmarshalEnvelope([]byte(`{"schemaVersion":1}`), nil)
+	if err == nil {
+		t.Fatalf("UnmarshalEnvelope(nil destination) returned nil error")
+	}
+}
+
+// TestHashDoesNotAliasCallerSalt guarantees a caller that mutates its
+// input salt slice after calling Hash cannot corrupt the envelope.
+// Aliasing would be a correctness bug; the envelope is the unit the
+// reconciler writes to etcd.
+func TestHashDoesNotAliasCallerSalt(t *testing.T) {
+	salt := append([]byte{}, fixtureSalt...)
+	env, err := Argon2id{}.Hash(fixturePlaintext, salt, fixturePepper, fixturePepperVersion, Argon2idDefault)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	// Mutate caller slice.
+	salt[0] ^= 0xFF
+	if !bytes.Equal(env.Salt, fixtureSalt) {
+		t.Fatalf("envelope.Salt aliased caller salt; mutation leaked in: got %x, want %x", env.Salt, fixtureSalt)
+	}
+	// Verify still works because the envelope has its own salt copy.
+	k := Argon2id{}
+	if err := k.Verify(fixturePlaintext, fixturePepper, env); err != nil {
+		t.Fatalf("Verify after caller salt mutation: unexpected error %v", err)
+	}
+}

--- a/internal/secretinjector/crypto/pbkdf2.go
+++ b/internal/secretinjector/crypto/pbkdf2.go
@@ -1,0 +1,37 @@
+//go:build fips
+
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is the FIPS-variant placeholder for the PBKDF2-HMAC-SHA512
+// binding. It is excluded from every non-FIPS build by the //go:build fips
+// tag above, so the default holos-secret-injector binary that M2 ships
+// never compiles against it.
+//
+// A future FIPS build-variant ticket (tracked as a post-M2 sub-issue of
+// HOL-747 — the M2 plan explicitly scopes the pluggability seam here and
+// defers the PBKDF2-HMAC-SHA512 primitive) will replace this body with a
+// real implementation that satisfies the [KDF] interface and is bound as
+// [Default] for FIPS builds via a build-tagged override.
+//
+// The body is intentionally empty under the fips tag so an -fips build
+// that does NOT land the override still fails loudly at link time on a
+// missing [Default] symbol rather than silently reverting to the argon2id
+// binding. A verifier that encounters an [Envelope] whose [Envelope.KDF]
+// is [KDFPBKDF2HMACSHA512] and that runs in a non-FIPS binary returns
+// [ErrKDFMismatch] via the normal routing path in kdf.go.
+
+package crypto


### PR DESCRIPTION
## Summary

- Introduce `internal/secretinjector/crypto/` — a zero-reconciler-contact leaf package that hosts the pluggability seam for hashing credentials. `KDF` interface + versioned `Envelope` record (`{schemaVersion, kdf, kdfParams, pepperVersion, salt, hash}`) lands the on-wire shape the Credential reconciler (HOL-751) will write verbatim to `v1.Secret.data["hash"]`.
- Bind `Argon2id` as the default non-FIPS implementation with pinned OWASP-cheat-sheet parameters (t=2, m=19456 KiB / 19 MiB, p=1, keyLen=32). Hash concatenates pepper to plaintext (salt stays separate so a future pepper rotation can re-hash without regenerating salt) and stamps the effective `Params` onto the envelope so `VerifyWithParams` can reject parameter drift.
- Reserve `pbkdf2.go` behind `//go:build fips` as an empty placeholder. An `-fips` build variant will bind PBKDF2-HMAC-SHA512 without touching reconciler code. The empty body ensures an `-fips` build that forgets to land the override fails loudly at link time rather than silently reverting to argon2id.
- Package doc pins the invariants: pepper is supplied by the caller on every call (never read from a side channel), `Envelope` is marshal-only (no `String` / `GoString`), and nothing in the package may log plaintext / hash / pepper / salt.
- 16 table-driven unit tests (94.7% statement coverage on the new package) cover deterministic hash under fixed fixtures, round-trip, wrong-plaintext / wrong-pepper mismatch, nil-pepper rejection, empty-plaintext / empty-salt / empty-pepper-version rejection, per-field `Params` validation, per-field drift rejection via `ErrParamMismatch`, foreign-KDF rejection, unknown-schema rejection at both `Verify` and `UnmarshalEnvelope`, envelope JSON round-trip + shape pinning, constant-time compare semantics, default binding check, nil-destination unmarshal, and caller-salt-aliasing protection.

Promotes `golang.org/x/crypto` from indirect to a direct `require` (was already transitively pulled by controller-runtime). No other dependencies change. ADR 031 disjoint-tree invariant holds: the new package imports only `golang.org/x/crypto/argon2` and stdlib.

Fixes HOL-748

## Test plan

- [x] `CGO_ENABLED=1 go test -race ./internal/secretinjector/crypto/...` green (94.7% coverage)
- [x] `go vet ./internal/secretinjector/crypto/...` and `go vet -tags fips ./internal/secretinjector/crypto/...` green (fips stub compiles standalone)
- [x] `make check-imports` green (ADR 031 disjoint-tree invariant holds)
- [ ] CI green across all matrix jobs