### PR TITLE
fix(templates): inject authoritative platform values into preview render

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -492,6 +492,13 @@ func (s *Server) Serve(ctx context.Context) error {
 		settingsPath, settingsHTTPHandler := consolev1connect.NewProjectSettingsServiceHandler(settingsHandler, protectedInterceptors)
 		mux.Handle(settingsPath, settingsHTTPHandler)
 
+		// HOL-644 / HOL-828: shared gateway-namespace resolver used by both the
+		// deployments handler (project→org→annotation) and the template-preview
+		// handler (org/folder→annotation). Constructed here so both handlers
+		// share the same instance without duplicating the resolution logic.
+		// orgsK8s and projectResolver are already available at this point.
+		gatewayResolver := organizations.NewGatewayNamespaceResolver(orgsK8s, projectResolver)
+
 		// Unified TemplateService handler — manages templates at org, folder, and
 		// project scopes in a single service (ADR 021).
 		folderGrantResolver := folders.NewFolderGrantResolver(foldersK8s)
@@ -500,7 +507,8 @@ func (s *Server) Serve(ctx context.Context) error {
 			WithFolderGrantResolver(folderGrantResolver).
 			WithProjectGrantResolver(projectResolver).
 			WithAncestorWalker(nsWalker).
-			WithProjectTemplateDriftChecker(projectTemplateDriftAdapter)
+			WithProjectTemplateDriftChecker(projectTemplateDriftAdapter).
+			WithOrganizationGatewayResolver(gatewayResolver)
 		templatesPath, templatesHTTPHandler := consolev1connect.NewTemplateServiceHandler(templatesHandler, protectedInterceptors)
 		mux.Handle(templatesPath, templatesHTTPHandler)
 
@@ -583,10 +591,8 @@ func (s *Server) Serve(ctx context.Context) error {
 		// gateway-namespace annotation so PlatformInput.gatewayNamespace
 		// reflects the platform engineer's configured value (set via the
 		// Organization service in HOL-643) rather than the historical
-		// hard-coded "istio-ingress". Reuses the existing projectResolver
-		// (a *projects.ProjectGrantResolver) for the project→org lookup;
-		// the annotation read goes through orgsK8s.
-		gatewayResolver := organizations.NewGatewayNamespaceResolver(orgsK8s, projectResolver)
+		// hard-coded "istio-ingress". gatewayResolver is constructed above
+		// (shared with the templates handler, HOL-828).
 		deploymentsHandler := deployments.NewHandler(deploymentsK8s, projectResolver, settingsK8s, templates.NewProjectScopedResolver(templatesK8s), &deployments.CueRenderer{}, deploymentsApplier).
 			WithAncestorWalker(projectFolderResolver).
 			WithAncestorTemplateProvider(ancestorTemplateResolver).

--- a/console/organizations/resolver.go
+++ b/console/organizations/resolver.go
@@ -100,3 +100,17 @@ func (r *GatewayNamespaceResolver) GetGatewayNamespace(ctx context.Context, proj
 	}
 	return GetGatewayNamespace(ns), nil
 }
+
+// GetOrgGatewayNamespace returns the value of the gateway-namespace annotation
+// directly from the named organization namespace, without a project→org lookup.
+// This is the entry point used by the template-preview handler where the request
+// scope may be org or folder level (no project to resolve through). Returns ""
+// when the annotation is unset; the templates handler falls back to
+// deployments.DefaultGatewayNamespace in that case.
+func (r *GatewayNamespaceResolver) GetOrgGatewayNamespace(ctx context.Context, org string) (string, error) {
+	ns, err := r.k8s.GetOrganization(ctx, org)
+	if err != nil {
+		return "", err
+	}
+	return GetGatewayNamespace(ns), nil
+}

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -20,6 +20,7 @@ import (
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/deployments"
 	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/resolver"
@@ -155,6 +156,25 @@ type Renderer interface {
 	RenderGroupedWithTemplateSources(ctx context.Context, cueTemplate string, templateSources []string, cuePlatformInput string, cueInput string) (*GroupedRenderResources, error)
 }
 
+// OrganizationGatewayResolver resolves the configured ingress-gateway
+// namespace for an organization. Implementations read the org namespace's
+// gateway-namespace annotation (v1alpha2.AnnotationGatewayNamespace, set via
+// the Organization service in HOL-643).
+//
+// GetGatewayNamespace takes a project slug and resolves the owning org first
+// (the deployments path). GetOrgGatewayNamespace takes an org name directly
+// and is used by the template-preview path where the request scope may be org
+// or folder level and there is no project to resolve through.
+//
+// Both methods return "" when the annotation is absent so the caller can apply
+// its own fallback (deployments.DefaultGatewayNamespace). A non-nil error is
+// treated as a soft failure and logged at WARN — the preview render MUST NOT
+// be rejected on a transient resolver miss.
+type OrganizationGatewayResolver interface {
+	GetGatewayNamespace(ctx context.Context, project string) (string, error)
+	GetOrgGatewayNamespace(ctx context.Context, org string) (string, error)
+}
+
 // ProjectTemplateDriftChecker exposes the minimal surface needed to serve
 // TemplateService.GetProjectTemplatePolicyState and to record the applied
 // render set on successful CreateTemplate/UpdateTemplate at project scope.
@@ -192,6 +212,13 @@ type Handler struct {
 	// — a nil value disables drift reporting and applied-state recording
 	// for project-scope templates (HOL-567).
 	projectTemplateDriftChecker ProjectTemplateDriftChecker
+	// gatewayResolver resolves the ingress-gateway namespace for the org
+	// owning the preview request's scope. HOL-828 wires this so the
+	// template-preview render path injects authoritative platform-owned
+	// values (gatewayNamespace at minimum) into the CUE unified value at the
+	// platform path, mirroring console/deployments/handler.go:buildPlatformInput.
+	// Nil means the preview falls back to deployments.DefaultGatewayNamespace.
+	gatewayResolver OrganizationGatewayResolver
 }
 
 // NewHandler creates a TemplateService handler. policyResolver is the
@@ -233,6 +260,105 @@ func (h *Handler) WithAncestorWalker(w AncestorWalker) *Handler {
 func (h *Handler) WithProjectTemplateDriftChecker(c ProjectTemplateDriftChecker) *Handler {
 	h.projectTemplateDriftChecker = c
 	return h
+}
+
+// WithOrganizationGatewayResolver configures the handler with a resolver that
+// returns the ingress-gateway namespace for an organization. When set,
+// renderTemplateGrouped injects the resolved value into the CUE platform path
+// before the user-supplied cue_platform_input is evaluated, mirroring
+// deployments/handler.go:buildPlatformInput (HOL-828). When unset, the
+// preview falls back to deployments.DefaultGatewayNamespace unchanged.
+func (h *Handler) WithOrganizationGatewayResolver(r OrganizationGatewayResolver) *Handler {
+	h.gatewayResolver = r
+	return h
+}
+
+// resolveGatewayNamespace returns the gateway namespace to inject into
+// PlatformInput for the preview render path. It mirrors the logic in
+// deployments/handler.go:resolveGatewayNamespace but routes through the
+// org-scoped entry points (since the preview namespace may be org or folder
+// scope rather than project scope).
+//
+// For project scope: delegates to GetGatewayNamespace (project→org→annotation).
+// For org/folder scope: delegates to GetOrgGatewayNamespace (org→annotation).
+// Falls back to deployments.DefaultGatewayNamespace on nil resolver, error,
+// or empty annotation. Errors are logged at WARN — the preview MUST NOT fail
+// on a transient resolver miss.
+func (h *Handler) resolveGatewayNamespace(ctx context.Context, kind scopeKind, name string) string {
+	if h.gatewayResolver == nil {
+		return deployments.DefaultGatewayNamespace
+	}
+	var gwNs string
+	var err error
+	switch kind {
+	case scopeKindProject:
+		gwNs, err = h.gatewayResolver.GetGatewayNamespace(ctx, name)
+	case scopeKindOrganization:
+		gwNs, err = h.gatewayResolver.GetOrgGatewayNamespace(ctx, name)
+	case scopeKindFolder:
+		// Folder scope: resolve via org annotation. Walk up to get org name from
+		// the resolver if available; if the resolver lookup fails, fall back to
+		// the default. We use the folder name here; if the resolver cannot map
+		// it to an org, GetOrgGatewayNamespace will return an error.
+		gwNs, err = h.gatewayResolver.GetOrgGatewayNamespace(ctx, name)
+	default:
+		return deployments.DefaultGatewayNamespace
+	}
+	if err != nil {
+		slog.WarnContext(ctx, "could not resolve org gateway namespace for preview, falling back to default",
+			slog.String("scopeKind", kind.String()),
+			slog.String("name", name),
+			slog.String("default", deployments.DefaultGatewayNamespace),
+			slog.Any("error", err),
+		)
+		return deployments.DefaultGatewayNamespace
+	}
+	if gwNs == "" {
+		return deployments.DefaultGatewayNamespace
+	}
+	return gwNs
+}
+
+// buildPreviewPlatformInput constructs a v1alpha2.PlatformInput from the
+// preview request's namespace scope. It mirrors deployments/handler.go:
+// buildPlatformInput but is adapted for the template-preview path where the
+// scope may be org or folder level (HOL-828).
+//
+// The returned PlatformInput is injected at the CUE platform path before the
+// user-supplied cue_platform_input is evaluated. CUE unification merges the
+// two: if the user supplies the same value the backend resolves, the result is
+// identical; if the user supplies a conflicting value, CUE surfaces a conflict
+// error (the desired behavior for pinned vs. resolved mismatches).
+func (h *Handler) buildPreviewPlatformInput(ctx context.Context, kind scopeKind, name string) v1alpha2.PlatformInput {
+	gwNs := h.resolveGatewayNamespace(ctx, kind, name)
+	pi := v1alpha2.PlatformInput{
+		GatewayNamespace: gwNs,
+	}
+	switch kind {
+	case scopeKindOrganization:
+		pi.Organization = name
+	case scopeKindProject:
+		pi.Project = name
+		// Resolve namespace for project scope when resolver is available.
+		if h.k8s != nil {
+			pi.Namespace = scopeNamespace(h.k8s.Resolver, kind, name)
+		}
+	case scopeKindFolder:
+		// Folder scope: no project/org in PlatformInput; gatewayNamespace is the
+		// primary value we inject.
+	}
+	return pi
+}
+
+// platformInputToCUE JSON-encodes pi and returns a CUE string that unifies
+// the struct at the platform path. The resulting string is prepended to the
+// render so the user-supplied cue_platform_input can unify over it.
+func platformInputToCUE(pi v1alpha2.PlatformInput) (string, error) {
+	b, err := json.Marshal(pi)
+	if err != nil {
+		return "", fmt.Errorf("marshal platform input: %w", err)
+	}
+	return "platform: " + string(b) + "\n", nil
 }
 
 // ListTemplates returns all templates in the given scope.
@@ -987,11 +1113,18 @@ func (h *Handler) RenderTemplate(
 }
 
 // renderTemplateGrouped resolves the effective ancestor-template source list
-// for the preview target and delegates to the renderer. Both paths — this
-// preview and the deployments apply path — now route through the same
-// K8sClient.ListEffectiveTemplateSources helper, so preview-vs-apply
-// divergence of the ancestor-source slice is structurally impossible
-// (HOL-562 Phase 2, HOL-564).
+// for the preview target, injects backend-resolved platform values, and
+// delegates to the renderer. Both paths — this preview and the deployments
+// apply path — now route through the same K8sClient.ListEffectiveTemplateSources
+// helper, so preview-vs-apply divergence of the ancestor-source slice is
+// structurally impossible (HOL-562 Phase 2, HOL-564).
+//
+// HOL-828: when a gatewayResolver is configured, renderTemplateGrouped builds
+// a v1alpha2.PlatformInput from the request's namespace scope, JSON-encodes it,
+// and unifies it at the CUE platform path before the user-supplied
+// cue_platform_input is evaluated. This mirrors buildPlatformInput in the
+// deployments handler and allows the HTTPRoute (v1) org template to render
+// without the user manually setting platform.gatewayNamespace.
 //
 // When the handler has no Kubernetes client (in-process test / no-k8s mode),
 // the render runs without any ancestor sources. The previous three-branch
@@ -1003,9 +1136,18 @@ func (h *Handler) renderTemplateGrouped(ctx context.Context, msg *consolev1.Rend
 	// HOL-619/HOL-723 made the request's namespace the authoritative
 	// identifier. Classify it for the preview-target-kind discriminator
 	// only; storage works directly against the namespace.
+	//
+	// msgKind and msgName are hoisted here (HOL-828) so the platform-input
+	// injection step below can access the classified scope without re-running
+	// classifyNamespace a second time.
+	msgKind := scopeKindUnspecified
+	var msgName string
+	if h.k8s != nil && msg.GetNamespace() != "" {
+		msgKind, msgName = classifyNamespace(h.k8s.Resolver, msg.GetNamespace())
+	}
+
 	if h.k8s != nil && h.walker != nil && msg.GetNamespace() != "" {
 		startNs := msg.GetNamespace()
-		msgKind, msgName := classifyNamespace(h.k8s.Resolver, startNs)
 		if msgKind == scopeKindUnspecified {
 			slog.WarnContext(ctx, "failed to classify namespace for render, falling back to plain render",
 				slog.String("namespace", startNs),
@@ -1037,14 +1179,35 @@ func (h *Handler) renderTemplateGrouped(ctx context.Context, msg *consolev1.Rend
 		}
 	}
 
+	// HOL-828: Build and inject backend-resolved PlatformInput at the CUE
+	// platform path before the user-supplied cue_platform_input. The JSON-
+	// encoded struct is prepended so CUE unifies the two inputs: identical
+	// values succeed; conflicting values surface a clear CUE error.
+	// Falls back gracefully: unclassified scope or nil resolver skips
+	// injection (no regression for callers that do not set a namespace).
+	cuePlatformInput := msg.CuePlatformInput
+	if msgKind != scopeKindUnspecified {
+		pi := h.buildPreviewPlatformInput(ctx, msgKind, msgName)
+		piCUE, err := platformInputToCUE(pi)
+		if err != nil {
+			slog.WarnContext(ctx, "could not encode platform input for preview, skipping injection",
+				slog.Any("error", err),
+			)
+		} else {
+			// Prepend the backend-resolved platform string; user-supplied input
+			// follows so CUE unification applies the user's overrides on top.
+			cuePlatformInput = piCUE + cuePlatformInput
+		}
+	}
+
 	if len(templateSources) == 0 {
-		grouped, err := h.renderer.RenderGrouped(ctx, msg.CueTemplate, msg.CuePlatformInput, msg.CueProjectInput)
+		grouped, err := h.renderer.RenderGrouped(ctx, msg.CueTemplate, cuePlatformInput, msg.CueProjectInput)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
 		}
 		return grouped, nil
 	}
-	grouped, err := h.renderer.RenderGroupedWithTemplateSources(ctx, msg.CueTemplate, templateSources, msg.CuePlatformInput, msg.CueProjectInput)
+	grouped, err := h.renderer.RenderGroupedWithTemplateSources(ctx, msg.CueTemplate, templateSources, cuePlatformInput, msg.CueProjectInput)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("template render failed: %w", err))
 	}

--- a/console/templates/handler_render_test.go
+++ b/console/templates/handler_render_test.go
@@ -1,0 +1,265 @@
+// handler_render_test.go exercises RenderTemplate with backend-injected
+// platform values (HOL-828). The tests verify that the template-preview path
+// resolves and injects authoritative platform-owned values — gatewayNamespace
+// at minimum — into the unified CUE value at the platform path, mirroring
+// console/deployments/handler.go:buildPlatformInput.
+package templates
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/holos-run/holos-console/console/deployments"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// httpRouteTemplate is the HTTPRoute (v1) org template CUE body. It references
+// platform.gatewayNamespace, which must be resolved by the backend when the
+// user does not supply it explicitly.
+const httpRouteTemplate = `
+// input and platform are available because platform templates are unified with
+// the deployment template before evaluation (ADR 016 Decision 8).
+input: #ProjectInput & {
+	port: >0 & <=65535 | *8080
+}
+platform: #PlatformInput
+
+// platformResources holds resources the platform team manages. The renderer
+// reads these only from organization/folder-level templates — project templates
+// that define platformResources are silently ignored (ADR 016 Decision 8).
+platformResources: {
+	namespacedResources: (platform.gatewayNamespace): {
+		// HTTPRoute routes traffic from the gateway to the project Service on port 80.
+		HTTPRoute: (input.name): {
+			apiVersion: "gateway.networking.k8s.io/v1"
+			kind:       "HTTPRoute"
+			metadata: {
+				name:      input.name
+				namespace: platform.gatewayNamespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+					"app.kubernetes.io/name":       input.name
+				}
+			}
+			spec: {
+				parentRefs: [{
+					group:     "gateway.networking.k8s.io"
+					kind:      "Gateway"
+					namespace: platform.gatewayNamespace
+					name:      "default"
+				}]
+				rules: [{
+					backendRefs: [{
+						name:      input.name
+						namespace: platform.namespace
+						port:      80
+					}]
+				}]
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// stubGatewayResolver is a test double for OrganizationGatewayResolver.
+type stubGatewayResolver struct {
+	gatewayNs    string // returned by GetGatewayNamespace (project path)
+	orgGatewayNs string // returned by GetOrgGatewayNamespace (org path)
+	err          error
+}
+
+func (s *stubGatewayResolver) GetGatewayNamespace(_ context.Context, _ string) (string, error) {
+	return s.gatewayNs, s.err
+}
+
+func (s *stubGatewayResolver) GetOrgGatewayNamespace(_ context.Context, _ string) (string, error) {
+	return s.orgGatewayNs, s.err
+}
+
+// makeOrgNamespace returns a Namespace representing an organization scope with
+// the given name, using the testResolver's org prefix.
+func makeOrgNamespace(orgName string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testResolver.OrgNamespace(orgName),
+		},
+	}
+}
+
+// newRenderHandler builds a minimal Handler wired for RenderTemplate tests.
+// It accepts a gatewayResolver and optional objects for the fake clientset.
+func newRenderHandler(t *testing.T, gatewayRes OrganizationGatewayResolver, objs ...runtime.Object) *Handler {
+	t.Helper()
+	cs := kfake.NewSimpleClientset(objs...)
+	k8sClient := newTestK8sClient(t, cs, testResolver)
+	renderer := NewCueRendererAdapter()
+	h := NewHandler(k8sClient, testResolver, renderer, nil)
+	if gatewayRes != nil {
+		h = h.WithOrganizationGatewayResolver(gatewayRes)
+	}
+	return h
+}
+
+// TestRenderTemplate_PlatformInjection verifies that the backend injects
+// platform-owned values (gatewayNamespace) into the CUE render, so the user
+// does not need to set platform.gatewayNamespace explicitly in the seed input.
+func TestRenderTemplate_PlatformInjection(t *testing.T) {
+	ctx := authedCtx("platform@localhost", []string{"owner"})
+	orgNs := testResolver.OrgNamespace("acme")
+
+	// seed platform input that does NOT include gatewayNamespace — the backend
+	// must inject it from the resolver. The seed omits organization/project/
+	// namespace so the backend-resolved values unify without conflict. A real
+	// frontend seed for an org-scope template only carries what the user typed,
+	// not placeholder empty strings for backend-owned fields.
+	seedPlatformInput := `platform: #PlatformInput`
+	// project input provides the deployment name — required by #ProjectInput.
+	projectInput := `input: {
+	name:  "my-service"
+	image: "nginx"
+	tag:   "latest"
+	port:  8080
+}`
+
+	t.Run("resolver returns custom value (used)", func(t *testing.T) {
+		resolver := &stubGatewayResolver{orgGatewayNs: "ci-private-apps-gateway"}
+		h := newRenderHandler(t, resolver, makeOrgNamespace("acme"))
+
+		resp, err := h.RenderTemplate(ctx, connect.NewRequest(&consolev1.RenderTemplateRequest{
+			CueTemplate:      httpRouteTemplate,
+			CuePlatformInput: seedPlatformInput,
+			CueProjectInput:  projectInput,
+			Namespace:        orgNs,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		yaml := resp.Msg.PlatformResourcesYaml
+		if !strings.Contains(yaml, "kind: HTTPRoute") {
+			t.Errorf("platform_resources_yaml must contain 'kind: HTTPRoute', got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "ci-private-apps-gateway") {
+			t.Errorf("platform_resources_yaml must contain resolved gatewayNamespace 'ci-private-apps-gateway', got:\n%s", yaml)
+		}
+		if resp.Msg.ProjectResourcesYaml != "" {
+			t.Errorf("expected empty project_resources_yaml for platform-only template, got:\n%s", resp.Msg.ProjectResourcesYaml)
+		}
+	})
+
+	t.Run("resolver returns empty (falls back to DefaultGatewayNamespace)", func(t *testing.T) {
+		resolver := &stubGatewayResolver{orgGatewayNs: ""}
+		h := newRenderHandler(t, resolver, makeOrgNamespace("acme"))
+
+		resp, err := h.RenderTemplate(ctx, connect.NewRequest(&consolev1.RenderTemplateRequest{
+			CueTemplate:      httpRouteTemplate,
+			CuePlatformInput: seedPlatformInput,
+			CueProjectInput:  projectInput,
+			Namespace:        orgNs,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		yaml := resp.Msg.PlatformResourcesYaml
+		if !strings.Contains(yaml, "kind: HTTPRoute") {
+			t.Errorf("platform_resources_yaml must contain 'kind: HTTPRoute', got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, deployments.DefaultGatewayNamespace) {
+			t.Errorf("platform_resources_yaml must contain default gateway namespace %q, got:\n%s", deployments.DefaultGatewayNamespace, yaml)
+		}
+	})
+
+	t.Run("resolver returns error (falls back to DefaultGatewayNamespace)", func(t *testing.T) {
+		resolver := &stubGatewayResolver{err: errResolverFailed}
+		h := newRenderHandler(t, resolver, makeOrgNamespace("acme"))
+
+		resp, err := h.RenderTemplate(ctx, connect.NewRequest(&consolev1.RenderTemplateRequest{
+			CueTemplate:      httpRouteTemplate,
+			CuePlatformInput: seedPlatformInput,
+			CueProjectInput:  projectInput,
+			Namespace:        orgNs,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error (resolver error is a soft failure), got: %v", err)
+		}
+		yaml := resp.Msg.PlatformResourcesYaml
+		if !strings.Contains(yaml, deployments.DefaultGatewayNamespace) {
+			t.Errorf("platform_resources_yaml must contain default gateway namespace %q on resolver error, got:\n%s", deployments.DefaultGatewayNamespace, yaml)
+		}
+	})
+
+	t.Run("nil resolver (falls back to DefaultGatewayNamespace)", func(t *testing.T) {
+		h := newRenderHandler(t, nil, makeOrgNamespace("acme"))
+
+		resp, err := h.RenderTemplate(ctx, connect.NewRequest(&consolev1.RenderTemplateRequest{
+			CueTemplate:      httpRouteTemplate,
+			CuePlatformInput: seedPlatformInput,
+			CueProjectInput:  projectInput,
+			Namespace:        orgNs,
+		}))
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		yaml := resp.Msg.PlatformResourcesYaml
+		if !strings.Contains(yaml, deployments.DefaultGatewayNamespace) {
+			t.Errorf("platform_resources_yaml must contain default gateway namespace %q with nil resolver, got:\n%s", deployments.DefaultGatewayNamespace, yaml)
+		}
+	})
+
+	t.Run("user supplies same value as backend resolves (unifies cleanly)", func(t *testing.T) {
+		resolver := &stubGatewayResolver{orgGatewayNs: "ci-private-apps-gateway"}
+		h := newRenderHandler(t, resolver, makeOrgNamespace("acme"))
+
+		// User supplies the same gatewayNamespace the backend resolves — CUE
+		// unification should succeed (string & "same" & "same" == "same").
+		// The input does not set fields like organization to avoid conflict with
+		// the backend-resolved "acme" value; only gatewayNamespace is pinned.
+		sameValuePlatformInput := `platform: gatewayNamespace: "ci-private-apps-gateway"`
+		resp, err := h.RenderTemplate(ctx, connect.NewRequest(&consolev1.RenderTemplateRequest{
+			CueTemplate:      httpRouteTemplate,
+			CuePlatformInput: sameValuePlatformInput,
+			CueProjectInput:  projectInput,
+			Namespace:        orgNs,
+		}))
+		if err != nil {
+			t.Fatalf("user-supplied same value should unify cleanly, got: %v", err)
+		}
+		yaml := resp.Msg.PlatformResourcesYaml
+		if !strings.Contains(yaml, "ci-private-apps-gateway") {
+			t.Errorf("platform_resources_yaml must contain the expected gateway namespace, got:\n%s", yaml)
+		}
+	})
+
+	t.Run("user supplies conflicting value (CUE conflict surfaces as error)", func(t *testing.T) {
+		resolver := &stubGatewayResolver{orgGatewayNs: "ci-private-apps-gateway"}
+		h := newRenderHandler(t, resolver, makeOrgNamespace("acme"))
+
+		// User supplies a different gatewayNamespace from what the backend
+		// resolves; CUE unification should yield a clean conflict error.
+		conflictingPlatformInput := `platform: gatewayNamespace: "different-gateway"`
+		_, err := h.RenderTemplate(ctx, connect.NewRequest(&consolev1.RenderTemplateRequest{
+			CueTemplate:      httpRouteTemplate,
+			CuePlatformInput: conflictingPlatformInput,
+			CueProjectInput:  projectInput,
+			Namespace:        orgNs,
+		}))
+		if err == nil {
+			t.Fatal("expected CUE conflict error when user supplies conflicting gatewayNamespace, got nil")
+		}
+	})
+}
+
+// errResolverFailed is a sentinel error returned by the stub resolver in the
+// "resolver errors" test case.
+var errResolverFailed = errType("resolver: simulated failure")
+
+type errType string
+
+func (e errType) Error() string { return string(e) }


### PR DESCRIPTION
## Summary

- Adds `OrganizationGatewayResolver` interface + `WithOrganizationGatewayResolver` option on `*templates.Handler`, mirroring the existing seam in `console/deployments`. HOL-828 Phase 1 of 4 for HOL-827.
- `renderTemplateGrouped` now builds a `v1alpha2.PlatformInput` from the request's namespace scope (project/org/folder) via `buildPreviewPlatformInput` and prepends its JSON-encoded form to the user-supplied `cue_platform_input`. CUE unifies the two: identical values succeed, conflicting literals surface a clean error.
- Adds `GetOrgGatewayNamespace(ctx, org)` to `organizations.GatewayNamespaceResolver` so the preview path can resolve the gateway annotation directly from an org namespace (the existing project→org hop doesn't apply at org/folder scope).
- Wires the existing `gatewayResolver` (already constructed for the deployments handler at `console.go:589`) into the templates handler. The construction is hoisted above `templatesHandler` so both share one instance.
- Falls back gracefully to `deployments.DefaultGatewayNamespace` ("istio-ingress") when the resolver is nil, errors, or returns empty; resolver errors are logged at WARN and never reject the preview.
- Adds `console/templates/handler_render_test.go` exercising `RenderTemplate` with the HTTPRoute (v1) template body. Covers the four required cases from the ticket (custom value used, empty fallback, error fallback, user conflict) plus nil-resolver and user-same-value cases.

Fixes HOL-828

## Test plan

- [x] `go test ./console/templates/... ./console/organizations/... ./console/deployments/...` passes (cached + `-count=1`)
- [x] `make test-go` passes end-to-end
- [x] `go vet ./...` is clean
- [x] `gofmt -l` on modified files is empty
- [x] `make check-imports` passes (ADR 031 invariant preserved)
- [x] New `TestRenderTemplate_PlatformInjection` subtests all pass (6/6)