### PR TITLE
chore(hol-806): final cleanup — CHANGELOG, docs, ADR 034 open-question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to holos-console are documented here.
+
+## [Unreleased]
+
+### Added — ProjectNamespace TemplatePolicyBinding for new Projects (HOL-806)
+
+Operators can now attach a `TemplatePolicyBinding` with
+`targetRefs.kind: ProjectNamespace` to an org- or folder-scoped ancestor
+namespace. When `CreateProject` is called, the console:
+
+1. Resolves all `ProjectNamespace` bindings that match the new project's
+   name (wildcards supported via `projectName: "*"`).
+2. Renders each referenced `Template` with platform inputs and collects
+   `platformResources` (cluster-scoped resources, the namespace itself,
+   and namespace-scoped resources).
+3. Merges any template-produced `Namespace` object with the
+   RPC-constructed `Namespace`. Conflicting field values are a hard error.
+4. Applies cluster-scoped resources, then the unified `Namespace`, then
+   namespace-scoped resources — in that order — using Server-Side Apply.
+5. Waits for `Namespace.status.phase == Active` before applying
+   namespace-scoped resources, then retries with exponential back-off on
+   transient API server errors (mirrors the ADR 034 §4 retry strategy).
+
+If no bindings match, `CreateProject` falls through to the existing typed
+namespace-create path unchanged.
+
+**New `TemplatePolicyBindingTargetKind` value**: `ProjectNamespace` joins
+the existing `ProjectTemplate` and `Deployment` values. No migration of
+existing bindings is required.
+
+**Frontend**: the `BindingForm` and `TargetRefEditor` components now
+surface `ProjectNamespace` as a selectable kind. Selecting it renders a
+project-name input with wildcard (`*`) support.
+
+**Two built-in example templates** are available in the UI picker:
+
+- `project-namespace-description-annotation-v1` — adds a `description`
+  annotation to the new namespace. Minimal starting point.
+- `project-namespace-reference-grant-v1` — emits a Gateway API
+  `ReferenceGrant` in the project namespace so HTTPRoutes in the org
+  gateway namespace can reference Services in the project namespace.
+
+**References**: ADR 034
+(`docs/adrs/034-namespace-template-policy-binding-for-new-projects.md`),
+PRs #1091 (ADR), #1093 (API types), #1096 (resolver), #1098 (render),
+#1100 (applier), #1107 (RPC wire-up), #1109 (examples), #1112 (frontend).

--- a/docs/adrs/034-namespace-template-policy-binding-for-new-projects.md
+++ b/docs/adrs/034-namespace-template-policy-binding-for-new-projects.md
@@ -218,6 +218,7 @@ HOL-817 remains open as of the HOL-806 cleanup sweep (HOL-815, 2026-04-21):
 the folder/org namespace customization work has not yet started and the
 design questions (new target kind vs. generalized `HierarchyNamespace`, RBAC
 scope for bindings at a higher scope, new admission policy) are still open.
+
 Per `CONTRIBUTING.md` §ADR Open Questions, this question will be closed when
 HOL-817 ships or is explicitly abandoned.
 

