### PR TITLE
chore(template-policy-bindings): cleanup stale comments and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to holos-console are documented here.
 
 ## [Unreleased]
 
+### Added — Ancestor-aware TemplatePolicyBinding policy picker (HOL-833)
+
+`BindingForm` now calls `ListLinkableTemplatePolicies` (scope + ancestor walk)
+instead of the single-scope `ListTemplatePolicies` RPC, so a folder-scoped
+binding can select policies stored at any ancestor folder or org scope.
+`AncestorChainResolver` validation on `CreateTemplatePolicyBinding` /
+`UpdateTemplatePolicyBinding` ensures the referenced policy is reachable from
+the binding's storage scope at authoring time (HOL-836).
+
+**References**: PRs #1119 (backend `ListLinkableTemplatePolicies`), #1120
+(frontend hook + BindingForm wiring), #1121 (ancestor-chain authoring
+validation).
+
 ### Added — ProjectNamespace TemplatePolicyBinding for new Projects (HOL-806)
 
 Operators can now attach a `TemplatePolicyBinding` with

--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -18,7 +18,7 @@ const (
 	LabelProject      = "console.holos.run/project"
 
 	// Label values.
-	ManagedByValue                 = "console.holos.run"
+	ManagedByValue           = "console.holos.run"
 	ResourceTypeOrganization = "organization"
 	ResourceTypeFolder       = "folder"
 	ResourceTypeProject      = "project"

--- a/console/policyresolver/applied_state_envtest_test.go
+++ b/console/policyresolver/applied_state_envtest_test.go
@@ -48,11 +48,11 @@ const (
 	renderStateEnvtestSelectorPrefix  = "ls"
 	// HOL-772 wildcard cascade prefixes — one per test so the namespace
 	// hierarchy each builds is uniquely named on the shared apiserver.
-	wildcardFolderCascadePrefix      = "wfc"
-	wildcardSiblingFolderPrefix      = "wsf"
-	wildcardProjectScopeCeilingPref  = "wpc"
-	wildcardDeploymentByNamePresent  = "wdp"
-	wildcardDeploymentByNameAbsent   = "wda"
+	wildcardFolderCascadePrefix     = "wfc"
+	wildcardSiblingFolderPrefix     = "wsf"
+	wildcardProjectScopeCeilingPref = "wpc"
+	wildcardDeploymentByNamePresent = "wdp"
+	wildcardDeploymentByNameAbsent  = "wda"
 )
 
 // startRenderStateEnvtest boots a Manager primed with the RenderState

--- a/console/policyresolver/cache_backed_test.go
+++ b/console/policyresolver/cache_backed_test.go
@@ -29,8 +29,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 

--- a/console/policyresolver/multi_pod_freshness_test.go
+++ b/console/policyresolver/multi_pod_freshness_test.go
@@ -333,4 +333,3 @@ func eventuallyResolveFolderResolverNames(
 	}
 	t.Fatalf("%s: want %v, last seen %v", message, wantSorted, lastSeen)
 }
-

--- a/console/templatepolicies/handler_test.go
+++ b/console/templatepolicies/handler_test.go
@@ -212,8 +212,8 @@ func TestCreateRejectsProjectScope(t *testing.T) {
 	h, fakeClient := newTestHandler(t, map[string]string{"owner@example.com": "owner"})
 
 	req := connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-		Namespace:  newProjectScope("billing-web"),
-		Policy: basicPolicy(newProjectScope("billing-web")),
+		Namespace: newProjectScope("billing-web"),
+		Policy:    basicPolicy(newProjectScope("billing-web")),
 	})
 	ctx := authedCtx("owner@example.com", nil)
 
