### PR TITLE
feat(projects): wire ProjectNamespace pipeline into CreateProject (HOL-812)

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -1168,15 +1168,22 @@ func (a *projectNSPipelineAdapter) Run(ctx context.Context, in projects.ProjectN
 		BaseNamespace:   in.BaseNamespace,
 		Platform:        in.Platform,
 	})
-	if err != nil {
-		return mapProjectNSOutcome(outcome), err
-	}
-	return mapProjectNSOutcome(outcome), nil
+	return mapProjectNSOutcome(outcome), err
 }
 
+// mapProjectNSOutcome converts from the pipeline's internal Outcome to
+// the handler-side enum. An explicit switch surfaces a compile-time
+// nudge if a new Outcome value is added to projectnspipeline and
+// callers forget to extend the mapping — the default branch falls back
+// to NoBindings so the handler never skips its typed Create on an
+// unrecognised outcome.
 func mapProjectNSOutcome(o projectnspipeline.Outcome) projects.ProjectNamespacePipelineOutcome {
-	if o == projectnspipeline.OutcomeBindingsApplied {
+	switch o {
+	case projectnspipeline.OutcomeBindingsApplied:
 		return projects.ProjectNamespacePipelineBindingsApplied
+	case projectnspipeline.OutcomeNoBindings:
+		return projects.ProjectNamespacePipelineNoBindings
+	default:
+		return projects.ProjectNamespacePipelineNoBindings
 	}
-	return projects.ProjectNamespacePipelineNoBindings
 }

--- a/console/console.go
+++ b/console/console.go
@@ -40,6 +40,8 @@ import (
 	"github.com/holos-run/holos-console/console/organizations"
 	"github.com/holos-run/holos-console/console/policyresolver"
 	"github.com/holos-run/holos-console/console/projects"
+	"github.com/holos-run/holos-console/console/projects/projectapply"
+	"github.com/holos-run/holos-console/console/projects/projectnspipeline"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/resources"
 	"github.com/holos-run/holos-console/console/rpc"
@@ -463,6 +465,28 @@ func (s *Server) Serve(ctx context.Context) error {
 		// analysis); REQUIRE rules are now enforced exclusively at render
 		// time via folderResolver (Layer A).
 		projectsHandler := projects.NewHandler(projectsK8s, orgGrantResolver)
+
+		// HOL-812: wire the ProjectNamespace pipeline
+		// (resolve → render → apply) into CreateProject. The pipeline is
+		// only active when every dependency is present — the dynamic
+		// client is required for SSA, and the controller-runtime cache
+		// powers the binding walker on the hot path. When any dependency
+		// is missing (bootstrap, tests, dev), WithProjectNamespacePipeline
+		// receives nil and the handler keeps using its existing
+		// Namespace-create path unchanged.
+		if dynamicClient != nil {
+			ancestorBindings := policyresolver.NewAncestorBindingLister(templatePolicyBindingsK8s, nsWalker, nsResolver)
+			projectNSResolver := policyresolver.NewProjectNamespaceResolver(ancestorBindings)
+			pipeline := projectnspipeline.New(
+				projectNSResolver,
+				projectnspipeline.NewPolicyGetterAdapter(templatePoliciesK8s),
+				projectnspipeline.NewTemplateGetterAdapter(templatesK8s),
+				templates.NewCueRendererAdapter(),
+				projectapply.NewApplier(dynamicClient, projectapply.NewDefaultGVRResolver()),
+			)
+			projectsHandler = projectsHandler.WithProjectNamespacePipeline(&projectNSPipelineAdapter{p: pipeline})
+		}
+
 		projectsPath, projectsHTTPHandler := consolev1connect.NewProjectServiceHandler(projectsHandler, protectedInterceptors)
 		mux.Handle(projectsPath, projectsHTTPHandler)
 
@@ -1119,4 +1143,40 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 			Raw: certDER,
 		},
 	}, nil
+}
+
+// projectNSPipelineAdapter converts between the projects handler's
+// ProjectNamespacePipeline interface and the concrete
+// projectnspipeline.Pipeline. The interface lives in console/projects so
+// the handler package does not depend on projectnspipeline (which would
+// pull in console/templates → console/deployments and cycle with the
+// deployments test suite that imports console/projects). The adapter
+// lives here in console/console.go where both packages are already
+// imported for production wiring.
+type projectNSPipelineAdapter struct {
+	p *projectnspipeline.Pipeline
+}
+
+// Run translates the handler-side input into the pipeline's native
+// Input and maps the Outcome back. BaseNamespace and Platform pass
+// through by reference/value — no defensive copy is necessary because
+// the handler does not mutate them after the Run call returns.
+func (a *projectNSPipelineAdapter) Run(ctx context.Context, in projects.ProjectNamespacePipelineInput) (projects.ProjectNamespacePipelineOutcome, error) {
+	outcome, err := a.p.Run(ctx, projectnspipeline.Input{
+		ProjectName:     in.ProjectName,
+		ParentNamespace: in.ParentNamespace,
+		BaseNamespace:   in.BaseNamespace,
+		Platform:        in.Platform,
+	})
+	if err != nil {
+		return mapProjectNSOutcome(outcome), err
+	}
+	return mapProjectNSOutcome(outcome), nil
+}
+
+func mapProjectNSOutcome(o projectnspipeline.Outcome) projects.ProjectNamespacePipelineOutcome {
+	if o == projectnspipeline.OutcomeBindingsApplied {
+		return projects.ProjectNamespacePipelineBindingsApplied
+	}
+	return projects.ProjectNamespacePipelineNoBindings
 }

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/rbac"
@@ -21,6 +23,54 @@ import (
 )
 
 const auditResourceType = "project"
