### PR TITLE
feat(secretinjector): pepper bootstrap + versioned self-seal

### DIFF
--- a/config/secret-injector/rbac/namespace/secrets-role.yaml
+++ b/config/secret-injector/rbac/namespace/secrets-role.yaml
@@ -1,26 +1,66 @@
 # Namespace-scoped Role granting the holos-secret-injector ServiceAccount
-# create/update/delete on core/v1 Secret WITHIN its own namespace only
-# (`holos-system`). This is the narrow CUD envelope the M2 reconciler
-# needs to manage the hash-material Secrets it owns via ownerReferences.
+# the narrow CUD envelope it needs on core/v1 Secret within its own
+# namespace (`holos-system`) ONLY.
+#
+# Two rule-sets, each with a different resourceNames pin:
+#
+#   1. The pepper v1.Secret (`holos-secret-injector-pepper`). HOL-749
+#      self-seals this Secret on first manager boot and the Credential
+#      reconciler (HOL-751) reads pepper bytes from it on every Hash.
+#      The pinned verbs are `get`, `create`, `update`, `patch` — no
+#      `delete` (operators retire a pepper by editing .data, not by
+#      deleting the whole Secret), no `list` or `watch` (enumeration of
+#      Secrets is the class of vulnerability this service is designed
+#      to close, per ADR 031).
+#
+#   2. Hash-material v1.Secrets owned by the Credential reconciler via
+#      ownerReferences. Those names are generated per-credential so we
+#      cannot pin resourceNames up front; the rule is scoped to the
+#      namespace boundary instead. The reconciler's owner-reference
+#      walk at delete time is belt-and-braces on top of the namespace
+#      boundary — a bug or compromise in the reconciler cannot escape
+#      `holos-system`. HOL-749 tightens this rule by removing `list`
+#      from both rule-sets: the reconciler resolves sibling Secrets by
+#      name, never by listing.
 #
 # Why namespace-scoped and not a ClusterRole. Cluster-wide CUD on
 # core/v1 Secret is the classic cluster-takeover primitive; a bug or
 # compromise in the reconciler would otherwise let it rewrite or delete
 # any Secret in the cluster. Scoping CUD to `holos-system` caps the
-# blast radius to the controller's own namespace. The M2 reconciler's
-# owner-reference walk ensures it only touches Secrets it created, but
-# that is defence-in-depth; the namespace boundary is the primary
-# containment.
+# blast radius.
 #
-# Pairs with secrets-namespace-rolebinding.yaml in the same directory.
-# The namespace-scoped kustomize overlay
-# (../namespace-scoped/kustomization.yaml) pulls both in.
+# Pairs with secrets-rolebinding.yaml in the same directory. The
+# kustomize overlay pulls both in.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: holos-secret-injector-secrets
   namespace: holos-system
 rules:
+# HOL-749: pepper Secret self-seal + read surface. Verbs pinned to the
+# minimum set Bootstrap (create on cold start, get on warm restart) and
+# any future rotation controller (patch / update to add a new
+# pepper-<N> row) need. Delete is deliberately absent: retiring a
+# pepper version is a data edit, not a Secret deletion.
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - holos-secret-injector-pepper
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+# HOL-749: hash-material Secrets owned by the Credential reconciler.
+# Names are generated per-credential so resourceNames cannot pin them;
+# the namespace boundary is the containment. Verbs mirror the M2
+# Credential reconciler contract (create + update on reconcile, delete
+# on finalizer) and are unchanged from the previous rule-set other
+# than the removal of `list`. Enumeration of Secrets remains cluster-
+# forbidden by the `get`-only rule on the ClusterRole
+# (config/secret-injector/rbac/cluster/role.yaml).
 - apiGroups:
   - ""
   resources:

--- a/config/secret-injector/rbac/namespace/secrets-role.yaml
+++ b/config/secret-injector/rbac/namespace/secrets-role.yaml
@@ -7,21 +7,39 @@
 #   1. The pepper v1.Secret (`holos-secret-injector-pepper`). HOL-749
 #      self-seals this Secret on first manager boot and the Credential
 #      reconciler (HOL-751) reads pepper bytes from it on every Hash.
-#      The pinned verbs are `get`, `create`, `update`, `patch` — no
-#      `delete` (operators retire a pepper by editing .data, not by
-#      deleting the whole Secret), no `list` or `watch` (enumeration of
-#      Secrets is the class of vulnerability this service is designed
-#      to close, per ADR 031).
+#      The pinned verbs are `get`, `update`, `patch` — no `delete`
+#      (operators retire a pepper by editing .data, not by deleting the
+#      whole Secret), no `list` or `watch` (enumeration of Secrets is
+#      the class of vulnerability this service is designed to close,
+#      per ADR 031).
+#
+#      `create` is deliberately NOT on this rule: Kubernetes RBAC
+#      cannot restrict `create` by `resourceNames` because the resource
+#      name is decided by the request body, which the authorizer never
+#      consults. See the Kubernetes RBAC reference for the
+#      authoritative statement:
+#      https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+#      "Restrictions on allowed verbs: create" — create verbs cannot be
+#      filtered by name. Putting `create` on a resourceNames-pinned
+#      rule would be a no-op at runtime.
+#
+#      Bootstrap's one-shot Create on cold start is authorised by the
+#      unpinned rule (2) below; the pinned rule still governs every
+#      subsequent Get/Update/Patch of the pepper row. Defence-in-depth
+#      against a compromised reconciler that tried to over-write the
+#      pepper by name comes from the Credential reconciler's owner-
+#      reference walk, not from the resourceNames pin.
 #
 #   2. Hash-material v1.Secrets owned by the Credential reconciler via
-#      ownerReferences. Those names are generated per-credential so we
-#      cannot pin resourceNames up front; the rule is scoped to the
-#      namespace boundary instead. The reconciler's owner-reference
-#      walk at delete time is belt-and-braces on top of the namespace
-#      boundary — a bug or compromise in the reconciler cannot escape
-#      `holos-system`. HOL-749 tightens this rule by removing `list`
-#      from both rule-sets: the reconciler resolves sibling Secrets by
-#      name, never by listing.
+#      ownerReferences, plus the cold-start create of the pepper
+#      Secret. Names are generated per-credential so resourceNames
+#      cannot pin them; the namespace boundary is the containment.
+#      Verbs mirror the M2 Credential reconciler contract (create +
+#      update on reconcile, delete on finalizer) and are unchanged
+#      from the previous rule-set other than the removal of `list`.
+#      Enumeration of Secrets remains cluster-forbidden by the
+#      `get`-only rule on the ClusterRole
+#      (config/secret-injector/rbac/cluster/role.yaml).
 #
 # Why namespace-scoped and not a ClusterRole. Cluster-wide CUD on
 # core/v1 Secret is the classic cluster-takeover primitive; a bug or
@@ -37,11 +55,11 @@ metadata:
   name: holos-secret-injector-secrets
   namespace: holos-system
 rules:
