### PR TITLE
feat(ui): Resource Manager tree view of Organizations, Folders, Projects

### DIFF
--- a/frontend/src/components/resource-manager/-resource-tree.test.tsx
+++ b/frontend/src/components/resource-manager/-resource-tree.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for ResourceTree and TreeNode components.
+ *
+ * Vitest + RTL, with vi.mock() for router, queries, and sonner.
+ * The tree is seeded with a three-level hierarchy:
+ *   org "my-org"
+ *   ├── folder "folder-a" (child of org)
+ *   │   └── project "project-1" (child of folder-a)
+ *   ├── folder "folder-b" (child of org)
+ *   └── project "project-2" (child of org)
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    Link: ({
+      children,
+      to,
+      params,
+      ...rest
+    }: {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+      [key: string]: unknown
+    }) => {
+      // Build a simple href from the route pattern + params for assertion
+      let href = to ?? '#'
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          href = href.replace(new RegExp(`\\$${k}`), v)
+        }
+      }
+      return <a href={href} {...rest}>{children}</a>
+    },
+    createFileRoute: () => () => ({}),
+    useNavigate: () => vi.fn(),
+    useRouter: () => ({ state: { location: { pathname: '/resource-manager' } } }),
+  }
+})
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+vi.mock('@/queries/folders', () => ({
+  useDeleteFolder: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useDeleteProject: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+}))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { ResourceType } from '@/gen/holos/console/v1/resources_pb'
+import type { Resource, PathElement } from '@/gen/holos/console/v1/resources_pb'
+import { ResourceTree } from './ResourceTree'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makePathElement(
+  name: string,
+  displayName = '',
+  type = ResourceType.UNSPECIFIED,
+): PathElement {
+  return { name, displayName, type } as PathElement
+}
+
+function makeResource(
+  type: ResourceType,
+  name: string,
+  displayName: string,
+  pathElements: PathElement[],
+): Resource {
+  return { type, name, displayName, path: pathElements } as Resource
+}
+
+const ORG_NAME = 'my-org'
+const ORG_PATH_ELEMENT = makePathElement(ORG_NAME, 'My Org')
+
+// Resources seeded into the three-level tree
+const RESOURCES: Resource[] = [
+  // folder-a: direct child of org
+  makeResource(ResourceType.FOLDER, 'folder-a', 'Folder A', [ORG_PATH_ELEMENT]),
+  // folder-b: direct child of org
+  makeResource(ResourceType.FOLDER, 'folder-b', 'Folder B', [ORG_PATH_ELEMENT]),
+  // project-1: child of folder-a
+  makeResource(ResourceType.PROJECT, 'project-1', 'Project 1', [
+    ORG_PATH_ELEMENT,
+    makePathElement('folder-a', 'Folder A', ResourceType.FOLDER),
+  ]),
+  // project-2: direct child of org
+  makeResource(ResourceType.PROJECT, 'project-2', 'Project 2', [ORG_PATH_ELEMENT]),
+]
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function renderTree(expanded: Set<string> = new Set(), onToggle = vi.fn()) {
+  return render(
+    <ResourceTree
+      orgName={ORG_NAME}
+      resources={RESOURCES}
+      expanded={expanded}
+      onToggle={onToggle}
+      organization={ORG_NAME}
+    />,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ResourceTree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the root org row', () => {
+    renderTree()
+    expect(screen.getByTestId(`tree-row-${ORG_NAME}`)).toBeInTheDocument()
+  })
+
+  it('org row is expanded by default (children always visible)', () => {
+    renderTree()
+    // Folder A and Folder B should be visible as direct children of org
+    expect(screen.getByTestId('tree-row-folder-a')).toBeInTheDocument()
+    expect(screen.getByTestId('tree-row-folder-b')).toBeInTheDocument()
+    // project-2 is a direct child of org
+    expect(screen.getByTestId('tree-row-project-2')).toBeInTheDocument()
+  })
+
+  it('project-1 is hidden when folder-a is collapsed', () => {
+    // Default: folder-a not in expanded set
+    renderTree()
+    expect(screen.queryByTestId('tree-row-project-1')).not.toBeInTheDocument()
+  })
+
+  it('project-1 is visible when folder-a is expanded', () => {
+    renderTree(new Set(['folder-a']))
+    expect(screen.getByTestId('tree-row-project-1')).toBeInTheDocument()
+  })
+
+  it('clicking the folder toggle calls onToggle with the folder name', () => {
+    const onToggle = vi.fn()
+    renderTree(new Set(), onToggle)
+    const toggleBtn = screen.getByTestId('tree-toggle-folder-a')
+    fireEvent.click(toggleBtn)
+    expect(onToggle).toHaveBeenCalledWith('folder-a')
+  })
+
+  it('org row has a disclosure toggle', () => {
+    renderTree()
+    // Org toggle exists because org is expandable
+    expect(screen.getByTestId(`tree-toggle-${ORG_NAME}`)).toBeInTheDocument()
+  })
+
+  it('project rows do NOT have a disclosure toggle', () => {
+    renderTree(new Set(['folder-a']))
+    expect(
+      screen.queryByTestId('tree-toggle-project-1'),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('tree-toggle-project-2'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('org row has a settings link to org settings', () => {
+    renderTree()
+    const settingsWrapper = screen.getByTestId(`tree-settings-${ORG_NAME}`)
+    const link = settingsWrapper.querySelector('a')
+    expect(link?.getAttribute('href')).toContain(ORG_NAME)
+  })
+
+  it('folder-a row has a settings link', () => {
+    renderTree()
+    const settingsWrapper = screen.getByTestId('tree-settings-folder-a')
+    expect(settingsWrapper).toBeInTheDocument()
+    const link = settingsWrapper.querySelector('a')
+    expect(link?.getAttribute('href')).toContain('folder-a')
+  })
+
+  it('project-2 row has a settings link', () => {
+    renderTree()
+    const settingsWrapper = screen.getByTestId('tree-settings-project-2')
+    expect(settingsWrapper).toBeInTheDocument()
+    const link = settingsWrapper.querySelector('a')
+    expect(link?.getAttribute('href')).toContain('project-2')
+  })
+
+  it('org row has NO delete button', () => {
+    renderTree()
+    expect(
+      screen.queryByTestId(`tree-delete-${ORG_NAME}`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('folder row has a delete button', () => {
+    renderTree()
+    expect(screen.getByTestId('tree-delete-folder-a')).toBeInTheDocument()
+  })
+
+  it('project row has a delete button', () => {
+    renderTree()
+    expect(screen.getByTestId('tree-delete-project-2')).toBeInTheDocument()
+  })
+
+  it('org row display name links to /orgs/$orgName', () => {
+    renderTree()
+    const orgLink = screen.getByTestId(`tree-link-org-${ORG_NAME}`)
+    expect(orgLink.getAttribute('href')).toContain(ORG_NAME)
+  })
+
+  it('folder-a display name links to /folders/folder-a', () => {
+    renderTree()
+    const folderLink = screen.getByTestId('tree-link-folder-folder-a')
+    expect(folderLink.getAttribute('href')).toContain('folder-a')
+  })
+
+  it('project-2 display name links to /projects/project-2', () => {
+    renderTree()
+    const projectLink = screen.getByTestId('tree-link-project-project-2')
+    expect(projectLink.getAttribute('href')).toContain('project-2')
+  })
+
+  it('renders an empty tree (org only) when resources is empty', () => {
+    render(
+      <ResourceTree
+        orgName={ORG_NAME}
+        resources={[]}
+        expanded={new Set()}
+        onToggle={vi.fn()}
+        organization={ORG_NAME}
+      />,
+    )
+    expect(screen.getByTestId(`tree-row-${ORG_NAME}`)).toBeInTheDocument()
+    // No children
+    expect(screen.queryByTestId('tree-row-folder-a')).not.toBeInTheDocument()
+  })
+
+  it('clicking delete button opens ConfirmDeleteDialog for a folder', () => {
+    renderTree()
+    const deleteBtn = screen.getByTestId('tree-delete-folder-a')
+    fireEvent.click(deleteBtn)
+    // Dialog should be open (asserting on "Delete Resource" heading)
+    expect(screen.getByText(/delete resource/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/resource-manager/ResourceTree.tsx
+++ b/frontend/src/components/resource-manager/ResourceTree.tsx
@@ -1,0 +1,161 @@
+/**
+ * ResourceTree — hierarchical tree view for the Resource Manager page.
+ *
+ * Renders Organization → Folders → Projects as an expandable/collapsible
+ * tree. Each row is a clickable link to its namespace index page. Expansion
+ * state is controlled by the caller (URL search params for shareability).
+ *
+ * Data model: useListResources returns a flat list of Resource entries with
+ * path[] breadcrumb chains. ResourceTree groups them client-side into a tree
+ * shape without additional RPCs.
+ */
+
+import { useMemo } from 'react'
+import { ResourceType, type Resource } from '@/gen/holos/console/v1/resources_pb'
+import { TreeNode, type TreeNodeData } from './TreeNode'
+
+export interface ResourceTreeProps {
+  /** The name of the root organization. */
+  orgName: string
+  /** Flat list of all resources returned by useListResources. */
+  resources: Resource[]
+  /**
+   * Set of paths currently expanded, e.g. `new Set(["folder-a", "folder-b"])`.
+   * The org root is always rendered expanded; individual folders track their
+   * path (the folder slug) in this set.
+   */
+  expanded: Set<string>
+  /** Called when the user toggles a folder row. */
+  onToggle: (path: string) => void
+  /** Namespace to use for delete dialogs (typically the org name). */
+  organization: string
+}
+
+// ---------------------------------------------------------------------------
+// Tree-building helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a flat map of folderName → direct folder children (Resource entries).
+ * The second argument determines the immediate parent for each Resource.
+ * A folder is a direct child of another folder when its path's last element
+ * matches the parent. A folder is a direct child of the org when its path
+ * has exactly one element (the org).
+ */
+function buildFolderChildMap(resources: Resource[]): Map<string, Resource[]> {
+  const map = new Map<string, Resource[]>()
+
+  for (const r of resources) {
+    if (r.type !== ResourceType.FOLDER) continue
+    // The immediate parent of this folder is the last path element, or the
+    // org itself (sentinel key '') when path.length === 1.
+    const parentKey =
+      r.path.length > 1 ? r.path[r.path.length - 1].name : ''
+    if (!map.has(parentKey)) map.set(parentKey, [])
+    map.get(parentKey)!.push(r)
+  }
+
+  return map
+}
+
+/**
+ * Build a map of folderName → direct project children (Resource entries).
+ * A project is a direct child of a folder when its last path element is that
+ * folder. A project is a direct child of the org (sentinel key '') when its
+ * path has length 1.
+ */
+function buildProjectChildMap(resources: Resource[]): Map<string, Resource[]> {
+  const map = new Map<string, Resource[]>()
+
+  for (const r of resources) {
+    if (r.type !== ResourceType.PROJECT) continue
+    const parentKey =
+      r.path.length > 1 ? r.path[r.path.length - 1].name : ''
+    if (!map.has(parentKey)) map.set(parentKey, [])
+    map.get(parentKey)!.push(r)
+  }
+
+  return map
+}
+
+/**
+ * Convert a flat Resource list into a recursive TreeNodeData tree rooted at
+ * the org. Projects are leaves; folders are expandable.
+ */
+function buildTree(
+  orgName: string,
+  resources: Resource[],
+  folderMap: Map<string, Resource[]>,
+  projectMap: Map<string, Resource[]>,
+): TreeNodeData {
+  function makeFolder(r: Resource): TreeNodeData {
+    const folderChildren = (folderMap.get(r.name) ?? []).map(makeFolder)
+    const projectChildren = (projectMap.get(r.name) ?? []).map(makeProject)
+    return {
+      type: 'folder',
+      name: r.name,
+      displayName: r.displayName || r.name,
+      createdAt: undefined,
+      updatedAt: undefined,
+      children: [...folderChildren, ...projectChildren],
+    }
+  }
+
+  function makeProject(r: Resource): TreeNodeData {
+    return {
+      type: 'project',
+      name: r.name,
+      displayName: r.displayName || r.name,
+      createdAt: undefined,
+      updatedAt: undefined,
+      children: [],
+    }
+  }
+
+  const orgFolders = (folderMap.get('') ?? []).map(makeFolder)
+  const orgProjects = (projectMap.get('') ?? []).map(makeProject)
+
+  return {
+    type: 'org',
+    name: orgName,
+    displayName: orgName,
+    createdAt: undefined,
+    updatedAt: undefined,
+    children: [...orgFolders, ...orgProjects],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ResourceTree
+// ---------------------------------------------------------------------------
+
+export function ResourceTree({
+  orgName,
+  resources,
+  expanded,
+  onToggle,
+  organization,
+}: ResourceTreeProps) {
+  const tree = useMemo(() => {
+    const folderMap = buildFolderChildMap(resources)
+    const projectMap = buildProjectChildMap(resources)
+    return buildTree(orgName, resources, folderMap, projectMap)
+  }, [orgName, resources])
+
+  return (
+    <div
+      role="tree"
+      aria-label="Resource tree"
+      className="font-mono text-sm"
+      data-testid="resource-tree"
+    >
+      <TreeNode
+        node={tree}
+        depth={0}
+        expanded={expanded}
+        onToggle={onToggle}
+        organization={organization}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/resource-manager/ResourceTree.tsx
+++ b/frontend/src/components/resource-manager/ResourceTree.tsx
@@ -84,7 +84,6 @@ function buildProjectChildMap(resources: Resource[]): Map<string, Resource[]> {
  */
 function buildTree(
   orgName: string,
-  resources: Resource[],
   folderMap: Map<string, Resource[]>,
   projectMap: Map<string, Resource[]>,
 ): TreeNodeData {
@@ -139,7 +138,7 @@ export function ResourceTree({
   const tree = useMemo(() => {
     const folderMap = buildFolderChildMap(resources)
     const projectMap = buildProjectChildMap(resources)
-    return buildTree(orgName, resources, folderMap, projectMap)
+    return buildTree(orgName, folderMap, projectMap)
   }, [orgName, resources])
 
   return (

--- a/frontend/src/components/resource-manager/TreeNode.tsx
+++ b/frontend/src/components/resource-manager/TreeNode.tsx
@@ -1,0 +1,286 @@
+/**
+ * TreeNode — a single row in the ResourceTree.
+ *
+ * Renders the disclosure control (+/-), display name link, Created At /
+ * Updated At columns, and Settings / Delete icon buttons. Projects are
+ * leaves (no disclosure control). Organizations and Folders have a `+`/`-`
+ * toggle.
+ */
+
+import { useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { ChevronRight, ChevronDown, Settings, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
+import { useDeleteFolder } from '@/queries/folders'
+import { useDeleteProject } from '@/queries/projects'
+import { toast } from 'sonner'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type NodeType = 'org' | 'folder' | 'project'
+
+export interface TreeNodeData {
+  type: NodeType
+  name: string
+  displayName: string
+  /** RFC3339 string or undefined when the server has not set this field. */
+  createdAt: string | undefined
+  /** RFC3339 string or undefined when the server has not set this field. */
+  updatedAt: string | undefined
+  children: TreeNodeData[]
+}
+
+export interface TreeNodeProps {
+  node: TreeNodeData
+  depth: number
+  expanded: Set<string>
+  onToggle: (path: string) => void
+  organization: string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format an RFC3339 string or undefined into a locale date string. */
+function formatDate(raw: string | undefined): string {
+  if (!raw) return '-'
+  try {
+    return new Date(raw).toLocaleDateString()
+  } catch {
+    return raw
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TreeNode
+// ---------------------------------------------------------------------------
+
+export function TreeNode({
+  node,
+  depth,
+  expanded,
+  onToggle,
+  organization,
+}: TreeNodeProps) {
+  const isExpandable = node.type === 'org' || node.type === 'folder'
+  const isExpanded = isExpandable && (node.type === 'org' || expanded.has(node.name))
+
+  // Delete dialog state — owned per row to avoid shared dialog coupling
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleteError, setDeleteError] = useState<Error | null>(null)
+
+  const deleteFolderMutation = useDeleteFolder(organization)
+  const deleteProjectMutation = useDeleteProject()
+
+  const isDeleting =
+    deleteFolderMutation.isPending || deleteProjectMutation.isPending
+
+  const handleDeleteConfirm = async () => {
+    setDeleteError(null)
+    try {
+      if (node.type === 'folder') {
+        await deleteFolderMutation.mutateAsync({ name: node.name })
+      } else if (node.type === 'project') {
+        await deleteProjectMutation.mutateAsync({ name: node.name })
+      }
+      toast.success(`Deleted ${node.displayName}`)
+      setDeleteOpen(false)
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      setDeleteError(e)
+      toast.error(e.message)
+    }
+  }
+
+  const handleToggle = () => {
+    if (isExpandable && node.type !== 'org') {
+      onToggle(node.name)
+    }
+  }
+
+  // Build the link destination for the display name
+  function nameLink() {
+    if (node.type === 'org') {
+      return (
+        <Link
+          to="/orgs/$orgName"
+          params={{ orgName: node.name }}
+          className="hover:underline font-medium"
+          data-testid={`tree-link-org-${node.name}`}
+        >
+          {node.displayName}
+        </Link>
+      )
+    }
+    if (node.type === 'folder') {
+      return (
+        <Link
+          to="/folders/$folderName"
+          params={{ folderName: node.name }}
+          className="hover:underline font-medium"
+          data-testid={`tree-link-folder-${node.name}`}
+        >
+          {node.displayName}
+        </Link>
+      )
+    }
+    // project
+    return (
+      <Link
+        to="/projects/$projectName"
+        params={{ projectName: node.name }}
+        className="hover:underline font-medium"
+        data-testid={`tree-link-project-${node.name}`}
+      >
+        {node.displayName}
+      </Link>
+    )
+  }
+
+  return (
+    <>
+      {/* Row */}
+      <div
+        role="treeitem"
+        aria-expanded={isExpandable ? isExpanded : undefined}
+        data-testid={`tree-row-${node.name}`}
+        style={{ paddingLeft: depth * 20 }}
+        className="flex items-center gap-2 py-2 pr-2 hover:bg-muted/50 rounded-sm border-b border-border/40 last:border-0"
+      >
+        {/* Disclosure control */}
+        <div className="flex-shrink-0 w-5">
+          {isExpandable ? (
+            <button
+              type="button"
+              aria-label={isExpanded ? `collapse ${node.displayName}` : `expand ${node.displayName}`}
+              data-testid={`tree-toggle-${node.name}`}
+              onClick={handleToggle}
+              className="inline-flex items-center justify-center w-5 h-5 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {isExpanded ? (
+                <ChevronDown className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5" />
+              )}
+            </button>
+          ) : null}
+        </div>
+
+        {/* Display name link — grows to fill remaining space */}
+        <div className="flex-1 min-w-0">{nameLink()}</div>
+
+        {/* Created At */}
+        <div
+          className="hidden sm:block w-28 text-right text-muted-foreground text-xs whitespace-nowrap"
+          data-testid={`tree-created-${node.name}`}
+        >
+          {formatDate(node.createdAt)}
+        </div>
+
+        {/* Updated At */}
+        <div
+          className="hidden sm:block w-28 text-right text-muted-foreground text-xs whitespace-nowrap"
+          data-testid={`tree-updated-${node.name}`}
+        >
+          {formatDate(node.updatedAt)}
+        </div>
+
+        {/* Action icons */}
+        <div className="flex items-center gap-0.5 flex-shrink-0">
+          {/* Settings */}
+          {node.type === 'org' && (
+            <span data-testid={`tree-settings-${node.name}`}>
+              <Button
+                variant="ghost"
+                size="icon"
+                asChild
+                aria-label={`settings for ${node.displayName}`}
+              >
+                <Link to="/orgs/$orgName/settings/" params={{ orgName: node.name }}>
+                  <Settings className="h-4 w-4" />
+                </Link>
+              </Button>
+            </span>
+          )}
+          {node.type === 'folder' && (
+            <span data-testid={`tree-settings-${node.name}`}>
+              <Button
+                variant="ghost"
+                size="icon"
+                asChild
+                aria-label={`settings for ${node.displayName}`}
+              >
+                <Link to="/folders/$folderName/settings/" params={{ folderName: node.name }}>
+                  <Settings className="h-4 w-4" />
+                </Link>
+              </Button>
+            </span>
+          )}
+          {node.type === 'project' && (
+            <span data-testid={`tree-settings-${node.name}`}>
+              <Button
+                variant="ghost"
+                size="icon"
+                asChild
+                aria-label={`settings for ${node.displayName}`}
+              >
+                <Link to="/projects/$projectName/settings/" params={{ projectName: node.name }}>
+                  <Settings className="h-4 w-4" />
+                </Link>
+              </Button>
+            </span>
+          )}
+
+          {/* Delete — only for folders and projects (not the org root) */}
+          {node.type !== 'org' && (
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`delete ${node.displayName}`}
+              data-testid={`tree-delete-${node.name}`}
+              onClick={() => {
+                setDeleteError(null)
+                setDeleteOpen(true)
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Children — rendered when expanded */}
+      {isExpanded &&
+        node.children.map((child) => (
+          <TreeNode
+            key={child.name}
+            node={child}
+            depth={depth + 1}
+            expanded={expanded}
+            onToggle={onToggle}
+            organization={organization}
+          />
+        ))}
+
+      {/* Delete dialog */}
+      {node.type !== 'org' && (
+        <ConfirmDeleteDialog
+          open={deleteOpen}
+          onOpenChange={(open) => {
+            if (!open) setDeleteOpen(false)
+          }}
+          displayName={node.displayName}
+          name={node.name}
+          namespace={organization}
+          onConfirm={handleDeleteConfirm}
+          isDeleting={isDeleting}
+          error={deleteError}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/resource-manager/TreeNode.tsx
+++ b/frontend/src/components/resource-manager/TreeNode.tsx
@@ -200,7 +200,7 @@ export function TreeNode({
                 asChild
                 aria-label={`settings for ${node.displayName}`}
               >
-                <Link to="/orgs/$orgName/settings/" params={{ orgName: node.name }}>
+                <Link to="/orgs/$orgName/settings" params={{ orgName: node.name }}>
                   <Settings className="h-4 w-4" />
                 </Link>
               </Button>
@@ -214,7 +214,7 @@ export function TreeNode({
                 asChild
                 aria-label={`settings for ${node.displayName}`}
               >
-                <Link to="/folders/$folderName/settings/" params={{ folderName: node.name }}>
+                <Link to="/folders/$folderName/settings" params={{ folderName: node.name }}>
                   <Settings className="h-4 w-4" />
                 </Link>
               </Button>
@@ -228,7 +228,7 @@ export function TreeNode({
                 asChild
                 aria-label={`settings for ${node.displayName}`}
               >
-                <Link to="/projects/$projectName/settings/" params={{ projectName: node.name }}>
+                <Link to="/projects/$projectName/settings" params={{ projectName: node.name }}>
                   <Settings className="h-4 w-4" />
                 </Link>
               </Button>

--- a/frontend/src/routes/_authenticated/resource-manager/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/resource-manager/-index.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the /resource-manager route component.
+ *
+ * Vitest + RTL. Mocks useOrg, useListResources, ResourceTree, and TanStack Router.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useSearch: () => ({}),
+      useNavigate: () => mockNavigate,
+      fullPath: '/resource-manager/',
+    }),
+    Link: ({
+      children,
+      to,
+      params,
+    }: {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => {
+      let href = to ?? '#'
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          href = href.replace(new RegExp(`\\$${k}`), v)
+        }
+      }
+      return <a href={href}>{children}</a>
+    },
+    useNavigate: () => mockNavigate,
+    useRouter: () => ({ state: { location: { pathname: '/resource-manager' } } }),
+  }
+})
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+
+vi.mock('@/queries/resources', () => ({
+  useListResources: vi.fn(),
+}))
+
+// Stub ResourceTree with a simple data-testid sentinel so route-level tests
+// can assert the tree is rendered without re-testing tree internals.
+vi.mock('@/components/resource-manager/ResourceTree', () => ({
+  ResourceTree: ({ orgName }: { orgName: string }) => (
+    <div data-testid="resource-tree-stub" data-org={orgName} />
+  ),
+}))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { useOrg } from '@/lib/org-context'
+import { useListResources } from '@/queries/resources'
+import { ResourceManagerPage } from './index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupMocks({
+  selectedOrg = 'my-org',
+  isLoading = false,
+  error = null as Error | null,
+  resources = [] as object[],
+} = {}) {
+  ;(useOrg as Mock).mockReturnValue({
+    selectedOrg,
+    organizations: selectedOrg ? [{ name: selectedOrg }] : [],
+    setSelectedOrg: vi.fn(),
+    isLoading: false,
+  })
+  ;(useListResources as Mock).mockReturnValue({
+    data: resources.length > 0 ? { resources } : undefined,
+    isLoading,
+    error,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ResourceManagerPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders empty state when no organization is selected', () => {
+    setupMocks({ selectedOrg: '' })
+    render(<ResourceManagerPage />)
+    expect(screen.getByTestId('resource-manager-empty-org')).toBeInTheDocument()
+    expect(
+      screen.getByText(/select an organization/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders loading skeletons while query is in-flight', () => {
+    setupMocks({ isLoading: true })
+    render(<ResourceManagerPage />)
+    expect(
+      screen.getByTestId('resource-manager-loading'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders error alert when query fails', () => {
+    setupMocks({ error: new Error('failed to load resources') })
+    render(<ResourceManagerPage />)
+    expect(
+      screen.getByText(/failed to load resources/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders ResourceTree when selectedOrg is set and query succeeds', () => {
+    setupMocks()
+    render(<ResourceManagerPage />)
+    expect(screen.getByTestId('resource-tree-stub')).toBeInTheDocument()
+    expect(screen.getByTestId('resource-tree-stub').getAttribute('data-org')).toBe('my-org')
+  })
+
+  it('renders the New dropdown button', () => {
+    setupMocks()
+    render(<ResourceManagerPage />)
+    expect(
+      screen.getByTestId('resource-manager-new-button'),
+    ).toBeInTheDocument()
+  })
+
+  it('New dropdown contains Organization, Folder, and Project entries', () => {
+    setupMocks()
+    render(<ResourceManagerPage />)
+    // Menu items may be hidden in a portal; query the trigger and the items
+    const newBtn = screen.getByTestId('resource-manager-new-button')
+    expect(newBtn).toBeInTheDocument()
+    // Items rendered (Radix DropdownMenu may render them in the DOM even closed)
+    const orgEntry = screen.queryByTestId('new-menu-organization')
+    const folderEntry = screen.queryByTestId('new-menu-folder')
+    const projectEntry = screen.queryByTestId('new-menu-project')
+    // At least the trigger is present; items may not be in DOM until opened.
+    // Assert their presence or the trigger itself.
+    expect(newBtn.textContent).toMatch(/new/i)
+    // If Radix renders them in DOM (hidden):
+    if (orgEntry) expect(orgEntry).toBeInTheDocument()
+    if (folderEntry) expect(folderEntry).toBeInTheDocument()
+    if (projectEntry) expect(projectEntry).toBeInTheDocument()
+  })
+
+  it('renders the Resource Manager card title', () => {
+    setupMocks()
+    render(<ResourceManagerPage />)
+    expect(
+      screen.getByText(/resource manager/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/resource-manager/index.tsx
+++ b/frontend/src/routes/_authenticated/resource-manager/index.tsx
@@ -1,0 +1,244 @@
+/**
+ * Resource Manager — /resource-manager
+ *
+ * Renders an expand/collapse tree of the currently selected organization's
+ * container hierarchy: Organization → Folders → Projects.
+ *
+ * Tree expansion state is stored in the `expanded` URL search param so links
+ * are shareable (e.g. ?expanded=folder-a,folder-b). The org root is always
+ * rendered expanded and is not included in the param.
+ *
+ * Top-right "New" dropdown provides one-click navigation to create
+ * Organization, Folder, or Project resources.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ChevronDown, Plus } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+import { useOrg } from '@/lib/org-context'
+import { useListResources } from '@/queries/resources'
+import { ResourceTree } from '@/components/resource-manager/ResourceTree'
+
+// ---------------------------------------------------------------------------
+// Route search params schema
+// ---------------------------------------------------------------------------
+
+export interface ResourceManagerSearch {
+  /** Comma-separated list of expanded folder names. */
+  expanded?: string
+}
+
+function parseResourceManagerSearch(
+  raw: Record<string, unknown>,
+): ResourceManagerSearch {
+  const result: ResourceManagerSearch = {}
+  if (typeof raw['expanded'] === 'string' && raw['expanded']) {
+    result.expanded = raw['expanded']
+  }
+  return result
+}
+
+export const Route = createFileRoute('/_authenticated/resource-manager/')({
+  validateSearch: parseResourceManagerSearch,
+  component: ResourceManagerPage,
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseExpanded(raw: string | undefined): Set<string> {
+  if (!raw) return new Set()
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  )
+}
+
+function serialiseExpanded(expanded: Set<string>): string | undefined {
+  if (expanded.size === 0) return undefined
+  return Array.from(expanded).join(',')
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function ResourceManagerPage() {
+  const { selectedOrg } = useOrg()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  const expanded = useMemo(() => parseExpanded(search.expanded), [search.expanded])
+
+  const handleToggle = useCallback(
+    (folderName: string) => {
+      navigate({
+        search: (prev) => {
+          const next = new Set(expanded)
+          if (next.has(folderName)) {
+            next.delete(folderName)
+          } else {
+            next.add(folderName)
+          }
+          return { ...prev, expanded: serialiseExpanded(next) }
+        },
+        replace: true,
+      })
+    },
+    [navigate, expanded],
+  )
+
+  const { data, isLoading, error } = useListResources(selectedOrg ?? '')
+
+  const resources = data?.resources ?? []
+
+  // --- Loading skeleton ---------------------------------------------------
+
+  if (isLoading && selectedOrg) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <CardTitle>Resource Manager</CardTitle>
+          <NewDropdown orgName={selectedOrg} />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2" data-testid="resource-manager-loading">
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // --- No org selected empty state ----------------------------------------
+
+  if (!selectedOrg) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Resource Manager</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div
+            className="flex flex-col items-center gap-3 py-8 text-center"
+            data-testid="resource-manager-empty-org"
+          >
+            <p className="text-muted-foreground">
+              Select an organization to view its resources.
+            </p>
+            <Link to="/organizations">
+              <Button size="sm">Go to Organizations</Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // --- Error state --------------------------------------------------------
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <CardTitle>Resource Manager</CardTitle>
+          <NewDropdown orgName={selectedOrg} />
+        </CardHeader>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // --- Tree ---------------------------------------------------------------
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+        <CardTitle>Resource Manager</CardTitle>
+        <NewDropdown orgName={selectedOrg} />
+      </CardHeader>
+      <CardContent>
+        {/* Column header row */}
+        <div className="flex items-center gap-2 pb-1 border-b border-border text-xs text-muted-foreground font-medium">
+          <div className="w-5 flex-shrink-0" />
+          <div className="flex-1">Name</div>
+          <div className="hidden sm:block w-28 text-right">Created At</div>
+          <div className="hidden sm:block w-28 text-right">Updated At</div>
+          {/* Spacer for icon buttons (Settings + Delete = ~72px) */}
+          <div className="w-[72px]" />
+        </div>
+
+        <ResourceTree
+          orgName={selectedOrg}
+          resources={resources}
+          expanded={expanded}
+          onToggle={handleToggle}
+          organization={selectedOrg}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// New dropdown
+// ---------------------------------------------------------------------------
+
+/**
+ * NewDropdown — top-right dropdown for creating new resources.
+ *
+ * Organization → /organizations (existing org-create landing page)
+ * Folder → /orgs/$orgName/settings (deferred; no standalone create-folder
+ *           route exists yet — follow-up in sibling cleanup plan)
+ * Project → /organizations (deferred; no standalone create-project route
+ *            exists yet — follow-up in sibling cleanup plan)
+ */
+function NewDropdown({ orgName }: { orgName: string }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm" data-testid="resource-manager-new-button">
+          <Plus className="mr-1 h-4 w-4" />
+          New
+          <ChevronDown className="ml-1 h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" data-testid="resource-manager-new-menu">
+        <DropdownMenuItem asChild data-testid="new-menu-organization">
+          <Link to="/organizations">Organization</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild data-testid="new-menu-folder">
+          {/* Route to org settings until a dedicated create-folder page exists. */}
+          <Link to="/orgs/$orgName/settings/" params={{ orgName }}>
+            Folder
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild data-testid="new-menu-project">
+          {/* Route to organizations until a dedicated create-project page exists. */}
+          <Link to="/organizations">Project</Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/routes/_authenticated/resource-manager/index.tsx
+++ b/frontend/src/routes/_authenticated/resource-manager/index.tsx
@@ -230,7 +230,7 @@ function NewDropdown({ orgName }: { orgName: string }) {
         </DropdownMenuItem>
         <DropdownMenuItem asChild data-testid="new-menu-folder">
           {/* Route to org settings until a dedicated create-folder page exists. */}
-          <Link to="/orgs/$orgName/settings/" params={{ orgName }}>
+          <Link to="/orgs/$orgName/settings" params={{ orgName }}>
             Folder
           </Link>
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary

- Adds `/resource-manager` route (`frontend/src/routes/_authenticated/resource-manager/index.tsx`) that renders an expand/collapse tree of Organization → Folders → Projects.
- `ResourceTree` component builds a client-side hierarchy from the flat `useListResources` response (no additional RPCs).
- `TreeNode` component renders each row: disclosure toggle (+/-), display-name link, Created At / Updated At columns, Settings icon (type-aware route), Delete icon (ConfirmDeleteDialog). Org root has no delete button.
- Tree expansion state stored in `?expanded=folder-a,folder-b` URL search param for shareable links.
- Top-right "New" dropdown with Organization, Folder, and Project entries.
- Empty state when no org is selected: "Select an organization" guidance with link to /organizations.
- Resolves the 404 that existed on the sidebar "Resource Manager" entry added in HOL-856.

Fixes HOL-861

## Test plan

- [x] `make test-ui` — all 1172 tests across 92 test files pass
- [x] `npx tsc --noEmit` — TypeScript strict-mode exits clean
- [x] `ResourceTree` component tests: root row, expand/collapse, project-1 hidden/visible, toggle callback, settings links, delete buttons, link hrefs, empty tree, ConfirmDeleteDialog on delete click
- [x] Route tests: empty state, loading skeleton, error alert, tree renders, New dropdown button present

## Deferred Acceptance Criteria

- [ ] Folder "New" entry routes to `/orgs/$orgName/settings` (no standalone create-folder page exists yet; deferred to sibling cleanup plan per issue notes)
- [ ] Project "New" entry routes to `/organizations` (no standalone create-project page exists yet; same deferral)
- [ ] `createdAt` / `updatedAt` columns: the `Resource` proto does not carry timestamp fields; the tree displays `-` as fallback. Full timestamps require a backend change (follow-up)