@@ -260,7 +260,7 @@ func TestReadPathsRejectProjectScope(t *testing.T) {
 			run: func() error {
 				_, err := h.GetTemplatePolicy(ctx, connect.NewRequest(&consolev1.GetTemplatePolicyRequest{
 					Namespace: newProjectScope("billing-web"),
-					Name:  "any",
+					Name:      "any",
 				}))
 				return err
 			},
@@ -269,8 +269,8 @@ func TestReadPathsRejectProjectScope(t *testing.T) {
 			name: "update",
 			run: func() error {
 				_, err := h.UpdateTemplatePolicy(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyRequest{
-					Namespace:  newProjectScope("billing-web"),
-					Policy: basicPolicy(newProjectScope("billing-web")),
+					Namespace: newProjectScope("billing-web"),
+					Policy:    basicPolicy(newProjectScope("billing-web")),
 				}))
 				return err
 			},
@@ -280,7 +280,7 @@ func TestReadPathsRejectProjectScope(t *testing.T) {
 			run: func() error {
 				_, err := h.DeleteTemplatePolicy(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyRequest{
 					Namespace: newProjectScope("billing-web"),
-					Name:  "any",
+					Name:      "any",
 				}))
 				return err
 			},
@@ -321,7 +321,7 @@ func TestCreatePolicyValidation(t *testing.T) {
 				Name: "bad-kind",
 				Rules: []*consolev1.TemplatePolicyRule{
 					{
-						Kind: consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_UNSPECIFIED,
+						Kind:     consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_UNSPECIFIED,
 						Template: &consolev1.LinkedTemplateRef{Namespace: "holos-org-acme", Name: "t"},
 					},
 				},
@@ -334,7 +334,7 @@ func TestCreatePolicyValidation(t *testing.T) {
 				Name: "bad-ref",
 				Rules: []*consolev1.TemplatePolicyRule{
 					{
-						Kind: consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE,
+						Kind:     consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE,
 						Template: &consolev1.LinkedTemplateRef{Namespace: "holos-org-acme", Name: ""},
 					},
 				},
@@ -373,8 +373,8 @@ func TestCreatePolicyValidation(t *testing.T) {
 				tt.policy.Namespace = newFolderScope("payments")
 			}
 			_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-				Namespace:  newFolderScope("payments"),
-				Policy: tt.policy,
+				Namespace: newFolderScope("payments"),
+				Policy:    tt.policy,
 			}))
 			if err == nil {
 				t.Fatal("expected validation error")
@@ -401,10 +401,10 @@ func TestCreatePolicyNamespaceValidation(t *testing.T) {
 	ctx := authedCtx("owner@example.com", nil)
 
 	tests := []struct {
-		name     string
-		reqNs    string
-		polNs    string
-		wantMsg  string
+		name    string
+		reqNs   string
+		polNs   string
+		wantMsg string
 	}{
 		{
 			name:    "missing policy namespace",
@@ -554,8 +554,8 @@ func TestCreatePolicyHappyPath(t *testing.T) {
 	ctx := authedCtx("owner@example.com", nil)
 
 	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-		Namespace:  newFolderScope("payments"),
-		Policy: basicPolicy(newFolderScope("payments")),
+		Namespace: newFolderScope("payments"),
+		Policy:    basicPolicy(newFolderScope("payments")),
 	}))
 	if err != nil {
 		t.Fatalf("CreateTemplatePolicy: %v", err)
@@ -574,8 +574,8 @@ func TestCreatePolicyPermissionDeniedForViewer(t *testing.T) {
 	ctx := authedCtx("viewer@example.com", nil)
 
 	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-		Namespace:  newFolderScope("payments"),
-		Policy: basicPolicy(newFolderScope("payments")),
+		Namespace: newFolderScope("payments"),
+		Policy:    basicPolicy(newFolderScope("payments")),
 	}))
 	if err == nil {
 		t.Fatal("expected permission denied")
@@ -590,8 +590,8 @@ func TestCreatePolicyAtOrgScope(t *testing.T) {
 	ctx := authedCtx("owner@example.com", nil)
 
 	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-		Namespace:  newOrgScope("acme"),
-		Policy: basicPolicy(newOrgScope("acme")),
+		Namespace: newOrgScope("acme"),
+		Policy:    basicPolicy(newOrgScope("acme")),
 	}))
 	if err != nil {
 		t.Fatalf("CreateTemplatePolicy at org scope: %v", err)
@@ -616,7 +616,7 @@ func TestDeleteMissingPolicyReturnsNotFound(t *testing.T) {
 
 	_, err := h.DeleteTemplatePolicy(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyRequest{
 		Namespace: newFolderScope("payments"),
-		Name:  "does-not-exist",
+		Name:      "does-not-exist",
 	}))
 	if err == nil {
 		t.Fatal("expected NotFound error")
@@ -695,8 +695,8 @@ func TestTemplateExistsProbeDoesNotBlockOnTransientError(t *testing.T) {
 
 	ctx := authedCtx("owner@example.com", nil)
 	_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-		Namespace:  newFolderScope("payments"),
-		Policy: basicPolicy(newFolderScope("payments")),
+		Namespace: newFolderScope("payments"),
+		Policy:    basicPolicy(newFolderScope("payments")),
 	}))
 	if err != nil {
 		t.Fatalf("transient probe error must not block create: %v", err)
@@ -713,8 +713,8 @@ func TestListPoliciesReturnsStoredRules(t *testing.T) {
 	ctx := authedCtx("owner@example.com", nil)
 
 	if _, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-		Namespace:  newFolderScope("payments"),
-		Policy: basicPolicy(newFolderScope("payments")),
+		Namespace: newFolderScope("payments"),
+		Policy:    basicPolicy(newFolderScope("payments")),
 	})); err != nil {
 		t.Fatalf("CreateTemplatePolicy: %v", err)
 	}
