### PR TITLE
fix(secretinjector/crypto): drop omitempty on required Params uint fields (HOL-838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,15 @@ project-name input with wildcard (`*`) support.
 (`docs/adrs/034-namespace-template-policy-binding-for-new-projects.md`),
 PRs #1091 (ADR), #1093 (API types), #1096 (resolver), #1098 (render),
 #1100 (applier), #1107 (RPC wire-up), #1109 (examples), #1112 (frontend).
+
+### Fixed — `crypto.Params` JSON shape pins required uint fields (HOL-838)
+
+Removed `,omitempty` from the `Time`, `Memory`, `Parallelism`, `KeyLength`,
+and `Iterations` JSON tags on `internal/secretinjector/crypto.Params`. A
+zero value — which `validateArgon2idParams` rejects on both Hash and
+Verify — is now serialized as an explicit `0` instead of being silently
+dropped. The envelope JSON shape now faithfully reflects the required
+fields, so a future KDF that forgets a zero-rejection check cannot
+silently round-trip a degenerate envelope. No on-wire break: envelopes
+produced by earlier code either contain the fields already (non-zero
+values pass `omitempty`) or fail `Verify` at the validator as before.

--- a/internal/secretinjector/crypto/kdf.go
+++ b/internal/secretinjector/crypto/kdf.go
@@ -58,20 +58,20 @@ const EnvelopeSchemaVersion = 1
 type Params struct {
 	// Time is the argon2id pass count (RFC 9106 §4 `t`). Ignored by
 	// PBKDF2-HMAC-SHA512.
-	Time uint32 `json:"time,omitempty"`
+	Time uint32 `json:"time"`
 	// Memory is the argon2id memory cost in KiB (RFC 9106 §4 `m`). Ignored
 	// by PBKDF2-HMAC-SHA512.
-	Memory uint32 `json:"memory,omitempty"`
+	Memory uint32 `json:"memory"`
 	// Parallelism is the argon2id lane count (RFC 9106 §4 `p`). Ignored
 	// by PBKDF2-HMAC-SHA512.
-	Parallelism uint8 `json:"parallelism,omitempty"`
+	Parallelism uint8 `json:"parallelism"`
 	// KeyLength is the derived-hash length in bytes. All bindings honor
 	// this field. argon2id's RFC 9106 recommendation is 32.
-	KeyLength uint32 `json:"keyLength,omitempty"`
+	KeyLength uint32 `json:"keyLength"`
 	// Iterations is the PBKDF2 iteration count. Ignored by argon2id. The
 	// field is present so an -fips binary's PBKDF2 binding can use the
 	// same [Params] struct.
-	Iterations uint32 `json:"iterations,omitempty"`
+	Iterations uint32 `json:"iterations"`
 }
 
 // Envelope is the self-describing record the Credential reconciler (HOL-751)

--- a/internal/secretinjector/crypto/kdf_test.go
+++ b/internal/secretinjector/crypto/kdf_test.go
@@ -384,6 +384,59 @@ func TestEnvelopeJSONRoundTrip(t *testing.T) {
 	}
 }
 