+
+// ProjectNamespacePipelineOutcome is what a ProjectNamespacePipeline
+// implementation tells the handler about the work it did. The concrete
+// implementation lives in console/projects/projectnspipeline — the
+// interface is defined here so the handler package does not depend on
+// projectnspipeline (which transitively imports console/templates,
+// console/deployments, and would collide with the deployments test
+// suite that imports console/projects).
+type ProjectNamespacePipelineOutcome int
+
+const (
+	// ProjectNamespacePipelineNoBindings mirrors
+	// projectnspipeline.OutcomeNoBindings: no bindings matched, the
+	// handler must run its existing Namespace-create path.
+	ProjectNamespacePipelineNoBindings ProjectNamespacePipelineOutcome = iota
+	// ProjectNamespacePipelineBindingsApplied mirrors
+	// projectnspipeline.OutcomeBindingsApplied: at least one binding
+	// matched and the applier completed the three-group SSA pipeline,
+	// so the handler must NOT also call CreateProject on the typed k8s
+	// client.
+	ProjectNamespacePipelineBindingsApplied
+)
+
+// ProjectNamespacePipelineInput carries the per-RPC values a
+// ProjectNamespacePipeline needs. Matches the shape of
+// projectnspipeline.Input — an adapter in console/console.go converts
+// between the two at wire-up time.
+type ProjectNamespacePipelineInput struct {
+	// ProjectName is the slug of the project being created.
+	ProjectName string
+	// ParentNamespace is the ancestor namespace the resolver walks from.
+	ParentNamespace string
+	// BaseNamespace is the Namespace object the RPC built; the applier
+	// uses it as the "base" the render path unifies template-produced
+	// Namespace patches into (ADR 034 Decision 1).
+	BaseNamespace *corev1.Namespace
+	// Platform is the platform-input block the renderer binds at the
+	// CUE `platform` path.
+	Platform v1alpha2.PlatformInput
+}
+
+// ProjectNamespacePipeline is the seam the handler talks to when
+// CreateProject runs. The concrete implementation is
+// projectnspipeline.Pipeline; a nil value leaves the handler on its
+// existing Namespace-create path unchanged.
+type ProjectNamespacePipeline interface {
+	Run(ctx context.Context, in ProjectNamespacePipelineInput) (ProjectNamespacePipelineOutcome, error)
+}
 
 // OrgResolver resolves organization-level grants for access checks.
 type OrgResolver interface {
@@ -39,11 +89,52 @@ type Handler struct {
 	consolev1connect.UnimplementedProjectServiceHandler
 	k8s         *K8sClient
 	orgResolver OrgResolver
+	// projectNSPipeline wires the HOL-812 resolve → render → apply flow.
+	// Nil (the default) falls through to the existing Namespace-create
+	// path so CreateProject keeps working during bootstrap or in tests
+	// that do not care about the ProjectNamespace feature. The concrete
+	// implementation lives in
+	// console/projects/projectnspipeline.Pipeline — an interface seam
+	// keeps the handler free of that package's transitive dependency on
+	// console/templates (which would form an import cycle with the
+	// deployments tests that import console/projects).
+	projectNSPipeline ProjectNamespacePipeline
+	// projectNSGatewayNamespace is the gateway namespace baked into the
+	// PlatformInput for ProjectNamespace renders. A future ADR 034 phase
+	// will read this per-org from the org settings; the constant here is
+	// only used when the handler was constructed without a per-request
+	// resolver. See ADR 034's open question on per-org gateway
+	// configuration.
+	projectNSGatewayNamespace string
 }
 
 // NewHandler creates a new ProjectService handler.
 func NewHandler(k8s *K8sClient, orgResolver OrgResolver) *Handler {
 	return &Handler{k8s: k8s, orgResolver: orgResolver}
+}
+
+// WithProjectNamespacePipeline wires the HOL-812 resolve → render →
+// apply pipeline into CreateProject. Passing nil leaves the handler on
+// the existing Namespace-create path.
+func (h *Handler) WithProjectNamespacePipeline(p ProjectNamespacePipeline) *Handler {
+	// A typed nil (e.g. (*projectnspipeline.Pipeline)(nil)) stored in
+	// an interface tests true for != nil at the interface level. Guard
+	// with reflect-free checks: only an explicit nil interface leaves
+	// the pipeline unset so the handler falls back to its existing
+	// Namespace-create path. Callers that want to "turn off" the
+	// pipeline should pass literal nil, not a typed nil value.
+	h.projectNSPipeline = p
+	return h
+}
+
+// WithProjectNamespaceGatewayNamespace sets the gateway namespace baked
+// into the PlatformInput for ProjectNamespace renders. Empty is allowed
+// (templates that reference platform.gatewayNamespace then see the
+// empty string and can constrain against it with a CUE default).
+// Deferred to HOL-806 Phase 7: read per-org from org settings.
+func (h *Handler) WithProjectNamespaceGatewayNamespace(ns string) *Handler {
+	h.projectNSGatewayNamespace = ns
+	return h
 }
 
 // ListProjects returns all projects the user has access to.
@@ -259,14 +350,18 @@ func (h *Handler) CreateProject(
 
 	// Create the project namespace, retrying on AlreadyExists when the name was
 	// auto-generated (race between GenerateIdentifier check and K8s create).
+	// HOL-812 wires the ProjectNamespace pipeline (resolve → render → apply)
+	// inside the same retry loop so the auto-generated-name retry behavior
+	// covers both paths (existing typed Create and SSA-via-applier) with a
+	// single branch.
 	const maxCreateRetries = 3
 	for attempt := range maxCreateRetries + 1 {
-		_, err = h.k8s.CreateProject(ctx, name, req.Msg.DisplayName, req.Msg.Description, req.Msg.Organization, parentNs, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+		err = h.createProjectOnce(ctx, name, req.Msg, parentNs, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 		if err == nil {
 			break
 		}
 		if !autoGenerated || !errors.IsAlreadyExists(err) || attempt >= maxCreateRetries {
-			return nil, mapK8sError(err)
+			return nil, mapProjectCreateError(err)
 		}
 		slog.InfoContext(ctx, "project create race detected, regenerating identifier",
 			slog.String("resource_type", auditResourceType),
@@ -291,6 +386,127 @@ func (h *Handler) CreateProject(
 	return connect.NewResponse(&consolev1.CreateProjectResponse{
 		Name: name,
 	}), nil
+}
+
+// createProjectOnce executes one attempt of the project-namespace
+// creation path: runs the HOL-812 ProjectNamespace pipeline when
+// configured, and falls through to the typed CreateProject call when
+// the pipeline returns OutcomeNoBindings (including the nil-pipeline
+// default). Separated from CreateProject so the retry loop wraps both
+// sides uniformly.
+//
+// Returns the raw error (not a connect.Error); the caller maps it via
+// mapProjectCreateError so the AlreadyExists retry-on-auto-generated-name
+// logic can still use errors.IsAlreadyExists. The only error category
+// mapProjectCreateError handles that mapK8sError does not is the
+// deadline-exceeded case — the applier's DeadlineExceededError matches
+// [context.DeadlineExceeded] via errors.Is, and mapProjectCreateError
+// translates that to connect.CodeDeadlineExceeded.
+func (h *Handler) createProjectOnce(
+	ctx context.Context,
+	name string,
+	msg *consolev1.CreateProjectRequest,
+	parentNs string,
+	creatorEmail string,
+	shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant,
+) error {
+	// Always build the base Namespace object up front — both paths need
+	// it (the typed Create call still uses it, and the pipeline needs
+	// it as the "base" the render path unifies into per ADR 034).
+	baseNs, err := h.k8s.BuildProjectNamespace(name, msg.DisplayName, msg.Description, msg.Organization, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+	if err != nil {
+		return err
+	}
+
+	// Pipeline (HOL-812): resolve ProjectNamespace bindings; if any
+	// match, render and apply via SSA. A nil pipeline falls through to
+	// the existing Namespace-create path so CreateProject keeps
+	// working during bootstrap or in tests that do not care about the
+	// ProjectNamespace feature.
+	if h.projectNSPipeline != nil {
+		outcome, pipeErr := h.projectNSPipeline.Run(ctx, ProjectNamespacePipelineInput{
+			ProjectName:     name,
+			ParentNamespace: parentAncestorNamespace(parentNs),
+			BaseNamespace:   baseNs,
+			Platform:        h.buildPlatformInput(ctx, msg, name, baseNs.Name, parentNs),
+		})
+		if pipeErr != nil {
+			return pipeErr
+		}
+		if outcome == ProjectNamespacePipelineBindingsApplied {
+			// The applier already SSA'd the Namespace and every
+			// associated resource; there is nothing else to write.
+			// Note this path does not surface AlreadyExists (SSA is
+			// idempotent), so the auto-generated-name retry is a
+			// no-op when the pipeline handles the create.
+			return nil
+		}
+	}
+
+	// Existing path: typed Create. Unchanged from pre-HOL-812 behavior.
+	_, err = h.k8s.client.CoreV1().Namespaces().Create(ctx, baseNs, metav1.CreateOptions{})
+	return err
+}
+
+// parentAncestorNamespace returns the namespace the ProjectNamespace
+// resolver walks from. For the HOL-812 scope this is the immediate
+// parent namespace the RPC already resolved (an organization or folder
+// namespace). A future folders-with-depth or org-hierarchy feature
+// may need to rewrite this to follow a different chain — ADR 034's
+// "ancestor-chain open question" is tracked against HOL-806 Phase 7.
+// Centralising the computation here keeps the fix to one call site.
+func parentAncestorNamespace(parentNs string) string { return parentNs }
+
+// buildPlatformInput assembles the PlatformInput block the
+// ProjectNamespace render path binds at the CUE `platform` path. The
+// shape mirrors what the deployment render path produces for the same
+// project (deployments/handler.go), minus per-deployment fields. A
+// future enhancement will resolve gatewayNamespace per-org from the
+// organization settings; for now the handler's static default wins.
+func (h *Handler) buildPlatformInput(ctx context.Context, msg *consolev1.CreateProjectRequest, projectName, namespaceName, parentNs string) v1alpha2.PlatformInput {
+	claims := rpc.ClaimsFromContext(ctx)
+	input := v1alpha2.PlatformInput{
+		Project:          projectName,
+		Namespace:        namespaceName,
+		Organization:     msg.Organization,
+		GatewayNamespace: h.projectNSGatewayNamespace,
+	}
+	if claims != nil {
+		input.Claims = v1alpha2.Claims{
+			Iss:           claims.Iss,
+			Sub:           claims.Sub,
+			Exp:           claims.Exp,
+			Iat:           claims.Iat,
+			Email:         claims.Email,
+			EmailVerified: claims.EmailVerified,
+			Name:          claims.Name,
+		}
+	}
+	// Folders: not populated here. The ProjectNamespace render path
+	// typically does not need the folder chain (templates parameterise
+	// on the new namespace and the org). If a template needs the folder
+	// chain, HOL-806 Phase 7 will plumb the nsWalker through — out of
+	// scope for HOL-812.
+	_ = parentNs
+	return input
+}
+
+// mapProjectCreateError maps a CreateProject-layer error to a connect
+// error, widening mapK8sError with the deadline-exceeded case the
+// HOL-812 apply path may return. The projectapply package's structured
+// DeadlineExceededError implements `Is(target error) bool` to match
+// [context.DeadlineExceeded] — we match via errors.Is rather than a
+// type assertion so this package can stay free of a projectapply
+// import. The projectapply -> templates -> deployments chain otherwise
+// collides with deployments tests that already import projects.
+// Any non-deadline error falls through to mapK8sError (which classifies
+// apierrors.Is*() kinds and maps the "not managed by" string into
+// CodeNotFound).
+func mapProjectCreateError(err error) error {
+	if stderrors.Is(err, context.DeadlineExceeded) {
+		return connect.NewError(connect.CodeDeadlineExceeded, err)
+	}
+	return mapK8sError(err)
 }
 
 // UpdateProject updates project metadata.

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -99,13 +99,6 @@ type Handler struct {
 	// console/templates (which would form an import cycle with the
 	// deployments tests that import console/projects).
 	projectNSPipeline ProjectNamespacePipeline
-	// projectNSGatewayNamespace is the gateway namespace baked into the
-	// PlatformInput for ProjectNamespace renders. A future ADR 034 phase
-	// will read this per-org from the org settings; the constant here is
-	// only used when the handler was constructed without a per-request
-	// resolver. See ADR 034's open question on per-org gateway
-	// configuration.
-	projectNSGatewayNamespace string
 }
 
 // NewHandler creates a new ProjectService handler.
@@ -114,26 +107,14 @@ func NewHandler(k8s *K8sClient, orgResolver OrgResolver) *Handler {
 }
 
 // WithProjectNamespacePipeline wires the HOL-812 resolve → render →
-// apply pipeline into CreateProject. Passing nil leaves the handler on
-// the existing Namespace-create path.
+// apply pipeline into CreateProject. Passing a nil interface value
+// leaves the handler on the existing Namespace-create path. Callers
+// that want to "turn off" the pipeline should pass literal nil, not a
+// typed nil value — a typed nil stored in an interface tests as
+// non-nil at the interface level and would cause the handler to
+// invoke .Run on a nil receiver.
 func (h *Handler) WithProjectNamespacePipeline(p ProjectNamespacePipeline) *Handler {
-	// A typed nil (e.g. (*projectnspipeline.Pipeline)(nil)) stored in
-	// an interface tests true for != nil at the interface level. Guard
-	// with reflect-free checks: only an explicit nil interface leaves
-	// the pipeline unset so the handler falls back to its existing
-	// Namespace-create path. Callers that want to "turn off" the
-	// pipeline should pass literal nil, not a typed nil value.
 	h.projectNSPipeline = p
-	return h
-}
-
-// WithProjectNamespaceGatewayNamespace sets the gateway namespace baked
-// into the PlatformInput for ProjectNamespace renders. Empty is allowed
-// (templates that reference platform.gatewayNamespace then see the
-// empty string and can constrain against it with a CUE default).
-// Deferred to HOL-806 Phase 7: read per-org from org settings.
-func (h *Handler) WithProjectNamespaceGatewayNamespace(ns string) *Handler {
-	h.projectNSGatewayNamespace = ns
 	return h
 }
 
@@ -428,7 +409,7 @@ func (h *Handler) createProjectOnce(
 			ProjectName:     name,
 			ParentNamespace: parentAncestorNamespace(parentNs),
 			BaseNamespace:   baseNs,
-			Platform:        h.buildPlatformInput(ctx, msg, name, baseNs.Name, parentNs),
+			Platform:        h.buildPlatformInput(ctx, msg, name, baseNs.Name),
 		})
 		if pipeErr != nil {
 			return pipeErr
@@ -460,16 +441,19 @@ func parentAncestorNamespace(parentNs string) string { return parentNs }
 // buildPlatformInput assembles the PlatformInput block the
 // ProjectNamespace render path binds at the CUE `platform` path. The
 // shape mirrors what the deployment render path produces for the same
-// project (deployments/handler.go), minus per-deployment fields. A
-// future enhancement will resolve gatewayNamespace per-org from the
-// organization settings; for now the handler's static default wins.
-func (h *Handler) buildPlatformInput(ctx context.Context, msg *consolev1.CreateProjectRequest, projectName, namespaceName, parentNs string) v1alpha2.PlatformInput {
+// project (deployments/handler.go), minus per-deployment fields.
+//
+// GatewayNamespace and the folder chain are intentionally omitted at
+// this phase. ADR 034 defers per-org gateway resolution and the
+// folders-with-depth walk to HOL-806 Phase 7; when that lands, this
+// helper is the one place to add them so the call site in
+// createProjectOnce stays a one-liner.
+func (h *Handler) buildPlatformInput(ctx context.Context, msg *consolev1.CreateProjectRequest, projectName, namespaceName string) v1alpha2.PlatformInput {
 	claims := rpc.ClaimsFromContext(ctx)
 	input := v1alpha2.PlatformInput{
-		Project:          projectName,
-		Namespace:        namespaceName,
-		Organization:     msg.Organization,
-		GatewayNamespace: h.projectNSGatewayNamespace,
+		Project:      projectName,
+		Namespace:    namespaceName,
+		Organization: msg.Organization,
 	}
 	if claims != nil {
 		input.Claims = v1alpha2.Claims{
@@ -482,12 +466,6 @@ func (h *Handler) buildPlatformInput(ctx context.Context, msg *consolev1.CreateP
 			Name:          claims.Name,
 		}
 	}
-	// Folders: not populated here. The ProjectNamespace render path
-	// typically does not need the folder chain (templates parameterise
-	// on the new namespace and the org). If a template needs the folder
-	// chain, HOL-806 Phase 7 will plumb the nsWalker through — out of
-	// scope for HOL-812.
-	_ = parentNs
 	return input
 }
 

--- a/console/projects/handler_project_namespace_test.go
+++ b/console/projects/handler_project_namespace_test.go
@@ -1,0 +1,415 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projects
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/holos-run/holos-console/console/policyresolver"
+	"github.com/holos-run/holos-console/console/projects/projectapply"
+	"github.com/holos-run/holos-console/console/projects/projectnspipeline"
+	"github.com/holos-run/holos-console/console/templates"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// --- Fakes for the pipeline seams -------------------------------------
+//
+// Each test wires its own Pipeline via projectnspipeline.New and injects
+// stubs for the resolver / policy getter / template getter / renderer /
+// applier seams so we can cover the four HOL-812 ACs (no bindings,
+// bindings happy path, render error, apply timeout) without standing up
+// the full resolver + CueRenderer + dynamic-client stack.
+
+// pipelineAdapter converts between the handler's
+// ProjectNamespacePipeline interface (defined in handler.go) and the
+// concrete projectnspipeline.Pipeline — mirrors the production adapter
+// in console/console.go. Isolated here so handler tests do not depend
+// on the wiring package.
+type pipelineAdapter struct {
+	p *projectnspipeline.Pipeline
+}
+
+func (a *pipelineAdapter) Run(ctx context.Context, in ProjectNamespacePipelineInput) (ProjectNamespacePipelineOutcome, error) {
+	out, err := a.p.Run(ctx, projectnspipeline.Input{
+		ProjectName:     in.ProjectName,
+		ParentNamespace: in.ParentNamespace,
+		BaseNamespace:   in.BaseNamespace,
+		Platform:        in.Platform,
+	})
+	var mapped ProjectNamespacePipelineOutcome
+	if out == projectnspipeline.OutcomeBindingsApplied {
+		mapped = ProjectNamespacePipelineBindingsApplied
+	}
+	return mapped, err
+}
+
+// wrap converts a concrete Pipeline into the handler's interface. Tests
+// call this rather than passing the Pipeline directly so the handler
+// package's interface contract is exercised.
+func wrap(p *projectnspipeline.Pipeline) ProjectNamespacePipeline {
+	return &pipelineAdapter{p: p}
+}
+
+type fakeBindingResolver struct {
+	bindings []*policyresolver.ResolvedBinding
+	err      error
+	calls    int
+}
+
+func (f *fakeBindingResolver) Resolve(_ context.Context, _, _ string) ([]*policyresolver.ResolvedBinding, error) {
+	f.calls++
+	return f.bindings, f.err
+}
+
+type fakePolicyGetter struct {
+	policy *projectnspipeline.Policy
+	err    error
+}
+
+func (f *fakePolicyGetter) GetPolicy(_ context.Context, _, _ string) (*projectnspipeline.Policy, error) {
+	return f.policy, f.err
+}
+
+type fakeTemplateGetter struct {
+	source string
+	err    error
+}
+
+func (f *fakeTemplateGetter) GetTemplateSource(_ context.Context, _, _ string) (string, error) {
+	return f.source, f.err
+}
+
+type fakeRenderer struct {
+	result *templates.ProjectNamespaceRenderResult
+	err    error
+	calls  int
+}
+
+func (f *fakeRenderer) RenderForProjectNamespace(_ context.Context, in templates.ProjectNamespaceRenderInput) (*templates.ProjectNamespaceRenderResult, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.result != nil {
+		return f.result, nil
+	}
+	// Default: pass through a result whose Namespace mirrors the base.
+	// Tests that want richer output override f.result.
+	ns := &unstructured.Unstructured{}
+	ns.SetAPIVersion("v1")
+	ns.SetKind("Namespace")
+	ns.SetName(in.BaseNamespace.Name)
+	return &templates.ProjectNamespaceRenderResult{Namespace: ns}, nil
+}
+
+type fakeApplier struct {
+	err   error
+	calls int
+}
+
+func (f *fakeApplier) Apply(_ context.Context, _ *templates.ProjectNamespaceRenderResult) error {
+	f.calls++
+	return f.err
+}
+
+// --- AC 1: no bindings → existing Namespace-create path unchanged -----
+
+func TestCreateProject_NoProjectNamespaceBindings_UsesExistingPath(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, nil)
+	logHandler := &testLogHandler{}
+	slog.SetDefault(slog.New(logHandler))
+
+	// Pipeline present but resolver returns no bindings — the handler
+	// must fall through to the typed Create path.
+	resolver := &fakeBindingResolver{bindings: nil}
+	applier := &fakeApplier{}
+	renderer := &fakeRenderer{}
+	handler = handler.WithProjectNamespacePipeline(wrap(projectnspipeline.New(
+		resolver,
+		&fakePolicyGetter{},
+		&fakeTemplateGetter{},
+		renderer,
+		applier,
+	)))
+
+	ctx := contextWithClaims("alice@example.com")
+	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "no-bindings",
+		Organization: "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "no-bindings" {
+		t.Errorf("expected name 'no-bindings', got %q", resp.Msg.Name)
+	}
+
+	// The resolver must have been consulted exactly once.
+	if resolver.calls != 1 {
+		t.Errorf("expected resolver called once, got %d", resolver.calls)
+	}
+	// Render and apply must not have run.
+	if renderer.calls != 0 {
+		t.Errorf("expected renderer not called, got %d", renderer.calls)
+	}
+	if applier.calls != 0 {
+		t.Errorf("expected applier not called, got %d", applier.calls)
+	}
+	// The typed create path must have written the namespace.
+	if _, err := fakeClient.CoreV1().Namespaces().Get(ctx, "holos-prj-no-bindings", metav1.GetOptions{}); err != nil {
+		t.Errorf("expected typed Create to persist namespace, got %v", err)
+	}
+	if r := logHandler.findRecord("project_ns_bindings_resolved"); r == nil {
+		t.Error("expected project_ns_bindings_resolved audit log")
+	}
+	if r := logHandler.findRecord("project_create"); r == nil {
+		t.Error("expected project_create audit log")
+	}
+}
+
+// --- AC 2: one matching binding → applier path, typed Create skipped --
+
+func TestCreateProject_OneProjectNamespaceBinding_AppliesAndSkipsTypedCreate(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, nil)
+	logHandler := &testLogHandler{}
+	slog.SetDefault(slog.New(logHandler))
+
+	// One resolved binding referencing one policy → one template.
+	resolver := &fakeBindingResolver{
+		bindings: []*policyresolver.ResolvedBinding{
+			{Name: "bind-1", Namespace: "holos-org-acme"},
+		},
+	}
+	policyGetter := &fakePolicyGetter{
+		policy: &projectnspipeline.Policy{
+			Namespace: "holos-org-acme",
+			Name:      "acme-baseline",
+			TemplateRefs: []projectnspipeline.TemplateRef{
+				{Namespace: "holos-org-acme", Name: "ns-labels"},
+			},
+		},
+	}
+	tmplGetter := &fakeTemplateGetter{source: "// cue template placeholder\npackage holos\n"}
+
+	renderer := &fakeRenderer{}
+	applier := &fakeApplier{}
+	handler = handler.WithProjectNamespacePipeline(wrap(projectnspipeline.New(
+		resolver,
+		policyGetter,
+		tmplGetter,
+		renderer,
+		applier,
+	)))
+
+	ctx := contextWithClaims("alice@example.com")
+	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "has-bindings",
+		Organization: "acme",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Msg.Name != "has-bindings" {
+		t.Errorf("expected name 'has-bindings', got %q", resp.Msg.Name)
+	}
+
+	if renderer.calls != 1 {
+		t.Errorf("expected renderer called once, got %d", renderer.calls)
+	}
+	if applier.calls != 1 {
+		t.Errorf("expected applier called once, got %d", applier.calls)
+	}
+
+	// The typed Create path MUST be skipped — the applier owns the
+	// Namespace SSA when bindings match. The fake clientset is blank
+	// apart from the pre-existing namespace "holos-prj-existing", so
+	// asking for the new project namespace should return NotFound.
+	if _, err := fakeClient.CoreV1().Namespaces().Get(ctx, "holos-prj-has-bindings", metav1.GetOptions{}); err == nil {
+		t.Error("expected typed Create to be skipped when applier handles SSA, but namespace exists")
+	}
+
+	if r := logHandler.findRecord("project_ns_apply_ok"); r == nil {
+		t.Error("expected project_ns_apply_ok audit log")
+	}
+	if r := logHandler.findRecord("project_ns_render_ok"); r == nil {
+		t.Error("expected project_ns_render_ok audit log")
+	}
+	if r := logHandler.findRecord("project_create"); r == nil {
+		t.Error("expected project_create audit log")
+	}
+}
+
+// --- AC 3: render error → CodeInternal surfaced via mapK8sError ------
+
+func TestCreateProject_ProjectNamespaceRenderError_ReturnsInternalError(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, nil)
+	logHandler := &testLogHandler{}
+	slog.SetDefault(slog.New(logHandler))
+
+	resolver := &fakeBindingResolver{
+		bindings: []*policyresolver.ResolvedBinding{
+			{Name: "bind-1", Namespace: "holos-org-acme"},
+		},
+	}
+	policyGetter := &fakePolicyGetter{
+		policy: &projectnspipeline.Policy{
+			Name: "acme-baseline",
+			TemplateRefs: []projectnspipeline.TemplateRef{
+				{Namespace: "holos-org-acme", Name: "bad"},
+			},
+		},
+	}
+	tmplGetter := &fakeTemplateGetter{source: "// broken cue"}
+	renderer := &fakeRenderer{err: errors.New("cue: synthetic render failure")}
+	applier := &fakeApplier{}
+	handler = handler.WithProjectNamespacePipeline(wrap(projectnspipeline.New(
+		resolver,
+		policyGetter,
+		tmplGetter,
+		renderer,
+		applier,
+	)))
+
+	ctx := contextWithClaims("alice@example.com")
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "render-err",
+		Organization: "acme",
+	}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeInternal {
+		t.Errorf("expected CodeInternal, got %v", connectErr.Code())
+	}
+
+	if applier.calls != 0 {
+		t.Errorf("expected applier not called on render error, got %d", applier.calls)
+	}
+	// Typed Create must NOT run — render failure blocks the whole path.
+	if _, err := fakeClient.CoreV1().Namespaces().Get(ctx, "holos-prj-render-err", metav1.GetOptions{}); err == nil {
+		t.Error("expected namespace not to be created on render error")
+	}
+
+	if r := logHandler.findRecord("project_ns_render_error"); r == nil {
+		t.Error("expected project_ns_render_error audit log")
+	}
+}
+
+// --- AC 4: apply timeout → CodeDeadlineExceeded ----------------------
+
+func TestCreateProject_ProjectNamespaceApplyTimeout_ReturnsDeadlineExceeded(t *testing.T) {
+	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
+	fakeClient := fake.NewClientset(existing)
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, nil)
+	logHandler := &testLogHandler{}
+	slog.SetDefault(slog.New(logHandler))
+
+	resolver := &fakeBindingResolver{
+		bindings: []*policyresolver.ResolvedBinding{
+			{Name: "bind-1", Namespace: "holos-org-acme"},
+		},
+	}
+	policyGetter := &fakePolicyGetter{
+		policy: &projectnspipeline.Policy{
+			Name: "acme-baseline",
+			TemplateRefs: []projectnspipeline.TemplateRef{
+				{Namespace: "holos-org-acme", Name: "ns-labels"},
+			},
+		},
+	}
+	tmplGetter := &fakeTemplateGetter{source: "// cue template placeholder\npackage holos\n"}
+	// Renderer produces a valid result (the default fakeRenderer behavior).
+	// Applier returns the structured DeadlineExceededError the real
+	// projectapply.Applier would return when the namespace-ready wait
+	// or the namespace-scoped apply retry exhausts its budget.
+	renderer := &fakeRenderer{}
+	applier := &fakeApplier{err: &projectapply.DeadlineExceededError{
+		Kind:       "Namespace",
+		Name:       "holos-prj-timeout",
+		LastPhase:  "Pending",
+		Classifier: "",
+	}}
+	handler = handler.WithProjectNamespacePipeline(wrap(projectnspipeline.New(
+		resolver,
+		policyGetter,
+		tmplGetter,
+		renderer,
+		applier,
+	)))
+
+	ctx := contextWithClaims("alice@example.com")
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name:         "timeout",
+		Organization: "acme",
+	}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeDeadlineExceeded {
+		t.Errorf("expected CodeDeadlineExceeded, got %v", connectErr.Code())
+	}
+
+	// Typed Create must NOT run — the applier took ownership of the
+	// Namespace even though it timed out, and running a typed Create
+	// afterwards would race the applier's own SSA on retry.
+	if _, err := fakeClient.CoreV1().Namespaces().Get(ctx, "holos-prj-timeout", metav1.GetOptions{}); err == nil {
+		t.Error("expected namespace not to be created via typed path on apply timeout")
+	}
+
+	if r := logHandler.findRecord("project_ns_apply_timeout"); r == nil {
+		t.Error("expected project_ns_apply_timeout audit log")
+	}
+}
+
+// --- Interface contract assertion ------------------------------------
+
+// Compile-time check that the in-test fakes satisfy the pipeline's
+// interface seams. Keeps a refactor that renames or splits an interface
+// from silently skipping these four ACs.
+var (
+	_ projectnspipeline.BindingResolver = (*fakeBindingResolver)(nil)
+	_ projectnspipeline.PolicyGetter    = (*fakePolicyGetter)(nil)
+	_ projectnspipeline.TemplateGetter  = (*fakeTemplateGetter)(nil)
+	_ projectnspipeline.Renderer        = (*fakeRenderer)(nil)
+	_ projectnspipeline.Applier         = (*fakeApplier)(nil)
+)

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -90,16 +90,16 @@ func (c *K8sClient) GetProject(ctx context.Context, name string) (*corev1.Namesp
 	return ns, nil
 }
 
-// CreateProject creates a new namespace with managed-by and resource-type labels.
-// parentNs is the Kubernetes namespace name of the immediate parent (org or folder namespace).
-// When non-empty, it is stored in the v1alpha2.AnnotationParent label for hierarchy traversal.
-func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+// BuildProjectNamespace constructs the in-memory *corev1.Namespace object
+// CreateProject would write, without contacting the cluster. The
+// HOL-812 CreateProject RPC wire-up uses this helper to produce the
+// "base" Namespace the HOL-810 render path unifies template-produced
+// Namespace patches into (ADR 034 Decision 1 — the RPC-built namespace
+// is always the base). The existing CreateProject path continues to
+// call this helper and then issue a typed Create so the no-bindings
+// happy path stays byte-identical to the pre-HOL-812 behavior.
+func (c *K8sClient) BuildProjectNamespace(name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	nsName := c.Resolver.ProjectNamespace(name)
-	slog.DebugContext(ctx, "creating project in kubernetes",
-		slog.String("name", name),
-		slog.String("namespace", nsName),
-		slog.String("parent", parentNs),
-	)
 	usersJSON, err := json.Marshal(shareUsers)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling share-users: %w", err)
@@ -146,12 +146,27 @@ func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, descri
 	if parentNs != "" {
 		labels[v1alpha2.AnnotationParent] = parentNs
 	}
-	ns := &corev1.Namespace{
+	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nsName,
 			Labels:      labels,
 			Annotations: annotations,
 		},
+	}, nil
+}
+
+// CreateProject creates a new namespace with managed-by and resource-type labels.
+// parentNs is the Kubernetes namespace name of the immediate parent (org or folder namespace).
+// When non-empty, it is stored in the v1alpha2.AnnotationParent label for hierarchy traversal.
+func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	slog.DebugContext(ctx, "creating project in kubernetes",
+		slog.String("name", name),
+		slog.String("namespace", c.Resolver.ProjectNamespace(name)),
+		slog.String("parent", parentNs),
+	)
+	ns, err := c.BuildProjectNamespace(name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+	if err != nil {
+		return nil, err
 	}
 	return c.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 }

--- a/console/projects/projectnspipeline/adapters.go
+++ b/console/projects/projectnspipeline/adapters.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package projectnspipeline
+
+import (
+	"context"
+
+	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+)
+
+// NewPolicyGetterAdapter wraps a function that looks up a TemplatePolicy
+// CRD by (namespace, name) and returns the decoded [Policy] the pipeline
+// needs. Production wiring in console/console.go passes the
+// templatepolicies K8sClient's GetPolicy method — the adapter projects
+// the CRD into the pipeline's minimal [Policy] shape so
+// console/projects/projectnspipeline does not import the full
+// templatepolicies package (which would create an import cycle via
+// policyresolver → ancestor_bindings → templatepolicies).
+type PolicyCRDGetter interface {
+	GetPolicy(ctx context.Context, namespace, name string) (*templatesv1alpha1.TemplatePolicy, error)
+}
+
+// NewPolicyGetterAdapter returns a PolicyGetter that dereferences the
+// CRD and keeps only the REQUIRE-rule template refs. EXCLUDE rules are
+// discarded per ADR 034 Decision 3 — a ProjectNamespace binding always
+// adds templates; there is no baseline set to subtract from at project
+// creation time. A nil getter yields an adapter whose GetPolicy returns
+// (nil, nil) — the pipeline treats that as "no templates contributed"
+// (the fail-open branch in collectTemplateSources).
+func NewPolicyGetterAdapter(g PolicyCRDGetter) PolicyGetter {
+	return &crdPolicyGetter{g: g}
+}
+
+type crdPolicyGetter struct {
+	g PolicyCRDGetter
+}
+
+func (a *crdPolicyGetter) GetPolicy(ctx context.Context, namespace, name string) (*Policy, error) {
+	if a == nil || a.g == nil {
+		return nil, nil
+	}
+	p, err := a.g.GetPolicy(ctx, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, nil
+	}
+	out := &Policy{
+		Namespace: p.Namespace,
+		Name:      p.Name,
+	}
+	for _, r := range p.Spec.Rules {
+		if r.Kind != templatesv1alpha1.TemplatePolicyKindRequire {
+			continue
+		}
+		ref := r.Template
+		if ref.Name == "" {
+			continue
+		}
+		out.TemplateRefs = append(out.TemplateRefs, TemplateRef{
+			Namespace:         ref.Namespace,
+			Name:              ref.Name,
+			VersionConstraint: ref.VersionConstraint,
+		})
+	}
+	return out, nil
+}
+
+// TemplateCRDGetter is the subset of the templates K8sClient the
+// pipeline's TemplateGetter needs. Defined locally to avoid a direct
+// dependency on console/templates — the CRD type is owned by
+// api/templates/v1alpha1 so the projection stays small.
+type TemplateCRDGetter interface {
+	GetTemplate(ctx context.Context, namespace, name string) (*templatesv1alpha1.Template, error)
+}
+
+// NewTemplateGetterAdapter wraps a typed templates getter and returns a
+// [TemplateGetter] that yields the Template's raw CUE source string.
+// A nil getter yields an adapter whose GetTemplateSource returns
+// ("", nil) — the pipeline then skips the ref, consistent with the
+// resolver's fail-open contract.
+func NewTemplateGetterAdapter(g TemplateCRDGetter) TemplateGetter {
+	return &crdTemplateGetter{g: g}
+}
+
+type crdTemplateGetter struct {
+	g TemplateCRDGetter
+}
+
+func (a *crdTemplateGetter) GetTemplateSource(ctx context.Context, namespace, name string) (string, error) {
+	if a == nil || a.g == nil {
+		return "", nil
+	}
+	t, err := a.g.GetTemplate(ctx, namespace, name)
+	if err != nil {
+		return "", err
+	}
+	if t == nil {
+		return "", nil
+	}
+	return t.Spec.CueTemplate, nil
+}

--- a/console/projects/projectnspipeline/pipeline.go
+++ b/console/projects/projectnspipeline/pipeline.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package projectnspipeline wires the HOL-809 resolver, HOL-810 renderer,
+// and HOL-811 applier into a single orchestration used by the
+// CreateProject RPC (HOL-812 / ADR 034 phase 6).
+//
+// The pipeline takes a parent namespace (the to-be-created project's
+// immediate org or folder ancestor), the RPC-built base Namespace, and
+// the project slug. It answers two questions via [Pipeline.Run]:
+//
+//  1. Are there any TemplatePolicyBindings with
+//     target.kind=ProjectNamespace matching this new project?
+//  2. If so, render every template the bindings name, hand the grouped
+//     result (cluster-scoped, Namespace, namespace-scoped) to the
+//     applier, and return [OutcomeBindingsApplied].
+//  3. Otherwise return [OutcomeNoBindings] so the caller runs its
+//     existing Namespace-create path unchanged.
+//
+// The package exposes small interface seams (BindingResolver,
+// PolicyGetter, TemplateGetter, Renderer, Applier) so the handler-level
+// unit tests in console/projects can inject fakes without pulling the
+// full policyresolver / templates stack into test wiring. The
+// production wiring in console/console.go threads the real resolvers,
+// the CueRendererAdapter, and the projectapply.Applier through these
+// seams via adapters.go.
+package projectnspipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/policyresolver"
+	"github.com/holos-run/holos-console/console/projects/projectapply"
+	"github.com/holos-run/holos-console/console/templates"
+)
+
+// Outcome is what Pipeline.Run tells the caller about the work it did.
+// CreateProject branches on this value: NoBindings means fall through to
+// the existing Namespace-create path; BindingsApplied means the applier
+// already SSA'd the Namespace and every associated resource, so no
+// further K8s write is required.
+type Outcome int
+
+const (
+	// OutcomeNoBindings indicates the ancestor chain above the parent
+	// namespace declared no TemplatePolicyBindings whose targets match
+	// the new project's namespace. The caller must run its existing
+	// Namespace-create path so the feature degrades to a no-op when
+	// unused.
+	OutcomeNoBindings Outcome = iota
+	// OutcomeBindingsApplied indicates at least one binding matched and
+	// the applier has completed the three-group SSA pipeline (ADR 034
+	// Decision 4). The caller must NOT also call CreateProject on the
+	// typed k8s client — the namespace is already SSA'd.
+	OutcomeBindingsApplied
+)
+
+// BindingResolver resolves TemplatePolicyBindings whose ProjectNamespace
+// targets match a to-be-created project. Implemented in production by
+// [policyresolver.ProjectNamespaceResolver]; the handler tests supply a
+// simple stub that returns a pre-canned slice.
+type BindingResolver interface {
+	Resolve(ctx context.Context, parentNamespace string, newProjectName string) ([]*policyresolver.ResolvedBinding, error)
+}
+
+// PolicyGetter fetches a single TemplatePolicy by namespace+name. The
+// resolver only hands us the binding's policy_ref; we still need to
+// dereference the ref to collect the rules (and therefore the Template
+// refs). Production wiring uses the templatepolicies K8sClient; tests
+// use an in-memory map.
+type PolicyGetter interface {
+	GetPolicy(ctx context.Context, namespace, name string) (*Policy, error)
+}
+
+// TemplateGetter fetches a single Template by namespace+name and
+// returns its CUE source. Production wiring uses the templates
+// K8sClient; tests use an in-memory map.
+type TemplateGetter interface {
+	GetTemplateSource(ctx context.Context, namespace, name string) (string, error)
+}
+
+// Renderer evaluates the collected template sources against the base
+// namespace and returns a grouped result. Matches
+// [templates.CueRendererAdapter.RenderForProjectNamespace] but wrapped
+// in an interface so handler-level tests can inject a stub (useful for
+// the "render error" AC).
+type Renderer interface {
+	RenderForProjectNamespace(ctx context.Context, in templates.ProjectNamespaceRenderInput) (*templates.ProjectNamespaceRenderResult, error)
+}
+
+// Applier runs the three-group SSA apply pipeline. Matches
+// [projectapply.Applier.Apply] as an interface so tests can inject a
+// stub that returns a canned [projectapply.DeadlineExceededError] for
+// the apply-timeout AC.
+type Applier interface {
+	Apply(ctx context.Context, result *templates.ProjectNamespaceRenderResult) error
+}
+
+// Policy is the minimal decoded form the pipeline needs from a
+// TemplatePolicy: the list of (template namespace, template name) refs
+// its REQUIRE rules point at. EXCLUDE rules are ignored by the
+// ProjectNamespace render path — ADR 034 Decision 3 leaves EXCLUDE
+// semantics to the deployment-time resolver; a ProjectNamespace binding
+// always contributes templates, never strips them, because there is no
+// baseline set to strip from.
+//
+// The type lives here rather than in the templatepolicies package to
+// keep handler-level tests free of the full CRD shape.
+type Policy struct {
+	// Namespace is the namespace the TemplatePolicy CRD lives in.
+	// Carried for audit logging / error messages only.
+	Namespace string
+	// Name is the TemplatePolicy's name.
+	Name string
+	// TemplateRefs enumerates the Template CRs the policy's REQUIRE
+	// rules name. Each ref uses the same (namespace, name) shape as
+	// the CRD's linked_template_ref.
+	TemplateRefs []TemplateRef
+}
+
+// TemplateRef identifies a Template CR by namespace+name. The render
+// path dereferences each ref to the Template's CUE source string via
+// TemplateGetter. VersionConstraint is carried forward for audit but
+// version pinning is outside the ProjectNamespace render-phase scope
+// (the deployment render path handles that; ADR 034 Decision 2 keeps
+// ProjectNamespace renders simple).
+type TemplateRef struct {
+	Namespace         string
+	Name              string
+	VersionConstraint string
+}
+
+// Input carries the per-RPC values Run needs to resolve → render → apply.
+type Input struct {
+	// ProjectName is the slug of the new project (e.g. "frontend").
+	ProjectName string
+	// ParentNamespace is the immediate ancestor namespace the resolver
+	// walks from (an organization or folder namespace). The new
+	// project's namespace does not exist yet; the walk starts here.
+	// ADR 034 open question — the ancestor namespace rule for
+	// projects created under folders in a future folders-with-depth
+	// feature — is deferred to HOL-806 Phase 7. For now we pass the
+	// immediate parent the RPC already resolved; the helper
+	// Handler.parentAncestorNamespace centralises this so the future
+	// fix touches one call site.
+	ParentNamespace string
+	// BaseNamespace is the Namespace object the RPC has already built
+	// (labels, annotations, share-grants). It becomes the "base" the
+	// render path unifies template-produced Namespace patches into
+	// (ADR 034 Decision 1 — "the RPC-built namespace is always the
+	// base").
+	BaseNamespace *corev1.Namespace
+	// Platform is the platform-input block the renderer binds at the
+	// CUE `platform` path. Callers fill this with
+	// (organization, project, namespace, gatewayNamespace, claims,
+	// folders) per the same shape the deployments render path uses.
+	Platform v1alpha2.PlatformInput
+}
+
+// Pipeline orchestrates the HOL-812 resolve → render → apply flow. One
+// Pipeline per process is intended (the struct is stateless apart from
+// its seams) and it is safe to call Run concurrently with distinct
+// Inputs.
+type Pipeline struct {
+	resolver  BindingResolver
+	policies  PolicyGetter
+	templates TemplateGetter
+	renderer  Renderer
+	applier   Applier
+}
+
+// New constructs a Pipeline wired with the given seams. Any nil seam
+// makes Run fail open (returns OutcomeNoBindings without an error) —
+// the handler treats a misconfigured pipeline the same way it would
+// treat a nil pipeline: fall through to the existing Namespace-create
+// path so CreateProject keeps working during a partial bootstrap.
+func New(
+	resolver BindingResolver,
+	policies PolicyGetter,
+	templateSources TemplateGetter,
+	renderer Renderer,
+	applier Applier,
+) *Pipeline {
+	return &Pipeline{
+		resolver:  resolver,
+		policies:  policies,
+		templates: templateSources,
+		renderer:  renderer,
+		applier:   applier,
+	}
+}
+
+// Run executes the resolve → render → apply pipeline for one
+// CreateProject call. Returns OutcomeNoBindings when no bindings match
+// (the caller runs its existing path); OutcomeBindingsApplied when the
+// applier succeeded (the caller returns the RPC response as-is).
+//
+// Audit log lines are emitted at every state transition so operators
+// can trace which path a CreateProject request took:
+//
+//   - project_ns_bindings_resolved (Info) — always, with match_count
+//   - project_ns_resolve_error     (Warn) — resolver returned an error
+//   - project_ns_render_ok         (Info) — render succeeded, counts
+//   - project_ns_render_error      (Warn) — render failed
+//   - project_ns_apply_ok          (Info) — applier returned nil
+//   - project_ns_apply_timeout     (Warn) — projectapply.DeadlineExceededError
+//   - project_ns_apply_error       (Warn) — any other applier error
+//
+// A resolver, renderer, or applier returning an error aborts the
+// pipeline immediately and the error propagates to the RPC layer. The
+// handler translates [projectapply.DeadlineExceededError] to
+// connect.CodeDeadlineExceeded; other errors go through mapK8sError or
+// connect.CodeInternal depending on their kind.
+func (p *Pipeline) Run(ctx context.Context, in Input) (Outcome, error) {
+	if p == nil || p.resolver == nil || p.policies == nil || p.templates == nil || p.renderer == nil || p.applier == nil {
+		slog.DebugContext(ctx, "project namespace pipeline is not fully wired; skipping",
+			slog.String("project", in.ProjectName),
+			slog.String("parentNamespace", in.ParentNamespace),
+		)
+		return OutcomeNoBindings, nil
+	}
+	if in.BaseNamespace == nil {
+		return OutcomeNoBindings, errors.New("projectnspipeline: BaseNamespace must not be nil")
+	}
+	if in.ProjectName == "" {
+		return OutcomeNoBindings, errors.New("projectnspipeline: ProjectName must not be empty")
+	}
+	if in.ParentNamespace == "" {
+		// No parent to walk — there can be no ancestor bindings. This
+		// mirrors the ProjectNamespaceResolver's own fail-open branch
+		// (project_namespace_resolver.go:116-123). Fall through without
+		// contacting the cluster.
+		return OutcomeNoBindings, nil
+	}
+
+	bindings, err := p.resolver.Resolve(ctx, in.ParentNamespace, in.ProjectName)
+	if err != nil {
+		slog.WarnContext(ctx, "project namespace bindings resolve error",
+			slog.String("action", "project_ns_resolve_error"),
+			slog.String("project", in.ProjectName),
+			slog.String("parent_namespace", in.ParentNamespace),
+			slog.Any("error", err),
+		)
+		return OutcomeNoBindings, fmt.Errorf("resolving project namespace bindings: %w", err)
+	}
+
+	slog.InfoContext(ctx, "project namespace bindings resolved",
+		slog.String("action", "project_ns_bindings_resolved"),
+		slog.String("project", in.ProjectName),
+		slog.String("parent_namespace", in.ParentNamespace),
+		slog.Int("match_count", len(bindings)),
+	)
+
+	if len(bindings) == 0 {
+		return OutcomeNoBindings, nil
+	}
+
+	// Collect the Template sources every binding's policy points at.
+	// Dedupe by (namespace, name) so two bindings that both reference
+	// the same Template CR do not re-render it. Ordering follows
+	// ancestor-walk order (closest ancestor first) — AncestorBindingLister's
+	// documented contract — so a folder binding takes precedence over
+	// the organization's default when both exist.
+	sources, err := p.collectTemplateSources(ctx, bindings)
+	if err != nil {
+		// Collection errors (policy-not-found, template-not-found) are
+		// classified as render-time errors for audit purposes: they
+		// block the same AC and map to the same connect code as a CUE
+		// evaluation failure. Keeping the audit action consistent keeps
+		// the operator-facing error surface small.
+		slog.WarnContext(ctx, "project namespace render error",
+			slog.String("action", "project_ns_render_error"),
+			slog.String("project", in.ProjectName),
+			slog.String("parent_namespace", in.ParentNamespace),
+			slog.Int("binding_count", len(bindings)),
+			slog.Any("error", err),
+		)
+		return OutcomeNoBindings, fmt.Errorf("collecting project namespace template sources: %w", err)
+	}
+
+	renderInput := templates.ProjectNamespaceRenderInput{
+		ProjectName:     in.ProjectName,
+		NamespaceName:   in.BaseNamespace.Name,
+		Platform:        in.Platform,
+		TemplateSources: sources,
+		BaseNamespace:   in.BaseNamespace,
+	}
+	rendered, err := p.renderer.RenderForProjectNamespace(ctx, renderInput)
+	if err != nil {
+		slog.WarnContext(ctx, "project namespace render error",
+			slog.String("action", "project_ns_render_error"),
+			slog.String("project", in.ProjectName),
+			slog.String("parent_namespace", in.ParentNamespace),
+			slog.Int("binding_count", len(bindings)),
+			slog.Int("template_source_count", len(sources)),
+			slog.Any("error", err),
+		)
+		return OutcomeNoBindings, fmt.Errorf("rendering project namespace: %w", err)
+	}
+
+	slog.InfoContext(ctx, "project namespace render ok",
+		slog.String("action", "project_ns_render_ok"),
+		slog.String("project", in.ProjectName),
+		slog.String("parent_namespace", in.ParentNamespace),
+		slog.Int("binding_count", len(bindings)),
+		slog.Int("template_source_count", len(sources)),
+		slog.Int("cluster_scoped_count", len(rendered.ClusterScoped)),
+		slog.Int("namespace_scoped_count", len(rendered.NamespaceScoped)),
+	)
+
+	if err := p.applier.Apply(ctx, rendered); err != nil {
+		var dl *projectapply.DeadlineExceededError
+		if errors.As(err, &dl) {
+			slog.WarnContext(ctx, "project namespace apply timeout",
+				slog.String("action", "project_ns_apply_timeout"),
+				slog.String("project", in.ProjectName),
+				slog.String("parent_namespace", in.ParentNamespace),
+				slog.String("blocked_kind", dl.Kind),
+				slog.String("blocked_name", dl.Name),
+				slog.String("blocked_namespace", dl.Namespace),
+				slog.Int("attempts", dl.Attempts),
+				slog.String("classifier", dl.Classifier),
+				slog.Any("error", err),
+			)
+			return OutcomeBindingsApplied, fmt.Errorf("applying project namespace: %w", err)
+		}
+		slog.WarnContext(ctx, "project namespace apply error",
+			slog.String("action", "project_ns_apply_error"),
+			slog.String("project", in.ProjectName),
+			slog.String("parent_namespace", in.ParentNamespace),
+			slog.Any("error", err),
+		)
+		return OutcomeBindingsApplied, fmt.Errorf("applying project namespace: %w", err)
+	}
+
+	slog.InfoContext(ctx, "project namespace apply ok",
+		slog.String("action", "project_ns_apply_ok"),
+		slog.String("project", in.ProjectName),
+		slog.String("parent_namespace", in.ParentNamespace),
+		slog.Int("binding_count", len(bindings)),
+		slog.Int("cluster_scoped_count", len(rendered.ClusterScoped)),
+		slog.Int("namespace_scoped_count", len(rendered.NamespaceScoped)),
+	)
+	return OutcomeBindingsApplied, nil
+}
+
+// collectTemplateSources dereferences every binding's policy_ref, walks
+// the policy's REQUIRE rules, and collects the CUE source for each
+// Template ref. Dedupes by (namespace, name) so a Template named by
+// multiple bindings/rules is only rendered once. A binding whose
+// policy_ref does not resolve fails the collection — the operator
+// pointed at a non-existent policy, which should surface to the RPC
+// caller rather than silently rendering an incomplete set.
+func (p *Pipeline) collectTemplateSources(ctx context.Context, bindings []*policyresolver.ResolvedBinding) ([]string, error) {
+	var sources []string
+	// Track (templateNamespace, templateName) so duplicates are rendered once.
+	type tmplKey struct{ ns, name string }
+	seenTmpl := make(map[tmplKey]bool)
+	// Cache policy fetches by (policyNamespace, policyName). Multiple
+	// bindings at different ancestor depths can reference the same
+	// policy — a single GetPolicy call per unique ref is enough.
+	type polKey struct{ ns, name string }
+	policyCache := make(map[polKey]*Policy)
+
+	for _, b := range bindings {
+		if b == nil || b.PolicyRef == nil {
+			// Already filtered by the resolver (project_namespace_resolver.go:140-142).
+			// Defensive re-check: a future resolver refactor that stops
+			// filtering must still be safe here.
+			continue
+		}
+		pk := polKey{ns: b.PolicyRef.GetNamespace(), name: b.PolicyRef.GetName()}
+		policy, cached := policyCache[pk]
+		if !cached {
+			fetched, err := p.policies.GetPolicy(ctx, pk.ns, pk.name)
+			if err != nil {
+				return nil, fmt.Errorf("loading policy %s/%s referenced by binding %s/%s: %w",
+					pk.ns, pk.name, b.Namespace, b.Name, err)
+			}
+			policy = fetched
+			policyCache[pk] = policy
+		}
+		if policy == nil {
+			continue
+		}
+		for _, ref := range policy.TemplateRefs {
+			if ref.Name == "" {
+				continue
+			}
+			key := tmplKey{ns: ref.Namespace, name: ref.Name}
+			if seenTmpl[key] {
+				continue
+			}
+			seenTmpl[key] = true
+			src, err := p.templates.GetTemplateSource(ctx, ref.Namespace, ref.Name)
+			if err != nil {
+				return nil, fmt.Errorf("loading template %s/%s (from policy %s/%s): %w",
+					ref.Namespace, ref.Name, pk.ns, pk.name, err)
+			}
+			if src == "" {
+				continue
+			}
+			sources = append(sources, src)
+		}
+	}
+	return sources, nil
+}