--- a/docs/adrs/034-namespace-template-policy-binding-for-new-projects.md
+++ b/docs/adrs/034-namespace-template-policy-binding-for-new-projects.md
@@ -214,6 +214,10 @@ Code generation (`make manifests`) must be run after modifying
 extend to Folder-backed and Organization-backed namespaces? This is
 deliberately out of scope for this phase. Tracked in
 [HOL-817](https://linear.app/holos-run/issue/HOL-817).
+HOL-817 remains open as of the HOL-806 cleanup sweep (HOL-815, 2026-04-21):
+the folder/org namespace customization work has not yet started and the
+design questions (new target kind vs. generalized `HierarchyNamespace`, RBAC
+scope for bindings at a higher scope, new admission policy) are still open.
 Per `CONTRIBUTING.md` §ADR Open Questions, this question will be closed when
 HOL-817 ships or is explicitly abandoned.
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -8,6 +8,37 @@ See `docs/testing.md` for the complete decision rule, the ConnectRPC mock patter
 
 Standard `*_test.go` files with table-driven tests. Uses `k8s.io/client-go/kubernetes/fake` for K8s operations. CLI integration tests use `testscript` in `console/testscript_test.go`.
 
+### Pipeline seam / interface-injection pattern (HOL-812)
+
+Multi-step pipelines (resolver → renderer → applier) expose small named
+interfaces as seams so handler-level tests can inject fakes without pulling
+the full dependency stack into test wiring. The production wiring lives in
+`console/console.go` and threads real implementations through adapters.
+
+Pattern in use: `console/projects/projectnspipeline` exposes
+`BindingResolver`, `PolicyGetter`, `TemplateGetter`, `Renderer`, and
+`Applier` interfaces. The handler-level test file
+`console/projects/handler_project_namespace_test.go` defines inline fakes
+for all five seams, wires them into a `projectnspipeline.Pipeline` via
+`projectnspipeline.New(...)`, and wraps it in a local `pipelineAdapter`
+that satisfies the handler's `ProjectNamespacePipeline` interface. Compile-
+time interface assertions (`var _ Iface = (*fakeImpl)(nil)`) at the bottom
+of the test file guard against silent drift when an interface is renamed or
+a method signature changes.
+
+Use this pattern whenever a handler delegates to a multi-step pipeline:
+define one interface per seam, keep fakes inline in the `_test.go` file,
+and add compile-time assertions for every seam.
+
+### envtest for production-only SSA invariants (HOL-811)
+
+Some invariants cannot be exercised against `k8s.io/client-go/kubernetes/fake`:
+FieldManager enforcement, real namespace-controller `.status.phase` transitions,
+and SSA merge semantics. `console/projects/projectapply/applier_envtest_test.go`
+runs these cases against a real `envtest` apiserver. Scope envtest tests to
+invariants the fake client cannot reach; keep the unit tests for per-branch
+semantics that do not require a real apiserver.
+
 ## UI Unit Tests
 
 Vitest + React Testing Library + jsdom. Mock query hooks (`@/queries/*`) with `vi.mock()` and `vi.fn()`. Route-directory test files must be prefixed with `-` (e.g. `-about.test.tsx`) so TanStack Router's generator ignores them. Run with `make test-ui`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -180,4 +180,14 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/queries/-templatePolicies.test.ts` | `aggregateFanOut` helper: idle/disabled queries, pending while fetching, org-only and org+folder concatenation, partial-failure tolerance, non-Error wrapping, empty input |
 | `src/components/create-org-dialog.test.tsx` | Create organization dialog: validation, submission |
 | `src/components/create-project-dialog.test.tsx` | Create project dialog: validation, submission |
+| `src/components/template-policy-bindings/BindingForm.test.tsx` | BindingForm: ProjectTemplate / Deployment / ProjectNamespace kind selection, project-name field shown/hidden, wildcard validation, submit / save paths (HOL-814) |
 | `src/index.test.ts` | App entry point smoke test |
+
+### Go test files (HOL-806)
+
+| File | What it covers |
+|---|---|
+| `console/projects/handler_project_namespace_test.go` | Four HOL-812 ACs: no bindings → typed-create path; one binding → applier path + typed-create skipped; render error → `CodeInternal`; apply timeout → `CodeDeadlineExceeded`. Uses inline fakes for all five pipeline seams. |
+| `console/projects/projectapply/applier_test.go` | Per-branch SSA semantics (cluster-scoped, namespace, namespace-scoped ordering; `DeadlineExceededError`; merge conflict detection) via `dynamicfake` client. |
+| `console/projects/projectapply/applier_envtest_test.go` | Production-only invariants against a real `envtest` apiserver: FieldManager enforcement, real namespace-controller `.status.phase` transition, end-to-end apply ordering. |
+| `console/templates/examples/examples_test.go` | Registry loads all four built-in examples; each compiles against the `v1alpha2` generated schema. |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -183,7 +183,7 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/components/template-policy-bindings/BindingForm.test.tsx` | BindingForm: ProjectTemplate / Deployment / ProjectNamespace kind selection, project-name field shown/hidden, wildcard validation, submit / save paths (HOL-814) |
 | `src/index.test.ts` | App entry point smoke test |
 
-### Go test files (HOL-806)
+### Go test files
 
 | File | What it covers |
 |---|---|


### PR DESCRIPTION
## Summary

- Creates `CHANGELOG.md` with the first `[Unreleased]` entry summarising the `ProjectNamespace` TemplatePolicyBinding feature shipped across HOL-806 phases (PRs #1091–#1112).
- Updates `docs/agents/testing-patterns.md` with two new patterns introduced by HOL-806: the pipeline seam / interface-injection Go testing pattern (HOL-812) and the envtest pattern for production-only SSA invariants (HOL-811).
- Updates `docs/testing.md` test-file table with the new Go and frontend test files from HOL-806.
- Updates `docs/adrs/034-…md` Open Questions section to confirm HOL-817 is still live as of the HOL-815 sweep, per `CONTRIBUTING.md` §ADR Open Questions.
- No TODO/FIXME strings left from HOL-807–HOL-814 (verified by grep scan).
- Pre-existing golangci-lint failures on `main` are unchanged (verified via `git stash`).

Fixes HOL-815

## Test plan

- [x] `make test-go` — all Go tests pass
- [x] `make test-ui` — all 1097 Vitest tests pass
- [x] `make vet` — no vet issues
- [x] `make check-imports` — no import boundary violations
- [x] `grep -rn "TODO\|FIXME" --include="*.go" --include="*.md" ...` — no stray HOL-807–814 scaffolding