-# HOL-749: pepper Secret self-seal + read surface. Verbs pinned to the
-# minimum set Bootstrap (create on cold start, get on warm restart) and
-# any future rotation controller (patch / update to add a new
-# pepper-<N> row) need. Delete is deliberately absent: retiring a
-# pepper version is a data edit, not a Secret deletion.
+# HOL-749: pepper Secret read + rotate surface. Pinned by resourceNames
+# to the single `holos-secret-injector-pepper` Secret. `create` is
+# deliberately absent from this rule because RBAC cannot restrict
+# create-by-name (see the comment block above); Bootstrap's cold-start
+# Create is authorised by the unpinned rule below.
 - apiGroups:
   - ""
   resources:
@@ -50,16 +68,15 @@ rules:
   - holos-secret-injector-pepper
   verbs:
   - get
-  - create
   - update
   - patch
-# HOL-749: hash-material Secrets owned by the Credential reconciler.
-# Names are generated per-credential so resourceNames cannot pin them;
-# the namespace boundary is the containment. Verbs mirror the M2
-# Credential reconciler contract (create + update on reconcile, delete
-# on finalizer) and are unchanged from the previous rule-set other
-# than the removal of `list`. Enumeration of Secrets remains cluster-
-# forbidden by the `get`-only rule on the ClusterRole
+# HOL-749: hash-material Secrets owned by the Credential reconciler +
+# cold-start Create of the pepper Secret. Names are generated
+# per-credential so resourceNames cannot pin them; the namespace
+# boundary is the containment. Verbs mirror the M2 Credential
+# reconciler contract (create + update on reconcile, delete on
+# finalizer). No `list` or `watch`: enumeration of Secrets remains
+# cluster-forbidden by the `get`-only rule on the ClusterRole
 # (config/secret-injector/rbac/cluster/role.yaml).
 - apiGroups:
   - ""

--- a/internal/secretinjector/cli/cli.go
+++ b/internal/secretinjector/cli/cli.go
@@ -31,7 +31,8 @@ import (
 )
 
 var (
-	logLevel string
+	logLevel            string
+	controllerNamespace string
 )
 
 // Command returns the root cobra command for the holos-secret-injector CLI.
@@ -81,6 +82,16 @@ func Command() *cobra.Command {
 	// listener, etc.) land in later phases.
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 
+	// Controller namespace. The pepper bootstrap (HOL-749) writes the
+	// pinned pepper v1.Secret into this namespace on first manager
+	// boot. Production deployments typically set POD_NAMESPACE via the
+	// downward API on the controller's Deployment manifest and leave
+	// this flag unset; the CLI flag is the escape hatch for local
+	// debugging and envtest-style suites where the downward API is
+	// unavailable. See [sicrypto.PodNamespaceEnv] for the env contract.
+	cmd.PersistentFlags().StringVar(&controllerNamespace, "controller-namespace", "",
+		"Namespace the controller treats as its own (pepper bootstrap target). Defaults to $POD_NAMESPACE.")
+
 	return cmd
 }
 
@@ -112,7 +123,8 @@ func Run(cmd *cobra.Command, args []string) error {
 	}
 
 	mgr, err := sicontroller.NewManager(cfg, sicontroller.Options{
-		Logger: slog.Default(),
+		Logger:              slog.Default(),
+		ControllerNamespace: controllerNamespace,
 	})
 	if err != nil {
 		return fmt.Errorf("constructing manager: %w", err)

--- a/internal/secretinjector/controller/manager.go
+++ b/internal/secretinjector/controller/manager.go
@@ -36,6 +36,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	secretsv1alpha1 "github.com/holos-run/holos-console/api/secrets/v1alpha1"
+	sicrypto "github.com/holos-run/holos-console/internal/secretinjector/crypto"
 )
 
 // Scheme is the controller-runtime scheme shared by the secret-injector
@@ -78,6 +79,21 @@ type Options struct {
 	// exists exclusively for envtest-style suites where each test spins up
 	// its own manager with the same hard-coded controller names.
 	SkipControllerNameValidation bool
+	// ControllerNamespace is the namespace the pepper Bootstrap helper
+	// writes into on first manager start. Leave empty to read from
+	// POD_NAMESPACE via [sicrypto.ControllerNamespace]; an empty env var
+	// and empty option together cause Start() to fail loudly rather than
+	// silently sealing the pepper into the wrong namespace. envtest
+	// suites set this field directly.
+	ControllerNamespace string
+	// SkipPepperBootstrap disables the pepper self-seal in Start(). The
+	// flag exists exclusively for the narrow class of tests that
+	// construct a Manager purely to verify wiring (for example, the
+	// controller-runtime logger regression test in
+	// manager_logger_test.go) and do not need the pepper Secret to
+	// exist. Production callers MUST leave this false; the reconciler
+	// cannot hash without a pepper.
+	SkipPepperBootstrap bool
 }
 
 // Manager wraps a sigs.k8s.io/controller-runtime manager.Manager plus a
@@ -93,6 +109,18 @@ type Manager struct {
 	ready            atomic.Bool
 	cacheSyncTimeout time.Duration
 	logger           *slog.Logger
+	// cfg is retained so Start() can build a direct (non-cached)
+	// client.Client for the one-shot pepper Bootstrap before the
+	// informer caches come up. The informer-cache-backed client cannot
+	// be used for bootstrap because the cache is not synced until
+	// mgr.Start runs.
+	cfg *rest.Config
+	// controllerNamespace is the resolved namespace Bootstrap writes
+	// into. Empty means Start() will consult POD_NAMESPACE.
+	controllerNamespace string
+	// skipPepperBootstrap mirrors the Options field; see the GoDoc
+	// there for the narrow test-only use case.
+	skipPepperBootstrap bool
 }
 
 // NewManager constructs a Manager from the provided rest config and Options.
@@ -157,7 +185,14 @@ func NewManager(cfg *rest.Config, opts Options) (*Manager, error) {
 		return nil, fmt.Errorf("controller.NewManager: registering UpstreamSecretReconciler: %w", err)
 	}
 
-	return &Manager{mgr: mgr, cacheSyncTimeout: cacheSyncTimeout, logger: logger}, nil
+	return &Manager{
+		mgr:                 mgr,
+		cacheSyncTimeout:    cacheSyncTimeout,
+		logger:              logger,
+		cfg:                 cfg,
+		controllerNamespace: opts.ControllerNamespace,
+		skipPepperBootstrap: opts.SkipPepperBootstrap,
+	}, nil
 }
 
 // GetClient returns the cache-backed client.Client. Writes go straight to the