+// TestEnvelopeJSONZeroFieldRoundTrip pins the on-wire shape for a
+// degenerate envelope whose [Params] are all zero. The required uint
+// fields deliberately do NOT carry `omitempty`, so marshaling must emit
+// "time":0, "memory":0, "parallelism":0, "keyLength":0, and
+// "iterations":0 rather than silently dropping them. A future KDF that
+// forgets its zero-rejection guard would otherwise round-trip a
+// degenerate envelope as an empty kdfParams object; pinning the shape
+// here forces that regression to fail loudly.
+func TestEnvelopeJSONZeroFieldRoundTrip(t *testing.T) {
+	original := Envelope{
+		SchemaVersion: EnvelopeSchemaVersion,
+		KDF:           KDFArgon2id,
+		KDFParams:     Params{},
+		PepperVersion: fixturePepperVersion,
+		Salt:          fixtureSalt,
+		Hash:          []byte("hash"),
+	}
+	encoded, err := MarshalEnvelope(original)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(encoded, &m); err != nil {
+		t.Fatalf("re-unmarshal to map: %v", err)
+	}
+	paramsAny, ok := m["kdfParams"].(map[string]any)
+	if !ok {
+		t.Fatalf("kdfParams is not a JSON object: %T", m["kdfParams"])
+	}
+	for _, k := range []string{"time", "memory", "parallelism", "keyLength", "iterations"} {
+		v, ok := paramsAny[k]
+		if !ok {
+			t.Errorf("kdfParams JSON missing required zero-valued key %q; have %v", k, paramsAny)
+			continue
+		}
+		num, ok := v.(float64)
+		if !ok {
+			t.Errorf("kdfParams[%q] = %T(%v), want JSON number", k, v, v)
+			continue
+		}
+		if num != 0 {
+			t.Errorf("kdfParams[%q] = %v, want 0", k, num)
+		}
+	}
+	var decoded Envelope
+	if err := UnmarshalEnvelope(encoded, &decoded); err != nil {
+		t.Fatalf("UnmarshalEnvelope: %v", err)
+	}
+	if diff := cmp.Diff(original, decoded); diff != "" {
+		t.Fatalf("zero-field envelope round-trip mismatch (-want +got):\n%s", diff)
+	}
+}
+
 // TestEnvelopeJSONShape pins the JSON field names so a downstream
 // operator script or a future parser in a sibling binary can rely on the
 // exact keys. A rename is a breaking wire change and should fail this
@@ -410,7 +463,7 @@ func TestEnvelopeJSONShape(t *testing.T) {
 	if !ok {
 		t.Fatalf("kdfParams is not a JSON object: %T", m["kdfParams"])
 	}
-	for _, k := range []string{"time", "memory", "parallelism", "keyLength"} {
+	for _, k := range []string{"time", "memory", "parallelism", "keyLength", "iterations"} {
 		if _, ok := paramsAny[k]; !ok {
 			t.Errorf("kdfParams JSON missing key %q; have %v", k, paramsAny)
 		}


### PR DESCRIPTION
Assignee: @jeffmccune ([jeff](https://linear.app/holos-run/profiles/jeff))

## Summary

PR #1103 (HOL-748) left one STYLE review finding unaddressed: the required uint fields on `internal/secretinjector/crypto.Params` — `Time`, `Memory`, `Parallelism`, `KeyLength`, `Iterations` — carried `,omitempty` on their JSON tags. A zero value (which every KDF validator rejects) was silently dropped from the envelope JSON instead of being serialized as `0`, so the on-wire shape did not faithfully reflect the required fields.

This PR drops `,omitempty` from all five fields so the envelope JSON now pins the full required shape. Not currently exploitable because `validateArgon2idParams` rejects zero on both Hash and Verify, but a future KDF that forgets a zero-rejection guard could silently round-trip a degenerate envelope; the truthful on-wire shape removes that footgun.

## Changes

- `internal/secretinjector/crypto/kdf.go` lines 61–74: removed `,omitempty` from the five required uint fields on `Params`.
- `internal/secretinjector/crypto/kdf_test.go`:
  - Added `TestEnvelopeJSONZeroFieldRoundTrip` — marshals an envelope with zero-valued `Params`, asserts each required key appears in the JSON with an explicit `0`, and confirms the round-trip preserves the zero shape.
  - Extended `TestEnvelopeJSONShape` to require the `iterations` key alongside the argon2id-relevant fields.
- `CHANGELOG.md`: `### Fixed` entry under `[Unreleased]` documenting the shape pin and the no-API-break reasoning.

## No on-wire break

- Non-zero envelopes written by earlier code already included all five fields (they bypassed `omitempty`), so round-trip under the new tags is byte-identical.
- Any future envelope that now emits `"time":0` is rejected at `Verify` time by `validateArgon2idParams` exactly as today — the `schemaVersion` gate plus the per-KDF zero-rejection guard hold the line.

## Testing

- `go test ./internal/secretinjector/crypto/...` — PASS
- `go test ./internal/secretinjector/controller/...` — PASS (isolated run)
- `make lint` — no new findings in `crypto/kdf*.go` (pre-existing issues elsewhere not touched)

## Linear

https://linear.app/holos-run/issue/HOL-838/fixsecretinjectorcrypto-remove-omitempty-on-required-params-uint

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->