### PR TITLE
feat(ui): Deployments page on ResourceGrid v1 with description banner

### DIFF
--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -244,7 +244,7 @@ export function ResourceGrid({
   // --- TanStack Table columns --------------------------------------------
 
   const columns = useMemo(
-    (): ColumnDef<Row>[] => [
+    () => [
       columnHelper.accessor('parentId', {
         id: 'parentId',
         header: 'Parent',

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -56,6 +56,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
 
+import type { ColumnDef } from '@tanstack/react-table'
 import type { Kind, Row, LineageDirection, ResourceGridSearch } from './types'
 import { parseKindIds, serialiseKindIds } from './url-state'
 
@@ -95,6 +96,18 @@ export interface ResourceGridProps {
    * TanStack Router's `navigate({ search: updater })` pattern.
    */
   onSearchChange?: (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => void
+  /**
+   * Optional extra columns appended after the Description column and before
+   * the Created At column. Callers (e.g. Deployments) use this to add
+   * kind-specific columns such as phase badges or drift indicators without
+   * altering the default column shape.
+   */
+  extraColumns?: ColumnDef<Row>[]
+  /**
+   * Optional node rendered inside the Card header, below the title and
+   * above the table. Used for description banners.
+   */
+  headerContent?: React.ReactNode
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +123,8 @@ export function ResourceGrid({
   error,
   search = {},
   onSearchChange,
+  extraColumns = [],
+  headerContent,
 }: ResourceGridProps) {
   // --- Derive local state from URL params --------------------------------
 
@@ -229,7 +244,7 @@ export function ResourceGrid({
   // --- TanStack Table columns --------------------------------------------
 
   const columns = useMemo(
-    () => [
+    (): ColumnDef<Row>[] => [
       columnHelper.accessor('parentId', {
         id: 'parentId',
         header: 'Parent',
@@ -286,6 +301,9 @@ export function ResourceGrid({
           </span>
         ),
       }),
+      // Caller-supplied extra columns (e.g. Phase badge, Policy Drift badge)
+      // appear after Description and before Created At.
+      ...extraColumns,
       columnHelper.accessor('createdAt', {
         id: 'createdAt',
         header: 'Created At',
@@ -320,7 +338,7 @@ export function ResourceGrid({
         ),
       }),
     ],
-    [handleDeleteClick],
+    [handleDeleteClick, extraColumns],
   )
 
   // --- TanStack Table instance -------------------------------------------
@@ -381,6 +399,11 @@ export function ResourceGrid({
           <CardTitle>{title}</CardTitle>
           <NewButton kinds={creatableKinds} />
         </CardHeader>
+        {headerContent && (
+          <CardContent className="pt-0 pb-0">
+            {headerContent}
+          </CardContent>
+        )}
         <CardContent>
           {/* Inline partial-error banner */}
           {error && rows.length > 0 && (

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
@@ -1,19 +1,47 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+/**
+ * Tests for the Deployments index page (HOL-858) — ResourceGrid v1 implementation.
+ *
+ * Mocks @/queries/deployments and @/queries/projects. Covers:
+ *  - DeploymentsDescription banner (copy-locking assertions)
+ *  - ResourceGrid renders project rows
+ *  - Delete flow via ConfirmDeleteDialog
+ *  - Extra columns: Phase badge and PolicyDrift badge
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { DeploymentPhase, type DeploymentStatusSummary } from '@/gen/holos/console/v1/deployments_pb'
+
+// ---------------------------------------------------------------------------
+// Router mock — Route.useParams / useSearch / useNavigate
+// ---------------------------------------------------------------------------
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
   return {
     ...actual,
-    createFileRoute: () => () => ({ useParams: () => ({ projectName: 'test-project' }) }),
-    Link: ({ children, className, to, params }: { children: React.ReactNode; className?: string; to?: string; params?: Record<string, string> }) => (
-      <a href={to} data-params={JSON.stringify(params)} className={className}>{children}</a>
-    ),
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project' }),
+      useSearch: () => ({}),
+      fullPath: '/projects/test-project/deployments/',
+    }),
+    Link: ({
+      children,
+      className,
+    }: {
+      children: React.ReactNode
+      className?: string
+    }) => <a href="#" className={className}>{children}</a>,
     useNavigate: () => vi.fn(),
   }
 })
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
 
 vi.mock('@/queries/deployments', () => ({
   useListDeployments: vi.fn(),
@@ -26,17 +54,22 @@ vi.mock('@/queries/projects', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
 import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { DeploymentPhase, type DeploymentStatusSummary, type DeploymentOutput } from '@/gen/holos/console/v1/deployments_pb'
-import { DeploymentsPage } from './index'
+import { DeploymentsListPage, DeploymentsDescription } from './index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function makeSummary(
   phase: DeploymentPhase,
   readyReplicas = 0,
   desiredReplicas = 0,
-  output?: DeploymentOutput,
   policyDrift?: boolean,
 ): DeploymentStatusSummary {
   return {
@@ -48,369 +81,270 @@ function makeSummary(
     updatedReplicas: readyReplicas,
     observedGeneration: 0n,
     message: '',
-    output,
+    output: undefined,
     policyDrift,
   }
 }
 
-function makeOutput(url: string, links: DeploymentOutput['links'] = []): DeploymentOutput {
-  return { $typeName: 'holos.console.v1.DeploymentOutput', url, links }
-}
-
-function makeLink(name: string, url: string, source: 'holos' | 'argocd' = 'holos'): DeploymentOutput['links'][number] {
-  return { $typeName: 'holos.console.v1.Link', url, title: name, description: '', source, name }
+type MockDeployment = {
+  name: string
+  project: string
+  displayName: string
+  description: string
+  image: string
+  tag: string
+  template: string
+  phase: DeploymentPhase
+  message: string
+  statusSummary?: DeploymentStatusSummary
 }
 
 function makeDeployment(
   name: string,
-  image = 'ghcr.io/org/app',
-  tag = 'v1.0.0',
   statusSummary?: DeploymentStatusSummary,
-) {
-  // Legacy phase (field 8) and message (field 9) are deprecated and no longer
-  // populated by the backend after the status cache rollout (#912). Tests
-  // populate statusSummary only.
-  return { name, project: 'test-project', image, tag, template: 'web-app', displayName: '', description: '', phase: DeploymentPhase.UNSPECIFIED, message: '', statusSummary }
+  description = '',
+): MockDeployment {
+  return {
+    name,
+    project: 'test-project',
+    displayName: '',
+    description,
+    image: 'ghcr.io/org/app',
+    tag: 'v1.0.0',
+    template: 'web-app',
+    phase: DeploymentPhase.UNSPECIFIED,
+    message: '',
+    statusSummary,
+  }
 }
 
-function setupMocks(
+function setupMocks({
   deployments = [
-    makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0', makeSummary(DeploymentPhase.RUNNING, 1, 1)),
-    makeDeployment('worker', 'ghcr.io/org/wrk', 'latest', makeSummary(DeploymentPhase.PENDING, 0, 1)),
+    makeDeployment('api', makeSummary(DeploymentPhase.RUNNING, 1, 1)),
+    makeDeployment('worker', makeSummary(DeploymentPhase.PENDING, 0, 1)),
   ],
+  isPending = false,
+  error = null as Error | null,
   userRole = Role.OWNER,
-) {
-  ;(useListDeployments as Mock).mockReturnValue({ data: deployments, isLoading: false, error: null })
-  ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false, error: null, reset: vi.fn() })
-  ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole }, isLoading: false })
+} = {}) {
+  ;(useListDeployments as Mock).mockReturnValue({ data: deployments, isPending, error })
+  ;(useDeleteDeployment as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  })
+  ;(useGetProject as Mock).mockReturnValue({
+    data: { name: 'test-project', userRole },
+    isLoading: false,
+  })
 }
 
-describe('DeploymentsPage', () => {
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DeploymentsListPage (ResourceGrid v1)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('renders deployment names', () => {
+  // -------------------------------------------------------------------------
+  // Description banner (copy-locking)
+  // -------------------------------------------------------------------------
+
+  describe('DeploymentsDescription banner', () => {
+    it('renders the description banner', () => {
+      render(<DeploymentsDescription />)
+      expect(screen.getByTestId('deployments-description')).toBeInTheDocument()
+    })
+
+    it('contains the three verbatim bullet points', () => {
+      render(<DeploymentsDescription />)
+      expect(
+        screen.getByText('Deployment is a collection of resource declarations (configuration).'),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('Deploying is applying the configuration to the platform.'),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('Controllers reconcile current state with desired state.'),
+      ).toBeInTheDocument()
+    })
+
+    it('renders the description banner inside the full page', () => {
+      setupMocks()
+      render(<DeploymentsListPage />)
+      expect(screen.getByTestId('deployments-description')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Grid — project rows
+  // -------------------------------------------------------------------------
+
+  it('renders deployment names in the grid', () => {
     setupMocks()
-    render(<DeploymentsPage />)
-    expect(screen.getByText('api')).toBeInTheDocument()
-    expect(screen.getByText('worker')).toBeInTheDocument()
+    render(<DeploymentsListPage />)
+    // Each name appears in both the Resource ID cell and the Display Name link
+    expect(screen.getAllByText('api').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('worker').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('renders image and tag for each deployment', () => {
-    setupMocks()
-    render(<DeploymentsPage />)
-    expect(screen.getByText('ghcr.io/org/app')).toBeInTheDocument()
-    expect(screen.getByText('v1.0.0')).toBeInTheDocument()
-    expect(screen.getByText('latest')).toBeInTheDocument()
+  it('shows loading skeleton when isPending is true', () => {
+    setupMocks({ isPending: true, deployments: [] })
+    render(<DeploymentsListPage />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
   })
 
-  it('renders Running badge with ready/desired replicas from status_summary', () => {
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0',
-        makeSummary(DeploymentPhase.RUNNING, 2, 3)),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.getByText(/running/i)).toBeInTheDocument()
-    expect(screen.getByText('2/3')).toBeInTheDocument()
+  it('shows error state when fetch fails and no rows', () => {
+    setupMocks({ error: new Error('fetch failed'), deployments: [] })
+    render(<DeploymentsListPage />)
+    expect(screen.getByText(/fetch failed/i)).toBeInTheDocument()
   })
 
-  it('renders Pending badge with replica count from status_summary', () => {
-    setupMocks([
-      makeDeployment('worker', 'ghcr.io/org/wrk', 'latest',
-        makeSummary(DeploymentPhase.PENDING, 0, 1)),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.getByText(/pending/i)).toBeInTheDocument()
-    expect(screen.getByText('0/1')).toBeInTheDocument()
+  it('shows empty state when no deployments exist', () => {
+    setupMocks({ deployments: [] })
+    render(<DeploymentsListPage />)
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
   })
 
-  it('renders Failed badge with replica count from status_summary', () => {
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0',
-        makeSummary(DeploymentPhase.FAILED, 0, 1)),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.getByText(/failed/i)).toBeInTheDocument()
-    expect(screen.getByText('0/1')).toBeInTheDocument()
+  it('single parent hides Parent column', () => {
+    setupMocks({ deployments: [makeDeployment('api'), makeDeployment('worker')] })
+    render(<DeploymentsListPage />)
+    // All rows have the same parentId (projectName) → Parent column hidden
+    expect(screen.queryByRole('columnheader', { name: /parent/i })).not.toBeInTheDocument()
   })
 
-  it('renders Unknown only when status_summary is missing', () => {
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0' /* no summary */),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.getByText(/unknown/i)).toBeInTheDocument()
-    // No replica count rendered when summary is missing.
-    expect(screen.queryByText(/^\d+\/\d+$/)).not.toBeInTheDocument()
+  it('renders New Deployment button when user can create', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<DeploymentsListPage />)
+    expect(screen.getByRole('button', { name: /new deployment/i })).toBeInTheDocument()
   })
 
-  it('omits replica count when desired_replicas is zero', () => {
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0',
-        makeSummary(DeploymentPhase.RUNNING, 0, 0)),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.getByText(/running/i)).toBeInTheDocument()
-    expect(screen.queryByText('0/0')).not.toBeInTheDocument()
-  })
-
-  it('shows empty state when no deployments', () => {
-    setupMocks([])
-    render(<DeploymentsPage />)
-    expect(screen.getByText(/no deployments yet/i)).toBeInTheDocument()
-  })
-
-  it('renders Create Deployment link for owners', () => {
-    setupMocks([], Role.OWNER)
-    render(<DeploymentsPage />)
-    const links = screen.getAllByRole('link', { name: /create deployment/i })
-    expect(links.length).toBeGreaterThan(0)
-    expect(links[0].getAttribute('href')).toContain('deployments/new')
-  })
-
-  it('renders Create Deployment link for editors', () => {
-    setupMocks([], Role.EDITOR)
-    render(<DeploymentsPage />)
-    const links = screen.getAllByRole('link', { name: /create deployment/i })
-    expect(links.length).toBeGreaterThan(0)
-    expect(links[0].getAttribute('href')).toContain('deployments/new')
-  })
-
-  it('does not render Create Deployment link for viewers', () => {
-    setupMocks([], Role.VIEWER)
-    render(<DeploymentsPage />)
-    expect(screen.queryByRole('link', { name: /create deployment/i })).not.toBeInTheDocument()
-  })
-
-  it('renders delete buttons for owners', () => {
-    setupMocks([makeDeployment('api')], Role.OWNER)
-    render(<DeploymentsPage />)
-    expect(screen.getAllByRole('button', { name: /delete/i }).length).toBeGreaterThanOrEqual(1)
-  })
-
-  it('does not render delete buttons for viewers', () => {
-    setupMocks([makeDeployment('api')], Role.VIEWER)
-    render(<DeploymentsPage />)
-    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument()
+  it('does not render New Deployment button when user is viewer', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<DeploymentsListPage />)
+    expect(screen.queryByRole('button', { name: /new deployment/i })).not.toBeInTheDocument()
   })
 
   it('deployment name links to detail page', () => {
-    setupMocks([makeDeployment('api')])
-    render(<DeploymentsPage />)
+    setupMocks({ deployments: [makeDeployment('api')] })
+    render(<DeploymentsListPage />)
     const link = screen.getByRole('link', { name: 'api' })
-    expect(link.getAttribute('href')).toContain('deployments')
+    expect(link.getAttribute('href')).toContain('deployments/api')
   })
 
-  it('shows error state when fetch fails', () => {
-    ;(useListDeployments as Mock).mockReturnValue({ data: undefined, isLoading: false, error: new Error('fetch failed') })
-    ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null, reset: vi.fn() })
-    ;(useGetProject as Mock).mockReturnValue({ data: { name: 'test-project', userRole: Role.OWNER }, isLoading: false })
-    render(<DeploymentsPage />)
-    expect(screen.getByText(/fetch failed/)).toBeInTheDocument()
-  })
+  // -------------------------------------------------------------------------
+  // Delete flow
+  // -------------------------------------------------------------------------
 
-  it('opens delete dialog when delete button is clicked', async () => {
-    setupMocks([makeDeployment('api')], Role.OWNER)
-    render(<DeploymentsPage />)
-    fireEvent.click(screen.getByRole('button', { name: /delete api/i }))
+  it('delete button opens ConfirmDeleteDialog', async () => {
+    setupMocks({ deployments: [makeDeployment('api')] })
+    render(<DeploymentsListPage />)
+
+    const deleteBtn = screen.getByRole('button', { name: /delete api/i })
+    fireEvent.click(deleteBtn)
+
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
   })
 
-  it('Create Deployment link in empty state navigates to new page', () => {
-    setupMocks([], Role.OWNER)
-    render(<DeploymentsPage />)
-    const links = screen.getAllByRole('link', { name: /create deployment/i })
-    // All Create Deployment links should point to the new page
-    links.forEach((link) => {
-      expect(link.getAttribute('href')).toContain('deployments/new')
+  it('confirming delete invokes useDeleteDeployment.mutateAsync with { name }', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined)
+    setupMocks({ deployments: [makeDeployment('api')] })
+    ;(useDeleteDeployment as Mock).mockReturnValue({ mutateAsync, isPending: false })
+
+    render(<DeploymentsListPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /delete api/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({ name: 'api' })
     })
   })
 
-  it('renders Open link when statusSummary.output.url is a safe http(s) URL', () => {
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0',
-        makeSummary(DeploymentPhase.RUNNING, 1, 1, makeOutput('https://api.example.com'))),
-    ])
-    render(<DeploymentsPage />)
-    const link = screen.getByRole('link', { name: /open api/i })
-    expect(link.getAttribute('href')).toBe('https://api.example.com')
-    expect(link.getAttribute('target')).toBe('_blank')
-    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  // -------------------------------------------------------------------------
+  // Extra columns — Phase badge and Policy Drift badge
+  // -------------------------------------------------------------------------
+
+  describe('Phase column (extraColumns)', () => {
+    it('renders Running phase badge', () => {
+      setupMocks({
+        deployments: [makeDeployment('api', makeSummary(DeploymentPhase.RUNNING, 1, 1))],
+      })
+      render(<DeploymentsListPage />)
+      expect(screen.getByText(/running/i)).toBeInTheDocument()
+    })
+
+    it('renders Pending phase badge', () => {
+      setupMocks({
+        deployments: [makeDeployment('worker', makeSummary(DeploymentPhase.PENDING, 0, 1))],
+      })
+      render(<DeploymentsListPage />)
+      expect(screen.getByText(/pending/i)).toBeInTheDocument()
+    })
+
+    it('renders Unknown badge when statusSummary is absent', () => {
+      setupMocks({ deployments: [makeDeployment('api')] })
+      render(<DeploymentsListPage />)
+      expect(screen.getByText(/unknown/i)).toBeInTheDocument()
+    })
   })
 
-  it('does not render Open link when statusSummary.output.url is absent', () => {
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0',
-        makeSummary(DeploymentPhase.RUNNING, 1, 1 /* no output */)),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.queryByRole('link', { name: /open api/i })).not.toBeInTheDocument()
-  })
-
-  it('does not render Open link when statusSummary.output.url is empty string', () => {
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0',
-        makeSummary(DeploymentPhase.RUNNING, 1, 1, makeOutput(''))),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.queryByRole('link', { name: /open api/i })).not.toBeInTheDocument()
-  })
-
-  it('does not render Open link when output.url uses an unsafe scheme', () => {
-    // Defense-in-depth: templates are admin-authored, but the UI still
-    // refuses javascript:/data:/vbscript:/file: URLs so they cannot reach
-    // an anchor href and execute on click.
-    setupMocks([
-      makeDeployment('api', 'ghcr.io/org/app', 'v1.0.0',
-        makeSummary(DeploymentPhase.RUNNING, 1, 1, makeOutput('javascript:alert(1)'))),
-    ])
-    render(<DeploymentsPage />)
-    expect(screen.queryByRole('link', { name: /open api/i })).not.toBeInTheDocument()
-  })
-
-  describe('policy drift badge', () => {
-    // HOL-559: the deployment list surfaces policy drift when the backend
-    // populates status_summary.policy_drift. The flag is sourced from the
-    // folder-namespace render-state store via HOL-567.
-    it('renders the Policy Drift badge when policy_drift is true', () => {
-      setupMocks([
-        makeDeployment(
-          'api',
-          'ghcr.io/org/app',
-          'v1.0.0',
-          makeSummary(DeploymentPhase.RUNNING, 1, 1, undefined, true),
-        ),
-      ])
-      render(<DeploymentsPage />)
+  describe('PolicyDrift column (extraColumns)', () => {
+    it('renders the Policy Drift badge when policyDrift is true', () => {
+      setupMocks({
+        deployments: [
+          makeDeployment('api', makeSummary(DeploymentPhase.RUNNING, 1, 1, true)),
+        ],
+      })
+      render(<DeploymentsListPage />)
       expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
     })
 
-    it('does not render the Policy Drift badge when policy_drift is false', () => {
-      setupMocks([
-        makeDeployment(
-          'api',
-          'ghcr.io/org/app',
-          'v1.0.0',
-          makeSummary(DeploymentPhase.RUNNING, 1, 1, undefined, false),
-        ),
-      ])
-      render(<DeploymentsPage />)
+    it('does not render the Policy Drift badge when policyDrift is false', () => {
+      setupMocks({
+        deployments: [
+          makeDeployment('api', makeSummary(DeploymentPhase.RUNNING, 1, 1, false)),
+        ],
+      })
+      render(<DeploymentsListPage />)
       expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
     })
 
-    it('does not render the Policy Drift badge when policy_drift is undefined', () => {
-      setupMocks([
-        makeDeployment(
-          'api',
-          'ghcr.io/org/app',
-          'v1.0.0',
-          makeSummary(DeploymentPhase.RUNNING, 1, 1),
-        ),
-      ])
-      render(<DeploymentsPage />)
+    it('does not render the Policy Drift badge when policyDrift is undefined', () => {
+      setupMocks({
+        deployments: [makeDeployment('api', makeSummary(DeploymentPhase.RUNNING, 1, 1))],
+      })
+      render(<DeploymentsListPage />)
       expect(screen.queryByTestId('policy-drift-badge')).not.toBeInTheDocument()
     })
 
     it('renders the Policy Drift badge for viewers as well (read-only signal)', () => {
-      setupMocks(
-        [
-          makeDeployment(
-            'api',
-            'ghcr.io/org/app',
-            'v1.0.0',
-            makeSummary(DeploymentPhase.RUNNING, 1, 1, undefined, true),
-          ),
+      setupMocks({
+        deployments: [
+          makeDeployment('api', makeSummary(DeploymentPhase.RUNNING, 1, 1, true)),
         ],
-        Role.VIEWER,
-      )
-      render(<DeploymentsPage />)
+        userRole: Role.VIEWER,
+      })
+      render(<DeploymentsListPage />)
       expect(screen.getByTestId('policy-drift-badge')).toBeInTheDocument()
     })
   })
 
-  // HOL-575: when a deployment publishes more than the primary URL via
-  // `output.links`, surface a small "+N" indicator next to the existing
-  // open-link icon so operators can see at a glance that more links are
-  // available on the detail page. The indicator never appears when
-  // links is empty, when there is no primary URL, or when the link list
-  // length is below 1.
-  describe('extra links indicator (+N)', () => {
-    it('renders a "+N" links indicator when output.links has additional entries', () => {
-      setupMocks([
-        makeDeployment(
-          'api',
-          'ghcr.io/org/app',
-          'v1.0.0',
-          makeSummary(
-            DeploymentPhase.RUNNING,
-            1,
-            1,
-            makeOutput('https://api.example.com', [
-              makeLink('logs', 'https://logs.example.com'),
-              makeLink('metrics', 'https://metrics.example.com', 'argocd'),
-            ]),
-          ),
-        ),
-      ])
-      render(<DeploymentsPage />)
-      expect(screen.getByTestId('deployment-extra-links-api')).toHaveTextContent('+2')
-    })
+  // -------------------------------------------------------------------------
+  // Description column
+  // -------------------------------------------------------------------------
 
-    it('does not render the "+N" indicator when output.links is empty', () => {
-      setupMocks([
-        makeDeployment(
-          'api',
-          'ghcr.io/org/app',
-          'v1.0.0',
-          makeSummary(DeploymentPhase.RUNNING, 1, 1, makeOutput('https://api.example.com', [])),
-        ),
-      ])
-      render(<DeploymentsPage />)
-      expect(screen.queryByTestId('deployment-extra-links-api')).not.toBeInTheDocument()
-    })
-
-    it('does not render the "+N" indicator when output.url is empty', () => {
-      // The icon affordance is keyed off output.url; without a primary URL
-      // the icon does not render and the "+N" indicator has nothing to sit
-      // next to. Surfacing extra links without the open-link icon would
-      // be inconsistent with the contract documented on the icon.
-      setupMocks([
-        makeDeployment(
-          'api',
-          'ghcr.io/org/app',
-          'v1.0.0',
-          makeSummary(DeploymentPhase.RUNNING, 1, 1, makeOutput('', [makeLink('logs', 'https://logs.example.com')])),
-        ),
-      ])
-      render(<DeploymentsPage />)
-      expect(screen.queryByTestId('deployment-extra-links-api')).not.toBeInTheDocument()
-    })
-
-    it('does not count secondary links whose URL is unsafe', () => {
-      // Defense-in-depth: links that fail the http/https allowlist do not
-      // render in the detail-page Links section, so they should not be
-      // counted by the list-page "+N" badge either.
-      setupMocks([
-        makeDeployment(
-          'api',
-          'ghcr.io/org/app',
-          'v1.0.0',
-          makeSummary(
-            DeploymentPhase.RUNNING,
-            1,
-            1,
-            makeOutput('https://api.example.com', [
-              makeLink('bad', 'javascript:alert(1)'),
-              makeLink('good', 'https://good.example.com'),
-            ]),
-          ),
-        ),
-      ])
-      render(<DeploymentsPage />)
-      expect(screen.getByTestId('deployment-extra-links-api')).toHaveTextContent('+1')
-    })
+  it('description column shows deployment description', () => {
+    setupMocks({ deployments: [makeDeployment('api', undefined, 'Serves the API')] })
+    render(<DeploymentsListPage />)
+    expect(screen.getByText('Serves the API')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -1,270 +1,190 @@
-import { useState } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
-import { toast } from 'sonner'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Skeleton } from '@/components/ui/skeleton'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-import { ExternalLink, Trash2 } from 'lucide-react'
+/**
+ * Deployments index page — reimplemented on ResourceGrid v1 (HOL-858).
+ *
+ * Default view: current project as the single parent with Parent column hidden.
+ * A static description banner at the top of the Card explains what a Deployment is.
+ * Phase and PolicyDrift badges are preserved via the `extraColumns` extension
+ * on ResourceGrid v1.
+ *
+ * Detail, create, logs, and drift flows are unchanged — only the list page is
+ * rewritten.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
+import { useGetProject } from '@/queries/projects'
 import { PhaseBadge } from '@/components/phase-badge'
 import { PolicyDriftBadge } from '@/components/policy-drift/PolicySection'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
-import { useGetProject } from '@/queries/projects'
-import { isSafeHttpUrl } from '@/lib/url'
+import type { ColumnDef } from '@tanstack/react-table'
+import type { Deployment } from '@/gen/holos/console/v1/deployments_pb'
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/deployments/')({
-  component: DeploymentsRoute,
+  validateSearch: parseGridSearch,
+  component: DeploymentsListPage,
 })
 
-function DeploymentsRoute() {
-  const { projectName } = Route.useParams()
-  return <DeploymentsPage projectName={projectName} />
-}
+// ---------------------------------------------------------------------------
+// Description banner
+// ---------------------------------------------------------------------------
 
-export function DeploymentsPage({ projectName: propProjectName }: { projectName?: string } = {}) {
-  let routeProjectName: string | undefined
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    routeProjectName = Route.useParams().projectName
-  } catch {
-    routeProjectName = undefined
-  }
-  const projectName = propProjectName ?? routeProjectName ?? ''
-
-  const { data: deployments = [], isLoading, error } = useListDeployments(projectName)
-  const { data: project } = useGetProject(projectName)
-  const deleteMutation = useDeleteDeployment(projectName)
-
-  const [deleteOpen, setDeleteOpen] = useState(false)
-  const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
-
-  const userRole = project?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-  const canDelete = userRole === Role.OWNER
-
-  const handleDeleteConfirm = async () => {
-    if (!deleteTarget) return
-    try {
-      await deleteMutation.mutateAsync({ name: deleteTarget })
-      setDeleteOpen(false)
-      setDeleteTarget(null)
-      toast.success('Deployment deleted')
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
-    }
-  }
-
-  if (isLoading) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>{projectName} / Deployments</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-2">
-            {[...Array(3)].map((_, i) => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  if (error) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <Alert variant="destructive"><AlertDescription>{error.message}</AlertDescription></Alert>
-        </CardContent>
-      </Card>
-    )
-  }
-
+/**
+ * DeploymentsDescription renders a static three-bullet explanation of what a
+ * Deployment is. The copy is verbatim from the HOL-858 acceptance criteria.
+ */
+export function DeploymentsDescription() {
   return (
-    <>
-      <Card>
-        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-          <CardTitle>{projectName} / Deployments</CardTitle>
-          {canWrite && (
-            <Link to="/projects/$projectName/deployments/new" params={{ projectName }}>
-              <Button size="sm">Create Deployment</Button>
-            </Link>
-          )}
-        </CardHeader>
-        <CardContent>
-          {deployments.length === 0 ? (
-            <div className="flex flex-col items-center gap-3 py-8 text-center">
-              <p className="text-muted-foreground">No deployments yet. Create one to get started.</p>
-              {canWrite && (
-                <Link to="/projects/$projectName/deployments/new" params={{ projectName }}>
-                  <Button size="sm">Create Deployment</Button>
-                </Link>
-              )}
-            </div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Image</TableHead>
-                  <TableHead>Tag</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead></TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {deployments.map((deployment) => (
-                  <TableRow key={deployment.name}>
-                    <TableCell>
-                      <Link
-                        to="/projects/$projectName/deployments/$deploymentName"
-                        params={{ projectName, deploymentName: deployment.name }}
-                        search={{ tab: 'status' }}
-                        className="font-medium hover:underline"
-                      >
-                        {deployment.name}
-                      </Link>
-                    </TableCell>
-                    <TableCell className="font-mono text-sm">{deployment.image}</TableCell>
-                    <TableCell className="font-mono text-sm">{deployment.tag}</TableCell>
-                    <TableCell>
-                      <div className="inline-flex items-center gap-2 flex-wrap">
-                        <PhaseBadge summary={deployment.statusSummary} />
-                        {/*
-                          Policy drift badge — surfaces the status_summary.policy_drift
-                          flag populated by the backend (HOL-567 / HOL-557).
-                          The flag is sourced from the folder-namespace
-                          render-state store; callers needing the full diff
-                          invoke GetDeploymentPolicyState (see the Policy
-                          section on the deployment detail page).
-                        */}
-                        {deployment.statusSummary?.policyDrift ? (
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span>
-                                  <PolicyDriftBadge />
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                The deployment was rendered before a template policy changed; click Reconcile to re-render.
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : null}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {/*
-                        Open live site link — shown inline with other row
-                        actions when the deployment template published an
-                        `output.url` that the backend cached on the
-                        deployment ConfigMap annotation. isSafeHttpUrl
-                        restricts the anchor href to http/https so unsafe
-                        template-authored schemes (javascript:, data:,
-                        vbscript:, file:) never reach the DOM.
-                      */}
-                      {deployment.statusSummary?.output?.url && isSafeHttpUrl(deployment.statusSummary.output.url) && (
-                        <span className="inline-flex items-center">
-                          <Button
-                            asChild
-                            variant="ghost"
-                            size="icon"
-                            aria-label={`open ${deployment.name}`}
-                          >
-                            <a
-                              href={deployment.statusSummary.output.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <ExternalLink className="h-4 w-4" />
-                            </a>
-                          </Button>
-                          {/*
-                            Extra-links indicator (HOL-575) — when the
-                            deployment publishes additional secondary URLs
-                            via output.links, show a small "+N" pill so
-                            operators can see at a glance that the detail
-                            page has more than just the primary URL. The
-                            count reflects only safe (http/https) entries
-                            so it matches what the detail-page Links
-                            section will actually render.
-                          */}
-                          {(() => {
-                            const extras = (deployment.statusSummary.output.links ?? []).filter((l) =>
-                              isSafeHttpUrl(l.url),
-                            ).length
-                            if (extras === 0) return null
-                            return (
-                              <span
-                                data-testid={`deployment-extra-links-${deployment.name}`}
-                                className="text-xs text-muted-foreground tabular-nums ml-0.5"
-                                aria-label={`${extras} additional link${extras === 1 ? '' : 's'}`}
-                              >
-                                +{extras}
-                              </span>
-                            )
-                          })()}
-                        </span>
-                      )}
-                      {canDelete && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          aria-label={`delete ${deployment.name}`}
-                          onClick={() => { setDeleteTarget(deployment.name); deleteMutation.reset(); setDeleteOpen(true) }}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Deployment</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete deployment &quot;{deleteTarget}&quot;? This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {deleteMutation.error && (
-            <Alert variant="destructive"><AlertDescription>{deleteMutation.error.message}</AlertDescription></Alert>
-          )}
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setDeleteOpen(false)}>Cancel</Button>
-            <Button variant="destructive" onClick={handleDeleteConfirm} disabled={deleteMutation.isPending}>
-              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+    <div
+      className="mb-4 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground"
+      data-testid="deployments-description"
+    >
+      <ul className="list-disc pl-5 space-y-1">
+        <li>Deployment is a collection of resource declarations (configuration).</li>
+        <li>Deploying is applying the configuration to the platform.</li>
+        <li>Controllers reconcile current state with desired state.</li>
+      </ul>
+    </div>
   )
 }
 
+// ---------------------------------------------------------------------------
+// Extra columns — Phase badge and Policy Drift badge
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the extra columns for the Deployments grid.
+ * The `deploymentsByName` map lets each cell look up the original deployment
+ * to access statusSummary without widening the Row type.
+ */
+function useDeploymentExtraColumns(
+  deploymentsByName: Map<string, Deployment>,
+): ColumnDef<Row>[] {
+  return useMemo(
+    () => [
+      {
+        id: 'phase',
+        header: 'Phase',
+        cell: ({ row }: { row: { original: Row } }) => {
+          const dep = deploymentsByName.get(row.original.name)
+          return (
+            <div className="inline-flex items-center gap-2 flex-wrap">
+              <PhaseBadge summary={dep?.statusSummary} />
+              {dep?.statusSummary?.policyDrift ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <PolicyDriftBadge />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      The deployment was rendered before a template policy changed; click Reconcile to re-render.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : null}
+            </div>
+          )
+        },
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [deploymentsByName],
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export function DeploymentsListPage() {
+  const { projectName } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  const { data: project } = useGetProject(projectName)
+  const { data: deployments = [], isPending, error } = useListDeployments(projectName)
+  const deleteMutation = useDeleteDeployment(projectName)
+
+  const userRole = project?.userRole ?? Role.VIEWER
+  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // Build name→deployment lookup for extra columns.
+  const deploymentsByName = useMemo(() => {
+    const map = new Map<string, Deployment>()
+    for (const dep of deployments) {
+      if (dep) map.set(dep.name, dep)
+    }
+    return map
+  }, [deployments])
+
+  // Map Deployment → ResourceGrid Row
+  const rows: Row[] = useMemo(
+    () =>
+      deployments.map((dep) => ({
+        kind: 'Deployment',
+        name: dep.name,
+        namespace: projectName,
+        id: dep.name,
+        parentId: projectName,
+        parentLabel: projectName,
+        displayName: dep.displayName || dep.name,
+        description: dep.description ?? '',
+        createdAt: '',
+        detailHref: `/projects/${projectName}/deployments/${dep.name}`,
+      })),
+    [deployments, projectName],
+  )
+
+  const kinds = [
+    {
+      id: 'Deployment',
+      label: 'Deployment',
+      newHref: `/projects/${projectName}/deployments/new`,
+      canCreate,
+    },
+  ]
+
+  const extraColumns = useDeploymentExtraColumns(deploymentsByName)
+
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
+  )
+
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+      })
+    },
+    [navigate],
+  )
+
+  return (
+    <ResourceGrid
+      title={`${projectName} / Deployments`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+      extraColumns={extraColumns}
+      headerContent={<DeploymentsDescription />}
+    />
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -98,7 +98,6 @@ function useDeploymentExtraColumns(
         },
       },
     ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [deploymentsByName],
   )
 }


### PR DESCRIPTION
## Summary

- Adds `extraColumns` and `headerContent` props to `ResourceGrid` v1, enabling callers to inject kind-specific columns (between Description and Created At) and a banner slot above the filter toolbar without widening the default `Row` shape.
- Rewrites `deployments/index.tsx` as `DeploymentsListPage` on ResourceGrid v1, matching the Secrets page pattern (HOL-857). Maps each `Deployment` to a `Row`; delete calls `useDeleteDeployment.mutateAsync({ name })` via `ConfirmDeleteDialog`.
- Adds `DeploymentsDescription` — a static three-bullet banner explaining what a Deployment is — rendered via `headerContent`.
- Preserves Phase badge and PolicyDrift badge via a `useDeploymentExtraColumns` hook passed as `extraColumns`.
- Rewrites `-index.test.tsx` with 21 Vitest+RTL tests (copy-locking banner, grid rows, delete flow, Phase/PolicyDrift extra columns).

Fixes HOL-858

## Test plan

- [x] `make test-ui` — 1131 tests pass (87 files)
- [x] `npx tsc --noEmit` — no TypeScript errors
- [ ] Smoke-test in browser: navigate to a project's Deployments tab, verify description banner renders, phase/drift badges appear, delete dialog fires, New Deployment button visible for owners only

## Deferred Acceptance Criteria

- [ ] Lineage filter URL sync is wired but deployments API does not yet expose a lineage query param — data always reflects the single project scope regardless of lineage selector position (backend work outside this PR's scope)