### PR TITLE
chore(frontend): reconcile preview seed comment for HOL-828 injection

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
@@ -23,9 +23,14 @@ import type { TemplateExample } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
-// Platform/project input defaults for the preview pane. The backend injects
-// org-owned values (e.g. gatewayNamespace — HOL-526) at render time regardless
-// of what the preview ships up, so these strings are cosmetic seed values only.
+// DEFAULT_PLATFORM_INPUT seeds the preview pane with cosmetic placeholder
+// values for the user-editable fields of #PlatformInput (project, namespace,
+// claims). The backend always injects the authoritative platform-owned fields
+// before evaluating the user-supplied input, so values like gatewayNamespace
+// (HOL-526) and organization are resolved server-side and must not be set here.
+// CUE unification merges the backend values with these seeds: fields present in
+// both must agree (identical strings unify; conflicting strings surface a CUE
+// error, which is the correct behavior for pinned vs. resolved mismatches).
 const DEFAULT_PLATFORM_INPUT = `platform: {
   project:          "example-project"
   namespace:        "prj-example-project"


### PR DESCRIPTION
## Summary

- Updates the comment on `DEFAULT_PLATFORM_INPUT` in the org-template editor to accurately describe the post-HOL-828 merge semantics: backend injects `gatewayNamespace` and `organization` (HOL-526) server-side; the frontend seed carries only cosmetic placeholder values for user-editable fields (`project`, `namespace`, `claims`).
- `DEFAULT_PLATFORM_INPUT` itself is unchanged — it already contains only the trimmed user-editable fields as introduced by HOL-828.
- No changes to backend files (`handler.go`, `render_adapter.go`) — those are clean with no stale scaffolding.
- No test changes needed — no test asserts on preview error text that would be affected.

Fixes HOL-831

## Manual Verification

The manual preview step (AC: start `make run` + `make dev`, create org template from HTTPRoute v1 example, click Preview) was not performed because this worktree runs in a headless CI environment without access to Dex + a real cluster. The backend-injection behavior was verified by the `TestRenderTemplate_PlatformInjection` tests in `console/templates/handler_render_test.go` (HOL-828/PR #1104) and the `TestExamplePreviewRender` / `TestExamplePreviewRender_KnownExamples` tests in `console/templates/examples/examples_test.go` (HOL-830/PR #1108), both of which confirm the HTTPRoute (v1) example renders cleanly with backend-injected `gatewayNamespace`.

## Test plan

- [x] `make test-ui` — 84 test files, 1091 tests passed
- [x] `make test-go` — all Go packages pass
- [x] `make fmt` — no changes (TypeScript comment only)
- [x] `make vet` — clean

## Deferred Acceptance Criteria

- [ ] Final manual verification: start `make run` + `make dev`, create a new org template from the HTTPRoute (v1) example, click Preview, and confirm the HTTPRoute manifest renders. (Headless environment — requires human verification.)