### PR TITLE
feat(frontend): add ProjectNamespace kind to BindingForm / TargetRefEditor

### DIFF
--- a/frontend/src/components/template-policy-bindings/BindingForm.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.tsx
@@ -159,13 +159,15 @@ export function BindingForm({
         className="rounded-md border border-border p-3 text-sm text-muted-foreground"
       >
         A TemplatePolicyBinding attaches one policy to a list of project
-        templates and deployments. Use the wildcard <code>*</code> in{' '}
-        <code>project_name</code> or <code>name</code> to expand a row to every
-        match the binding's storage scope can reach — a folder-scoped binding
-        can only touch resources under that folder, an organization-scoped
-        binding can touch every project in the org. <code>kind</code> is never
-        wildcarded: use a separate row for each kind so audit logs stay
-        readable.
+        templates, deployments, or project namespaces. Use the wildcard{' '}
+        <code>*</code> in <code>project_name</code> or <code>name</code> to
+        expand a row to every match the binding's storage scope can reach — a
+        folder-scoped binding can only touch resources under that folder, an
+        organization-scoped binding can touch every project in the org.{' '}
+        <code>kind</code> is never wildcarded: use a separate row for each kind
+        so audit logs stay readable. A <code>project_namespace</code> row
+        matches the namespace created for each new project under the selected
+        ancestor when <code>project_name</code> is <code>*</code>.
       </div>
 
       <div>

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
@@ -37,9 +37,10 @@ function entryKey(e: MatchEntry): string {
 }
 
 function kindLabel(kind: TemplatePolicyBindingTargetKind): string {
-  return kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
-    ? 'deployment'
-    : 'project_template'
+  if (kind === TemplatePolicyBindingTargetKind.DEPLOYMENT) return 'deployment'
+  if (kind === TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE)
+    return 'project_namespace'
+  return 'project_template'
 }
 
 export type MatchesPreviewParentScope =
@@ -577,15 +578,27 @@ function Probe({
   store: ProbeStore
 }) {
   const isDeployment = kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
+  const isProjectNamespace =
+    kind === TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE
   const namespace = namespaceForProject(projectName)
-  // Both hooks are always called to satisfy React's hook-order rule. Only
+  // All hooks are always called to satisfy React's hook-order rule. Only
   // the relevant side is read; the other is short-circuited by passing '' /
   // the hook's internal enabled: !!... check.
-  const templates = useListTemplates(isDeployment ? '' : namespace)
+  const templates = useListTemplates(
+    isDeployment || isProjectNamespace ? '' : namespace,
+  )
   const deployments = useListDeployments(isDeployment ? projectName : '')
 
-  const pending = isDeployment ? !!deployments.isLoading : !!templates.isLoading
-  const error = isDeployment ? deployments.error : templates.error
+  const pending = isDeployment
+    ? !!deployments.isLoading
+    : isProjectNamespace
+      ? false
+      : !!templates.isLoading
+  const error = isDeployment
+    ? deployments.error
+    : isProjectNamespace
+      ? null
+      : templates.error
 
   const matches: MatchEntry[] = useMemo(() => {
     // When the probe failed we publish an empty match list with the
@@ -600,10 +613,17 @@ function Probe({
         name: d.name,
       }))
     }
+    if (isProjectNamespace) {
+      // A ProjectNamespace binding targets the namespace resource for the
+      // project itself. The conventional name matches the project name.
+      // There is exactly one namespace per project so we synthesize the
+      // single entry directly — no list RPC is needed.
+      return [{ kind, projectName, name: projectName }]
+    }
     return (templates.data ?? [])
       .filter((t) => scopeLabelFromNamespace(t.namespace) === 'project')
       .map((t) => ({ kind, projectName, name: t.name }))
-  }, [error, isDeployment, kind, projectName, templates.data, deployments.data])
+  }, [error, isDeployment, isProjectNamespace, kind, projectName, templates.data, deployments.data])
 
   // Publish during render. The store dedupes on equal values so this does
   // not loop; changes to `matches` / `pending` / `error` produce a single

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.test.tsx
@@ -544,4 +544,171 @@ describe('TargetRefEditor', () => {
       screen.queryByRole('button', { name: /remove target 1/i }),
     ).not.toBeInTheDocument()
   })