@@ -905,8 +905,8 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 			name: "Create at folder scope (no folder grant)",
 			run: func() error {
 				_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-					Namespace:  newFolderScope("payments"),
-					Policy: basicPolicy(newFolderScope("payments")),
+					Namespace: newFolderScope("payments"),
+					Policy:    basicPolicy(newFolderScope("payments")),
 				}))
 				return err
 			},
@@ -916,8 +916,8 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 			name: "Create at organization scope (no org grant)",
 			run: func() error {
 				_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-					Namespace:  newOrgScope("acme"),
-					Policy: basicPolicy(newOrgScope("acme")),
+					Namespace: newOrgScope("acme"),
+					Policy:    basicPolicy(newOrgScope("acme")),
 				}))
 				return err
 			},
@@ -927,8 +927,8 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 			name: "Create targeting project namespace (storage-isolation rejection)",
 			run: func() error {
 				_, err := h.CreateTemplatePolicy(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyRequest{
-					Namespace:  newProjectScope("billing-web"),
-					Policy: basicPolicy(newProjectScope("billing-web")),
+					Namespace: newProjectScope("billing-web"),
+					Policy:    basicPolicy(newProjectScope("billing-web")),
 				}))
 				return err
 			},
@@ -940,9 +940,9 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 				_, err := h.UpdateTemplatePolicy(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyRequest{
 					Namespace: newFolderScope("payments"),
 					Policy: &consolev1.TemplatePolicy{
-						Name:     "require-httproute",
+						Name:      "require-httproute",
 						Namespace: newFolderScope("payments"),
-						Rules:    []*consolev1.TemplatePolicyRule{sampleRule()},
+						Rules:     []*consolev1.TemplatePolicyRule{sampleRule()},
 					},
 				}))
 				return err
@@ -954,7 +954,7 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 			run: func() error {
 				_, err := h.DeleteTemplatePolicy(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyRequest{
 					Namespace: newFolderScope("payments"),
-					Name:  "require-httproute",
+					Name:      "require-httproute",
 				}))
 				return err
 			},
@@ -965,7 +965,7 @@ func TestProjectOwnerCannotMutatePolicy(t *testing.T) {
 			run: func() error {
 				_, err := h.DeleteTemplatePolicy(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyRequest{
 					Namespace: newProjectScope("billing-web"),
-					Name:  "any",
+					Name:      "any",
 				}))
 				return err
 			},

--- a/console/templatepolicies/k8s.go
+++ b/console/templatepolicies/k8s.go
@@ -314,4 +314,3 @@ func crdKindToProto(k templatesv1alpha1.TemplatePolicyKind) consolev1.TemplatePo
 		return consolev1.TemplatePolicyKind_TEMPLATE_POLICY_KIND_UNSPECIFIED
 	}
 }
-

--- a/console/templatepolicybindings/handler_test.go
+++ b/console/templatepolicybindings/handler_test.go
@@ -275,7 +275,7 @@ func TestReadPathsRejectProjectScope(t *testing.T) {
 			run: func() error {
 				_, err := h.GetTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.GetTemplatePolicyBindingRequest{
 					Namespace: newProjectScopeRef("billing-web"),
-					Name:  "any",
+					Name:      "any",
 				}))
 				return err
 			},
