### PR TITLE
fix(deployments): surface CUE evaluation errors in preview render path

### DIFF
--- a/console/deployments/render.go
+++ b/console/deployments/render.go
@@ -169,8 +169,34 @@ func evaluateWithInputs(cueSource string, ancestorSources []string, inputs Rende
 	}
 
 	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
-	if namespacedValue.Err() != nil || !namespacedValue.Exists() {
-		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' (structured output format required)")
+	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
+
+	// Three-way distinction (mirrors evaluateCueInput in render_raw_cue.go):
+	//   1. Neither path exists → template is missing the required
+	//      structured-output fields; keep the existing message.
+	//   2. At least one path exists but carries a CUE evaluation error (e.g.
+	//      non-concrete dynamic field key) → surface the CUE error verbatim so
+	//      template authors can act on the real cause.
+	//   3. At least one path exists with no error → happy path.
+	//
+	// Note: LookupPath on a missing field returns a value that is both
+	// !Exists() AND has a non-nil Err(), so we must test Exists() first before
+	// inspecting Err() — Err() alone cannot distinguish "absent" from "broken".
+	projExists := namespacedValue.Exists()
+	platExists := platformNamespacedValue.Exists()
+
+	if !projExists && !platExists {
+		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
+	}
+	if projExists {
+		if err := namespacedValue.Err(); err != nil {
+			return nil, fmt.Errorf("projectResources.namespacedResources: %w", err)
+		}
+	}
+	if platExists {
+		if err := platformNamespacedValue.Err(); err != nil {
+			return nil, fmt.Errorf("platformResources.namespacedResources: %w", err)
+		}
 	}
 
 	return evaluateStructuredGrouped(unified, inputs.ReadPlatformResources)

--- a/console/deployments/render_raw_cue.go
+++ b/console/deployments/render_raw_cue.go
@@ -69,9 +69,33 @@ func evaluateCueInput(cueSource string, readPlatformResources bool) (*GroupedRes
 
 	namespacedValue := unified.LookupPath(cue.ParsePath("projectResources.namespacedResources"))
 	platformNamespacedValue := unified.LookupPath(cue.ParsePath("platformResources.namespacedResources"))
-	if (namespacedValue.Err() != nil || !namespacedValue.Exists()) &&
-		(platformNamespacedValue.Err() != nil || !platformNamespacedValue.Exists()) {
+
+	// Three-way distinction:
+	//   1. Neither path exists → template is missing the required
+	//      structured-output fields; keep the existing message.
+	//   2. At least one path exists but carries a CUE evaluation error (e.g.
+	//      non-concrete dynamic field key) → surface the CUE error verbatim so
+	//      template authors can act on the real cause.
+	//   3. At least one path exists with no error → happy path.
+	//
+	// Note: LookupPath on a missing field returns a value that is both
+	// !Exists() AND has a non-nil Err(), so we must test Exists() first before
+	// inspecting Err() — Err() alone cannot distinguish "absent" from "broken".
+	projExists := namespacedValue.Exists()
+	platExists := platformNamespacedValue.Exists()
+
+	if !projExists && !platExists {
 		return nil, fmt.Errorf("template must define 'projectResources.namespacedResources' or 'platformResources.namespacedResources' (structured output format required)")
+	}
+	if projExists {
+		if err := namespacedValue.Err(); err != nil {
+			return nil, fmt.Errorf("projectResources.namespacedResources: %w", err)
+		}
+	}
+	if platExists {
+		if err := platformNamespacedValue.Err(); err != nil {
+			return nil, fmt.Errorf("platformResources.namespacedResources: %w", err)
+		}
 	}
 
 	return evaluateStructuredGrouped(unified, readPlatformResources)

--- a/console/deployments/render_test.go
+++ b/console/deployments/render_test.go
@@ -3346,3 +3346,322 @@ func TestCueRenderer_MultiNamespaceResources(t *testing.T) {
 		}
 	})
 }