+
+  // --- HOL-814 ProjectNamespace kind coverage ---------------------------------
+
+  it('renders the ProjectNamespace option in the kind selector', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[makeTarget()]}
+        onChange={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    const kindTrigger = within(row).getByRole('combobox', {
+      name: /target 1 kind/i,
+    })
+    await user.click(kindTrigger)
+    expect(
+      await screen.findByRole('option', { name: /project namespace/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('kind switch from PROJECT_TEMPLATE to PROJECT_NAMESPACE clears the name', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onChange = vi.fn()
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+            projectName: 'proj-a',
+            name: 'ingress',
+          }),
+        ]}
+        onChange={onChange}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    const kindTrigger = within(row).getByRole('combobox', {
+      name: /target 1 kind/i,
+    })
+    await user.click(kindTrigger)
+    await user.click(
+      await screen.findByRole('option', { name: /project namespace/i }),
+    )
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const next = onChange.mock.calls[0][0] as TargetRefDraft[]
+    expect(next[0]).toMatchObject({
+      kind: TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE,
+      projectName: 'proj-a',
+      name: '',
+    })
+  })
+
+  it('shows "All project namespaces (*)" wildcard when kind=PROJECT_NAMESPACE and project is literal', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE,
+            projectName: 'proj-a',
+            name: '',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 name/i }),
+    )
+    expect(
+      await screen.findByText(/All project namespaces \(\*\)/i),
+    ).toBeInTheDocument()
+  })
+
+  it('name picker wildcard reads "All project namespaces (*)" when kind=PROJECT_NAMESPACE', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE,
+            projectName: 'proj-a',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    await user.click(
+      within(row).getByRole('combobox', { name: /target 1 name/i }),
+    )
+    expect(
+      await screen.findByText(/All project namespaces \(\*\)/i),
+    ).toBeInTheDocument()
+    // Deployment and template labels must not appear
+    expect(screen.queryByText(/All deployments \(\*\)/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/All project templates \(\*\)/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders PROJECT_NAMESPACE row without crashing when projectName="*"', () => {
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE,
+            projectName: '*',
+            name: '*',
+          }),
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('target-ref-row-0')).toBeInTheDocument()
+  })
+
+  it('round-trip: switching from PROJECT_NAMESPACE back to PROJECT_TEMPLATE works', async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+    const onChange = vi.fn()
+    render(
+      <TargetRefEditor
+        organization="test-org"
+        targets={[
+          makeTarget({
+            kind: TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE,
+            projectName: 'proj-a',
+            name: 'proj-a',
+          }),
+        ]}
+        onChange={onChange}
+      />,
+    )
+    const row = screen.getByTestId('target-ref-row-0')
+    const kindTrigger = within(row).getByRole('combobox', {
+      name: /target 1 kind/i,
+    })
+    await user.click(kindTrigger)
+    await user.click(
+      await screen.findByRole('option', { name: /^project template$/i }),
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const next = onChange.mock.calls[0][0] as TargetRefDraft[]
+    expect(next[0]).toMatchObject({
+      kind: TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE,
+      projectName: 'proj-a',
+      name: '',
+    })
+  })
 })

--- a/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
+++ b/frontend/src/components/template-policy-bindings/TargetRefEditor.tsx
@@ -35,6 +35,10 @@ const KIND_OPTIONS: Array<{
     label: 'Project Template',
   },
   { value: TemplatePolicyBindingTargetKind.DEPLOYMENT, label: 'Deployment' },
+  {
+    value: TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE,
+    label: 'Project Namespace',
+  },
 ]
 
 // Synthetic combobox items for the wildcard sentinel. Using the literal
@@ -44,11 +48,14 @@ const WILDCARD_PROJECT_ITEM: ComboboxItem = {
   value: WILDCARD,
   label: 'All projects (*)',
 }