@@ -284,8 +284,8 @@ func TestReadPathsRejectProjectScope(t *testing.T) {
 			name: "update",
 			run: func() error {
 				_, err := h.UpdateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyBindingRequest{
-					Namespace:   newProjectScopeRef("billing-web"),
-					Binding: basicBinding(newProjectScopeRef("billing-web")),
+					Namespace: newProjectScopeRef("billing-web"),
+					Binding:   basicBinding(newProjectScopeRef("billing-web")),
 				}))
 				return err
 			},
@@ -295,7 +295,7 @@ func TestReadPathsRejectProjectScope(t *testing.T) {
 			run: func() error {
 				_, err := h.DeleteTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.DeleteTemplatePolicyBindingRequest{
 					Namespace: newProjectScopeRef("billing-web"),
-					Name:  "any",
+					Name:      "any",
 				}))
 				return err
 			},
@@ -402,12 +402,12 @@ func TestCreateUnauthenticated(t *testing.T) {
 	binding := basicBinding(folder)
 	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
 		Namespace: folder,
-		Name:     "local-policy",
+		Name:      "local-policy",
 	}
 
 	_, err := h.CreateTemplatePolicyBinding(context.Background(), connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
-		Namespace:   folder,
-		Binding: binding,
+		Namespace: folder,
+		Binding:   binding,
 	}))
 	if err == nil {
 		t.Fatal("expected unauthenticated rejection")
@@ -432,7 +432,7 @@ func TestCreateValidation(t *testing.T) {
 	validPolicyRef := func() *consolev1.LinkedTemplatePolicyRef {
 		return &consolev1.LinkedTemplatePolicyRef{
 			Namespace: folder,
-			Name:     "local-policy",
+			Name:      "local-policy",
 		}
 	}
 	validTarget := func() *consolev1.TemplatePolicyBindingTargetRef {
@@ -452,7 +452,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "missing policy_ref",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:       "bad",
-				Namespace:   folder,
+				Namespace:  folder,
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
 			},
 			wantMsg: "policy_ref is required",
@@ -461,7 +461,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "policy_ref missing scope_ref",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:       "bad",
-				Namespace:   folder,
+				Namespace:  folder,
 				PolicyRef:  &consolev1.LinkedTemplatePolicyRef{Name: "x"},
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
 			},
@@ -470,11 +470,11 @@ func TestCreateValidation(t *testing.T) {
 		{
 			name: "policy_ref project scope",
 			binding: &consolev1.TemplatePolicyBinding{
-				Name:     "bad",
+				Name:      "bad",
 				Namespace: folder,
 				PolicyRef: &consolev1.LinkedTemplatePolicyRef{
 					Namespace: newProjectScopeRef("p"),
-					Name:     "x",
+					Name:      "x",
 				},
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
 			},
@@ -484,7 +484,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "target_refs empty",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:       "bad",
-				Namespace:   folder,
+				Namespace:  folder,
 				PolicyRef:  validPolicyRef(),
 				TargetRefs: nil,
 			},
@@ -494,7 +494,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "target kind unspecified",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:      "bad",
-				Namespace:  folder,
+				Namespace: folder,
 				PolicyRef: validPolicyRef(),
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
 					{
@@ -510,7 +510,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "target name missing",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:      "bad",
-				Namespace:  folder,
+				Namespace: folder,
 				PolicyRef: validPolicyRef(),
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
 					{
@@ -525,7 +525,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "target project_name invalid DNS label",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:      "bad",
-				Namespace:  folder,
+				Namespace: folder,
 				PolicyRef: validPolicyRef(),
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
 					{
@@ -541,7 +541,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "target name invalid DNS label",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:      "bad",
-				Namespace:  folder,
+				Namespace: folder,
 				PolicyRef: validPolicyRef(),
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
 					{
@@ -557,7 +557,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "target project_name missing",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:      "bad",
-				Namespace:  folder,
+				Namespace: folder,
 				PolicyRef: validPolicyRef(),
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
 					{
@@ -572,7 +572,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "duplicate target triples",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:      "bad",
-				Namespace:  folder,
+				Namespace: folder,
 				PolicyRef: validPolicyRef(),
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{
 					validTarget(),
@@ -585,7 +585,7 @@ func TestCreateValidation(t *testing.T) {
 			name: "invalid name",
 			binding: &consolev1.TemplatePolicyBinding{
 				Name:       "Bad_Name",
-				Namespace:   folder,
+				Namespace:  folder,
 				PolicyRef:  validPolicyRef(),
 				TargetRefs: []*consolev1.TemplatePolicyBindingTargetRef{validTarget()},
 			},
@@ -595,8 +595,8 @@ func TestCreateValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
-				Namespace:   folder,
-				Binding: tt.binding,
+				Namespace: folder,
+				Binding:   tt.binding,
 			}))
 			if err == nil {
 				t.Fatal("expected validation error")
@@ -696,12 +696,12 @@ func TestCreateRejectsMissingPolicy(t *testing.T) {
 	binding := basicBinding(folder)
 	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
 		Namespace: folder,
-		Name:     "does-not-exist",
+		Name:      "does-not-exist",
 	}
 
 	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
-		Namespace:   folder,
-		Binding: binding,
+		Namespace: folder,
+		Binding:   binding,
 	}))
 	if err == nil {
 		t.Fatal("expected missing-policy rejection")
@@ -736,12 +736,12 @@ func TestCreateRejectsOutOfChainPolicy(t *testing.T) {
 	// folder; the ancestor walker says "not reachable".
 	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
 		Namespace: newOrgScopeRef("other-org"),
-		Name:     "platform-policy",
+		Name:      "platform-policy",
 	}
 
 	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
-		Namespace:   folder,
-		Binding: binding,
+		Namespace: folder,
+		Binding:   binding,
 	}))
 	if err == nil {
 		t.Fatal("expected out-of-chain rejection")
@@ -774,12 +774,12 @@ func TestCreateAcceptsAncestorPolicy(t *testing.T) {
 	binding := basicBinding(folder)
 	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
 		Namespace: newOrgScopeRef("acme"),
-		Name:     "platform-policy",
+		Name:      "platform-policy",
 	}
 
 	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
-		Namespace:   folder,
-		Binding: binding,
+		Namespace: folder,
+		Binding:   binding,
 	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -804,7 +804,7 @@ func TestCreateRejectsBadProjectName(t *testing.T) {
 	binding := basicBinding(folder)
 	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
 		Namespace: folder,
-		Name:     "local-policy",
+		Name:      "local-policy",
 	}
 	binding.TargetRefs = []*consolev1.TemplatePolicyBindingTargetRef{
 		{
@@ -815,8 +815,8 @@ func TestCreateRejectsBadProjectName(t *testing.T) {
 	}
 
 	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
-		Namespace:   folder,
-		Binding: binding,
+		Namespace: folder,
+		Binding:   binding,
 	}))
 	if err == nil {
 		t.Fatal("expected bad-project rejection")
@@ -939,12 +939,12 @@ func TestUpdateMissingReturnsNotFound(t *testing.T) {
 	binding := basicBinding(folder)
 	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
 		Namespace: folder,
-		Name:     "local-policy",
+		Name:      "local-policy",
 	}
 
 	_, err := h.UpdateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.UpdateTemplatePolicyBindingRequest{
-		Namespace:   folder,
-		Binding: binding,
+		Namespace: folder,
+		Binding:   binding,
 	}))
 	if err == nil {
 		t.Fatal("expected NotFound")
@@ -1108,12 +1108,12 @@ func TestPolicyProbeErrorFailsInternal(t *testing.T) {
 	binding := basicBinding(folder)
 	binding.PolicyRef = &consolev1.LinkedTemplatePolicyRef{
 		Namespace: folder,
-		Name:     "whatever",
+		Name:      "whatever",
 	}
 
 	_, err := h.CreateTemplatePolicyBinding(ctx, connect.NewRequest(&consolev1.CreateTemplatePolicyBindingRequest{
-		Namespace:   folder,
-		Binding: binding,
+		Namespace: folder,
+		Binding:   binding,
 	}))
 	if err == nil {
 		t.Fatal("expected probe failure to surface as error")

--- a/console/templates/handler_linkable_test.go
+++ b/console/templates/handler_linkable_test.go
@@ -435,7 +435,7 @@ func TestListLinkableTemplatesIncludeSelfScope(t *testing.T) {
 
 			ctx := authedCtx(ownerEmail, nil)
 			req := connect.NewRequest(&consolev1.ListLinkableTemplatesRequest{
-				Namespace:            tt.scope,
+				Namespace:        tt.scope,
 				IncludeSelfScope: tt.includeSelfScope,
 			})
 

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -703,7 +703,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 		handler.WithAncestorWalker(walker)
 
 		msg := &consolev1.RenderTemplateRequest{
-			Namespace:       projectScopeRef(project),
+			Namespace:   projectScopeRef(project),
 			CueTemplate: validCue,
 			LinkedTemplates: []*consolev1.LinkedTemplateRef{
 				folderLinkedRef(folder, "payments-policy"),
@@ -792,7 +792,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 		handler.WithAncestorWalker(walker)
 
 		msg := &consolev1.RenderTemplateRequest{
-			Namespace:       projectScopeRef(project),
+			Namespace:   projectScopeRef(project),
 			CueTemplate: validCue,
 			LinkedTemplates: []*consolev1.LinkedTemplateRef{
 				orgLinkedRef(org, "httproute"),
@@ -910,7 +910,7 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 		handler := NewHandler(k8s, r, renderer, policyresolver.NewNoopResolver())
 		handler.WithAncestorWalker(walker)
 		_, err := handler.renderTemplateGrouped(context.Background(), &consolev1.RenderTemplateRequest{
-			Namespace:       projectScopeRef(project),
+			Namespace:   projectScopeRef(project),
 			CueTemplate: validCue,
 			LinkedTemplates: []*consolev1.LinkedTemplateRef{
 				folderLinkedRef(folder, "shared"),
@@ -1241,7 +1241,7 @@ input: #ProjectInput & {
 			ctx := authedCtx(tt.email, nil)
 			resp, err := handler.GetTemplateDefaults(ctx, connect.NewRequest(&consolev1.GetTemplateDefaultsRequest{
 				Namespace: tt.scope,
-				Name:  tt.tmplName,
+				Name:      tt.tmplName,
 			}))
 
 			if tt.want.wantErr {
@@ -1438,7 +1438,7 @@ func TestGetTemplateDefaultsValidation(t *testing.T) {
 			authedCtx("anyone@localhost", nil),
 			connect.NewRequest(&consolev1.GetTemplateDefaultsRequest{
 				Namespace: projectScopeRef("p"),
-				Name:  "",
+				Name:      "",
 			}),
 		)
 		if err == nil {
@@ -1454,7 +1454,7 @@ func TestGetTemplateDefaultsValidation(t *testing.T) {
 			context.Background(),
 			connect.NewRequest(&consolev1.GetTemplateDefaultsRequest{
 				Namespace: projectScopeRef("p"),
-				Name:  "foo",
+				Name:      "foo",
 			}),
 		)
 		if err == nil {

--- a/console/templates/handler_updates_test.go
+++ b/console/templates/handler_updates_test.go
@@ -92,7 +92,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:        projectScopeRef(project),
+			Namespace:    projectScopeRef(project),
 			TemplateName: "web-app",
 		})
 
@@ -118,7 +118,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:        projectScopeRef(project),
+			Namespace:    projectScopeRef(project),
 			TemplateName: "web-app",
 		})
 
@@ -149,7 +149,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:        projectScopeRef(project),
+			Namespace:    projectScopeRef(project),
 			TemplateName: "web-app",
 		})
 
@@ -189,7 +189,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:        projectScopeRef(project),
+			Namespace:    projectScopeRef(project),
 			TemplateName: "web-app",
 		})
 
@@ -218,7 +218,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:        projectScopeRef(project),
+			Namespace:    projectScopeRef(project),
 			TemplateName: "web-app",
 		})
 
@@ -255,7 +255,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:        projectScopeRef(project),
+			Namespace:    projectScopeRef(project),
 			TemplateName: "standalone",
 		})
 
@@ -316,7 +316,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:          projectScopeRef(project),
+			Namespace:      projectScopeRef(project),
 			TemplateName:   "web-app",
 			IncludeCurrent: true,
 		})
@@ -354,7 +354,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:          projectScopeRef(project),
+			Namespace:      projectScopeRef(project),
 			TemplateName:   "web-app",
 			IncludeCurrent: false,
 		})
