### PR TITLE
docs(secretinjector): M2 reference + AGENTS.md pointers + idempotence cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,70 @@ make test-go
 ## Binary layout
 
 This repo ships two independent binaries from disjoint source trees per [ADR 031](https://github.com/holos-run/holos-console-docs/blob/main/docs/adrs/031-secret-injector-binary-split.md). The `holos-console` web application owns `cmd/holos-console/`, `api/templates/`, `internal/controller/`, `config/holos-console/{crd,rbac,admission}/`, and `Dockerfile.console`; the `holos-secret-injector` controller owns `cmd/secret-injector/`, `api/secrets/`, `internal/secretinjector/`, `config/secret-injector/{crd,rbac}/`, and `Dockerfile.secret-injector`. Shared infrastructure (`console/`, `frontend/`, `proto/`, `pkg/`) is fair game for either binary. The one hard invariant: **no cross-imports** between `internal/controller` and `internal/secretinjector`. `make check-imports` enforces this locally and in CI; if you find yourself reaching across the boundary, lift the shared code into `pkg/` instead. Secret material never travels through templates CRs — CRs carry metadata and `v1.Secret` refs only (ADR 031's no-sensitive-on-CRs rule).
+
+## Secret Injection Service
+
+`holos-secret-injector` is the M2 control-plane binary. Its source tree is
+`internal/secretinjector/` (reconcilers), `api/secrets/v1alpha1/` (CRD
+types), `internal/secretinjector/crypto/` (KDF + pepper), and
+`config/secret-injector/` (manifests, admission policies, RBAC).
+
+### Reconciler package
+
+`internal/secretinjector/controller/` — three reconcilers registered by
+`NewManager`:
+
+| Reconciler | Kind | Primary action |
+|------------|------|----------------|
+| `UpstreamSecretReconciler` | `UpstreamSecret` | Validates upstream v1.Secret exists; publishes `ResolvedRefs` condition |
+| `CredentialReconciler` | `Credential` | Mints KSUID + salt, calls KDF.Hash, materialises hash `v1.Secret` |
+| `SecretInjectionPolicyBindingReconciler` | `SecretInjectionPolicyBinding` | Resolves policy ref; emits `AuthorizationPolicy` (Istio) |
+
+### Envtest suite
+
+`internal/secretinjector/controller/suite_test.go` — the authoritative
+cross-reconciler integration test. Boots a real API server via
+`sigs.k8s.io/controller-runtime/pkg/envtest`, installs all four
+`secrets.holos.run` CRDs plus the Istio `AuthorizationPolicy` CRD, loads
+every `ValidatingAdmissionPolicy` from `config/secret-injector/admission/`,
+and runs all three reconcilers simultaneously. The suite skips (not fails)
+when the envtest binaries are absent; run `setup-envtest use` to install them.
+
+### Marshal-scan invariant gate
+
+`internal/secretinjector/controller/invariant_test.go` — called after every
+reconcile step in the envtest suite. GETs every CR, marshals it to JSON and
+YAML, and asserts that the forbidden byte patterns from
+`api/secrets/v1alpha1/invariant_patterns.go` produce zero matches in both
+representations. A match fails the test without printing the offending bytes.
+
+### No-sensitive-values invariant (MUST READ before editing any CR field)
+
+**CRs in `secrets.holos.run/v1alpha1` are control objects, not vaults.**
+
+They carry references, selectors, lifecycle metadata, phase, and conditions.
+They MUST NEVER carry: plaintext credential material, hash bytes, salt bytes,
+pepper bytes, API key prefixes, last-4 digits, or any truncation of a
+credential that reveals non-trivial entropy. This is the same invariant that
+governs `holos-console` template CRs (ADR 031) — it extends to every CR in
+this service.
+
+Any agent adding or editing a field in this group must:
+
+1. Verify the field type does not accept sensitive bytes (string fields that
+   accept arbitrary values are the most dangerous).
+2. Add or update the test in `*_invariant_test.go` that asserts the new
+   field cannot be populated with forbidden patterns.
+3. Run `make test-go` to confirm the marshal-scan gate passes.
+
+See `api/secrets/v1alpha1/doc.go` for the full rationale and list of
+allowed vs. forbidden field categories.
+
+### M2 technical reference
+
+Repo-local docs for the M2 reconcilers (agents need them co-located with
+the code):
+
+- [docs/secret-injector/kdf.md](docs/secret-injector/kdf.md) — KDF pluggability seam: `KDF` interface, argon2id defaults, `-fips` swap story, `Envelope` JSON contract.
+- [docs/secret-injector/pepper-bootstrap.md](docs/secret-injector/pepper-bootstrap.md) — Pepper bootstrap runbook: Secret shape, versioning contract, Post-MVP rotation notes, RBAC envelope.
+- [docs/secret-injector/lifecycle.md](docs/secret-injector/lifecycle.md) — Credential lifecycle contract: single-ownerReference model, delete-cascade semantics, backup/restore ordering, admission vs. reconciler enforcement split.

--- a/docs/secret-injector/kdf.md
+++ b/docs/secret-injector/kdf.md
@@ -25,7 +25,7 @@ primitive is injected by `Default()` in a build-tagged file.
 
 ## The KDF interface
 
-`KDF` lives in `internal/secretinjector/crypto/kdf.go`. Its three-method
+`KDF` lives in `internal/secretinjector/crypto/kdf.go`. Its four-method
 surface is deliberately minimal:
 
 ```

--- a/docs/secret-injector/kdf.md
+++ b/docs/secret-injector/kdf.md
@@ -1,0 +1,187 @@
+# KDF Pluggability Reference
+
+`internal/secretinjector/crypto` — M2 reference for HOL-747.
+
+## Why a pluggable seam
+
+The Secret Injection Service must satisfy two operating contexts with a
+single codebase:
+
+1. **Default builds** — most clusters, most operators. No FIPS constraint.
+   Argon2id is the correct choice: it is the algorithm referenced in
+   [OWASP Password Storage Cheat Sheet][owasp] and [RFC 9106][rfc9106],
+   and its memory-hard design defends against ASIC-accelerated offline
+   brute-force more effectively than iteration-count-only algorithms.
+
+2. **FIPS-validated builds** (`-fips` build tag) — FedRAMP clusters where
+   the NIST SP 800-131A validated algorithm set is contractually required.
+   Argon2id is not in the validated set; PBKDF2-HMAC-SHA512 is. The
+   `-fips` build tag swaps the binding at compile time without changing any
+   reconciler logic.
+
+The `KDF` interface is the seam that makes both contexts possible from a
+single source tree. Reconcilers depend only on `KDF`; the concrete
+primitive is injected by `Default()` in a build-tagged file.
+
+## The KDF interface
+
+`KDF` lives in `internal/secretinjector/crypto/kdf.go`. Its three-method
+surface is deliberately minimal:
+
+```
+ID() KDFID
+DefaultParams() Params
+Hash(plaintext, salt, pepper []byte, pepperVersion string, params Params) (Envelope, error)
+Verify(plaintext, pepper []byte, envelope Envelope, wantParams Params) error
+```
+
+`ID()` returns the stable algorithm identifier (`"argon2id"`,
+`"pbkdf2-hmac-sha512"`) that travels on the wire inside every
+`Envelope.KDF` field. A verifier routes to the matching binding by
+comparing this string. Case differences are prevented: `KDFID` values are
+lowercase ASCII by definition.
+
+`DefaultParams()` returns the pinned cost parameters the reconciler uses on
+the hot path. Parameters are not read from a config file or environment
+variable: a silent parameter change is a reviewable diff, and an envelope
+written under old parameters cannot verify against new parameters (see
+`ErrParamMismatch`), which forces a re-hash at next login. Surfacing drift
+as an error rather than tolerating it is a deliberate security property.
+
+`Hash` concatenates the pepper to the plaintext before feeding the combined
+buffer into the underlying primitive. The pepper is NOT folded into the
+salt so a future pepper rotation can re-hash a credential without
+regenerating its per-credential salt — the two can change independently.
+
+`Verify` is strict: it rejects an envelope whose stored `KDFParams` differ
+from the caller-supplied `wantParams` before touching the primitive. Drift
+rejection is part of the interface contract, not a concrete-only extra. To
+re-hash during a cost-bump migration the caller invokes `Hash` with the new
+params and writes the new envelope; `Verify` is never permissive.
+
+## Default binding: argon2id
+
+`internal/secretinjector/crypto/argon2id.go`  
+Build tag: `!fips` (active in all non-FIPS builds)
+
+The default parameters track the OWASP recommendation:
+
+| Parameter   | Value   | Meaning                  |
+|-------------|---------|--------------------------|
+| Time        | 2       | 2 passes (RFC 9106 §4 t) |
+| Memory      | 19456   | 19 MiB in KiB            |
+| Parallelism | 1       | single lane              |
+| KeyLength   | 32      | 32-byte output           |
+
+These values are pinned in `Argon2idDefault` in `argon2id.go`. Any change
+to them is a breaking change to all envelopes stored under the previous
+parameters: Verify will return `ErrParamMismatch` on the next login until
+the hash is re-derived. That is intentional — the reconciler must explicitly
+re-hash rather than silently accept a changed cost.
+
+`argon2id.go` normalises params before stamping them onto the returned
+`Envelope`: the PBKDF2-only `Iterations` field is zeroed so a shared
+`Params` struct that was populated for a PBKDF2 call site cannot leak an
+unrelated field into an argon2id envelope and cause spurious mismatches on
+Verify.
+
+## Reserved binding: PBKDF2-HMAC-SHA512
+
+`internal/secretinjector/crypto/pbkdf2.go`  
+Build tag: `fips` (excluded from all default builds)
+
+The `-fips` placeholder reserves the `KDFID` constant
+`"pbkdf2-hmac-sha512"` so verifier routing tables can include the string
+before the primitive ships. The placeholder body is intentionally empty
+under the `fips` tag: an `-fips` build that does NOT land a real
+implementation fails loudly at link time on a missing `Default` symbol
+rather than silently reverting to argon2id. A verifier running under a
+non-FIPS binary that encounters an envelope with `kdf: "pbkdf2-hmac-sha512"`
+returns `ErrKDFMismatch` via the standard routing path.
+
+The full PBKDF2-HMAC-SHA512 implementation is deferred to a post-M2 ticket
+under HOL-747.
+
+## Build-tag wiring
+
+`internal/secretinjector/crypto/default_nofips.go` (`!fips` build tag):
+
+```go
+func Default() KDF {
+    return Argon2id{}
+}
+```
+
+The `-fips` override will supply an identical `Default()` signature that
+returns a `PBKDF2HMACSHA512{}` value. Reconcilers always call `Default()`
+and never reference the concrete type, so the swap is invisible above the
+`KDF` interface.
+
+## Envelope: the on-wire JSON contract
+
+Every successful `Hash` call returns an `Envelope` value. The Credential
+reconciler serialises it via `MarshalEnvelope` and writes the resulting
+bytes verbatim to `v1.Secret.data["envelope"]` on the hash Secret.
+
+```json
+{
+  "schemaVersion": 1,
+  "kdf": "argon2id",
+  "kdfParams": {
+    "time": 2,
+    "memory": 19456,
+    "parallelism": 1,
+    "keyLength": 32
+  },
+  "pepperVersion": "1",
+  "salt": "<base64-encoded 32-byte random salt — PLACEHOLDER_DO_NOT_COPY>",
+  "hash": "<base64-encoded 32-byte derived hash — PLACEHOLDER_DO_NOT_COPY>"
+}
+```
+
+The `Envelope` struct has no `String` method, no `GoString` method, and no
+logging helpers: a stray `%v` cannot leak hash bytes into an operator log.
+The envelope is the ONLY legitimate carrier of hash material out of
+`internal/secretinjector/crypto`; callers that reach into fields directly
+rather than round-tripping through `MarshalEnvelope`/`UnmarshalEnvelope`
+violate the contract.
+
+`UnmarshalEnvelope` rejects any envelope whose `schemaVersion` is not
+equal to `EnvelopeSchemaVersion` (currently 1). A future schema extension
+bumps this constant in the same commit that introduces the new shape and
+extends the decoder to tolerate both versions. An older binary that sees a
+`schemaVersion: 2` envelope returns `ErrUnknownSchemaVersion` rather than
+silently misinterpreting the record.
+
+## Errors
+
+All sentinel errors live in `kdf.go` and are matchable with `errors.Is`:
+
+| Error | Trigger |
+|-------|---------|
+| `ErrNilPepper` | Hash/Verify called with nil or empty pepper |
+| `ErrEmptyPlaintext` | Hash/Verify called with nil or empty plaintext |
+| `ErrEmptySalt` | Hash/Verify called with nil or empty salt |
+| `ErrEmptyPepperVersion` | Hash called without a pepper version string |
+| `ErrKDFMismatch` | Verify: envelope KDF != receiver ID |
+| `ErrParamMismatch` | Verify: envelope KDFParams != wantParams |
+| `ErrUnknownSchemaVersion` | Verify: schemaVersion not recognized |
+| `ErrHashMismatch` | Verify: constant-time comparison failed |
+| `ErrInvalidParams` | Hash/Verify: zero or nonsensical params field |
+
+## Testing
+
+Unit tests live at:
+
+- `internal/secretinjector/crypto/kdf_test.go` — interface contract tests
+- `internal/secretinjector/crypto/argon2id_test.go` (via `kdf_test.go`)
+- `internal/secretinjector/crypto/default_nofips_test.go`
+
+The cross-reconciler envtest suite in
+`internal/secretinjector/controller/suite_test.go` exercises the full
+Hash→Envelope→marshal path against a real API server and validates that no
+envelope bytes appear on any CR (marshal-scan gate, see
+`internal/secretinjector/controller/invariant_test.go`).
+
+[owasp]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+[rfc9106]: https://www.rfc-editor.org/rfc/rfc9106

--- a/docs/secret-injector/lifecycle.md
+++ b/docs/secret-injector/lifecycle.md
@@ -1,0 +1,190 @@
+# Credential Lifecycle Contract
+
+`internal/secretinjector/controller` — M2 reference for HOL-747.
+
+## The ownerReference atomicity model
+
+Every materialised `Credential` owns exactly one sibling `v1.Secret` that
+carries the JSON-encoded `Envelope` (see [kdf.md](kdf.md) for the envelope
+shape). The relationship is a Kubernetes controller ownerReference — set by
+`ctrl.SetControllerReference` in the Credential reconciler — which means:
+
+- The hash Secret lists the Credential as its **sole controller-type owner**.
+- Kubernetes garbage-collects the hash Secret automatically when the
+  Credential is deleted (delete cascade, no operator action required).
+- A hash Secret that loses its owner (for example, one orphaned during a
+  misconfigured restore) is not re-adopted: `isOwnedByCredential` checks
+  the owner UID, not the name, so a Credential deleted and recreated with
+  the same name but a fresh UID materialises its own envelope from first
+  principles rather than inheriting the previous hash.
+
+The deterministic secret name is `<credentialName>-hash` in the Credential's
+own namespace. This allows `kubectl get secrets <credentialName>-hash` to
+locate the hash material, but `Status.HashSecretRef` is the authoritative
+pointer: callers must consult the status field, not the naming convention,
+in case the name derivation changes in a future version.
+
+### Why a single ownerReference
+
+Kubernetes rejects a second controller owner on an existing object (only one
+entry may have `controller: true`). The reconciler enforces the same rule
+explicitly: if a Secret with the derived name already exists but its owner
+UID does not match the current Credential, the reconciler returns an error
+rather than clobbering the Secret. This prevents a name-squatting attack
+where a rogue Credential's delete triggers GC of another Credential's hash
+material via a stolen ownerReference.
+
+## Hash Secret: the data["envelope"] contract
+
+The hash Secret carries one key:
+
+| Key | Value |
+|-----|-------|
+| `envelope` | JSON-encoded `sicrypto.Envelope` (see [kdf.md](kdf.md)) |
+
+The `envelope` value is **immutable** once written. The reconciler does not
+update an existing envelope — it creates a new one if the Secret is missing
+or unowned, and otherwise trusts the stored envelope. An operator who edits
+the `envelope` value manually breaks the Verify path for that Credential
+without surfacing any condition change; the reconciler notices only on the
+next login attempt. Manual edits to the hash Secret are unsupported.
+
+GoDoc for the write site (`credential_controller.go`):
+
+```
+credentialHashEnvelopeKey = "envelope"
+```
+
+The JSON contract, its immutability, and its backing struct are documented
+in `internal/secretinjector/crypto/kdf.go` and referenced from this constant.
+
+## Credential lifecycle phases
+
+The reconciler drives the Credential through mutually exclusive phases in
+this priority order:
+
+| Phase | Trigger | Hash Secret |
+|-------|---------|-------------|
+| `Revoked` | `spec.revoked = true` | Deleted eagerly; GC follows |
+| `Expired` | `spec.expiresAt` elapsed | Retained (read-only, expired) |
+| `Rotating` | A successor exists in rotation group (grace window) | Retained |
+| `Retired` | Grace window elapsed | Retained |
+| `Active` | Accepted + hash materialised | Created or verified |
+
+Revocation is **terminal**: the reconciler deletes the hash Secret eagerly
+(not via GC) so a Revoked Credential cannot be verified against a stale
+envelope after the phase change. `DeletePropagationBackground` lets the API
+server reclaim the object asynchronously; the reconciler does not wait.
+
+## Delete-cascade semantics
+
+To delete a Credential and its hash material:
+
+```
+kubectl delete credential <name> -n <namespace>
+```
+
+The garbage collector cascades to the hash Secret via the ownerReference
+within the API server's default GC period (typically seconds). No additional
+`kubectl delete secret` step is required.
+
+**Backup/restore ordering**: always restore the `v1.Secret`
+(`holos-secret-injector-pepper`) containing the pepper material **before**
+restoring Credential objects. A Credential whose `status.pepperVersion` names
+a version absent from the restored pepper Secret cannot be verified until its
+hash is re-derived against the restored (or new) pepper material. The
+Credential itself can be restored independently of its hash Secret — the
+reconciler will re-materialise the hash Secret on the next reconcile if
+`Status.HashSecretRef` is missing or the referenced Secret is gone.
+
+## Admission vs. reconciler enforcement
+
+The M2 invariant set is split across two enforcement layers:
+
+### Admission layer (`config/secret-injector/admission/`)
+
+ValidatingAdmissionPolicies fire at create/update time and are the **first
+line of defence**. They reject structurally invalid objects so the reconciler
+never sees them:
+
+| Policy | Invariant |
+|--------|-----------|
+| `credential-authn-type-apikey-only.yaml` | `spec.authentication.type` must be `APIKey` (OIDC reserved) |
+| `credential-upstreamref-same-namespace.yaml` | Cross-namespace `spec.upstreamSecretRef` rejected |
+| `secretinjectionpolicy-authn-type-apikey-only.yaml` | Same type constraint on SecretInjectionPolicy |
+| `secretinjectionpolicybinding-folder-or-org-only.yaml` | Binding scope must be folder or organization |
+| `secretinjectionpolicybinding-policyref-same-namespace-or-ancestor.yaml` | Policy ref must be same namespace or ancestor |
+| `secretinjectionpolicy-folder-or-org-only.yaml` | Policy scope must be folder or organization |
+| `upstreamsecret-project-only.yaml` | UpstreamSecret scope must be project |
+| `upstreamsecret-valuetemplate-no-control-chars.yaml` | No control characters in value templates |
+| `namespace-scope-label-immutable.yaml` | Scope labels are immutable after creation |
+
+Admission runs with CEL expressions inside the API server; no external
+webhook is required.
+
+### Reconciler layer (marshal-scan gate)
+
+The Credential reconciler re-checks the same structural invariants as a
+belt-and-braces guard against objects that bypass admission (`kubectl apply
+--server-side --force`, direct etcd writes). The re-check is cheaper than
+admission because it fires only on objects the reconciler was already going
+to process. See `credentialAcceptedCondition` in `credential_controller.go`:
+an object that fails the re-check gets `Accepted=False` and stays `NotReady`
+without entering the materialisation path.
+
+The **marshal-scan gate** (`internal/secretinjector/controller/invariant_test.go`)
+is the automated enforcement point for the dominant "no sensitive values on
+CRs" invariant. After every reconcile in the envtest suite, the gate GETs
+every CR, marshals it to both JSON and YAML, and asserts that the forbidden
+byte patterns from `api/secrets/v1alpha1/invariant_patterns.go` produce zero
+matches. The gate covers patterns:
+
+| Pattern | What it detects |
+|---------|----------------|
+| `api-key-prefix` | `sih_[A-Za-z0-9_-]{20,}` — caller-facing API key on a CR |
+| `argon2id-envelope` | `$argon2id$` — PHC-string argon2id envelope on a CR |
+
+A match in either the JSON or YAML form fails the test without printing the
+matched bytes (doing so would leak the credential material the invariant is
+written to prevent).
+
+### Division summary
+
+```
+Admission (create/update)       Reconciler (steady-state)
+─────────────────────────       ─────────────────────────
+Type constraints                Re-check type constraints (belt-and-braces)
+Cross-namespace ref rejection   Status conditions reflect rejected spec
+Scope label immutability        Marshal-scan gate: no sensitive bytes on CRs
+Control-char guards             OwnerReference atomicity enforcement
+```
+
+Invariants that admission owns are **gate invariants**: they prevent bad
+objects from entering the API server. Invariants the reconciler enforces are
+**runtime invariants**: they prevent bad state from propagating even when
+a bad object slips through admission.
+
+## No-sensitive-values invariant (agents reading this cold)
+
+**Every CR in `secrets.holos.run/v1alpha1` is a control object, not a vault.**
+
+CRs carry: references, selectors, lifecycle metadata, phase, and conditions.
+
+CRs NEVER carry: plaintext credential material, hash bytes, salt bytes,
+pepper bytes, API key prefixes, last-4 digits, or any truncation of a
+credential that reveals non-trivial entropy.
+
+This invariant is not optional. It is enforced by:
+
+1. ValidatingAdmissionPolicies at the API server boundary.
+2. The Credential reconciler's `Accepted` condition gate.
+3. The marshal-scan test in `invariant_test.go` that runs after every
+   reconcile in the envtest suite.
+
+Any agent editing a CR field in `secrets.holos.run/v1alpha1` MUST verify
+that the field does not carry sensitive bytes before committing. The
+marshal-scan test is the automated gate, but it fires only in the envtest
+suite — a field added without a test may only surface in production.
+
+See `api/secrets/v1alpha1/doc.go` for the full rationale and the list of
+allowed vs. forbidden field categories.

--- a/docs/secret-injector/pepper-bootstrap.md
+++ b/docs/secret-injector/pepper-bootstrap.md
@@ -67,7 +67,8 @@ precisely to prevent the losing replica from overwriting the winning pepper.
 Bootstrap returns an error and the manager refuses to start if:
 
 - The namespace is empty (the `POD_NAMESPACE` downward-API variable was not
-  set on the Deployment — see `config/secret-injector/deployment/deployment.yaml`).
+  set on the Deployment — see `cmd/secret-injector/` for the binary entrypoint
+  and `config/secret-injector/rbac/namespace/` for the namespace-scoped wiring).
 - The Secret exists but carries no `pepper-<N>` data rows (an operator
   manually cleared `.data`).
 - The highest-numbered row is empty.
@@ -141,8 +142,7 @@ None of these fields contain or hint at the pepper bytes themselves.
 
 ## Testing
 
-- `internal/secretinjector/crypto/pepper_test.go` — `SecretLoader` unit tests
-- `internal/secretinjector/crypto/pepper_bootstrap.go` — `Bootstrap` unit tests (same file)
+- `internal/secretinjector/crypto/pepper_test.go` — `SecretLoader` unit tests and `Bootstrap` unit tests (cold-start, warm-restart, and race-on-create paths)
 - The cross-reconciler envtest suite wires a test pepper seed via
   `suite_test.go` and verifies that no pepper bytes appear on any CR via
   the marshal-scan gate.

--- a/docs/secret-injector/pepper-bootstrap.md
+++ b/docs/secret-injector/pepper-bootstrap.md
@@ -1,0 +1,148 @@
+# Pepper Bootstrap Runbook
+
+`internal/secretinjector/crypto` — M2 reference for HOL-747.
+
+## Why pepper exists
+
+A pepper is a cluster-wide secret value concatenated with the plaintext
+before hashing. It defends against offline brute-force in the event an
+attacker exfiltrates the hash Secret: without the pepper bytes the attacker
+cannot reproduce the argon2id input, so the cost of a brute-force attack is
+the full argon2id cost _plus_ a 256-bit random search. Even a nation-state
+adversary who steals every hash in the cluster cannot run any useful
+offline attack without also stealing the pepper Secret.
+
+The pepper bytes NEVER travel through a CR. They live exclusively in a
+`v1.Secret` in the controller's own namespace, protected by a namespaced
+RBAC `Role` rather than the cluster-wide `ClusterRole` that governs the
+CRDs. This is the same principle documented in `api/secrets/v1alpha1/doc.go`
+for credential material: tight RBAC, encryption-at-rest, no audit-log
+exposure through `kubectl get -o yaml` on a higher-traffic object class.
+
+## Secret shape
+
+The controller reads from and writes to a single, pinned `v1.Secret`:
+
+```
+namespace: <controller namespace>   # resolved from POD_NAMESPACE env var
+name:      holos-secret-injector-pepper
+type:      Opaque
+```
+
+`data` entries follow the pattern `pepper-<N>` where `<N>` is a
+positive decimal integer (version 1 is the first seal):
+
+```yaml
+# EXAMPLE — values are synthetic placeholders, not real pepper bytes.
+# Never copy-paste from a doc; the real bytes are random and opaque.
+data:
+  pepper-1: <base64-encoded 32-byte random seed — PLACEHOLDER_DO_NOT_COPY>
+```
+
+Keys that do not match the `pepper-<positive-int>` format are silently
+ignored. This allows future extensions (for example, a `salt-seed` key)
+to coexist in the same Secret without corrupting version discovery.
+
+## First-boot self-seal
+
+`Bootstrap` in `internal/secretinjector/crypto/pepper_bootstrap.go` is
+called exactly once per manager process, from `controller.Manager.Start`,
+before the first `Reconcile` runs. On a missing Secret it:
+
+1. Generates 32 random bytes from `crypto/rand` (256-bit seed).
+2. Creates the Secret with `data["pepper-1"] = <seed>`.
+3. Returns `BootstrapResult{ActiveVersion: 1, Created: true, BytesLength: 32}`.
+
+The manager logs the result so operators can distinguish a first-boot seal
+(`Created: true`) from a warm restart (`Created: false`) at a glance.
+Bootstrap never logs the pepper bytes, never returns them, and never exposes
+them on the `BootstrapResult` struct — only the integer version and the byte
+length appear in telemetry.
+
+If `Create` returns `AlreadyExists` (two manager replicas racing at startup),
+Bootstrap re-reads the winner's Secret and reports its active version. The
+single-replica deployment is the common case; the two-round-trip path exists
+precisely to prevent the losing replica from overwriting the winning pepper.
+
+Bootstrap returns an error and the manager refuses to start if:
+
+- The namespace is empty (the `POD_NAMESPACE` downward-API variable was not
+  set on the Deployment — see `config/secret-injector/deployment/deployment.yaml`).
+- The Secret exists but carries no `pepper-<N>` data rows (an operator
+  manually cleared `.data`).
+- The highest-numbered row is empty.
+
+**A failure at Bootstrap is fatal**: the reconciler cannot hash without a
+pepper, and falling back to an unpeppered hash would be a silent security
+regression. The manager must not report readiness on an unusable pepper.
+
+## RBAC envelope
+
+The controller's `ClusterRole` grants `get` on `core/v1 Secret` in the
+controller's own namespace — not `list` or `watch`. Enumeration of Secrets
+is the class of vulnerability the service is designed to close (see ADR 031).
+The `SecretLoader` that reads the pepper Secret uses a non-cached direct
+client (`client.New`, not `mgr.GetClient()`) specifically because a
+cache-backed client would lazily start a Secret informer on first `Get`,
+requiring `list/watch` that real RBAC forbids.
+
+## Versioning contract
+
+Every `Envelope` stores the integer pepper version (`pepperVersion`) that
+was active at `Hash` time. The Credential reconciler passes this string
+to `KDF.Hash` and the verifier calls `Loader.Get(ctx, pepperVersion)` to
+look up the matching bytes on `Verify`. This means:
+
+- **Multiple pepper versions can coexist** in the Secret's `.data` during a
+  rotation window. A credential hashed under version 1 is still verifiable
+  while version 2 is active for new hashes.
+- **The active version is always the highest integer** present in `.data`.
+  `Loader.Active` returns the max-version row and its bytes; new `Hash`
+  calls stamp that version onto the envelope.
+- **Version integers are monotonically assigned**. The first seal writes
+  version 1; a rotation appends version 2, then version 3, and so on.
+  Gaps in the sequence are safe but confusing; avoid them.
+
+## Rotation lifecycle (Post-MVP)
+
+The rotation controller that appends a new `pepper-<N+1>` row, triggers
+re-hash of all active Credentials, and eventually retires the old row is
+a Post-MVP deliverable (tracked under HOL-747). The `SecretLoader`'s read
+surface is already rotation-ready: every call fetches the current state of
+the Secret, so an external rotation takes effect on the next reconcile
+without a manager restart.
+
+Until the rotation controller ships:
+
+1. An operator who needs to rotate manually can append a new `pepper-<N+1>`
+   row to the Secret. The `SecretLoader` will report the new version on the
+   next call to `Active`. Active Credentials will be re-hashed at next login
+   or the next periodic reconcile.
+2. Retire an old row only after every Credential that referenced it has been
+   re-hashed. An operator who deletes a row prematurely will see
+   `ErrPepperVersionNotFound` surface on Verify for any credential still
+   carrying the retired version.
+3. The backup/restore ordering rule: restore the pepper Secret before
+   restoring Credentials. A Credential whose `status.pepperVersion` names a
+   version absent from the restored pepper Secret cannot be verified until
+   its hash is re-derived from the restored or new pepper material.
+
+## Observability
+
+`BootstrapResult` exposes three telemetry-safe fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `ActiveVersion` | `int32` | Highest pepper version in .data |
+| `Created` | `bool` | True on first-boot seal; false on warm restart |
+| `BytesLength` | `int` | Byte length of active row (32 for a healthy seal) |
+
+None of these fields contain or hint at the pepper bytes themselves.
+
+## Testing
+
+- `internal/secretinjector/crypto/pepper_test.go` — `SecretLoader` unit tests
+- `internal/secretinjector/crypto/pepper_bootstrap.go` — `Bootstrap` unit tests (same file)
+- The cross-reconciler envtest suite wires a test pepper seed via
+  `suite_test.go` and verifies that no pepper bytes appear on any CR via
+  the marshal-scan gate.

--- a/internal/secretinjector/controller/credential_controller.go
+++ b/internal/secretinjector/controller/credential_controller.go
@@ -64,6 +64,25 @@ const credentialHashSecretSuffix = "-hash"
 // "no sensitive values on CRs" invariant because the bytes still live
 // exclusively in the v1.Secret, which has the tighter RBAC surface
 // (see api/secrets/v1alpha1/doc.go).
+//
+// JSON contract — the value at this key is a UTF-8 JSON object produced by
+// [sicrypto.MarshalEnvelope]. The canonical shape (schemaVersion=1) is:
+//
+//	{
+//	  "schemaVersion": 1,
+//	  "kdf": "argon2id",
+//	  "kdfParams": {"time":2,"memory":19456,"parallelism":1,"keyLength":32},
+//	  "pepperVersion": "<decimal-integer-string>",
+//	  "salt": "<base64-encoded 32-byte random salt>",
+//	  "hash": "<base64-encoded 32-byte derived hash>"
+//	}
+//
+// Immutability: the reconciler writes this key once (at materialisation)
+// and does not update it on subsequent reconciles unless the hash Secret
+// is missing or unowned. Callers MUST NOT mutate the bytes after write;
+// an in-place edit breaks the Verify path without surfacing a condition
+// change. To re-hash (for example after a cost-bump migration), delete
+// the Credential and recreate it so the reconciler mints a fresh envelope.
 const credentialHashEnvelopeKey = "envelope"
 
 // credentialExpiryRequeueFloor is the minimum Reconcile.RequeueAfter the
@@ -109,7 +128,7 @@ const credentialExpiryRequeueFloor = time.Second
 // The read surface is RBAC-protected and the bytes never flow through
 // the Credential CR, but this means the "Credential is a hash of a
 // caller-facing key, not of an upstream secret" flow is stubbed. See
-// the TODO(M4) comment in materialiseHashEnvelope below.
+// the TODO(HOL-675) comment in materialiseHashEnvelope below.
 type CredentialReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
@@ -381,11 +400,11 @@ type hashEnvelopeResult struct {
 // Credential. Returns the active pepper version and the materialised
 // Secret's name.
 //
-// TODO(M4): the plaintext source is the upstream v1.Secret named by
-// spec.upstreamSecretRef as a bridge until the issuer RPC lands in M4
-// (HOL-675 → M4 plan). When the issuer ships, this read is replaced by
-// an authenticated per-request surface and the Credential no longer
-// reads the upstream Secret.
+// TODO(HOL-675): the plaintext source is the upstream v1.Secret named by
+// spec.upstreamSecretRef as a bridge until the issuer RPC lands (HOL-675
+// M4 plan). When the issuer ships, this read is replaced by an
+// authenticated per-request surface and the Credential no longer reads
+// the upstream Secret.
 func (r *CredentialReconciler) materialiseHashEnvelope(ctx context.Context, cred *secretsv1alpha1.Credential) (int32, hashEnvelopeResult, error) {
 	plaintext, err := r.readUpstreamPlaintext(ctx, cred)
 	if err != nil {
@@ -467,9 +486,9 @@ func (r *CredentialReconciler) materialiseHashEnvelope(ctx context.Context, cred
 // references are rejected at admission (see HOL-703), so an empty
 // Namespace field defaults to the Credential's own namespace.
 //
-// TODO(M4): replace this read with the authenticated per-request surface
-// exposed by the issuer RPC. Until M4 lands, this read is the single
-// biggest plaintext-path shortcut in the injector's M2 scope.
+// TODO(HOL-675): replace this read with the authenticated per-request
+// surface exposed by the issuer RPC. Until HOL-675 lands, this read is
+// the single biggest plaintext-path shortcut in the injector's M2 scope.
 func (r *CredentialReconciler) readUpstreamPlaintext(ctx context.Context, cred *secretsv1alpha1.Credential) ([]byte, error) {
 	ns := cred.Spec.UpstreamSecretRef.Namespace
 	if ns == "" {


### PR DESCRIPTION
## Summary

- Creates `docs/secret-injector/` with three M2 reference docs co-located with the code (per AGENTS.md routing — not holos-console-docs, because agents need these adjacent to the source):
  - `kdf.md` — KDF pluggability seam: interface, argon2id defaults (OWASP t=2,m=19456,p=1,l=32), the `-fips` build-tag swap story reserving PBKDF2-HMAC-SHA512, and the `Envelope` JSON contract
  - `pepper-bootstrap.md` — operator runbook for `holos-secret-injector-pepper` Secret, versioning contract (max-integer active row), Post-MVP rotation notes, RBAC envelope (direct client, no list/watch)
  - `lifecycle.md` — single-ownerReference atomicity model, delete-cascade semantics, backup/restore ordering, and the admission vs. reconciler enforcement split (including the marshal-scan gate)
- Adds a "Secret Injection Service" section to `AGENTS.md` naming the reconciler package, the envtest suite, the marshal-scan gate, and reproducing the no-sensitive-values invariant call-out
- Converts `TODO(M4)` comments in `credential_controller.go` to `TODO(HOL-675)` with concrete ticket citations; no anonymous TODOs remain
- Enhances `credentialHashEnvelopeKey` GoDoc to document `data["envelope"]` JSON contract and immutability inline at the write site
- Verified: `make manifests-secrets && git diff --exit-code` emits zero diff; `make generate && git diff --exit-code` emits zero diff

Fixes HOL-754

## Test plan

- [x] `make manifests-secrets && git diff --exit-code` — zero diff (idempotent)
- [x] `make generate && git diff --exit-code` — zero diff (idempotent)
- [x] `go test ./internal/secretinjector/... ./api/secrets/...` — all pass
- [x] `make test-go` — all pass (pre-existing lint issues on main are unchanged; 38 issues pre-existed on main before this branch)
- [ ] CI green