### PR DESCRIPTION
## Summary
- New `console/projects/projectnspipeline` package orchestrates resolve → render → apply for the HOL-812 ProjectNamespace pipeline.
- CreateProject handler builds the base Namespace, runs the pipeline; if any TemplatePolicyBinding with target.kind=ProjectNamespace matches, the applier's three-group SSA pipeline (HOL-811) owns the namespace creation and every associated resource; otherwise the existing typed Namespace.Create path runs unchanged. Both paths live inside the same auto-generated-name retry loop so AlreadyExists races behave identically.
- Audit log lines emitted at every state transition (`project_ns_bindings_resolved`, `project_ns_resolve_error`, `project_ns_render_ok`, `project_ns_render_error`, `project_ns_apply_ok`, `project_ns_apply_timeout`, `project_ns_apply_error`). `DeadlineExceededError` maps to `connect.CodeDeadlineExceeded` via `errors.Is`; other errors route through the existing `mapK8sError`.
- Handler exposes a small `ProjectNamespacePipeline` interface; the production adapter lives in `console/console.go` to avoid a `projects → projectnspipeline → templates → deployments → projects(test)` import cycle.
- 4 new handler tests cover the no-bindings, one-binding, render-error, and apply-timeout ACs; existing `TestCreateProject_*` tests unchanged.

Fixes HOL-812

## Test plan
- [ ] `go test ./console/... -count=1` — all packages pass
- [ ] `CGO_ENABLED=1 go test -race ./console/...` — race clean
- [ ] `go vet ./console/...` — clean
- [ ] Manual: with the Manager + dynamic client wired and a TemplatePolicyBinding with `target.kind=ProjectNamespace` in an org namespace, CreateProject applies via SSA and produces a namespace matching the rendered Namespace patches
- [ ] Manual: with no matching binding, CreateProject persists the base namespace via the typed path (unchanged behavior)