### PR TITLE
feat(ui): ResourceGrid v1 component and ConfirmDeleteDialog

### DIFF
--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -1,0 +1,390 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+
+// Mock TanStack Router — ResourceGrid uses Link and the search/navigate props
+// are passed in directly from the parent route, so we only need Link.
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    Link: ({
+      children,
+      to,
+    }: {
+      children: React.ReactNode
+      to?: string
+    }) => <a href={to ?? '#'}>{children}</a>,
+    useNavigate: () => vi.fn(),
+  }
+})
+
+// Mock sonner toast so we can assert on it.
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { toast } from 'sonner'
+import type { Mock } from 'vitest'
+import { ResourceGrid } from './ResourceGrid'
+import type { Kind, Row, ResourceGridSearch } from './types'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeRow(overrides: Partial<Row> = {}): Row {
+  return {
+    kind: 'secret',
+    id: 'abc-123',
+    name: 'my-secret',
+    namespace: 'project-billing',
+    parentId: 'project-billing',
+    parentLabel: 'billing',
+    displayName: 'My Secret',
+    description: 'A test secret',
+    createdAt: '2025-01-01T00:00:00Z',
+    detailHref: '/secrets/my-secret',
+    ...overrides,
+  }
+}
+
+const SECRET_KIND: Kind = {
+  id: 'secret',
+  label: 'Secret',
+  newHref: '/secrets/new',
+  canCreate: true,
+}
+
+const DEPLOYMENT_KIND: Kind = {
+  id: 'deployment',
+  label: 'Deployment',
+  newHref: '/deployments/new',
+  canCreate: true,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderGrid(
+  overrides: Partial<{
+    title: string
+    kinds: Kind[]
+    rows: Row[]
+    onDelete: (row: Row) => Promise<void>
+    isLoading: boolean
+    error: Error | null
+    search: ResourceGridSearch
+    onSearchChange: (
+      updater: (prev: ResourceGridSearch) => ResourceGridSearch,
+    ) => void
+  }> = {},
+) {
+  const props = {
+    title: 'Test Resources',
+    kinds: [SECRET_KIND],
+    rows: [makeRow()],
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    isLoading: false,
+    error: null,
+    search: {} as ResourceGridSearch,
+    onSearchChange: vi.fn(),
+    ...overrides,
+  }
+  return render(<ResourceGrid {...props} />)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ResourceGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // --- Loading state ---
+
+  it('renders skeleton loader when isLoading is true', () => {
+    renderGrid({ isLoading: true, rows: [] })
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders error card when error is set and rows are empty', () => {
+    renderGrid({ error: new Error('fetch failed'), rows: [] })
+    expect(screen.getByText('fetch failed')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders inline partial-error banner when error and rows coexist', () => {
+    renderGrid({ error: new Error('partial error') })
+    expect(
+      screen.getByTestId('resource-grid-partial-error'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('table')).toBeInTheDocument()
+  })
+
+  // --- Column rendering ---
+
+  it('renders expected column headers', () => {
+    renderGrid()
+    expect(
+      screen.getByRole('columnheader', { name: /display name/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /description/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /created at/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders row display name and description', () => {
+    renderGrid()
+    expect(screen.getByText('My Secret')).toBeInTheDocument()
+    expect(screen.getByText('A test secret')).toBeInTheDocument()
+  })
+
+  it('links display name to detailHref', () => {
+    renderGrid()
+    const link = screen.getByRole('link', { name: /my secret/i })
+    expect(link).toHaveAttribute('href', '/secrets/my-secret')
+  })
+
+  // --- Parent ID column hiding ---
+
+  it('hides Parent column when exactly one parent is in the row set', () => {
+    // Single parent: parentId is the same for all rows.
+    renderGrid({
+      rows: [
+        makeRow({ parentId: 'project-billing' }),
+        makeRow({ name: 'other', id: 'def-456', parentId: 'project-billing' }),
+      ],
+    })
+    // When column is hidden there is no "Parent" column header visible.
+    expect(
+      screen.queryByRole('columnheader', { name: /^parent$/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows Parent column when multiple parents are in the row set', () => {
+    renderGrid({
+      rows: [
+        makeRow({ parentId: 'project-billing' }),
+        makeRow({
+          name: 'other',
+          id: 'def-456',
+          parentId: 'project-other',
+          parentLabel: 'other',
+        }),
+      ],
+    })
+    expect(
+      screen.getByRole('columnheader', { name: /^parent$/i }),
+    ).toBeInTheDocument()
+  })
+
+  // --- Search filter ---
+
+  it('filters rows via global search input by display name', () => {
+    const onSearchChange = vi.fn()
+    renderGrid({
+      rows: [
+        makeRow({ name: 'alpha', displayName: 'Alpha Resource' }),
+        makeRow({
+          name: 'beta',
+          id: 'beta-1',
+          displayName: 'Beta Resource',
+          description: 'desc',
+        }),
+      ],
+      onSearchChange,
+    })
+    const input = screen.getByRole('textbox', { name: /search/i })
+    fireEvent.change(input, { target: { value: 'Alpha' } })
+    expect(onSearchChange).toHaveBeenCalled()
+  })
+
+  it('passes globalFilter from search prop to the table', () => {
+    renderGrid({
+      rows: [
+        makeRow({ name: 'alpha', displayName: 'Alpha Resource' }),
+        makeRow({
+          name: 'beta',
+          id: 'beta-1',
+          displayName: 'Beta Resource',
+          description: 'desc',
+        }),
+      ],
+      search: { search: 'Beta' },
+    })
+    // Only the Beta row should be visible
+    expect(screen.getByText('Beta Resource')).toBeInTheDocument()
+    expect(screen.queryByText('Alpha Resource')).not.toBeInTheDocument()
+  })
+
+  // --- Kind filter ---
+
+  it('does not render kind filter when only one kind', () => {
+    renderGrid({ kinds: [SECRET_KIND] })
+    expect(screen.queryByTestId('kind-filter')).not.toBeInTheDocument()
+  })
+
+  it('renders kind filter checkboxes when multiple kinds', () => {
+    renderGrid({
+      kinds: [SECRET_KIND, DEPLOYMENT_KIND],
+      rows: [
+        makeRow({ kind: 'secret' }),
+        makeRow({
+          kind: 'deployment',
+          id: 'dep-1',
+          name: 'my-dep',
+          displayName: 'My Deployment',
+          description: '',
+        }),
+      ],
+    })
+    expect(screen.getByTestId('kind-filter')).toBeInTheDocument()
+    expect(screen.getByLabelText('Filter Secret')).toBeInTheDocument()
+    expect(screen.getByLabelText('Filter Deployment')).toBeInTheDocument()
+  })
+
+  it('filters rows by kind when kind filter is used via search prop', () => {
+    renderGrid({
+      kinds: [SECRET_KIND, DEPLOYMENT_KIND],
+      rows: [
+        makeRow({ kind: 'secret', displayName: 'My Secret' }),
+        makeRow({
+          kind: 'deployment',
+          id: 'dep-1',
+          name: 'my-dep',
+          displayName: 'My Deployment',
+          description: '',
+        }),
+      ],
+      search: { kind: 'deployment' },
+    })
+    expect(screen.getByText('My Deployment')).toBeInTheDocument()
+    expect(screen.queryByText('My Secret')).not.toBeInTheDocument()
+  })
+
+  // --- Lineage filter ---
+
+  it('renders lineage filter controls', () => {
+    renderGrid()
+    expect(screen.getByTestId('lineage-filter')).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /lineage direction/i })).toBeInTheDocument()
+    expect(
+      screen.getByTestId('lineage-recursive-checkbox'),
+    ).toBeInTheDocument()
+  })
+
+  it('recursive checkbox is unchecked by default', () => {
+    renderGrid({ search: {} })
+    const checkbox = screen.getByTestId('lineage-recursive-checkbox')
+    // The shadcn Checkbox renders as a button with aria-checked
+    expect(checkbox).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('calls onSearchChange with recursive=1 when recursive checkbox is clicked', () => {
+    const onSearchChange = vi.fn()
+    renderGrid({ onSearchChange, search: {} })
+    const checkbox = screen.getByTestId('lineage-recursive-checkbox')
+    fireEvent.click(checkbox)
+    expect(onSearchChange).toHaveBeenCalled()
+    // Verify the updater produces recursive=1
+    const updater = (onSearchChange as Mock).mock.calls[0][0]
+    expect(updater({})).toMatchObject({ recursive: '1' })
+  })
+
+  it('shows recursive checkbox as checked when search.recursive is "1"', () => {
+    renderGrid({ search: { recursive: '1' } })
+    const checkbox = screen.getByTestId('lineage-recursive-checkbox')
+    expect(checkbox).toHaveAttribute('aria-checked', 'true')
+  })
+
+  // --- New button ---
+
+  it('renders a single New button when one kind with newHref and canCreate', () => {
+    renderGrid({ kinds: [SECRET_KIND] })
+    expect(
+      screen.getByRole('link', { name: /new secret/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('does not render New button when canCreate is false', () => {
+    renderGrid({ kinds: [{ ...SECRET_KIND, canCreate: false }] })
+    expect(
+      screen.queryByRole('link', { name: /new secret/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders a "New" dropdown button when multiple creatableKinds', () => {
+    renderGrid({
+      kinds: [SECRET_KIND, DEPLOYMENT_KIND],
+      rows: [],
+    })
+    // The dropdown trigger is a button labelled "New"
+    expect(screen.getByRole('button', { name: /new/i })).toBeInTheDocument()
+  })
+
+  // --- Delete flow ---
+
+  it('opens ConfirmDeleteDialog when trash icon is clicked', async () => {
+    renderGrid()
+    const deleteBtn = screen.getByRole('button', { name: /delete my secret/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() =>
+      expect(screen.getByRole('dialog')).toBeInTheDocument(),
+    )
+  })
+
+  it('calls onDelete and shows success toast on confirm', async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined)
+    renderGrid({ onDelete })
+    fireEvent.click(screen.getByRole('button', { name: /delete my secret/i }))
+    await waitFor(() => screen.getByRole('dialog'))
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await waitFor(() => expect(onDelete).toHaveBeenCalledOnce())
+    expect(toast.success).toHaveBeenCalled()
+  })
+
+  it('shows error toast when onDelete throws', async () => {
+    const onDelete = vi.fn().mockRejectedValue(new Error('delete failed'))
+    renderGrid({ onDelete })
+    fireEvent.click(screen.getByRole('button', { name: /delete my secret/i }))
+    await waitFor(() => screen.getByRole('dialog'))
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+  })
+
+  it('closes dialog on Cancel without calling onDelete', async () => {
+    const onDelete = vi.fn()
+    renderGrid({ onDelete })
+    fireEvent.click(screen.getByRole('button', { name: /delete my secret/i }))
+    await waitFor(() => screen.getByRole('dialog'))
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+    )
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+
+  // --- Empty state ---
+
+  it('renders empty state when rows array is empty', () => {
+    renderGrid({ rows: [] })
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders no-match message when filter produces zero visible rows', () => {
+    renderGrid({
+      rows: [makeRow()],
+      search: { search: 'zzz-no-match' },
+    })
+    expect(
+      screen.getByText(/no resources match the current filters/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react'
-import { Link, useNavigate } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import {
   useReactTable,

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -1,0 +1,620 @@
+/**
+ * ResourceGrid v1 — reusable table component for Secrets, Deployments, and
+ * Templates.
+ *
+ * Features:
+ *  - TanStack Table with global search (includesString)
+ *  - Multi-kind filter (URL ?kind=a,b)
+ *  - Lineage filter (URL ?lineage=ancestors&recursive=0)
+ *  - New button / dropdown
+ *  - Row-level delete via ConfirmDeleteDialog
+ *  - URL sync via TanStack Router useSearch / useNavigate
+ *
+ * See HOL-855 for the full acceptance criteria.
+ */
+
+import { useState, useMemo, useCallback } from 'react'
+import { Link, useNavigate } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getFilteredRowModel,
+  flexRender,
+  createColumnHelper,
+  type VisibilityState,
+} from '@tanstack/react-table'
+import { Trash2, ChevronDown } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
+
+import type { Kind, Row, LineageDirection, ResourceGridSearch } from './types'
+import { parseKindIds, serialiseKindIds } from './url-state'
+
+// ---------------------------------------------------------------------------
+// Column helper
+// ---------------------------------------------------------------------------
+
+const columnHelper = createColumnHelper<Row>()
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ResourceGridProps {
+  /** Title shown in the Card header. */
+  title: string
+  /** The resource kinds this grid indexes. */
+  kinds: Kind[]
+  /** All rows — filtering happens inside the component. */
+  rows: Row[]
+  /**
+   * Async callback invoked after the user confirms a deletion.
+   * Throw to surface an error toast.
+   */
+  onDelete: (row: Row) => Promise<void>
+  /** While true, renders a skeleton loader instead of the table. */
+  isLoading?: boolean
+  /** If set and no rows exist yet, renders an error card. */
+  error?: Error | null
+  /**
+   * The currently active search params from TanStack Router.  Pass the
+   * result of `useSearch(...)` from the parent route.
+   */
+  search?: ResourceGridSearch
+  /**
+   * Called when the grid needs to update the URL.  The signature matches
+   * TanStack Router's `navigate({ search: updater })` pattern.
+   */
+  onSearchChange?: (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => void
+}
+
+// ---------------------------------------------------------------------------
+// ResourceGrid
+// ---------------------------------------------------------------------------
+
+export function ResourceGrid({
+  title,
+  kinds,
+  rows,
+  onDelete,
+  isLoading = false,
+  error,
+  search = {},
+  onSearchChange,
+}: ResourceGridProps) {
+  // --- Derive local state from URL params --------------------------------
+
+  const selectedKindIds = useMemo(
+    () => parseKindIds(search.kind),
+    [search.kind],
+  )
+
+  const globalFilter = search.search ?? ''
+  const lineageDirection: LineageDirection = search.lineage ?? 'descendants'
+  const recursive = search.recursive === '1'
+
+  // --- URL updater helpers -----------------------------------------------
+
+  const updateSearch = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      onSearchChange?.(updater)
+    },
+    [onSearchChange],
+  )
+
+  const setGlobalFilter = useCallback(
+    (value: string) => {
+      updateSearch((prev) => ({ ...prev, search: value || undefined }))
+    },
+    [updateSearch],
+  )
+
+  const setKindIds = useCallback(
+    (ids: string[]) => {
+      updateSearch((prev) => ({
+        ...prev,
+        kind: serialiseKindIds(ids) ?? undefined,
+      }))
+    },
+    [updateSearch],
+  )
+
+  const setLineageDirection = useCallback(
+    (dir: LineageDirection) => {
+      updateSearch((prev) => ({ ...prev, lineage: dir }))
+    },
+    [updateSearch],
+  )
+
+  const setRecursive = useCallback(
+    (val: boolean) => {
+      updateSearch((prev) => ({ ...prev, recursive: val ? '1' : '0' }))
+    },
+    [updateSearch],
+  )
+
+  // --- Delete dialog state -----------------------------------------------
+
+  const [deleteTarget, setDeleteTarget] = useState<Row | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<Error | null>(null)
+
+  const handleDeleteClick = useCallback((row: Row) => {
+    setDeleteTarget(row)
+    setDeleteError(null)
+  }, [])
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteTarget) return
+    setIsDeleting(true)
+    setDeleteError(null)
+    try {
+      await onDelete(deleteTarget)
+      setDeleteTarget(null)
+      toast.success(`Deleted ${deleteTarget.displayName || deleteTarget.name}`)
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      setDeleteError(e)
+      toast.error(e.message)
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [deleteTarget, onDelete])
+
+  // --- Derive unique parent IDs in the current row set -------------------
+
+  const uniqueParentIds = useMemo(
+    () => Array.from(new Set(rows.map((r) => r.parentId).filter(Boolean))),
+    [rows],
+  )
+  const singleParent = uniqueParentIds.length === 1
+
+  // --- Column visibility: hide parentId when exactly one parent ----------
+
+  const columnVisibility: VisibilityState = useMemo(
+    () => ({ parentId: !singleParent }),
+    [singleParent],
+  )
+
+  // --- Filter rows by selected kind IDs ----------------------------------
+
+  const kindFilteredRows = useMemo(() => {
+    if (selectedKindIds.length === 0) return rows
+    const kindSet = new Set(selectedKindIds)
+    return rows.filter((r) => kindSet.has(r.kind))
+  }, [rows, selectedKindIds])
+
+  // --- Lineage filter ----------------------------------------------------
+
+  const lineageFilteredRows = useMemo(() => {
+    // Lineage filtering is applied by the consumer's data-fetching layer
+    // in later phases.  The grid itself exposes the URL state; advanced
+    // multi-level walk logic belongs in the route.  We pass rows through
+    // unchanged here so the component stays data-source-agnostic.
+    //
+    // The lineage direction and recursive values are exposed via the search
+    // props so parent routes can consume them in their query hooks.
+    return kindFilteredRows
+  }, [kindFilteredRows])
+
+  // --- TanStack Table columns --------------------------------------------
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor('parentId', {
+        id: 'parentId',
+        header: 'Parent',
+        cell: ({ row }) => (
+          <span className="text-muted-foreground text-sm">
+            {row.original.parentLabel || row.original.parentId}
+          </span>
+        ),
+      }),
+      columnHelper.accessor('id', {
+        id: 'resourceId',
+        header: 'Resource ID',
+        cell: ({ getValue }) => (
+          <span className="font-mono text-muted-foreground text-sm">
+            {getValue()}
+          </span>
+        ),
+      }),
+      columnHelper.accessor(
+        (row) => row.displayName || row.name,
+        {
+          id: 'displayName',
+          header: 'Display Name',
+          cell: ({ row }) => {
+            const label = row.original.displayName || row.original.name
+            if (row.original.detailHref) {
+              return (
+                <a
+                  href={row.original.detailHref}
+                  className="font-medium hover:underline"
+                  title={row.original.name}
+                >
+                  {label}
+                </a>
+              )
+            }
+            return (
+              <span className="font-medium" title={row.original.name}>
+                {label}
+              </span>
+            )
+          },
+        },
+      ),
+      columnHelper.accessor('description', {
+        id: 'description',
+        header: 'Description',
+        cell: ({ getValue }) => (
+          <span
+            className="max-w-md truncate block text-muted-foreground text-sm"
+            title={getValue()}
+          >
+            {getValue()}
+          </span>
+        ),
+      }),
+      columnHelper.accessor('createdAt', {
+        id: 'createdAt',
+        header: 'Created At',
+        cell: ({ getValue }) => {
+          const raw = getValue()
+          try {
+            return (
+              <span className="text-muted-foreground text-sm whitespace-nowrap">
+                {new Date(raw).toLocaleDateString()}
+              </span>
+            )
+          } catch {
+            return <span className="text-muted-foreground text-sm">{raw}</span>
+          }
+        },
+      }),
+      // Actions column — no accessor, uses the full row
+      columnHelper.display({
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <div className="flex justify-end">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`delete ${row.original.displayName || row.original.name}`}
+              onClick={() => handleDeleteClick(row.original)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ),
+      }),
+    ],
+    [handleDeleteClick],
+  )
+
+  // --- TanStack Table instance -------------------------------------------
+
+  const table = useReactTable({
+    data: lineageFilteredRows,
+    columns,
+    state: { globalFilter, columnVisibility },
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: 'includesString',
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  })
+
+  // --- Loading skeleton --------------------------------------------------
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2" data-testid="resource-grid-loading">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // --- Error state (only when no rows available) -------------------------
+
+  if (error && rows.length === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // --- Determine New button behaviour ------------------------------------
+
+  const creatableKinds = kinds.filter((k) => k.canCreate && k.newHref)
+
+  // --- Render ------------------------------------------------------------
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <CardTitle>{title}</CardTitle>
+          <NewButton kinds={creatableKinds} />
+        </CardHeader>
+        <CardContent>
+          {/* Inline partial-error banner */}
+          {error && rows.length > 0 && (
+            <Alert
+              variant="destructive"
+              className="mb-4"
+              data-testid="resource-grid-partial-error"
+            >
+              <AlertDescription>{error.message}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Filter toolbar */}
+          <div className="mb-3 flex flex-col sm:flex-row gap-2 sm:items-center flex-wrap">
+            <Input
+              placeholder={`Search ${title.toLowerCase()}…`}
+              value={globalFilter}
+              onChange={(e) => setGlobalFilter(e.target.value)}
+              className="max-w-sm"
+              aria-label={`Search ${title}`}
+            />
+
+            {/* Multi-kind filter — only when more than one kind */}
+            {kinds.length > 1 && (
+              <KindFilter
+                kinds={kinds}
+                selectedKindIds={selectedKindIds}
+                onChange={setKindIds}
+              />
+            )}
+
+            {/* Lineage filter */}
+            <LineageFilterControl
+              direction={lineageDirection}
+              recursive={recursive}
+              onDirectionChange={setLineageDirection}
+              onRecursiveChange={setRecursive}
+            />
+          </div>
+
+          {/* Empty state */}
+          {rows.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <p className="text-muted-foreground">No resources found.</p>
+            </div>
+          ) : (
+            <>
+              {table.getRowModel().rows.length === 0 && (
+                <div className="mb-3 rounded-md border border-dashed border-border p-4 text-center">
+                  <p className="text-sm text-muted-foreground">
+                    No resources match the current filters.
+                  </p>
+                </div>
+              )}
+              <Table>
+                <TableHeader>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <TableHead key={header.id}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.map((row) => (
+                    <TableRow key={row.id}>
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDeleteDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null)
+        }}
+        displayName={deleteTarget?.displayName}
+        name={deleteTarget?.name ?? ''}
+        namespace={deleteTarget?.namespace ?? ''}
+        onConfirm={handleDeleteConfirm}
+        isDeleting={isDeleting}
+        error={deleteError}
+      />
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** "New" button — single link when one kind, dropdown when multiple. */
+function NewButton({ kinds }: { kinds: Kind[] }) {
+  if (kinds.length === 0) return null
+
+  if (kinds.length === 1) {
+    const kind = kinds[0]
+    return (
+      <Link to={kind.newHref!}>
+        <Button size="sm">New {kind.label}</Button>
+      </Link>
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm">
+          New <ChevronDown className="ml-1 h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {kinds.map((kind) => (
+          <DropdownMenuItem key={kind.id} asChild>
+            <Link to={kind.newHref!}>{kind.label}</Link>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/** Kind filter checkboxes — rendered only when kinds.length > 1. */
+function KindFilter({
+  kinds,
+  selectedKindIds,
+  onChange,
+}: {
+  kinds: Kind[]
+  selectedKindIds: string[]
+  onChange: (ids: string[]) => void
+}) {
+  const selectedSet = new Set(selectedKindIds)
+
+  const toggle = (id: string) => {
+    const next = new Set(selectedSet)
+    if (next.has(id)) {
+      next.delete(id)
+    } else {
+      next.add(id)
+    }
+    onChange(Array.from(next))
+  }
+
+  return (
+    <div
+      className="flex flex-wrap gap-2 items-center"
+      aria-label="Filter by kind"
+      data-testid="kind-filter"
+    >
+      {kinds.map((kind) => (
+        <div key={kind.id} className="flex items-center gap-1">
+          <Checkbox
+            id={`kind-${kind.id}`}
+            checked={selectedSet.size === 0 || selectedSet.has(kind.id)}
+            onCheckedChange={() => toggle(kind.id)}
+            aria-label={`Filter ${kind.label}`}
+          />
+          <Label htmlFor={`kind-${kind.id}`} className="text-sm cursor-pointer">
+            {kind.label}
+          </Label>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Lineage direction select + recursive checkbox. */
+function LineageFilterControl({
+  direction,
+  recursive,
+  onDirectionChange,
+  onRecursiveChange,
+}: {
+  direction: LineageDirection
+  recursive: boolean
+  onDirectionChange: (d: LineageDirection) => void
+  onRecursiveChange: (r: boolean) => void
+}) {
+  return (
+    <div
+      className="flex items-center gap-2"
+      aria-label="Lineage filter"
+      data-testid="lineage-filter"
+    >
+      <Select
+        value={direction}
+        onValueChange={(v) => onDirectionChange(v as LineageDirection)}
+      >
+        <SelectTrigger className="w-[160px]" aria-label="Lineage direction">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="ancestors">Ancestors</SelectItem>
+          <SelectItem value="descendants">Descendants</SelectItem>
+          <SelectItem value="both">Both</SelectItem>
+        </SelectContent>
+      </Select>
+      <div className="flex items-center gap-1">
+        <Checkbox
+          id="lineage-recursive"
+          checked={recursive}
+          onCheckedChange={(checked) => onRecursiveChange(checked === true)}
+          aria-label="Recursive lineage"
+          data-testid="lineage-recursive-checkbox"
+        />
+        <Label
+          htmlFor="lineage-recursive"
+          className="text-sm cursor-pointer"
+        >
+          Recursive
+        </Label>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/resource-grid/types.ts
+++ b/frontend/src/components/resource-grid/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Types for the ResourceGrid v1 component and its consumers.
+ *
+ * These types are exported so that later phases (Secrets, Deployments,
+ * Templates) can import them directly without re-declaring their own shapes.
+ */
+
+/**
+ * Describes a single resource kind the grid can display. When `canCreate` is
+ * true and `newHref` is provided, the grid renders a "New" button (or dropdown
+ * entry) that navigates to that href.
+ */
+export interface Kind {
+  /** Stable identifier used in URL ?kind= params and as a React key. */
+  id: string
+  /** Human-readable label shown in filter chips and dropdown entries. */
+  label: string
+  /** If provided, the "New" button links here. */
+  newHref?: string
+  /** Whether the current user may create resources of this kind. */
+  canCreate?: boolean
+}
+
+/**
+ * A single row in the ResourceGrid. The generic version lets callers attach
+ * extra data in `extra` for row-level actions without altering the grid API.
+ */
+export interface Row {
+  /** Must match a `Kind.id` entry passed to `kinds`. */
+  kind: string
+  /** Kubernetes resource name. */
+  name: string
+  /** Kubernetes namespace the resource lives in. */
+  namespace: string
+  /** Stable identifier for the resource (e.g. UID or compound key). */
+  id: string
+  /** Parent resource name / namespace — used by the lineage filter. */
+  parentId: string
+  /** Human-readable label for the parent (e.g. project or folder name). */
+  parentLabel: string
+  /** User-facing display name (falls back to `name` if empty). */
+  displayName: string
+  /** Short description shown in the truncated Description column. */
+  description: string
+  /** ISO-8601 creation timestamp string. */
+  createdAt: string
+  /** If provided, the display name links to this href. */
+  detailHref?: string
+}
+
+/**
+ * Lineage filter direction.  "ancestors" = rows whose parentId matches a
+ * parent of the active namespace; "descendants" = rows whose parentId is a
+ * child; "both" = union.
+ */
+export type LineageDirection = 'ancestors' | 'descendants' | 'both'
+
+/**
+ * Parsed representation of the URL lineage params.
+ */
+export interface LineageFilter {
+  direction: LineageDirection
+  recursive: boolean
+}
+
+/**
+ * The shape of the URL search params owned by the ResourceGrid.  Consumers
+ * extend this type in their route's `validateSearch` to merge grid params with
+ * any route-specific params.
+ */
+export interface ResourceGridSearch {
+  /** Comma-separated list of kind IDs to display. Empty = all. */
+  kind?: string
+  /** Global search string. */
+  search?: string
+  /** Lineage direction: "ancestors" | "descendants" | "both". */
+  lineage?: LineageDirection
+  /**
+   * Whether the lineage traversal is recursive.  "1" = true, "0" = false.
+   * We store as string so TanStack Router's `parseSearchWith` keeps it a
+   * simple literal without schema coercion.
+   */
+  recursive?: '0' | '1'
+}

--- a/frontend/src/components/resource-grid/url-state.ts
+++ b/frontend/src/components/resource-grid/url-state.ts
@@ -1,0 +1,92 @@
+/**
+ * url-state.ts — helpers for parsing and serialising the ResourceGrid's URL
+ * search params.
+ *
+ * Both the ResourceGrid component itself and each consumer route's
+ * `validateSearch` import from this module so the encoding is never
+ * duplicated.
+ */
+
+import type { LineageDirection, ResourceGridSearch } from './types'
+
+const VALID_LINEAGE_DIRECTIONS = new Set<string>([
+  'ancestors',
+  'descendants',
+  'both',
+])
+
+/**
+ * Parse an untrusted query-string object into a validated `ResourceGridSearch`.
+ * All fields are optional; unknown / invalid values fall back to the defaults
+ * documented below.
+ *
+ * Consumers call this from their route's `validateSearch`:
+ *
+ * ```ts
+ * import { parseGridSearch } from '@/components/resource-grid/url-state'
+ *
+ * export const Route = createFileRoute('...')({
+ *   validateSearch: parseGridSearch,
+ *   component: MyPage,
+ * })
+ * ```
+ */
+export function parseGridSearch(raw: Record<string, unknown>): ResourceGridSearch {
+  const result: ResourceGridSearch = {}
+
+  const kind = raw['kind']
+  if (typeof kind === 'string' && kind.length > 0) {
+    result.kind = kind
+  }
+
+  const search = raw['search']
+  if (typeof search === 'string' && search.length > 0) {
+    result.search = search
+  }
+
+  const lineage = raw['lineage']
+  if (typeof lineage === 'string' && VALID_LINEAGE_DIRECTIONS.has(lineage)) {
+    result.lineage = lineage as LineageDirection
+  }
+
+  const recursive = raw['recursive']
+  if (recursive === '1') {
+    result.recursive = '1'
+  } else if (recursive === '0') {
+    result.recursive = '0'
+  }
+  // Default (absent) → treated as '0' (non-recursive) by the grid.
+
+  return result
+}
+
+/**
+ * Serialise a `ResourceGridSearch` back to a plain object suitable for
+ * TanStack Router's `search` param (undefined fields are omitted, which
+ * removes them from the URL).
+ */
+export function serialiseGridSearch(
+  params: ResourceGridSearch,
+): Record<string, string | undefined> {
+  return {
+    kind: params.kind || undefined,
+    search: params.search || undefined,
+    lineage: params.lineage || undefined,
+    recursive: params.recursive,
+  }
+}
+
+/** Parse comma-separated kind IDs from the URL `?kind=` param. */
+export function parseKindIds(raw: string | undefined): string[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+/** Serialise an array of kind IDs to the `?kind=` param value. */
+export function serialiseKindIds(ids: string[]): string | undefined {
+  if (ids.length === 0) return undefined
+  return ids.join(',')
+}

--- a/frontend/src/components/ui/-confirm-delete-dialog.test.tsx
+++ b/frontend/src/components/ui/-confirm-delete-dialog.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+import { ConfirmDeleteDialog } from './confirm-delete-dialog'
+
+describe('ConfirmDeleteDialog', () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    name: 'my-secret',
+    namespace: 'project-billing',
+    onConfirm: vi.fn().mockResolvedValue(undefined),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders dialog with resource name and namespace', () => {
+    render(<ConfirmDeleteDialog {...defaultProps} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('my-secret')).toBeInTheDocument()
+    expect(screen.getByText('project-billing')).toBeInTheDocument()
+  })
+
+  it('renders displayName when provided', () => {
+    render(
+      <ConfirmDeleteDialog
+        {...defaultProps}
+        displayName="My Secret"
+      />,
+    )
+    expect(screen.getByText('My Secret')).toBeInTheDocument()
+  })
+
+  it('falls back to name when displayName is absent', () => {
+    render(<ConfirmDeleteDialog {...defaultProps} />)
+    // name "my-secret" should be displayed as the bold label
+    expect(screen.getByText('my-secret')).toBeInTheDocument()
+  })
+
+  it('does not render when open is false', () => {
+    render(<ConfirmDeleteDialog {...defaultProps} open={false} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('calls onConfirm when Delete button is clicked', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    render(<ConfirmDeleteDialog {...defaultProps} onConfirm={onConfirm} />)
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce())
+  })
+
+  it('calls onOpenChange(false) when Cancel is clicked', () => {
+    const onOpenChange = vi.fn()
+    render(
+      <ConfirmDeleteDialog {...defaultProps} onOpenChange={onOpenChange} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('disables buttons while isDeleting is true', () => {
+    render(<ConfirmDeleteDialog {...defaultProps} isDeleting={true} />)
+    expect(screen.getByRole('button', { name: /deleting/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+  })
+
+  it('renders Delete text when isDeleting is false', () => {
+    render(<ConfirmDeleteDialog {...defaultProps} isDeleting={false} />)
+    expect(
+      screen.getByRole('button', { name: /^delete$/i }),
+    ).not.toBeDisabled()
+  })
+
+  it('renders error alert when error prop is set', () => {
+    render(
+      <ConfirmDeleteDialog
+        {...defaultProps}
+        error={new Error('delete failed')}
+      />,
+    )
+    expect(screen.getByText('delete failed')).toBeInTheDocument()
+  })
+
+  it('does not render error alert when error is null', () => {
+    render(<ConfirmDeleteDialog {...defaultProps} error={null} />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/confirm-delete-dialog.tsx
+++ b/frontend/src/components/ui/confirm-delete-dialog.tsx
@@ -1,0 +1,91 @@
+/**
+ * ConfirmDeleteDialog — shared shadcn/ui Dialog for destructive deletes.
+ *
+ * Shows the resource name and namespace, then calls `onConfirm()` on Delete.
+ * The caller owns the `open` / `onOpenChange` state so multiple rows in a
+ * grid can share a single instance of this dialog.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+export interface ConfirmDeleteDialogProps {
+  /** Controls whether the dialog is open. */
+  open: boolean
+  /** Called when the dialog should close (cancel or after confirm). */
+  onOpenChange: (open: boolean) => void
+  /**
+   * Display name of the resource to delete (shown in the dialog body).
+   * Falls back to the `name` field if empty.
+   */
+  displayName?: string
+  /** Kubernetes resource name shown in the description. */
+  name: string
+  /** Kubernetes namespace shown in the description. */
+  namespace: string
+  /**
+   * Async function invoked when the user clicks Delete.
+   * The dialog stays open while this is in progress.
+   */
+  onConfirm: () => Promise<void>
+  /** Whether the delete mutation is currently in flight. */
+  isDeleting?: boolean
+  /** If set, renders a destructive alert inside the dialog. */
+  error?: Error | null
+}
+
+export function ConfirmDeleteDialog({
+  open,
+  onOpenChange,
+  displayName,
+  name,
+  namespace,
+  onConfirm,
+  isDeleting = false,
+  error,
+}: ConfirmDeleteDialogProps) {
+  const label = displayName || name
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Resource</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete <strong>{label}</strong> in
+            namespace <code>{namespace}</code>? This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        )}
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isDeleting}
+          >
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `frontend/src/components/resource-grid/types.ts` — `Kind`, `Row`, `LineageFilter`, `ResourceGridSearch` types exported for all downstream phases.
- Adds `frontend/src/components/resource-grid/url-state.ts` — `parseGridSearch` / `serialiseGridSearch` helpers so route `validateSearch` and the grid share identical URL encoding.
- Adds `frontend/src/components/resource-grid/ResourceGrid.tsx` — TanStack Table with global search (`includesString`), multi-kind filter (hidden when `kinds.length === 1`), lineage direction + recursive checkbox, New button/dropdown, row-level delete via `ConfirmDeleteDialog`, Parent ID column auto-hidden when exactly one parent, and URL sync via `search` / `onSearchChange` props.
- Adds `frontend/src/components/ui/confirm-delete-dialog.tsx` — shared shadcn/ui Dialog factored from the existing deployments delete pattern.
- Adds 26 unit tests for `ResourceGrid` and 10 unit tests for `ConfirmDeleteDialog`.

Fixes HOL-855

## Test plan

- [x] `make test-ui` — 87 test files, 1150 tests, all passing.
- [x] ResourceGrid tests cover: column hiding (one parent), multi-kind dropdown, lineage filter toggling, delete-confirm happy + cancel paths, URL sync on filter change, search filter, empty/error states.
- [x] ConfirmDeleteDialog tests cover: open/close, displayName fallback, isDeleting state, error alert, cancel flow.