@@ -379,7 +379,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:          projectScopeRef(project),
+			Namespace:      projectScopeRef(project),
 			TemplateName:   "web-app",
 			IncludeCurrent: true,
 		})
@@ -408,7 +408,7 @@ func TestCheckUpdates(t *testing.T) {
 
 		ctx := authedCtx(ownerEmail, nil)
 		req := connect.NewRequest(&consolev1.CheckUpdatesRequest{
-			Namespace:          projectScopeRef(project),
+			Namespace:      projectScopeRef(project),
 			TemplateName:   "web-app",
 			IncludeCurrent: true,
 		})

--- a/console/templates/policy_state_test.go
+++ b/console/templates/policy_state_test.go
@@ -103,7 +103,7 @@ func TestGetProjectTemplatePolicyState(t *testing.T) {
 			ctx:  context.Background(),
 			req: &consolev1.GetProjectTemplatePolicyStateRequest{
 				Namespace: projectScopeRef(project),
-				Name:  tmplName,
+				Name:      tmplName,
 			},
 			wantCode: connect.CodeUnauthenticated,
 		},
@@ -116,7 +116,7 @@ func TestGetProjectTemplatePolicyState(t *testing.T) {
 			ctx:  otherCtx,
 			req: &consolev1.GetProjectTemplatePolicyStateRequest{
 				Namespace: projectScopeRef(project),
-				Name:  tmplName,
+				Name:      tmplName,
 			},
 			seedTemplate: true,
 			wantCode:     connect.CodePermissionDenied,
@@ -126,7 +126,7 @@ func TestGetProjectTemplatePolicyState(t *testing.T) {
 			ctx:  ownerCtx,
 			req: &consolev1.GetProjectTemplatePolicyStateRequest{
 				Namespace: projectScopeRef(project),
-				Name:  tmplName,
+				Name:      tmplName,
 			},
 			seedTemplate: false,
 			wantCode:     connect.CodeNotFound,
@@ -136,7 +136,7 @@ func TestGetProjectTemplatePolicyState(t *testing.T) {
 			ctx:  ownerCtx,
 			req: &consolev1.GetProjectTemplatePolicyStateRequest{
 				Namespace: projectScopeRef(project),
-				Name:  tmplName,
+				Name:      tmplName,
 			},
 			seedTemplate: true,
 			checker:      nil,
@@ -147,7 +147,7 @@ func TestGetProjectTemplatePolicyState(t *testing.T) {
 			ctx:  ownerCtx,
 			req: &consolev1.GetProjectTemplatePolicyStateRequest{
 				Namespace: projectScopeRef(project),
-				Name:  tmplName,
+				Name:      tmplName,
 			},
 			seedTemplate: true,
 			checker:      &stubProjectTemplateDriftChecker{stateErr: errors.New("resolver down")},
@@ -158,7 +158,7 @@ func TestGetProjectTemplatePolicyState(t *testing.T) {
 			ctx:  ownerCtx,
 			req: &consolev1.GetProjectTemplatePolicyStateRequest{
 				Namespace: projectScopeRef(project),
-				Name:  tmplName,
+				Name:      tmplName,
 			},
 			seedTemplate: true,
 			checker:      &stubProjectTemplateDriftChecker{stateResult: happyState},

--- a/console/templates/testhelpers_test.go
+++ b/console/templates/testhelpers_test.go
@@ -22,8 +22,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	kfake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -232,8 +232,8 @@ func makeReleaseCRDWithData(ns, templateName, version, cue, defaults string) *te
 			Name:      ReleaseObjectName(templateName, v),
 			Namespace: ns,
 			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:          v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType:       "template-release",
+				v1alpha2.LabelManagedBy:        v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType:     "template-release",
 				"console.holos.run/release-of": templateName,
 			},
 		},

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -66,8 +66,8 @@ export function useListTemplatePolicies(namespace: string) {
 // useListLinkableTemplatePolicies fetches all TemplatePolicies reachable from
 // the given scope namespace by walking the ancestor chain up to the org root.
 // The response carries a per-item owning namespace so the UI can render a scope
-// badge without a second round-trip. HOL-835 wires this into BindingForm so
-// folder-scoped bindings can select org-scoped or parent-folder-scoped policies.
+// badge without a second round-trip. BindingForm uses this hook so folder-scoped
+// bindings can select org-scoped or parent-folder-scoped policies (HOL-835).
 //
 // Do NOT use this for admin list views — those should call useListTemplatePolicies
 // to stay single-scope. This hook is additive and does not replace the single-scope

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -17,8 +17,8 @@ limitations under the License.
 package controller
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // mergeCondition stamps the reconciler-observed generation onto cond and

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -880,4 +880,3 @@ func findRepoRoot() (string, error) {
 		dir = parent
 	}
 }
-

--- a/internal/secretinjector/controller/rbac.go
+++ b/internal/secretinjector/controller/rbac.go
@@ -23,13 +23,16 @@ limitations under the License.
 // templates-group rbac file established in HOL-620.
 //
 // Notes on the least-privilege envelope we're encoding here:
+//
 //   - Full CRUD on every secrets.holos.run kind (the M2 reconcilers own
 //     these). Status and finalizers are split out per controller-runtime
 //     idiom so the reconciler can update status without needing write on
 //     spec, and so finalizer removal is auditable as its own rule.
+//
 //   - CRUD on security.istio.io AuthorizationPolicy because the M2
 //     SecretInjectionPolicyBinding reconciler synthesises AP objects that
 //     enforce the caller allow-list at the mesh layer.
+//
 //   - `get` ONLY on core/v1 Secret at the cluster-role level. Enumeration
 //     (list/watch) is the vulnerability this service is meant to close —
 //     the reconciler resolves refs by name+namespace, never by listing.
@@ -48,8 +51,10 @@ limitations under the License.
 //     blockOwnerDeletion=true) guarantees the hash Secret is
 //     garbage-collected atomically when the Credential is deleted. No
 //     cluster-wide Secret enumeration path is opened by this design.
+//
 //   - `get/list/watch` on Namespace so the reconciler can resolve the
 //     hierarchy labels the admission policies enforce against.
+//
 //   - `create/patch` on Event so the reconciler can emit standard
 //     controller-runtime events.
 //

--- a/proto/holos/console/v1/template_policy_bindings.proto
+++ b/proto/holos/console/v1/template_policy_bindings.proto
@@ -24,9 +24,11 @@ option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;con
 // in the same hierarchy level. The HOL-618 admission plugin enforces this
 // by rejecting any TemplatePolicyBinding created in a project namespace.
 //
-// Handler wiring, RBAC enforcement, and ConnectRPC registration land in the
-// follow-on sub-ticket (HOL-595). This file defines only the proto contract
-// so subsequent phases have types to work against.
+// Handler wiring, RBAC enforcement, and ConnectRPC registration shipped in
+// HOL-595. The ancestor-aware policy picker (ListLinkableTemplatePolicies) is
+// available via TemplatePolicyService and is wired into BindingForm so
+// folder-scoped bindings can select org-scoped or parent-folder-scoped
+// policies (HOL-835).
 service TemplatePolicyBindingService {
   // ListTemplatePolicyBindings returns all TemplatePolicyBinding resources
   // visible in the given namespace. Requires
@@ -93,8 +95,8 @@ enum TemplatePolicyBindingTargetKind {
   // `project_name` accepts the literal wildcard "*" (HOL-767) to match
   // every new project reachable via the binding's ancestor-walk. `name`
   // is the namespace slug (typically the project name). Resolver behavior
-  // for this kind is wired in a later phase; the enum value is defined
-  // here so downstream code has a typed value to reference.
+  // for this kind is wired in HOL-806; the full CreateProject integration
+  // (apply-on-create, SSA, retry) shipped in PRs #1093–#1112.
   TEMPLATE_POLICY_BINDING_TARGET_KIND_PROJECT_NAMESPACE = 3;
 }
 


### PR DESCRIPTION
## Summary

- Updates `proto/template_policy_bindings.proto` service comment: removes stale "Handler wiring lands in follow-on HOL-595" sentence and replaces "Resolver behavior wired in a later phase" for the `PROJECT_NAMESPACE` enum value with accurate shipped references.
- Updates `frontend/src/queries/templatePolicies.ts`: reframes HOL-835 reference from forward-looking to a shipped fact.
- Adds CHANGELOG entry for the ancestor-aware `TemplatePolicyBinding` policy picker (HOL-833) under Unreleased.
- Applies `go fmt` formatting across the codebase (formatting-only).

All callers of `useListTemplatePolicies` were audited: both route-level callers (`folders/$folderName/template-policies/index.tsx` and `folders/$folderName/index.tsx`) are legitimate admin list views and correctly remain on the single-scope hook. `BindingForm` already uses `useListLinkableTemplatePolicies`.

Fixes HOL-837

## Test plan

- [x] `make fmt && make vet` clean
- [x] `make test-go` passes (85 packages)
- [x] `make test-ui` passes (85 test files, 1114 tests)
- [x] `make lint` pre-existing failures only (none in changed files)