### PR TITLE
feat(templates): add two embedded ProjectNamespace example templates

### DIFF
--- a/console/templates/examples/examples_test.go
+++ b/console/templates/examples/examples_test.go
@@ -17,8 +17,8 @@ func TestExamples(t *testing.T) {
 		t.Fatalf("Examples() error: %v", err)
 	}
 
-	// There must be exactly two examples.
-	if got, want := len(list), 2; got != want {
+	// There must be exactly four examples.
+	if got, want := len(list), 4; got != want {
 		t.Fatalf("Examples() returned %d examples, want %d", got, want)
 	}
 
@@ -28,7 +28,12 @@ func TestExamples(t *testing.T) {
 		byName[ex.Name] = ex
 	}
 
-	wantNames := []string{"httproute-v1", "allowed-project-resource-kinds-v1"}
+	wantNames := []string{
+		"httproute-v1",
+		"allowed-project-resource-kinds-v1",
+		"project-namespace-description-annotation-v1",
+		"project-namespace-reference-grant-v1",
+	}
 	for _, name := range wantNames {
 		ex, ok := byName[name]
 		if !ok {

--- a/console/templates/examples/project-namespace-description-annotation-v1.cue
+++ b/console/templates/examples/project-namespace-description-annotation-v1.cue
@@ -1,0 +1,57 @@
+// Project namespace description annotation — org/folder-level platform template.
+// Unifies a single "description" annotation onto the new project's namespace.
+// No other resources are produced. Use this as the minimal starting point for
+// any template that only needs to label or annotate a namespace at creation time.
+//
+// To activate: create a TemplatePolicyBinding that references this template and
+// sets targetRefs.kind = ProjectNamespace.
+//
+// Example TemplatePolicyBinding snippet:
+//
+//   apiVersion: console.holos.run/v1alpha2
+//   kind: TemplatePolicyBinding
+//   metadata:
+//     name: namespace-description
+//     namespace: holos-org-acme          # ancestor (org or folder) namespace
+//   spec:
+//     targetRefs:
+//       - kind: ProjectNamespace
+//     templateRef:
+//       name: namespace-description-template
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "Project Namespace Description Annotation (v1)"
+name:        "project-namespace-description-annotation-v1"
+description: "Adds a description annotation to the new project's namespace. Minimal ProjectNamespace example — no other resources."
+
+cueTemplate: """
+	// platform is available because platform templates are unified with the
+	// deployment template before evaluation (ADR 016 Decision 8).
+	platform: #PlatformInput
+
+	// platformResources holds resources the platform team manages. The renderer
+	// reads platformResources from org/folder-level templates when a
+	// TemplatePolicyBinding targets ProjectNamespace (ADR 034 Decision 2).
+	platformResources: {
+		// Patch the new project's namespace with a human-readable description.
+		// The Namespace object is merged (not replaced) into the base namespace
+		// the RPC constructs, so existing labels and annotations are preserved.
+		clusterResources: {
+			Namespace: (platform.namespace): {
+				apiVersion: "v1"
+				kind:       "Namespace"
+				metadata: {
+					name: platform.namespace
+					annotations: {
+						"console.holos.run/description": "Managed by the Holos platform team."
+					}
+				}
+			}
+		}
+		namespacedResources: {}
+	}
+	"""

--- a/console/templates/examples/project-namespace-reference-grant-v1.cue
+++ b/console/templates/examples/project-namespace-reference-grant-v1.cue
@@ -1,0 +1,72 @@
+// Project namespace ReferenceGrant — org/folder-level platform template.
+// Emits a Gateway API ReferenceGrant (gateway.networking.k8s.io/v1beta1)
+// in the new project's namespace. The grant allows HTTPRoutes in the
+// gateway namespace to reference Services in the project namespace —
+// the standard pattern for exposing a project's workloads through the
+// org-managed ingress gateway.
+//
+// To activate: create a TemplatePolicyBinding that references this template and
+// sets targetRefs.kind = ProjectNamespace.
+//
+// Example TemplatePolicyBinding snippet:
+//
+//   apiVersion: console.holos.run/v1alpha2
+//   kind: TemplatePolicyBinding
+//   metadata:
+//     name: namespace-reference-grant
+//     namespace: holos-org-acme          # ancestor (org or folder) namespace
+//   spec:
+//     targetRefs:
+//       - kind: ProjectNamespace
+//     templateRef:
+//       name: namespace-reference-grant-template
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "Project Namespace ReferenceGrant (v1)"
+name:        "project-namespace-reference-grant-v1"
+description: "Emits a Gateway API ReferenceGrant in the new project namespace, allowing the gateway to forward traffic to project Services."
+
+cueTemplate: """
+	// platform is available because platform templates are unified with the
+	// deployment template before evaluation (ADR 016 Decision 8).
+	platform: #PlatformInput
+
+	// platformResources holds resources the platform team manages. The renderer
+	// reads platformResources from org/folder-level templates when a
+	// TemplatePolicyBinding targets ProjectNamespace (ADR 034 Decision 2).
+	platformResources: {
+		// Emit the ReferenceGrant in the new project namespace (namespace-scoped).
+		// The HOL-811 applier applies this after the namespace becomes Active.
+		namespacedResources: (platform.namespace): {
+			ReferenceGrant: "allow-from-gateway": {
+				apiVersion: "gateway.networking.k8s.io/v1beta1"
+				kind:       "ReferenceGrant"
+				metadata: {
+					name:      "allow-from-gateway"
+					namespace: platform.namespace
+					labels: {
+						"app.kubernetes.io/managed-by": "console.holos.run"
+					}
+				}
+				spec: {
+					// Allow HTTPRoutes in the gateway namespace to reference
+					// Services in this project namespace.
+					from: [{
+						group:     "gateway.networking.k8s.io"
+						kind:      "HTTPRoute"
+						namespace: platform.gatewayNamespace
+					}]
+					to: [{
+						group: ""
+						kind:  "Service"
+					}]
+				}
+			}
+		}
+		clusterResources: {}
+	}
+	"""

--- a/console/templates/handler_examples_test.go
+++ b/console/templates/handler_examples_test.go
@@ -1,7 +1,7 @@
 // handler_examples_test.go exercises the ListTemplateExamples RPC introduced
 // in HOL-797. The acceptance criteria are:
 //
-//   - The happy path returns exactly two examples (one per embedded *.cue file).
+//   - The happy path returns exactly four examples (one per embedded *.cue file).
 //   - Results are sorted by name ascending so the UI can rely on a stable order.
 //   - Each entry has non-empty DisplayName, Description, and CueTemplate.
 package templates
@@ -33,7 +33,7 @@ func newExamplesTestHandler(t *testing.T) *Handler {
 }
 
 // TestListTemplateExamples_HappyPath verifies that ListTemplateExamples returns
-// exactly two examples (matching the two *.cue files embedded in the examples
+// exactly four examples (matching the four *.cue files embedded in the examples
 // package), each with non-empty fields, and sorted by name ascending.
 func TestListTemplateExamples_HappyPath(t *testing.T) {
 	handler := newExamplesTestHandler(t)
@@ -46,7 +46,7 @@ func TestListTemplateExamples_HappyPath(t *testing.T) {
 	}
 
 	got := resp.Msg.GetExamples()
-	const wantCount = 2
+	const wantCount = 4
 	if len(got) != wantCount {
 		t.Fatalf("ListTemplateExamples() returned %d examples, want %d", len(got), wantCount)
 	}
@@ -91,7 +91,7 @@ func TestListTemplateExamples_SortedByName(t *testing.T) {
 	}
 }
 
-// TestListTemplateExamples_KnownNames verifies the two expected built-in
+// TestListTemplateExamples_KnownNames verifies the four expected built-in
 // example slugs are present, anchoring the test to the actual embedded files.
 func TestListTemplateExamples_KnownNames(t *testing.T) {
 	handler := newExamplesTestHandler(t)
@@ -108,7 +108,12 @@ func TestListTemplateExamples_KnownNames(t *testing.T) {
 		byName[ex.GetName()] = ex
 	}
 
-	wantNames := []string{"allowed-project-resource-kinds-v1", "httproute-v1"}
+	wantNames := []string{
+		"allowed-project-resource-kinds-v1",
+		"httproute-v1",
+		"project-namespace-description-annotation-v1",
+		"project-namespace-reference-grant-v1",
+	}
 	for _, name := range wantNames {
 		if _, ok := byName[name]; !ok {
 			t.Errorf("example %q not found in ListTemplateExamples response", name)

--- a/console/templates/render_project_namespace_examples_test.go
+++ b/console/templates/render_project_namespace_examples_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+// render_project_namespace_examples_test.go verifies that the two embedded
+// ProjectNamespace example templates (HOL-813) produce the expected output
+// when rendered through RenderForProjectNamespace. Each test mirrors what an
+// operator would see after wiring a TemplatePolicyBinding with
+// targetRefs.kind=ProjectNamespace.
+//
+// Test data: the cueTemplate strings are copied verbatim from the registry CUE
+// files so that changes to the examples surface as test failures here too.
+
+import (
+	"context"
+	"testing"
+)
+
+// descriptionAnnotationTemplate is the cueTemplate body from
+// console/templates/examples/project-namespace-description-annotation-v1.cue.
+const descriptionAnnotationTemplate = `
+platform: #PlatformInput
+
+platformResources: {
+	clusterResources: {
+		Namespace: (platform.namespace): {
+			apiVersion: "v1"
+			kind:       "Namespace"
+			metadata: {
+				name: platform.namespace
+				annotations: {
+					"console.holos.run/description": "Managed by the Holos platform team."
+				}
+			}
+		}
+	}
+	namespacedResources: {}
+}
+`
+
+// TestRenderProjectNamespace_DescriptionAnnotationExample verifies that the
+// description-annotation example template (project-namespace-description-
+// annotation-v1) unifies a single "console.holos.run/description" annotation
+// onto the new project namespace. No other resources are emitted.
+//
+// AC (HOL-813): rendering template 1 with a fixed project name produces a
+// namespace with the expected annotation key and value.
+func TestRenderProjectNamespace_DescriptionAnnotationExample(t *testing.T) {
+	adapter := NewCueRendererAdapter()
+	in := projectNamespaceInputs("my-project", "holos-prj-my-project", []string{
+		descriptionAnnotationTemplate,
+	})
+
+	got, err := adapter.RenderForProjectNamespace(context.Background(), in)
+	if err != nil {
+		t.Fatalf("RenderForProjectNamespace error: %v", err)
+	}
+
+	// The template produces only a Namespace patch — no other resources.
+	if len(got.ClusterScoped) != 0 {
+		t.Errorf("expected 0 cluster-scoped resources, got %d", len(got.ClusterScoped))
+	}
+	if len(got.NamespaceScoped) != 0 {
+		t.Errorf("expected 0 namespace-scoped resources, got %d", len(got.NamespaceScoped))
+	}
+
+	// The expected annotation must be present on the unified Namespace.
+	anns := got.Namespace.GetAnnotations()
+	const (
+		wantKey = "console.holos.run/description"
+		wantVal = "Managed by the Holos platform team."
+	)
+	if got := anns[wantKey]; got != wantVal {
+		t.Errorf("Namespace annotation %q = %q, want %q", wantKey, got, wantVal)
+	}
+
+	// Base annotations set by the RPC must be preserved — the merge is additive.
+	if anns["console.holos.run/display-name"] != "My Project" {
+		t.Errorf("expected base annotation console.holos.run/display-name=My Project preserved, got %q",
+			anns["console.holos.run/display-name"])
+	}
+
+	// The namespace name and identity must be unchanged.
+	if got.Namespace.GetName() != "holos-prj-my-project" {
+		t.Errorf("Namespace name = %q, want holos-prj-my-project", got.Namespace.GetName())
+	}
+}
+
+// referenceGrantTemplate is the cueTemplate body from
+// console/templates/examples/project-namespace-reference-grant-v1.cue.
+const referenceGrantTemplate = `
+platform: #PlatformInput
+
+platformResources: {
+	namespacedResources: (platform.namespace): {
+		ReferenceGrant: "allow-from-gateway": {
+			apiVersion: "gateway.networking.k8s.io/v1beta1"
+			kind:       "ReferenceGrant"
+			metadata: {
+				name:      "allow-from-gateway"
+				namespace: platform.namespace
+				labels: {
+					"app.kubernetes.io/managed-by": "console.holos.run"
+				}
+			}
+			spec: {
+				from: [{
+					group:     "gateway.networking.k8s.io"
+					kind:      "HTTPRoute"
+					namespace: platform.gatewayNamespace
+				}]
+				to: [{
+					group: ""
+					kind:  "Service"
+				}]
+			}
+		}
+	}
+	clusterResources: {}
+}
+`
+
+// TestRenderProjectNamespace_ReferenceGrantExample verifies that the
+// reference-grant example template (project-namespace-reference-grant-v1)
+// emits a single ReferenceGrant in the new project namespace. The cluster-
+// scoped bucket must be empty and the namespace must be the project namespace.
+//
+// AC (HOL-813): rendering template 2 produces a ReferenceGrant with
+// metadata.namespace set to the new project's namespace.
+func TestRenderProjectNamespace_ReferenceGrantExample(t *testing.T) {
+	adapter := NewCueRendererAdapter()
+	in := projectNamespaceInputs("my-project", "holos-prj-my-project", []string{
+		referenceGrantTemplate,
+	})
+
+	got, err := adapter.RenderForProjectNamespace(context.Background(), in)
+	if err != nil {
+		t.Fatalf("RenderForProjectNamespace error: %v", err)
+	}
+
+	// The template produces one namespace-scoped ReferenceGrant only.
+	if len(got.ClusterScoped) != 0 {
+		t.Errorf("expected 0 cluster-scoped resources, got %d", len(got.ClusterScoped))
+	}
+	if len(got.NamespaceScoped) != 1 {
+		t.Fatalf("expected 1 namespace-scoped resource, got %d", len(got.NamespaceScoped))
+	}
+
+	rg := got.NamespaceScoped[0]
+
+	// Kind and apiVersion must match the Gateway API ReferenceGrant.
+	if rg.GetKind() != "ReferenceGrant" {
+		t.Errorf("resource kind = %q, want ReferenceGrant", rg.GetKind())
+	}
+	if rg.GetAPIVersion() != "gateway.networking.k8s.io/v1beta1" {
+		t.Errorf("resource apiVersion = %q, want gateway.networking.k8s.io/v1beta1", rg.GetAPIVersion())
+	}
+
+	// metadata.namespace must equal the new project namespace.
+	if rg.GetNamespace() != "holos-prj-my-project" {
+		t.Errorf("ReferenceGrant namespace = %q, want holos-prj-my-project", rg.GetNamespace())
+	}
+
+	// metadata.name must be set.
+	if rg.GetName() != "allow-from-gateway" {
+		t.Errorf("ReferenceGrant name = %q, want allow-from-gateway", rg.GetName())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `project-namespace-description-annotation-v1.cue` — minimal example that unifies a single `console.holos.run/description` annotation onto the new project's namespace via `platformResources.clusterResources`. No other resources.
- Adds `project-namespace-reference-grant-v1.cue` — example that emits a Gateway API `ReferenceGrant` (v1beta1) in the new project namespace via `platformResources.namespacedResources`, demonstrating namespace-scoped resource emission.
- Both CUE files include inline `TemplatePolicyBinding` YAML snippets and comments explaining the `targetRefs.kind: ProjectNamespace` wiring (AC: README/docstring requirement).
- Updates `examples_test.go` and `handler_examples_test.go` count assertions: 2 → 4.
- Adds `render_project_namespace_examples_test.go`: two focused tests render each example through `RenderForProjectNamespace` and assert the annotation key/value (template 1) and `ReferenceGrant` kind/apiVersion/namespace (template 2).

Fixes HOL-813

## Test plan

- [x] `go test ./console/templates/... ./console/templates/examples/...` passes locally (all green)
- [x] `TestRenderProjectNamespace_DescriptionAnnotationExample` — renders template 1, asserts `console.holos.run/description` annotation present, base annotations preserved, zero cluster/namespace-scoped extra resources
- [x] `TestRenderProjectNamespace_ReferenceGrantExample` — renders template 2, asserts one `ReferenceGrant` in `NamespaceScoped` with `metadata.namespace=holos-prj-my-project`
- [x] `TestExamples` — registry loads all 4 examples, each compiles against v1alpha2 schema
- [x] `TestListTemplateExamples_HappyPath` — RPC returns 4 examples with non-empty fields
- [x] `TestListTemplateExamples_KnownNames` — all 4 slugs present in RPC response