-function wildcardNameItem(isDeployment: boolean): ComboboxItem {
-  return {
-    value: WILDCARD,
-    label: isDeployment ? 'All deployments (*)' : 'All project templates (*)',
+function wildcardNameItem(kind: TemplatePolicyBindingTargetKind): ComboboxItem {
+  if (kind === TemplatePolicyBindingTargetKind.DEPLOYMENT) {
+    return { value: WILDCARD, label: 'All deployments (*)' }
   }
+  if (kind === TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE) {
+    return { value: WILDCARD, label: 'All project namespaces (*)' }
+  }
+  return { value: WILDCARD, label: 'All project templates (*)' }
 }
 
 export type TargetRefEditorProps = {
@@ -166,6 +173,8 @@ function TargetRow({
   disabled,
 }: TargetRowProps) {
   const isDeployment = target.kind === TemplatePolicyBindingTargetKind.DEPLOYMENT
+  const isProjectNamespace =
+    target.kind === TemplatePolicyBindingTargetKind.PROJECT_NAMESPACE
   const projectIsWildcard = target.projectName === WILDCARD
   const isLiteralProject = !!target.projectName && !projectIsWildcard
 
@@ -196,29 +205,43 @@ function TargetRow({
     isLiteralProject ? target.projectName : '',
   )
 
-  // KIND_OPTIONS omits UNSPECIFIED, so kind is always DEPLOYMENT or
-  // PROJECT_TEMPLATE. Branching on a single `isDeployment` flag keeps the
-  // contract explicit and avoids an unreachable fallthrough.
+  // KIND_OPTIONS omits UNSPECIFIED. Branching keeps the contract explicit:
+  // PROJECT_NAMESPACE names reference the namespace resource under the project;
+  // DEPLOYMENT names reference deployments; PROJECT_TEMPLATE names reference
+  // project-scope templates.
   const nameItems: ComboboxItem[] = useMemo(() => {
-    const wildcard = wildcardNameItem(isDeployment)
+    const wildcard = wildcardNameItem(target.kind)
     if (!isLiteralProject) {
       // No backing list when project is unset or wildcard — only the
       // wildcard sentinel is offered.
       return [wildcard]
     }
-    const literal = isDeployment
-      ? deployments.map((d) => ({
-          value: d.name,
-          label: d.displayName ? `${d.displayName} (${d.name})` : d.name,
-        }))
-      : projectTemplates
-          .filter((t) => scopeLabelFromNamespace(t.namespace) === 'project')
-          .map((t) => ({
-            value: t.name,
-            label: t.displayName ? `${t.displayName} (${t.name})` : t.name,
-          }))
+    if (isDeployment) {
+      const literal = deployments.map((d) => ({
+        value: d.name,
+        label: d.displayName ? `${d.displayName} (${d.name})` : d.name,
+      }))
+      return [wildcard, ...literal]
+    }
+    if (isProjectNamespace) {
+      // ProjectNamespace targets reference the namespace resource itself.
+      // The conventional name is the project name; offer it as the only
+      // literal option alongside the wildcard sentinel.
+      const namespaceItem: ComboboxItem = {
+        value: target.projectName,
+        label: target.projectName,
+      }
+      return [wildcard, namespaceItem]
+    }
+    // PROJECT_TEMPLATE: list project-scope templates.
+    const literal = projectTemplates
+      .filter((t) => scopeLabelFromNamespace(t.namespace) === 'project')
+      .map((t) => ({
+        value: t.name,
+        label: t.displayName ? `${t.displayName} (${t.name})` : t.name,
+      }))
     return [wildcard, ...literal]
-  }, [isDeployment, isLiteralProject, projectTemplates, deployments])
+  }, [target.kind, target.projectName, isDeployment, isProjectNamespace, isLiteralProject, projectTemplates, deployments])
 
   return (
     <div
@@ -300,7 +323,9 @@ function TargetRow({
               placeholder={
                 isDeployment
                   ? 'Select a deployment...'
-                  : 'Select a project template...'
+                  : isProjectNamespace
+                    ? 'Select a project namespace...'
+                    : 'Select a project template...'
               }
               searchPlaceholder="Search..."
               aria-label={`Target ${index + 1} name`}
@@ -327,7 +352,9 @@ function TargetRow({
                 placeholder={
                   isDeployment
                     ? 'Deployment name or *'
-                    : 'Template name or *'
+                    : isProjectNamespace
+                      ? 'Namespace name or *'
+                      : 'Template name or *'
                 }
                 aria-label={`Target ${index + 1} name`}
                 disabled={disabled}


### PR DESCRIPTION
## Summary
- Adds `PROJECT_NAMESPACE` to `KIND_OPTIONS` in `TargetRefEditor.tsx` with label "Project Namespace" and appropriate wildcard/help copy
- Updates `wildcardNameItem()` to return "All project namespaces (*)" for the new kind
- Updates `TargetRow` name-picker to offer the project name as the conventional namespace name for a literal project (one namespace per project — no extra list RPC needed)
- Updates `MatchesPreview` `kindLabel()` and `Probe` to handle `PROJECT_NAMESPACE` (synthesizes one match entry per project without extra RPCs)
- Updates `BindingForm` info text to mention project namespaces and wildcard semantics
- Adds 6 new Vitest/RTL unit tests covering: option visibility, kind-switch, wildcard label, wildcard row render, round-trip

Fixes HOL-814

## Test plan
- [x] `make test-ui` passes — 1097 tests, 84 files, zero failures
- [x] `TargetRefEditor.test.tsx` has 24 tests (18 existing + 6 new for PROJECT_NAMESPACE)
- [ ] Navigate to a TemplatePolicyBinding create page; confirm "Project Namespace" appears in the Kind dropdown
- [ ] Select kind=ProjectNamespace with a literal project; confirm the name picker offers the project name and the wildcard sentinel
- [ ] Select kind=ProjectNamespace with project="*"; confirm the literal name input and wildcard button render