### PR TITLE
feat(ui): Templates help pane toggled by ? icon

### DIFF
--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -108,6 +108,11 @@ export interface ResourceGridProps {
    * above the table. Used for description banners.
    */
   headerContent?: React.ReactNode
+  /**
+   * Optional extra actions rendered in the Card header to the left of the
+   * New button. Use for icon buttons such as the Templates help pane toggle.
+   */
+  headerActions?: React.ReactNode
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +130,7 @@ export function ResourceGrid({
   onSearchChange,
   extraColumns = [],
   headerContent,
+  headerActions,
 }: ResourceGridProps) {
   // --- Derive local state from URL params --------------------------------
 
@@ -397,7 +403,10 @@ export function ResourceGrid({
       <Card>
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
           <CardTitle>{title}</CardTitle>
-          <NewButton kinds={creatableKinds} />
+          <div className="flex items-center gap-2">
+            {headerActions}
+            <NewButton kinds={creatableKinds} />
+          </div>
         </CardHeader>
         {headerContent && (
           <CardContent className="pt-0 pb-0">

--- a/frontend/src/components/templates/-templates-help-pane.test.tsx
+++ b/frontend/src/components/templates/-templates-help-pane.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for TemplatesHelpPane (HOL-860).
+ *
+ * Covers:
+ *   - Component renders the three content sections and summary
+ *   - onOpenChange callback fires when open state changes
+ *
+ * NOTE: The Sheet's Esc-key and overlay-click behaviour is driven by
+ * Radix UI internals. Those interactions are exercised in the route-level
+ * tests at frontend/src/routes/_authenticated/projects/$projectName/templates/-index-help.test.tsx
+ * where the full URL-param lifecycle can be asserted via mock router hooks.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+import { TemplatesHelpPane } from './TemplatesHelpPane'
+
+// ---------------------------------------------------------------------------
+// Radix pointer-capture polyfills for jsdom
+// ---------------------------------------------------------------------------
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+
+describe('TemplatesHelpPane', () => {
+  it('renders all three section headings when open', () => {
+    render(<TemplatesHelpPane open={true} onOpenChange={vi.fn()} />)
+
+    // Use testid-scoped queries to avoid ambiguity — each section has exactly one h3.
+    const templateSection = screen.getByTestId('help-section-template')
+    const policySection = screen.getByTestId('help-section-template-policy')
+    const bindingSection = screen.getByTestId('help-section-template-policy-binding')
+
+    expect(templateSection.querySelector('h3')).toHaveTextContent('Template')
+    expect(policySection.querySelector('h3')).toHaveTextContent('Template Policy')
+    expect(bindingSection.querySelector('h3')).toHaveTextContent('Template Policy Binding')
+  })
+
+  it('renders the summary paragraph when open', () => {
+    render(<TemplatesHelpPane open={true} onOpenChange={vi.fn()} />)
+
+    expect(
+      screen.getByText(/Authors write templates.*product teams deploy/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the Template section copy block', () => {
+    render(<TemplatesHelpPane open={true} onOpenChange={vi.fn()} />)
+
+    const section = screen.getByTestId('help-section-template')
+    expect(section).toBeInTheDocument()
+    expect(section.textContent).toMatch(/reusable CUE configuration/i)
+    expect(section.textContent).toMatch(/cloned, edited, and scoped/i)
+  })
+
+  it('renders the TemplatePolicy section copy block', () => {
+    render(<TemplatesHelpPane open={true} onOpenChange={vi.fn()} />)
+
+    const section = screen.getByTestId('help-section-template-policy')
+    expect(section).toBeInTheDocument()
+    expect(section.textContent).toMatch(/constraint authored at organization/i)
+  })
+
+  it('renders the TemplatePolicyBinding section copy block', () => {
+    render(<TemplatesHelpPane open={true} onOpenChange={vi.fn()} />)
+
+    const section = screen.getByTestId('help-section-template-policy-binding')
+    expect(section).toBeInTheDocument()
+    expect(section.textContent).toMatch(/attaches a policy to one or more templates/i)
+    expect(section.textContent).toMatch(/enforcement point/i)
+  })
+
+  it('does not render section content when closed', () => {
+    render(<TemplatesHelpPane open={false} onOpenChange={vi.fn()} />)
+
+    // When Sheet is closed, content should not be in the document.
+    expect(screen.queryByTestId('help-section-template')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('help-section-template-policy')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('help-section-template-policy-binding')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/templates/TemplatesHelpPane.tsx
+++ b/frontend/src/components/templates/TemplatesHelpPane.tsx
@@ -1,0 +1,86 @@
+/**
+ * TemplatesHelpPane — static help content for the Templates index page.
+ *
+ * Explains the three template-family resource kinds and how they relate.
+ * Rendered inside a shadcn Sheet (side="right") toggled by the ? icon
+ * in the Templates Card header.
+ *
+ * Keep copy in TSX (not MDX) to avoid any build-system changes (HOL-860).
+ */
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+
+export interface TemplatesHelpPaneProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function TemplatesHelpPane({ open, onOpenChange }: TemplatesHelpPaneProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Templates — how it works</SheetTitle>
+          <SheetDescription>
+            Three resource kinds work together to let platform teams govern
+            configuration templates across projects.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="px-4 pb-6 space-y-6 text-sm">
+          {/* Template */}
+          <section data-testid="help-section-template">
+            <h3 className="font-semibold text-base mb-1">Template</h3>
+            <p className="text-muted-foreground leading-relaxed">
+              A <strong>Template</strong> is a reusable CUE configuration packaged as a
+              custom resource. Platform and product authors write templates to express
+              standard infrastructure shapes — service meshes, ingress rules, storage
+              classes, and more. Templates can be cloned, edited, and scoped at the
+              organization, folder, or project level so teams can specialise them
+              without modifying the originals.
+            </p>
+          </section>
+
+          {/* TemplatePolicy */}
+          <section data-testid="help-section-template-policy">
+            <h3 className="font-semibold text-base mb-1">Template Policy</h3>
+            <p className="text-muted-foreground leading-relaxed">
+              A <strong>Template Policy</strong> is a constraint authored at organization
+              or folder scope. It expresses what is allowed or required in descendant
+              templates — for example, mandating a minimum replica count or prohibiting
+              certain image registries. Policies propagate down the namespace hierarchy
+              so platform and security teams can apply guardrails without touching each
+              project.
+            </p>
+          </section>
+
+          {/* TemplatePolicyBinding */}
+          <section data-testid="help-section-template-policy-binding">
+            <h3 className="font-semibold text-base mb-1">Template Policy Binding</h3>
+            <p className="text-muted-foreground leading-relaxed">
+              A <strong>Template Policy Binding</strong> attaches a policy to one or more
+              templates. It is the enforcement point: without a binding a policy has no
+              effect. Bindings are authored by platform engineers, security managers, or
+              ISRM teams and can target a single template or a set of templates across
+              multiple projects.
+            </p>
+          </section>
+
+          {/* Summary */}
+          <section data-testid="help-section-summary">
+            <p className="text-muted-foreground leading-relaxed border-t pt-4">
+              Authors write templates; platform, SM, and ISRM teams attach policy via
+              bindings; product teams deploy.
+            </p>
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-index-help.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-index-help.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Tests for the Templates index help pane integration (HOL-860).
+ *
+ * Covers:
+ *   - ? icon button is rendered in the page header
+ *   - Clicking the ? icon opens the help sheet (navigates with help=1)
+ *   - URL ?help=1 opens the sheet on initial render
+ *   - Esc key closes the sheet (calls navigate to drop help param)
+ *   - Copy blocks are present when open
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+
+// ---------------------------------------------------------------------------
+// Radix pointer-capture polyfills for jsdom
+// ---------------------------------------------------------------------------
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+
+// ---------------------------------------------------------------------------
+// Router mock — useSearch is configurable per test via searchRef
+// ---------------------------------------------------------------------------
+
+const searchRef = { current: {} as Record<string, unknown> }
+const navigateMock = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project' }),
+      useSearch: () => searchRef.current,
+      fullPath: '/projects/test-project/templates/',
+    }),
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to?: string
+      className?: string
+    }) => (
+      <a href={to ?? '#'} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => navigateMock,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Console-config mock — predictable namespace prefixes
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/queries/templates', () => ({
+  useAllTemplatesForOrg: vi.fn(),
+}))
+
+vi.mock('@/queries/templatePolicies', () => ({
+  useAllTemplatePoliciesForOrg: vi.fn(),
+}))
+
+vi.mock('@/queries/templatePolicyBindings', () => ({
+  useAllTemplatePolicyBindingsForOrg: vi.fn(),
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useGetProject: vi.fn(),
+}))
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQueryClient: vi.fn().mockReturnValue({
+      invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    }),
+  }
+})
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn().mockReturnValue({
+    deleteTemplate: vi.fn().mockResolvedValue({}),
+    deleteTemplatePolicy: vi.fn().mockResolvedValue({}),
+    deleteTemplatePolicyBinding: vi.fn().mockResolvedValue({}),
+  }),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { useAllTemplatesForOrg } from '@/queries/templates'
+import { useAllTemplatePoliciesForOrg } from '@/queries/templatePolicies'
+import { useAllTemplatePolicyBindingsForOrg } from '@/queries/templatePolicyBindings'
+import { useGetProject } from '@/queries/projects'
+import { useGetOrganization } from '@/queries/organizations'
+import { useOrg } from '@/lib/org-context'
+import { ProjectTemplatesIndexPage } from './index'
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+function makeTemplate(name: string, namespace = 'project-test-project') {
+  return { name, namespace, displayName: name, description: '', cueTemplate: '' }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+function setupMocks({
+  templates = [makeTemplate('my-template')],
+  orgName = 'acme',
+  projectRole = Role.OWNER,
+  orgRole = Role.OWNER,
+}: {
+  templates?: ReturnType<typeof makeTemplate>[]
+  orgName?: string | null
+  projectRole?: number
+  orgRole?: number
+} = {}) {
+  ;(useOrg as Mock).mockReturnValue({ selectedOrg: orgName })
+  ;(useGetProject as Mock).mockReturnValue({
+    data: { name: 'test-project', userRole: projectRole },
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: orgName, userRole: orgRole },
+    isPending: false,
+  })
+  ;(useAllTemplatesForOrg as Mock).mockReturnValue({
+    data: templates,
+    isPending: false,
+    error: null,
+  })
+  ;(useAllTemplatePoliciesForOrg as Mock).mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  })
+  ;(useAllTemplatePolicyBindingsForOrg as Mock).mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ProjectTemplatesIndexPage — help pane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    searchRef.current = {}
+    navigateMock.mockClear()
+  })
+
+  it('renders the ? help icon button', () => {
+    setupMocks()
+    render(<ProjectTemplatesIndexPage projectName="test-project" />)
+    expect(
+      screen.getByRole('button', { name: /help.*templates overview/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('clicking the ? icon triggers navigate with help=1', () => {
+    setupMocks()
+    render(<ProjectTemplatesIndexPage projectName="test-project" />)
+    const helpBtn = screen.getByRole('button', { name: /help.*templates overview/i })
+    fireEvent.click(helpBtn)
+
+    expect(navigateMock).toHaveBeenCalled()
+    // Extract the search updater and call it to verify it sets help=1
+    const callArg = navigateMock.mock.calls[0][0] as {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>
+    }
+    const result = callArg.search({})
+    expect(result.help).toBe('1')
+  })
+
+  it('opens the help sheet when URL search has help=1', () => {
+    searchRef.current = { help: '1' }
+    setupMocks()
+    render(<ProjectTemplatesIndexPage projectName="test-project" />)
+
+    // Sheet content should be visible
+    expect(screen.getByTestId('help-section-template')).toBeInTheDocument()
+    expect(screen.getByTestId('help-section-template-policy')).toBeInTheDocument()
+    expect(screen.getByTestId('help-section-template-policy-binding')).toBeInTheDocument()
+    expect(screen.getByTestId('help-section-summary')).toBeInTheDocument()
+  })
+
+  it('help sheet is closed (no sections) when URL has no help param', () => {
+    searchRef.current = {}
+    setupMocks()
+    render(<ProjectTemplatesIndexPage projectName="test-project" />)
+
+    expect(screen.queryByTestId('help-section-template')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('help-section-template-policy')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('help-section-template-policy-binding')).not.toBeInTheDocument()
+  })
+
+  it('Esc key closes the sheet by calling navigate to drop help param', () => {
+    searchRef.current = { help: '1' }
+    setupMocks()
+    // navigateMock must not throw during Radix's internal event dispatch
+    navigateMock.mockImplementation(() => undefined)
+
+    render(<ProjectTemplatesIndexPage projectName="test-project" />)
+
+    // Sheet should be open
+    expect(screen.getByTestId('help-section-template')).toBeInTheDocument()
+
+    // Press Esc — Radix Sheet fires onOpenChange(false) on Esc
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+
+    // navigate should have been called to remove the help param
+    expect(navigateMock).toHaveBeenCalled()
+    const callArg = navigateMock.mock.calls[0][0] as {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>
+    }
+    const result = callArg.search({ help: '1', kind: 'Template' })
+    expect(result.help).toBeUndefined()
+  })
+
+  it('copy blocks contain expected text when open', () => {
+    searchRef.current = { help: '1' }
+    setupMocks()
+    render(<ProjectTemplatesIndexPage projectName="test-project" />)
+
+    const templateSection = screen.getByTestId('help-section-template')
+    expect(templateSection.textContent).toMatch(/reusable CUE configuration/i)
+
+    const policySection = screen.getByTestId('help-section-template-policy')
+    expect(policySection.textContent).toMatch(/constraint authored at organization/i)
+
+    const bindingSection = screen.getByTestId('help-section-template-policy-binding')
+    expect(bindingSection.textContent).toMatch(/enforcement point/i)
+
+    const summarySection = screen.getByTestId('help-section-summary')
+    expect(summarySection.textContent).toMatch(/Authors write templates/i)
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -20,6 +20,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import { useQueryClient } from '@tanstack/react-query'
+import { HelpCircle } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { TemplateService } from '@/gen/holos/console/v1/templates_pb.js'
 import { TemplatePolicyService } from '@/gen/holos/console/v1/template_policies_pb.js'
@@ -28,6 +29,8 @@ import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import { Button } from '@/components/ui/button'
+import { TemplatesHelpPane } from '@/components/templates/TemplatesHelpPane'
 import { useGetProject } from '@/queries/projects'
 import { useGetOrganization } from '@/queries/organizations'
 import { useAllTemplatesForOrg } from '@/queries/templates'
@@ -41,11 +44,29 @@ import {
 } from '@/lib/template-row-link'
 
 // ---------------------------------------------------------------------------
+// Route search — extends ResourceGridSearch with the help pane state
+// ---------------------------------------------------------------------------
+
+export interface TemplatesSearch extends ResourceGridSearch {
+  /** "1" = help pane open, absent = closed. */
+  help?: '1'
+}
+
+function parseTemplatesSearch(raw: Record<string, unknown>): TemplatesSearch {
+  const base = parseGridSearch(raw)
+  const result: TemplatesSearch = { ...base }
+  if (raw['help'] === '1') {
+    result.help = '1'
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
 // Route definition
 // ---------------------------------------------------------------------------
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/')({
-  validateSearch: parseGridSearch,
+  validateSearch: parseTemplatesSearch,
   component: ProjectTemplatesIndexRoute,
 })
 
@@ -63,8 +84,28 @@ export function ProjectTemplatesIndexPage({
 }: {
   projectName: string
 }) {
-  const search = Route.useSearch()
+  const search = Route.useSearch() as TemplatesSearch
   const navigate = useNavigate({ from: Route.fullPath })
+
+  // Help pane state — persisted in URL as ?help=1
+  const helpOpen = search.help === '1'
+
+  const handleHelpOpenChange = useCallback(
+    (open: boolean) => {
+      navigate({
+        search: (prev) => {
+          const next = { ...(prev as TemplatesSearch) }
+          if (open) {
+            next.help = '1'
+          } else {
+            delete next.help
+          }
+          return next
+        },
+      })
+    },
+    [navigate],
+  )
 
   // Derive orgName from the OrgContext — the route is project-scoped so there
   // is no $orgName in the URL.
@@ -254,7 +295,16 @@ export function ProjectTemplatesIndexPage({
   const handleSearchChange = useCallback(
     (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
       navigate({
-        search: (prev) => updater(prev as ResourceGridSearch),
+        search: (prev) => {
+          const typedPrev = prev as TemplatesSearch
+          const updated = updater(typedPrev)
+          // Preserve the help param across grid-search updates.
+          const next: TemplatesSearch = { ...updated }
+          if (typedPrev.help) {
+            next.help = typedPrev.help
+          }
+          return next
+        },
       })
     },
     [navigate],
@@ -269,16 +319,32 @@ export function ProjectTemplatesIndexPage({
     )
   }
 
+  const helpButton = (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Help — Templates overview"
+      onClick={() => handleHelpOpenChange(true)}
+      data-testid="templates-help-button"
+    >
+      <HelpCircle className="h-5 w-5" />
+    </Button>
+  )
+
   return (
-    <ResourceGrid
-      title={`${projectName} / Templates`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isLoading}
-      error={firstError}
-      search={searchWithDefaults}
-      onSearchChange={handleSearchChange}
-    />
+    <>
+      <ResourceGrid
+        title={`${projectName} / Templates`}
+        kinds={kinds}
+        rows={rows}
+        onDelete={handleDelete}
+        isLoading={isLoading}
+        error={firstError}
+        search={searchWithDefaults}
+        onSearchChange={handleSearchChange}
+        headerActions={helpButton}
+      />
+      <TemplatesHelpPane open={helpOpen} onOpenChange={handleHelpOpenChange} />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a `TemplatesHelpPane` component (`frontend/src/components/templates/TemplatesHelpPane.tsx`) — a right-side shadcn `Sheet` (`sm:max-w-xl`) with static prose for Template, TemplatePolicy, and TemplatePolicyBinding, plus a summary paragraph
- Adds a `HelpCircle` (?) icon button to the ResourceGrid card header via new `headerActions` prop on `ResourceGrid`
- Wires URL-driven open state in the Templates index route: `?help=1` opens the pane, Esc/overlay-click clears the param; grid-search navigations preserve the help param
- Unit tests: component-level (sections present/absent), route-level (icon renders, click navigates, URL opens pane, Esc drops param, copy text present)

Fixes HOL-860

## Test plan
- [x] `make test-ui` passes — 1147 tests across 90 test files, all green
- [ ] Navigate to a project's Templates page; confirm `?` icon appears in the card header
- [ ] Click `?`: sheet slides open from the right at ~xl width, shows three sections + summary
- [ ] Share URL with `?help=1`: page loads with pane open
- [ ] Press Esc or click overlay: pane closes and `?help` disappears from the URL