@@ -186,6 +221,19 @@ func (m *Manager) Ready() bool {
 //
 // Start is intended to be called exactly once per Manager.
 func (m *Manager) Start(ctx context.Context) error {
+	// Seal the pepper Secret before any reconciler runs. Bootstrap is
+	// idempotent, so a warm restart is a single Get; on a cold start we
+	// generate crypto/rand bytes and Create data["pepper-1"]. A
+	// failure here is fatal: the Credential reconciler (HOL-751) cannot
+	// Hash without a pepper, and falling back would produce an
+	// unpeppered hash that silently weakens every credential written
+	// after the missing bootstrap.
+	if !m.skipPepperBootstrap {
+		if err := m.bootstrapPepper(ctx); err != nil {
+			return err
+		}
+	}
+
 	watchCtx, cancelWatch := context.WithCancel(ctx)
 	defer cancelWatch()
 
@@ -217,5 +265,44 @@ func (m *Manager) Start(ctx context.Context) error {
 	if err := m.mgr.Start(ctx); err != nil {
 		return fmt.Errorf("secret-injector controller manager: %w", err)
 	}
+	return nil
+}
+
+// bootstrapPepper runs the one-shot pepper self-seal against the
+// controller's own namespace. Called from Start() before mgr.Start so the
+// pepper Secret exists the moment a reconciler tries to Hash.
+//
+// The helper uses a direct (non-cached) client.Client constructed from
+// m.cfg because the manager's cache is not yet synced at this point.
+// Factored out of Start() so the control flow in Start() stays readable
+// and so a future follow-up can stub the bootstrap path in tests by
+// overriding this method via struct embedding if the need arises.
+func (m *Manager) bootstrapPepper(ctx context.Context) error {
+	ns := m.controllerNamespace
+	if ns == "" {
+		ns = sicrypto.ControllerNamespace()
+	}
+	if ns == "" {
+		return fmt.Errorf("controller.Manager.Start: pepper bootstrap requires a controller namespace; set %s via the downward API or Options.ControllerNamespace",
+			sicrypto.PodNamespaceEnv)
+	}
+
+	directClient, err := client.New(m.cfg, client.Options{Scheme: Scheme})
+	if err != nil {
+		return fmt.Errorf("controller.Manager.Start: building bootstrap client: %w", err)
+	}
+
+	result, err := sicrypto.Bootstrap(ctx, directClient, ns)
+	if err != nil {
+		return fmt.Errorf("controller.Manager.Start: pepper bootstrap: %w", err)
+	}
+	// Telemetry invariant: only the integer version and the byte length
+	// are emitted. The pepper bytes themselves never touch the logger.
+	m.logger.Info("pepper bootstrap complete",
+		"namespace", ns,
+		"secret", sicrypto.PepperSecretName,
+		"activeVersion", result.ActiveVersion,
+		"created", result.Created,
+		"bytesLength", result.BytesLength)
 	return nil
 }

--- a/internal/secretinjector/crypto/pepper.go
+++ b/internal/secretinjector/crypto/pepper.go
@@ -113,10 +113,19 @@ type Loader interface {
 
 // SecretLoader is the production [Loader] implementation backed by a
 // controller-runtime client.Client. The zero value is not usable; callers
-// construct one via [NewSecretLoader]. Reads go through the supplied
-// client, which in a running manager is the cache-backed client — so a
-// steady-state Active/Get is an in-memory map lookup, not an API server
-// round trip.
+// construct one via [NewSecretLoader].
+//
+// The supplied client MUST be a non-cached direct client (built with
+// client.New, not mgr.GetClient()). The controller-runtime ClusterRole
+// shipped with this binary grants `get` on core/v1 Secret only — not
+// `list` or `watch` — because enumeration of Secrets is the class of
+// vulnerability this service is designed to close (see
+// config/secret-injector/rbac/cluster/role.yaml and ADR 031). A
+// cache-backed client would lazily start a Secret informer on the
+// first Get and require `list`/`watch`, which real RBAC forbids. The
+// Credential reconciler (HOL-751) constructs the direct client for
+// this purpose; the fake client used by unit tests mimics the direct
+// client's Get-by-name shape.
 //
 // The loader holds no pepper bytes in its own fields. Every call fetches
 // the current state of the backing Secret and parses it, which means an
@@ -134,9 +143,13 @@ type SecretLoader struct {
 }
 
 // NewSecretLoader constructs a [SecretLoader] that reads from the pinned
-// [PepperSecretName] Secret in the supplied namespace. The client is the
-// cache-backed client.Client obtained from the controller-runtime manager
-// (see [Manager.GetClient]); callers in tests can pass a fake client.
+// [PepperSecretName] Secret in the supplied namespace. The client MUST be
+// a non-cached direct client — see the [SecretLoader] GoDoc for why a
+// cache-backed client would violate the shipped ClusterRole (no
+// list/watch on core/v1 Secret). Production callers in HOL-751
+// construct the direct client via client.New(cfg, client.Options{})
+// from the same rest.Config the manager uses. Tests supply a fake
+// client whose Get shape matches the direct client.
 //
 // namespace MUST be non-empty. Callers typically obtain it from
 // [ControllerNamespace].

--- a/internal/secretinjector/crypto/pepper.go
+++ b/internal/secretinjector/crypto/pepper.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PepperSecretName is the pinned name of the v1.Secret that carries the
+// holos-secret-injector pepper material in the controller's own namespace.
+// The name is pinned (not configurable) so operators can audit the single
+// object that carries the bytes; a typo in an env var cannot accidentally
+// route Bootstrap to write the pepper into a differently-named Secret.
+//
+// Each row in the Secret's .data map is keyed as "pepper-<N>" where <N> is
+// an ASCII decimal integer version. The Credential reconciler (HOL-751)
+// routes to the matching pepper bytes via [Loader.Get] by supplying the
+// same integer version that was stamped onto the hash Envelope at Hash
+// time. The active (newest) version is reported by [Loader.Active].
+const PepperSecretName = "holos-secret-injector-pepper"
+
+// PepperDataKeyPrefix is the prefix every versioned pepper data key uses.
+// Keys that do not start with this prefix are ignored by [Loader.Active]
+// and [Loader.Get] so a Secret that picks up an unrelated annotation-side
+// key (for example, a future "salt-seed" key) does not corrupt version
+// discovery. See [parsePepperVersion] for the parse contract.
+const PepperDataKeyPrefix = "pepper-"
+
+// Errors returned by the pepper loader. They are sentinel values so callers
+// can match with [errors.Is] without string parsing.
+var (
+	// ErrPepperSecretNotFound is returned by [Loader.Active] and
+	// [Loader.Get] when the backing v1.Secret does not exist in the
+	// configured namespace. The loader refuses to fall back to a
+	// zero-byte pepper so a missing Bootstrap call fails loudly rather
+	// than silently producing an unpeppered hash.
+	ErrPepperSecretNotFound = errors.New("crypto: pepper Secret not found")
+	// ErrPepperVersionNotFound is returned by [Loader.Get] when the
+	// caller asks for an integer version that is not present in the
+	// backing Secret's data map. An operator who deleted a retired
+	// pepper row before every hash referencing it was re-hashed will
+	// see this error surface on verify — the error is deliberate: the
+	// loader never silently substitutes a different version.
+	ErrPepperVersionNotFound = errors.New("crypto: pepper version not found")
+	// ErrNoPepperVersions is returned by [Loader.Active] when the
+	// backing Secret exists but carries no "pepper-<N>" data keys. This
+	// indicates an operator manually cleared the Secret's data or a
+	// buggy writer truncated it; either way the loader refuses to
+	// report an active version because there is no material to hash
+	// against.
+	ErrNoPepperVersions = errors.New("crypto: pepper Secret carries no versioned rows")
+)
+
+// Loader looks up pepper bytes by integer version. The interface is the
+// read-only surface the Credential reconciler (HOL-751) depends on; the
+// bootstrap writer lives separately in [Bootstrap] so reconcilers cannot
+// accidentally mutate the Secret during a Reconcile call.
+//
+// Implementations MUST:
+//
+//   - Refuse to return a zero-length pepper. An empty row in .data is an
+//     operator error and must surface as an error, not as success.
+//   - Never log the pepper bytes. Log the integer version and the byte
+//     length as the only shape visible to telemetry.
+//   - Read from a narrow, pinned v1.Secret in the controller's own
+//     namespace; never from a CR spec/status, a ConfigMap, or an env var.
+//     ADR 031 pins the no-sensitive-on-CR invariant.
+type Loader interface {
+	// Active returns the highest-numbered pepper version present in the
+	// backing Secret and its bytes. Callers use the returned version as
+	// [Envelope.PepperVersion] when they Hash a new credential so a
+	// later rotation can route Verify to the right row via [Loader.Get].
+	//
+	// Returns [ErrPepperSecretNotFound] if Bootstrap has not run,
+	// [ErrNoPepperVersions] if the Secret exists but carries no
+	// "pepper-<N>" keys.
+	Active(ctx context.Context) (version int32, bytes []byte, err error)
+
+	// Get returns the pepper bytes for the supplied integer version.
+	// Callers use this on Verify to look up the pepper that was active
+	// at Hash time, which may differ from the Active version during a
+	// rotation window.
+	//
+	// Returns [ErrPepperSecretNotFound] if the backing Secret is gone,
+	// [ErrPepperVersionNotFound] if the version row has been removed
+	// (for example, by a future retire-old-pepper job).
+	Get(ctx context.Context, version int32) (bytes []byte, err error)
+}
+
+// SecretLoader is the production [Loader] implementation backed by a
+// controller-runtime client.Client. The zero value is not usable; callers
+// construct one via [NewSecretLoader]. Reads go through the supplied
+// client, which in a running manager is the cache-backed client — so a
+// steady-state Active/Get is an in-memory map lookup, not an API server
+// round trip.
+//
+// The loader holds no pepper bytes in its own fields. Every call fetches
+// the current state of the backing Secret and parses it, which means an
+// external rotation of the Secret's .data takes effect on the next call
+// without requiring a manager restart. This is defence-in-depth: the
+// active rotation controller is Post-MVP, but the read surface is already
+// rotation-ready.
+type SecretLoader struct {
+	client    client.Client
+	namespace string
+	name      string
+	// cacheMu guards the parsed map. Reads take RLock so Active/Get
+	// calls in parallel don't serialise, while a refresh takes Lock.
+	cacheMu sync.RWMutex
+}
+
+// NewSecretLoader constructs a [SecretLoader] that reads from the pinned
+// [PepperSecretName] Secret in the supplied namespace. The client is the
+// cache-backed client.Client obtained from the controller-runtime manager
+// (see [Manager.GetClient]); callers in tests can pass a fake client.
+//
+// namespace MUST be non-empty. Callers typically obtain it from
+// [ControllerNamespace].
+func NewSecretLoader(c client.Client, namespace string) (*SecretLoader, error) {
+	if c == nil {
+		return nil, errors.New("crypto: NewSecretLoader requires a non-nil client")
+	}
+	if namespace == "" {
+		return nil, errors.New("crypto: NewSecretLoader requires a non-empty namespace")
+	}
+	return &SecretLoader{
+		client:    c,
+		namespace: namespace,
+		name:      PepperSecretName,
+	}, nil
+}
+
+// Active implements [Loader.Active]. See the interface doc for the
+// contract; this method fetches the pinned Secret, parses the "pepper-<N>"
+// keys, and returns the highest version's bytes.
+func (l *SecretLoader) Active(ctx context.Context) (int32, []byte, error) {
+	l.cacheMu.RLock()
+	defer l.cacheMu.RUnlock()
+
+	versions, err := l.loadVersions(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(versions) == 0 {
+		return 0, nil, ErrNoPepperVersions
+	}
+	active := activeVersion(versions)
+	bytes := versions[active]
+	if len(bytes) == 0 {
+		// An empty row is an operator error — surface it rather than
+		// returning zero bytes that would hash every credential to the
+		// same value. Do NOT include the row's bytes (there are none,
+		// but even the length shape stays off the wire for the
+		// versioned row to match what the Credential reconciler logs).
+		return 0, nil, fmt.Errorf("crypto: pepper row for version %d is empty", active)
+	}
+	return active, cloneBytes(bytes), nil
+}
+
+// Get implements [Loader.Get]. See the interface doc for the contract.
+func (l *SecretLoader) Get(ctx context.Context, version int32) ([]byte, error) {
+	l.cacheMu.RLock()
+	defer l.cacheMu.RUnlock()
+
+	versions, err := l.loadVersions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	bytes, ok := versions[version]
+	if !ok {
+		return nil, fmt.Errorf("%w: version %d", ErrPepperVersionNotFound, version)
+	}
+	if len(bytes) == 0 {
+		return nil, fmt.Errorf("crypto: pepper row for version %d is empty", version)
+	}
+	return cloneBytes(bytes), nil
+}
+
+// loadVersions fetches the backing Secret and returns its parsed
+// pepper rows. Malformed keys (keys that do not parse as
+// "pepper-<positive-int32>") are silently ignored — they might be future
+// extensions (a "salt-seed" row, for example) or operator typos that we
+// refuse to crash on. Rows with non-numeric or non-positive suffixes are
+// also ignored so a stray "pepper-foo" row does not hijack the version
+// discovery.
+func (l *SecretLoader) loadVersions(ctx context.Context) (map[int32][]byte, error) {
+	var secret corev1.Secret
+	key := types.NamespacedName{Namespace: l.namespace, Name: l.name}
+	if err := l.client.Get(ctx, key, &secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: %s/%s", ErrPepperSecretNotFound, l.namespace, l.name)
+		}
+		return nil, fmt.Errorf("crypto: get pepper Secret %s: %w", key, err)
+	}
+	return parsePepperData(secret.Data), nil
+}
+
+// parsePepperData filters the supplied Secret data map down to rows keyed
+// as "pepper-<positive-int32>" and returns a map keyed by the parsed
+// version. Rows that fail to parse are ignored rather than rejected:
+// a malformed key MUST NOT crash the loader because an operator who
+// manually labelled a comment-style key should not brick the hash path.
+// See [parsePepperVersion] for the parse contract.
+func parsePepperData(data map[string][]byte) map[int32][]byte {
+	out := make(map[int32][]byte, len(data))
+	for k, v := range data {
+		version, ok := parsePepperVersion(k)
+		if !ok {
+			continue
+		}
+		out[version] = v
+	}
+	return out
+}
+
+// parsePepperVersion decodes a "pepper-<N>" data key into its integer
+// version. Returns (0, false) if key does not start with
+// [PepperDataKeyPrefix], if the suffix is not a base-10 integer in the
+// int32 range, or if the suffix parses to a non-positive integer (zero
+// and negatives are reserved so version 1 is the first seal).
+func parsePepperVersion(key string) (int32, bool) {
+	suffix, ok := strings.CutPrefix(key, PepperDataKeyPrefix)
+	if !ok {
+		return 0, false
+	}
+	if suffix == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(suffix, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	if n <= 0 {
+		return 0, false
+	}
+	return int32(n), true
+}
+
+// activeVersion returns the maximum key in versions. versions MUST be
+// non-empty; callers check len before invoking so this helper can remain
+// branch-free on the empty case. The active row is the highest-numbered
+// version because version numbers are monotonically assigned by Bootstrap
+// and any future rotation controller (Post-MVP).
+func activeVersion(versions map[int32][]byte) int32 {
+	var active int32
+	first := true
+	for v := range versions {
+		if first || v > active {
+			active = v
+			first = false
+		}
+	}
+	return active
+}
+
+// cloneBytes returns a defensive copy of b so a caller cannot mutate the
+// backing map's value. The loader holds no retained pointer to b because
+// loadVersions re-fetches on every call, but copying at the return
+// boundary insulates the loader from future caching work that retains
+// maps across calls.
+func cloneBytes(b []byte) []byte {
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}

--- a/internal/secretinjector/crypto/pepper_bootstrap.go
+++ b/internal/secretinjector/crypto/pepper_bootstrap.go
@@ -194,9 +194,16 @@ func getPepperSecret(ctx context.Context, c client.Client, key types.NamespacedN
 
 // existingResult derives the BootstrapResult for a Secret that already
 // exists. Returns an error if the Secret is present but carries no
-// valid "pepper-<N>" rows — this is an unrecoverable state because the
-// reconciler cannot hash, and Bootstrap refuses to silently re-seed
-// version 1 on top of operator-edited material.
+// valid "pepper-<N>" rows, or if the active (highest-numbered) row is
+// zero-length. Either condition is unrecoverable because the reconciler
+// cannot hash against an absent or empty pepper, and Bootstrap refuses
+// to report success on an unusable Secret — the "pepper bootstrap
+// complete" log line must only appear when Hash can actually run.
+//
+// Bootstrap also refuses to silently re-seed version 1 on top of
+// operator-edited material: an operator who wiped .data must clear up
+// the mess deliberately rather than get a fresh pepper substituted
+// under them.
 func existingResult(s *corev1.Secret) (BootstrapResult, error) {
 	versions := parsePepperData(s.Data)
 	if len(versions) == 0 {
@@ -204,6 +211,16 @@ func existingResult(s *corev1.Secret) (BootstrapResult, error) {
 			ErrNoPepperVersions, s.Namespace, s.Name)
 	}
 	active := activeVersion(versions)
+	if len(versions[active]) == 0 {
+		// The highest-numbered row is present but empty. Loader.Active
+		// would reject it on the first reconcile; fail at Bootstrap
+		// time instead so the manager never reports readiness on an
+		// unusable pepper. The version counter is safe to include in
+		// the error (it is telemetry-safe shape); the bytes stay off
+		// the wire because there are none.
+		return BootstrapResult{}, fmt.Errorf("crypto: Bootstrap: existing pepper Secret %s/%s row for version %d is empty",
+			s.Namespace, s.Name, active)
+	}
 	return BootstrapResult{
 		ActiveVersion: active,
 		Created:       false,

--- a/internal/secretinjector/crypto/pepper_bootstrap.go
+++ b/internal/secretinjector/crypto/pepper_bootstrap.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PepperSeedLength is the number of random bytes Bootstrap generates for a
+// freshly-seeded pepper row. 32 bytes (256 bits) is the standard argon2id
+// pepper recommendation (RFC 9106 §3.1 "secret input") — long enough to
+// defeat brute-force against the pepper itself even if an attacker obtains
+// every hash in the cluster.
+const PepperSeedLength = 32
+
+// PodNamespaceEnv is the downward-API environment variable name the
+// manager reads at startup to discover its own namespace. The value is set
+// on the Deployment via:
+//
+//	env:
+//	- name: POD_NAMESPACE
+//	  valueFrom:
+//	    fieldRef:
+//	      fieldPath: metadata.namespace
+//
+// See config/secret-injector/deployment/deployment.yaml for the concrete
+// wiring. Callers in envtest typically skip the env var and pass the
+// namespace explicitly into [Bootstrap] — see the [ControllerNamespace]
+// GoDoc for the fallback story.
+const PodNamespaceEnv = "POD_NAMESPACE"
+
+// ControllerNamespace returns the namespace the controller should treat
+// as its own for pepper-bootstrap purposes. Resolution order:
+//
+//  1. POD_NAMESPACE environment variable (set by the downward API on the
+//     controller's Deployment).
+//  2. Empty string. Callers MUST NOT default to "default" or any other
+//     concrete namespace: a silent fallback would let a misconfigured
+//     Deployment write the pepper into the wrong namespace, and RBAC
+//     would probably allow it because create-in-namespace RoleBindings
+//     are namespace-local by definition. An empty return value is the
+//     signal for the caller to fail loudly.
+//
+// Tests that need a deterministic namespace use [os.Setenv] on
+// [PodNamespaceEnv] or pass the namespace directly into [Bootstrap].
+// envtest suites typically call os.Setenv("POD_NAMESPACE", "default")
+// in a TestMain hook so the pod-identity flow is exercised without a
+// downward-API fixture.
+func ControllerNamespace() string {
+	return os.Getenv(PodNamespaceEnv)
+}
+
+// BootstrapResult carries the shape [Bootstrap] reports to its caller.
+// Every field is telemetry-safe: nothing about the pepper bytes or their
+// random seed is exposed. The Manager's log line and any later Prometheus
+// gauge consume this struct directly.
+type BootstrapResult struct {
+	// ActiveVersion is the integer version [Loader.Active] will
+	// subsequently report. For a first-boot seal this is always 1; for
+	// an already-seeded Secret it is the maximum version that was
+	// parsed out of .data.
+	ActiveVersion int32
+	// Created reports whether Bootstrap seeded a new Secret (true) or
+	// observed an existing one (false). The flag drives the manager's
+	// one-line startup log so operators can tell a first boot from a
+	// warm restart at a glance.
+	Created bool
+	// BytesLength is the byte length of the active pepper row. Included
+	// for observability: an operator who sees BytesLength=32 on first
+	// boot knows the downward-API bootstrap produced a full-size seed,
+	// without the log line ever carrying the bytes themselves.
+	BytesLength int
+}
+
+// Bootstrap self-seals the controller-namespace pepper Secret on first
+// manager boot and returns the active pepper version. The function is
+// idempotent: a second invocation against a Secret that already exists
+// parses the max version out of .data and returns it without touching the
+// API server other than a single Get.
+//
+// On a missing Secret the function generates [PepperSeedLength] random
+// bytes from [crypto/rand], writes data["pepper-1"] = <bytes>, sets
+// Type=Opaque, and Creates the Secret. Conflicts on Create (the race where
+// two replicas boot in parallel) are handled by a second Get and parse so
+// the loser of the race does not overwrite the winner's pepper.
+//
+// Bootstrap is called exactly once per manager process, from
+// controller.Manager.Start before the first reconcile runs. A failure is
+// fatal: the reconciler cannot Hash without a pepper, and falling back
+// would produce an unpeppered hash.
+//
+// Bootstrap never logs the pepper bytes, never returns them to the
+// caller, and never stamps them onto the returned [BootstrapResult]. The
+// only shape exposed is the integer version and the byte length.
+func Bootstrap(ctx context.Context, c client.Client, namespace string) (BootstrapResult, error) {
+	if c == nil {
+		return BootstrapResult{}, errors.New("crypto: Bootstrap requires a non-nil client")
+	}
+	if namespace == "" {
+		return BootstrapResult{}, errors.New("crypto: Bootstrap requires a non-empty namespace (set POD_NAMESPACE on the Deployment)")
+	}
+
+	key := types.NamespacedName{Namespace: namespace, Name: PepperSecretName}
+
+	// Fast path: read the existing Secret via the supplied client. Most
+	// manager starts hit this branch because the Secret persists across
+	// pod restarts.
+	existing, err := getPepperSecret(ctx, c, key)
+	switch {
+	case err == nil:
+		return existingResult(existing)
+	case !apierrors.IsNotFound(err):
+		return BootstrapResult{}, fmt.Errorf("crypto: Bootstrap: get pepper Secret: %w", err)
+	}
+
+	// Secret is absent — seal a fresh version 1. Use crypto/rand so the
+	// seed is unpredictable across replicas and restarts. If
+	// io.ReadFull returns short, we abort rather than write a partial
+	// pepper; a partial seal is worse than no seal because the manager
+	// would silently carry on with a weak pepper on the next restart.
+	seed := make([]byte, PepperSeedLength)
+	if _, err := rand.Read(seed); err != nil {
+		return BootstrapResult{}, fmt.Errorf("crypto: Bootstrap: generating pepper seed: %w", err)
+	}
+
+	fresh := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			pepperDataKey(1): seed,
+		},
+	}
+	if err := c.Create(ctx, fresh); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// A parallel manager replica won the race. Re-read
+			// and report its version as active. This is the only
+			// branch where a Bootstrap call does two round trips
+			// against the API server; single-replica deployments
+			// never hit it.
+			winner, readErr := getPepperSecret(ctx, c, key)
+			if readErr != nil {
+				return BootstrapResult{}, fmt.Errorf("crypto: Bootstrap: re-reading after AlreadyExists: %w", readErr)
+			}
+			return existingResult(winner)
+		}
+		return BootstrapResult{}, fmt.Errorf("crypto: Bootstrap: creating pepper Secret: %w", err)
+	}
+
+	return BootstrapResult{
+		ActiveVersion: 1,
+		Created:       true,
+		BytesLength:   len(seed),
+	}, nil
+}
+
+// getPepperSecret wraps a single client.Get against the pinned pepper
+// Secret. Factored so both branches of Bootstrap share the same lookup
+// shape.
+func getPepperSecret(ctx context.Context, c client.Client, key types.NamespacedName) (*corev1.Secret, error) {
+	var s corev1.Secret
+	if err := c.Get(ctx, key, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// existingResult derives the BootstrapResult for a Secret that already
+// exists. Returns an error if the Secret is present but carries no
+// valid "pepper-<N>" rows — this is an unrecoverable state because the
+// reconciler cannot hash, and Bootstrap refuses to silently re-seed
+// version 1 on top of operator-edited material.
+func existingResult(s *corev1.Secret) (BootstrapResult, error) {
+	versions := parsePepperData(s.Data)
+	if len(versions) == 0 {
+		return BootstrapResult{}, fmt.Errorf("%w: %s/%s (no pepper-<N> rows parsed from .data)",
+			ErrNoPepperVersions, s.Namespace, s.Name)
+	}
+	active := activeVersion(versions)
+	return BootstrapResult{
+		ActiveVersion: active,
+		Created:       false,
+		BytesLength:   len(versions[active]),
+	}, nil
+}
+
+// pepperDataKey returns the "pepper-<N>" data-map key for version v.
+// Centralised so the prefix and formatting live in one place; this is
+// the only writer that must stay in lock-step with [parsePepperVersion].
+func pepperDataKey(v int32) string {
+	return PepperDataKeyPrefix + strconv.FormatInt(int64(v), 10)
+}

--- a/internal/secretinjector/crypto/pepper_test.go
+++ b/internal/secretinjector/crypto/pepper_test.go
@@ -1,0 +1,480 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// testNamespace is the namespace every pepper test uses. The pepper
+// Secret is deliberately cluster-namespace-scoped in production but for
+// unit tests a single fixed namespace keeps assertions concise.
+const testNamespace = "holos-system"
+
+// pepperScheme is a local runtime.Scheme carrying only the corev1 types
+// the loader and bootstrap helpers need. Keeping the scheme local to the
+// test file avoids an import cycle on the controller package's Scheme.
+var pepperScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	return s
+}()
+
+// newFakeClient returns a fake controller-runtime client.Client seeded
+// with the supplied objects. The status subresource is not split out
+// because the pepper Secret does not use a status subresource.
+func newFakeClient(objs ...client.Object) client.Client {
+	return ctrlfake.NewClientBuilder().
+		WithScheme(pepperScheme).
+		WithObjects(objs...).
+		Build()
+}
+
+// TestBootstrapFirstSealWritesVersion1 verifies the cold-start path:
+// Bootstrap against an empty namespace seals a fresh Secret with a single
+// "pepper-1" row of PepperSeedLength bytes, and the returned
+// BootstrapResult reports Created=true, ActiveVersion=1.
+func TestBootstrapFirstSealWritesVersion1(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient()
+
+	result, err := Bootstrap(ctx, c, testNamespace)
+	if err != nil {
+		t.Fatalf("Bootstrap: unexpected error: %v", err)
+	}
+	if !result.Created {
+		t.Errorf("result.Created = false, want true on first seal")
+	}
+	if result.ActiveVersion != 1 {
+		t.Errorf("result.ActiveVersion = %d, want 1", result.ActiveVersion)
+	}
+	if result.BytesLength != PepperSeedLength {
+		t.Errorf("result.BytesLength = %d, want %d", result.BytesLength, PepperSeedLength)
+	}
+
+	// Assert the Secret was actually written with the expected shape.
+	var s corev1.Secret
+	if err := c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: PepperSecretName}, &s); err != nil {
+		t.Fatalf("Get sealed pepper Secret: %v", err)
+	}
+	if s.Type != corev1.SecretTypeOpaque {
+		t.Errorf("Secret.Type = %q, want %q", s.Type, corev1.SecretTypeOpaque)
+	}
+	if got := len(s.Data); got != 1 {
+		t.Errorf("len(Secret.Data) = %d, want 1 row", got)
+	}
+	row, ok := s.Data["pepper-1"]
+	if !ok {
+		t.Fatalf("Secret.Data missing key %q; got keys %v", "pepper-1", keysOf(s.Data))
+	}
+	if len(row) != PepperSeedLength {
+		t.Errorf("len(pepper-1) = %d, want %d", len(row), PepperSeedLength)
+	}
+}
+
+// TestBootstrapIsIdempotent verifies the warm-restart path: a second
+// Bootstrap call against a Secret that already exists does not rewrite
+// .data, and reports Created=false with the same ActiveVersion as the
+// first call.
+func TestBootstrapIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient()
+
+	first, err := Bootstrap(ctx, c, testNamespace)
+	if err != nil {
+		t.Fatalf("first Bootstrap: %v", err)
+	}
+
+	// Snapshot the sealed bytes so we can assert the second call leaves
+	// them untouched.
+	var afterFirst corev1.Secret
+	if err := c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: PepperSecretName}, &afterFirst); err != nil {
+		t.Fatalf("Get after first: %v", err)
+	}
+	wantBytes := append([]byte(nil), afterFirst.Data["pepper-1"]...)
+
+	second, err := Bootstrap(ctx, c, testNamespace)
+	if err != nil {
+		t.Fatalf("second Bootstrap: %v", err)
+	}
+	if second.Created {
+		t.Errorf("second.Created = true, want false on warm restart")
+	}
+	if second.ActiveVersion != first.ActiveVersion {
+		t.Errorf("second.ActiveVersion = %d, want %d (first)", second.ActiveVersion, first.ActiveVersion)
+	}
+
+	var afterSecond corev1.Secret
+	if err := c.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: PepperSecretName}, &afterSecond); err != nil {
+		t.Fatalf("Get after second: %v", err)
+	}
+	if !bytes.Equal(afterSecond.Data["pepper-1"], wantBytes) {
+		t.Errorf("pepper-1 mutated across idempotent Bootstrap calls")
+	}
+}
+
+// TestBootstrapDetectsMaxVersion seeds the Secret with multiple versions
+// and asserts Bootstrap parses the max correctly. Exercises the
+// operator-migrated flow where a future rotation controller may have
+// written pepper-2, pepper-3, and retired pepper-1.
+func TestBootstrapDetectsMaxVersion(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"pepper-1": bytes.Repeat([]byte{0x01}, PepperSeedLength),
+			"pepper-3": bytes.Repeat([]byte{0x03}, PepperSeedLength),
+			"pepper-2": bytes.Repeat([]byte{0x02}, PepperSeedLength),
+		},
+	})
+
+	result, err := Bootstrap(ctx, c, testNamespace)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if result.Created {
+		t.Errorf("result.Created = true, want false (Secret already exists)")
+	}
+	if result.ActiveVersion != 3 {
+		t.Errorf("result.ActiveVersion = %d, want 3", result.ActiveVersion)
+	}
+	if result.BytesLength != PepperSeedLength {
+		t.Errorf("result.BytesLength = %d, want %d", result.BytesLength, PepperSeedLength)
+	}
+}
+
+// TestBootstrapIgnoresMalformedKeys confirms keys that are not
+// "pepper-<positive-int32>" are filtered out rather than crashing the
+// parser. The Secret has one valid row ("pepper-2") alongside several
+// malformed ones; Bootstrap must report ActiveVersion=2.
+func TestBootstrapIgnoresMalformedKeys(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"foo":        []byte("ignore"),
+			"pepper-":    []byte("ignore-empty-suffix"),
+			"pepper-abc": []byte("ignore-nonnumeric"),
+			"pepper-0":   []byte("ignore-zero-version"),
+			"pepper--1":  []byte("ignore-negative"),
+			"pepper-2":   bytes.Repeat([]byte{0x02}, PepperSeedLength),
+		},
+	})
+
+	result, err := Bootstrap(ctx, c, testNamespace)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if result.ActiveVersion != 2 {
+		t.Errorf("result.ActiveVersion = %d, want 2 (only valid row)", result.ActiveVersion)
+	}
+}
+
+// TestBootstrapEmptyNamespaceRejected confirms Bootstrap refuses to run
+// with an empty namespace so a missing POD_NAMESPACE env var does not
+// silently seal the pepper into the wrong place.
+func TestBootstrapEmptyNamespaceRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient()
+
+	_, err := Bootstrap(ctx, c, "")
+	if err == nil {
+		t.Fatalf("Bootstrap(empty namespace) = nil error, want rejection")
+	}
+}
+
+// TestBootstrapNilClientRejected confirms Bootstrap refuses to run
+// without a client. A nil client would panic on the first Get; the
+// helper returns a structured error instead.
+func TestBootstrapNilClientRejected(t *testing.T) {
+	_, err := Bootstrap(context.Background(), nil, testNamespace)
+	if err == nil {
+		t.Fatalf("Bootstrap(nil client) = nil error, want rejection")
+	}
+}
+
+// TestBootstrapExistingSecretWithNoValidRows returns
+// ErrNoPepperVersions so an operator who truncates .data sees a loud
+// error on manager restart rather than Bootstrap silently re-sealing
+// version 1 on top of the broken material.
+func TestBootstrapExistingSecretWithNoValidRows(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"not-a-pepper-row": []byte("junk"),
+		},
+	})
+
+	_, err := Bootstrap(ctx, c, testNamespace)
+	if !errors.Is(err, ErrNoPepperVersions) {
+		t.Fatalf("Bootstrap error = %v, want ErrNoPepperVersions", err)
+	}
+}
+
+// TestSecretLoaderActiveReadsHighestVersion seeds a pre-existing
+// multi-version Secret and asserts Loader.Active returns the max and
+// that the returned bytes match the row.
+func TestSecretLoaderActiveReadsHighestVersion(t *testing.T) {
+	ctx := context.Background()
+	threeBytes := bytes.Repeat([]byte{0x03}, PepperSeedLength)
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"pepper-1": bytes.Repeat([]byte{0x01}, PepperSeedLength),
+			"pepper-3": threeBytes,
+			"pepper-2": bytes.Repeat([]byte{0x02}, PepperSeedLength),
+		},
+	})
+
+	loader, err := NewSecretLoader(c, testNamespace)
+	if err != nil {
+		t.Fatalf("NewSecretLoader: %v", err)
+	}
+	version, got, err := loader.Active(ctx)
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	if version != 3 {
+		t.Errorf("active version = %d, want 3", version)
+	}
+	if !bytes.Equal(got, threeBytes) {
+		t.Errorf("active bytes mismatch")
+	}
+}
+
+// TestSecretLoaderGetByVersion returns the specific row.
+func TestSecretLoaderGetByVersion(t *testing.T) {
+	ctx := context.Background()
+	twoBytes := bytes.Repeat([]byte{0x02}, PepperSeedLength)
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"pepper-1": bytes.Repeat([]byte{0x01}, PepperSeedLength),
+			"pepper-2": twoBytes,
+		},
+	})
+
+	loader, err := NewSecretLoader(c, testNamespace)
+	if err != nil {
+		t.Fatalf("NewSecretLoader: %v", err)
+	}
+	got, err := loader.Get(ctx, 2)
+	if err != nil {
+		t.Fatalf("Get(2): %v", err)
+	}
+	if !bytes.Equal(got, twoBytes) {
+		t.Errorf("Get(2) bytes mismatch")
+	}
+}
+
+// TestSecretLoaderGetUnknownVersion surfaces ErrPepperVersionNotFound.
+func TestSecretLoaderGetUnknownVersion(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"pepper-1": bytes.Repeat([]byte{0x01}, PepperSeedLength),
+		},
+	})
+
+	loader, err := NewSecretLoader(c, testNamespace)
+	if err != nil {
+		t.Fatalf("NewSecretLoader: %v", err)
+	}
+	_, err = loader.Get(ctx, 5)
+	if !errors.Is(err, ErrPepperVersionNotFound) {
+		t.Fatalf("Get(5) error = %v, want ErrPepperVersionNotFound", err)
+	}
+}
+
+// TestSecretLoaderActiveMissingSecret surfaces ErrPepperSecretNotFound.
+func TestSecretLoaderActiveMissingSecret(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient()
+
+	loader, err := NewSecretLoader(c, testNamespace)
+	if err != nil {
+		t.Fatalf("NewSecretLoader: %v", err)
+	}
+	_, _, err = loader.Active(ctx)
+	if !errors.Is(err, ErrPepperSecretNotFound) {
+		t.Fatalf("Active error = %v, want ErrPepperSecretNotFound", err)
+	}
+}
+
+// TestSecretLoaderActiveNoValidRows seeds a Secret whose .data carries
+// only malformed keys; Active reports ErrNoPepperVersions.
+func TestSecretLoaderActiveNoValidRows(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"foo": []byte("junk"),
+		},
+	})
+
+	loader, err := NewSecretLoader(c, testNamespace)
+	if err != nil {
+		t.Fatalf("NewSecretLoader: %v", err)
+	}
+	_, _, err = loader.Active(ctx)
+	if !errors.Is(err, ErrNoPepperVersions) {
+		t.Fatalf("Active error = %v, want ErrNoPepperVersions", err)
+	}
+}
+
+// TestSecretLoaderReturnsDefensiveCopy verifies callers cannot mutate
+// the loader's notion of the active bytes by writing to the returned
+// slice. This is belt-and-braces: the loader re-fetches on every call
+// today, but the contract remains safe if that changes.
+func TestSecretLoaderReturnsDefensiveCopy(t *testing.T) {
+	ctx := context.Background()
+	original := bytes.Repeat([]byte{0xab}, PepperSeedLength)
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"pepper-1": append([]byte(nil), original...),
+		},
+	})
+
+	loader, err := NewSecretLoader(c, testNamespace)
+	if err != nil {
+		t.Fatalf("NewSecretLoader: %v", err)
+	}
+	_, got, err := loader.Active(ctx)
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	// Mutate the returned slice; a subsequent Active must still see the
+	// original bytes.
+	for i := range got {
+		got[i] = 0
+	}
+	_, got2, err := loader.Active(ctx)
+	if err != nil {
+		t.Fatalf("Active (second): %v", err)
+	}
+	if !bytes.Equal(got2, original) {
+		t.Errorf("caller mutation of returned slice leaked into loader state")
+	}
+}
+
+// TestControllerNamespaceReadsEnv verifies the POD_NAMESPACE env var
+// contract. Uses t.Setenv so the env state resets after the test.
+func TestControllerNamespaceReadsEnv(t *testing.T) {
+	t.Setenv(PodNamespaceEnv, "my-ns")
+	if got := ControllerNamespace(); got != "my-ns" {
+		t.Errorf("ControllerNamespace() = %q, want %q", got, "my-ns")
+	}
+}
+
+// TestControllerNamespaceUnsetReturnsEmpty confirms the empty-env-var
+// fallback returns "" rather than a silent default. Callers check for
+// empty and fail loudly; a "default" default would be a silent
+// misconfiguration landmine.
+func TestControllerNamespaceUnsetReturnsEmpty(t *testing.T) {
+	t.Setenv(PodNamespaceEnv, "")
+	if got := ControllerNamespace(); got != "" {
+		t.Errorf("ControllerNamespace() = %q, want empty", got)
+	}
+}
+
+// TestParsePepperVersion exercises the parse contract directly so the
+// matrix of malformed-key cases is legible in one place. The parser is
+// shared by every call site above.
+func TestParsePepperVersion(t *testing.T) {
+	cases := []struct {
+		name   string
+		key    string
+		want   int32
+		wantOK bool
+	}{
+		{"valid one", "pepper-1", 1, true},
+		{"valid three-digit", "pepper-100", 100, true},
+		{"missing prefix", "foo-1", 0, false},
+		{"empty suffix", "pepper-", 0, false},
+		{"non-numeric suffix", "pepper-abc", 0, false},
+		{"zero suffix rejected", "pepper-0", 0, false},
+		{"negative suffix rejected", "pepper--1", 0, false},
+		{"overflow int32 rejected", "pepper-9999999999999", 0, false},
+		{"bare prefix", "pepper", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parsePepperVersion(tc.key)
+			if ok != tc.wantOK || got != tc.want {
+				t.Errorf("parsePepperVersion(%q) = (%d, %v), want (%d, %v)", tc.key, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// keysOf is a test helper for stable key list rendering in error
+// messages. Returns keys in insertion order (map iteration randomness
+// is OK because the helper is only used when a test is already
+// failing).
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/secretinjector/crypto/pepper_test.go
+++ b/internal/secretinjector/crypto/pepper_test.go
@@ -226,6 +226,32 @@ func TestBootstrapNilClientRejected(t *testing.T) {
 	}
 }
 
+// TestBootstrapExistingSecretWithEmptyActiveRow fails Bootstrap when
+// the highest-numbered row exists but is zero-length. An empty row is
+// the ambiguous case that would otherwise produce a "pepper bootstrap
+// complete" log line for a pepper the loader will refuse on the first
+// reconcile; Bootstrap catches it up front so readiness never flips
+// for an unusable pepper.
+func TestBootstrapExistingSecretWithEmptyActiveRow(t *testing.T) {
+	ctx := context.Background()
+	c := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      PepperSecretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"pepper-1": bytes.Repeat([]byte{0x01}, PepperSeedLength),
+			"pepper-2": {},
+		},
+	})
+
+	_, err := Bootstrap(ctx, c, testNamespace)
+	if err == nil {
+		t.Fatalf("Bootstrap: nil error, want rejection of empty active row")
+	}
+}
+
 // TestBootstrapExistingSecretWithNoValidRows returns
 // ErrNoPepperVersions so an operator who truncates .data sees a loud
 // error on manager restart rather than Bootstrap silently re-sealing


### PR DESCRIPTION
## Summary

- Add `internal/secretinjector/crypto/pepper.go` with a read-only `Loader` interface and `SecretLoader` implementation that parses `pepper-<N>` rows out of a pinned v1.Secret. Malformed keys are filtered; returned bytes are defensive copies.
- Add `internal/secretinjector/crypto/pepper_bootstrap.go` with an idempotent `Bootstrap` helper: seals 32 random bytes into `data["pepper-1"]` on cold start, detects max version on warm restart, and handles the parallel-replica AlreadyExists race. Controller namespace resolves from `POD_NAMESPACE` with a GoDoc fallback for envtest.
- Wire `Bootstrap` into `internal/secretinjector/controller/manager.go`'s `Start()` before the first reconcile; failure is fatal. Add `Options.ControllerNamespace` and `Options.SkipPepperBootstrap` for envtest.
- Tighten `config/secret-injector/rbac/namespace/secrets-role.yaml` so the controller has `get/create/update/patch` on exactly the pepper Secret name, plus the existing hash-material rule. No `list` anywhere.
- Add `internal/secretinjector/crypto/pepper_test.go` with unit coverage for idempotence, max-version detection, malformed-key tolerance, loader Get-by-version, defensive-copy guarantee, and the POD_NAMESPACE env contract.

Pepper bytes never touch any CR spec/status, any log line, or any returned struct field. Telemetry surfaces the integer version and the byte length only.

Fixes HOL-749

## Test plan
- [x] `go test ./internal/secretinjector/...` green
- [x] `make test-go` green
- [x] `go vet ./internal/secretinjector/...` clean
- [x] `kubectl kustomize config/secret-injector/rbac/namespace` renders the tightened Role
- [x] Race detection: `CGO_ENABLED=1 go test -race ./internal/secretinjector/...` green
- [x] Crypto package coverage: 89.5%