+
+// --- CUE error diagnostic tests (HOL-829) ---
+
+// noResourcesTemplate defines neither projectResources.namespacedResources
+// nor platformResources.namespacedResources — triggers the "structured output
+// format required" message.
+const noResourcesTemplate = `
+input: {
+	name: string
+}
+
+platform: {
+	project:   string
+	namespace: string
+}
+`
+
+// nonConcretePlatformNSTemplate uses a dynamic struct key that references a
+// platform field that is not yet concrete (gatewayNamespace is not supplied).
+// The CUE engine cannot evaluate the key, so the path carries an Err().
+// The renderer must surface that CUE error, not the generic "structured output
+// format required" message.
+const nonConcretePlatformNSTemplate = `
+platform: {
+	project:          string
+	namespace:        string
+	gatewayNamespace: string
+}
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+_labels: {
+	"app.kubernetes.io/name":       input.name
+	"app.kubernetes.io/managed-by": "console.holos.run"
+}
+
+platformResources: namespacedResources: (platform.gatewayNamespace): {
+	ConfigMap: "gw-config": {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      "gw-config"
+			namespace: platform.gatewayNamespace
+			labels:    _labels
+		}
+	}
+}
+`
+
+// platformOnlyTemplate defines only platformResources (no projectResources).
+// With ReadPlatformResources=true this must succeed.
+const platformOnlyTemplate = `
+platform: {
+	project:          string
+	namespace:        string
+	gatewayNamespace: string
+}
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+_labels: {
+	"app.kubernetes.io/name":       input.name
+	"app.kubernetes.io/managed-by": "console.holos.run"
+}
+
+platformResources: namespacedResources: "istio-ingress": {
+	ConfigMap: "gw-config": {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      "gw-config"
+			namespace: "istio-ingress"
+			labels:    _labels
+		}
+	}
+}
+`
+
+// projectOnlyTemplate defines only projectResources (no platformResources).
+// This must succeed on both project-level and org-level render paths.
+const projectOnlyTemplate = `
+platform: {
+	project:   string
+	namespace: string
+}
+
+input: {
+	name:  string
+	image: string
+	tag:   string
+}
+
+_labels: {
+	"app.kubernetes.io/name":       input.name
+	"app.kubernetes.io/managed-by": "console.holos.run"
+}
+
+projectResources: namespacedResources: (platform.namespace): {
+	ConfigMap: (input.name): {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      input.name
+			namespace: platform.namespace
+			labels:    _labels
+		}
+	}
+}
+`
+
+// TestCueErrorDiagnostics verifies the three-way branch in evaluateWithInputs
+// and evaluateCueInput (via EvaluateGroupedCUE) introduced by HOL-829.
+func TestCueErrorDiagnostics(t *testing.T) {
+	renderer := &CueRenderer{}
+	namespace := "prj-my-project"
+	platform := v1alpha2.PlatformInput{
+		Project:          "my-project",
+		Namespace:        namespace,
+		GatewayNamespace: "istio-ingress",
+	}
+	project := v1alpha2.ProjectInput{
+		Name:  "web-app",
+		Image: "nginx",
+		Tag:   "1.25",
+		Port:  8080,
+	}
+
+	t.Run("template with no resources returns structured-output-format message", func(t *testing.T) {
+		_, err := renderer.Render(context.Background(), noResourcesTemplate, nil, RenderInputs{
+			Platform:              platform,
+			Project:               project,
+			ReadPlatformResources: true,
+		})
+		if err == nil {
+			t.Fatal("expected error for template with no resources")
+		}
+		if !strings.Contains(err.Error(), "structured output format required") {
+			t.Errorf("expected 'structured output format required' message, got: %v", err)
+		}
+	})
+
+	t.Run("template with non-concrete dynamic key surfaces CUE error not generic message", func(t *testing.T) {
+		// Pass a PlatformInput that intentionally omits GatewayNamespace so
+		// that the platform.gatewayNamespace field stays non-concrete inside CUE
+		// even after unification.
+		partialPlatform := v1alpha2.PlatformInput{
+			Project:   "my-project",
+			Namespace: namespace,
+			// GatewayNamespace deliberately left empty so the dynamic key is
+			// non-concrete; the CUE engine propagates an error on that path.
+			GatewayNamespace: "",
+		}
+		_, err := renderer.Render(context.Background(), nonConcretePlatformNSTemplate, nil, RenderInputs{
+			Platform:              partialPlatform,
+			Project:               project,
+			ReadPlatformResources: true,
+		})
+		if err == nil {
+			t.Fatal("expected error for non-concrete dynamic key template")
+		}
+		// Must NOT be the generic "structured output format required" message.
+		if strings.Contains(err.Error(), "structured output format required") {
+			t.Errorf("expected CUE error message, got generic structured-output error: %v", err)
+		}
+		// Must surface the path prefix so authors can locate the issue.
+		if !strings.Contains(err.Error(), "platformResources.namespacedResources") {
+			t.Errorf("expected path 'platformResources.namespacedResources' in error, got: %v", err)
+		}
+	})
+
+	t.Run("platform-only template succeeds with ReadPlatformResources=true", func(t *testing.T) {
+		grouped, err := renderer.Render(context.Background(), platformOnlyTemplate, nil, RenderInputs{
+			Platform:              platform,
+			Project:               project,
+			ReadPlatformResources: true,
+		})
+		if err != nil {
+			t.Fatalf("expected no error for platform-only template, got %v", err)
+		}
+		if len(grouped.Platform) != 1 {
+			t.Errorf("expected 1 platform resource, got %d", len(grouped.Platform))
+		}
+	})
+
+	t.Run("project-only template succeeds", func(t *testing.T) {
+		grouped, err := renderer.Render(context.Background(), projectOnlyTemplate, nil, RenderInputs{
+			Platform: platform,
+			Project:  project,
+		})
+		if err != nil {
+			t.Fatalf("expected no error for project-only template, got %v", err)
+		}
+		if len(grouped.Project) != 1 {
+			t.Errorf("expected 1 project resource, got %d", len(grouped.Project))
+		}
+	})
+}
+
+// rawPlatformOnlyTemplate is a fully-concrete CUE source suitable for the
+// raw-CUE entry point (EvaluateGroupedCUE). It defines only
+// platformResources with concrete struct keys — no unresolved input/platform
+// references — so no platform/project input injection is needed.
+const rawPlatformOnlyTemplate = `
+platformResources: namespacedResources: "istio-ingress": {
+	ConfigMap: "gw-config": {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      "gw-config"
+			namespace: "istio-ingress"
+			labels: "app.kubernetes.io/managed-by": "console.holos.run"
+		}
+	}
+}
+`
+
+// rawProjectOnlyTemplate is a fully-concrete CUE source suitable for the
+// raw-CUE entry point. It defines only projectResources with concrete keys.
+const rawProjectOnlyTemplate = `
+projectResources: namespacedResources: "my-ns": {
+	ConfigMap: "app-config": {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      "app-config"
+			namespace: "my-ns"
+			labels: "app.kubernetes.io/managed-by": "console.holos.run"
+		}
+	}
+}
+`
+
+// rawNonConcretePlatformNSTemplate is suitable for the raw-CUE path: it uses
+// a non-concrete dynamic key (platform.gatewayNamespace) that cannot be
+// resolved because platform remains unconstrained — exactly as the preview
+// render path receives it before client values are injected.
+const rawNonConcretePlatformNSTemplate = `
+platform: {
+	project:          string
+	namespace:        string
+	gatewayNamespace: string
+}
+
+platformResources: namespacedResources: (platform.gatewayNamespace): {
+	ConfigMap: "gw-config": {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      "gw-config"
+			namespace: platform.gatewayNamespace
+			labels: "app.kubernetes.io/managed-by": "console.holos.run"
+		}
+	}
+}
+`
+
+// TestEvaluateGroupedCUEErrorDiagnostics exercises the same three-way branch
+// via the raw-CUE entry point (EvaluateGroupedCUE → evaluateCueInput) so that
+// both code paths are covered.
+func TestEvaluateGroupedCUEErrorDiagnostics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no resources returns structured-output-format message", func(t *testing.T) {
+		source := noResourcesTemplate
+		_, err := EvaluateGroupedCUE(ctx, source, true)
+		if err == nil {
+			t.Fatal("expected error for template with no resources")
+		}
+		if !strings.Contains(err.Error(), "structured output format required") {
+			t.Errorf("expected 'structured output format required' message, got: %v", err)
+		}
+	})
+
+	t.Run("non-concrete dynamic key surfaces CUE error not generic message", func(t *testing.T) {
+		// Raw-CUE source leaves platform.gatewayNamespace unconstrained
+		// (like the preview path does before the client injects values), so
+		// the dynamic struct key is non-concrete and the CUE engine propagates
+		// an error on that path.
+		source := rawNonConcretePlatformNSTemplate
+		_, err := EvaluateGroupedCUE(ctx, source, true)
+		if err == nil {
+			t.Fatal("expected error for non-concrete dynamic key in raw CUE path")
+		}
+		if strings.Contains(err.Error(), "structured output format required") {
+			t.Errorf("expected CUE error message, got generic structured-output error: %v", err)
+		}
+		if !strings.Contains(err.Error(), "platformResources.namespacedResources") {
+			t.Errorf("expected path prefix in error, got: %v", err)
+		}
+	})
+
+	t.Run("platform-only template succeeds", func(t *testing.T) {
+		grouped, err := EvaluateGroupedCUE(ctx, rawPlatformOnlyTemplate, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(grouped.Platform) != 1 {
+			t.Errorf("expected 1 platform resource, got %d", len(grouped.Platform))
+		}
+	})
+
+	t.Run("project-only template succeeds", func(t *testing.T) {
+		grouped, err := EvaluateGroupedCUE(ctx, rawProjectOnlyTemplate, false)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(grouped.Project) != 1 {
+			t.Errorf("expected 1 project resource, got %d", len(grouped.Project))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Rewrite the `namespacedResources` existence check in both `evaluateCueInput` (render_raw_cue.go) and `evaluateWithInputs` (render.go) to distinguish three cases:
  1. Path absent (neither project nor platform `namespacedResources` exists) → keep existing "structured output format required" message
  2. Path exists but has a CUE evaluation error (e.g. non-concrete dynamic field key like `(platform.gatewayNamespace)`) → return the CUE error verbatim, prefixed with the offending path
  3. Path exists with no error → proceed to `evaluateStructuredGrouped` (happy path)
- Root cause: `LookupPath` on a missing field returns a value that is simultaneously `!Exists()` AND has a non-nil `Err()`; testing `Err() != nil || !Exists()` cannot distinguish "absent" from "broken". Fix: test `Exists()` first, then inspect `Err()` only when the path exists.
- Add 8 table-driven tests covering all branches for both `CueRenderer.Render` and `EvaluateGroupedCUE` entry points.

Fixes HOL-829

## Test plan
- [x] `go test ./console/deployments/...` passes
- [x] `TestCueErrorDiagnostics` — all 4 sub-tests pass (no-resources, non-concrete key, platform-only, project-only)
- [x] `TestEvaluateGroupedCUEErrorDiagnostics` — all 4 sub-tests pass (raw-CUE entry point)
- [x] All existing `console/deployments` tests continue to pass
- [x] Pre-existing `TestScripts` data-race failure in `console/testscript_test.go` confirmed unrelated to this change (present on `main` before this branch)