### PR TITLE
chore(ui): MVP-demo scope cleanup and agent-facing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,33 @@ All testing guidance lives in this repo. Read the entries below in order the fir
 
 **Make targets**: `make test-go` (Go tests), `make test-ui` (Vitest unit tests), `make test-e2e` (Playwright, needs `make certs` and a k3d cluster), `make test` (all three). Run `make generate` before committing if proto or generated code is affected.
 
+## MVP UI — ResourceGrid v1 and 4-item sidebar nav (HOL-854)
+
+The HOL-854 plan shipped seven phases (HOL-855 – HOL-861) that replace the old
+two-tree sidebar with a flat 4-item nav and a shared table component. Key files
+added:
+
+| File / dir | Phase | Purpose |
+|---|---|---|
+| `frontend/src/components/resource-grid/` | HOL-855 | `ResourceGrid` v1 table, `types.ts`, `url-state.ts` |
+| `frontend/src/components/ui/confirm-delete-dialog.tsx` | HOL-855 | Shared delete confirmation dialog |
+| `frontend/src/components/app-sidebar.tsx` | HOL-856 | Flat 4-item nav (Secrets, Deployments, Templates, Resource Manager) |
+| `frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx` | HOL-857 | Secrets page on ResourceGrid v1 |
+| `frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx` | HOL-858 | Deployments page on ResourceGrid v1 |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx` | HOL-859 | Unified Templates index on ResourceGrid v1 |
+| `frontend/src/components/templates/TemplatesHelpPane.tsx` | HOL-860 | Templates help pane (? icon toggle) |
+| `frontend/src/components/resource-manager/` | HOL-861 | Resource Manager tree view at `/resource-manager` |
+| `frontend/src/routes/_authenticated/resource-manager/index.tsx` | HOL-861 | Resource Manager route |
+
+**Design note**: `docs/ui/resource-grid-v1.md` — columns, filter contract, URL
+state format, extension points (`extraColumns`, `onDelete`), and when to use
+ResourceGrid v1 vs. the Resource Manager tree.
+
+**Deferred**: Legacy sidebar destinations (Project tree, Organization tree,
+`/orgs/$orgName/resources`, folder-scoped index pages) are still present in
+the codebase but no longer reachable via the sidebar. Their removal is tracked
+in a sibling cleanup plan.
+
 ## Guardrails
 
 - [Demo Docs Routing](https://github.com/holos-run/holos-console-docs/tree/main/demo) — Demo setup materials and CUE example snippets belong in `holos-run/holos-console-docs/demo/`, **not** in this repo; demo-related issues must include concrete examples and operator guidance.

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,6 +43,24 @@ semantics that do not require a real apiserver.
 
 Vitest + React Testing Library + jsdom. Mock query hooks (`@/queries/*`) with `vi.mock()` and `vi.fn()`. Route-directory test files must be prefixed with `-` (e.g. `-about.test.tsx`) so TanStack Router's generator ignores them. Run with `make test-ui`.
 
+### ResourceGrid v1 unit-test pattern (HOL-855)
+
+`frontend/src/components/resource-grid/-resource-grid.test.tsx` is the
+reference for testing pages built on `ResourceGrid`. The pattern:
+
+1. Import `ResourceGrid` and pass a synthetic `kinds` + `rows` array.
+2. Do **not** mock `@/components/resource-grid`; test the component directly.
+3. Mock only the TanStack Router primitives (`Link`, `useNavigate`) and
+   shadcn primitives that are not present in jsdom (e.g. `dialog`).
+4. Assert visible column headers, row cell content, filter controls, empty
+   state, loading skeleton (`data-testid="resource-grid-loading"`), and the
+   delete-confirm dialog flow.
+
+Route-level tests for pages that wrap `ResourceGrid` (e.g. Secrets, Deployments,
+Templates) follow the same mock-query pattern as other route tests. They do not
+need to re-exercise filter logic — one line asserting the grid renders is
+sufficient at the page level.
+
 ## E2E Tests
 
 Playwright in `frontend/e2e/`. `make test-e2e` orchestrates the full stack (builds Go binary, starts Go backend on :8443 and Vite on :5173). For tight iteration, start servers once and run targeted tests — see `docs/e2e-testing.md` for the full workflow including K8s-backed tests.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -180,6 +180,14 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/queries/-templatePolicies.test.ts` | `aggregateFanOut` helper: idle/disabled queries, pending while fetching, org-only and org+folder concatenation, partial-failure tolerance, non-Error wrapping, empty input |
 | `src/components/create-org-dialog.test.tsx` | Create organization dialog: validation, submission |
 | `src/components/create-project-dialog.test.tsx` | Create project dialog: validation, submission |
+| `src/components/resource-grid/-resource-grid.test.tsx` | ResourceGrid v1: column headers, kind filter, lineage filter, global search, empty/loading/error states, delete-confirm dialog |
+| `src/components/ui/-confirm-delete-dialog.test.tsx` | ConfirmDeleteDialog: open/close, confirm, error, isDeleting state |
+| `src/components/-app-sidebar.tree.test.tsx` | Sidebar integration (real primitives): enabled entries render Link, disabled entries render tooltip-wrapped button |
+| `src/components/templates/-templates-help-pane.test.tsx` | TemplatesHelpPane: renders help content sections |
+| `src/components/resource-manager/-resource-tree.test.tsx` | ResourceTree: expand/collapse, leaf nodes, empty state |
+| `src/routes/_authenticated/resource-manager/-index.test.tsx` | Resource Manager page: renders ResourceTree, loading/error states |
+| `src/routes/_authenticated/projects/$projectName/templates/-index-help.test.tsx` | Templates index with help pane: ? icon toggle, pane visibility |
+| `src/lib/-template-row-link.test.ts` | templateRowLink helper: namespace/name → detail href mapping |
 | `src/components/template-policy-bindings/BindingForm.test.tsx` | BindingForm: ProjectTemplate / Deployment / ProjectNamespace kind selection, project-name field shown/hidden, wildcard validation, submit / save paths (HOL-814) |
 | `src/index.test.ts` | App entry point smoke test |
 

--- a/docs/ui/resource-grid-v1.md
+++ b/docs/ui/resource-grid-v1.md
@@ -1,0 +1,210 @@
+# ResourceGrid v1 — Design Note
+
+> **Agent quick-read** (~4 min). Covers everything you need to add a new
+> resource kind to an existing grid, or to wire a new page onto `ResourceGrid`.
+
+## Location
+
+```
+frontend/src/components/resource-grid/
+  ResourceGrid.tsx   — the component
+  types.ts           — Row, Kind, LineageDirection, ResourceGridSearch
+  url-state.ts       — parseGridSearch / serialiseGridSearch / parseKindIds / serialiseKindIds
+```
+
+## What ResourceGrid v1 does
+
+`ResourceGrid` is a TanStack Table wrapper that provides:
+
+- A **global search** box (`?search=`) using `includesString` filtering.
+- A **multi-kind filter** (`?kind=a,b`) rendered as checkboxes when more than
+  one `Kind` is passed. Checking all or none = show everything.
+- A **lineage filter** (`?lineage=ancestors|descendants|both` + `?recursive=1`)
+  — the grid reads these from URL state and exposes them via `search` props so
+  the parent route's data-fetching layer can act on them. The grid itself passes
+  rows through unchanged (data-source-agnostic).
+- A **"New" button** — a single Link when one creatable kind exists, a dropdown
+  when multiple exist.
+- **Row-level delete** via `ConfirmDeleteDialog`; callers supply an `onDelete`
+  async callback.
+- **Parent column auto-hide** — the `parentId` / `parentLabel` column is hidden
+  automatically when all rows share the same parent.
+
+## Columns (default order)
+
+| Column | Source field | Notes |
+|---|---|---|
+| Parent | `row.parentId` / `row.parentLabel` | Hidden when all rows share one parent |
+| Resource ID | `row.id` | Monospace, muted |
+| Display Name | `row.displayName` \|\| `row.name` | Links to `row.detailHref` if present |
+| Description | `row.description` | Truncated, max-width |
+| _(extraColumns)_ | caller-supplied | Inserted after Description |
+| Created At | `row.createdAt` | ISO-8601 string, rendered via `toLocaleDateString()` |
+| Actions | — | Delete icon button; triggers ConfirmDeleteDialog |
+
+## The `Row` interface
+
+```ts
+interface Row {
+  kind: string        // must match a Kind.id
+  name: string        // Kubernetes resource name
+  namespace: string   // Kubernetes namespace
+  id: string          // stable identifier (UID or compound key)
+  parentId: string    // parent resource name/namespace
+  parentLabel: string // human label for parent (e.g. project display name)
+  displayName: string // user-facing label (falls back to name)
+  description: string
+  createdAt: string   // ISO-8601
+  detailHref?: string // makes displayName a link
+}
+```
+
+## The `Kind` interface
+
+```ts
+interface Kind {
+  id: string          // stable, used in ?kind= URL param
+  label: string       // shown in checkboxes and dropdown
+  newHref?: string    // "New" button destination
+  canCreate?: boolean // controls whether "New" button appears
+}
+```
+
+## URL state contract
+
+All search params flow through `ResourceGridSearch`:
+
+```ts
+interface ResourceGridSearch {
+  kind?: string          // comma-separated Kind.id list; absent = show all
+  search?: string        // global filter string
+  lineage?: 'ancestors' | 'descendants' | 'both'
+  recursive?: '0' | '1' // '0' / absent = non-recursive (default)
+}
+```
+
+Consumer routes call `parseGridSearch` from `url-state.ts` inside
+`validateSearch`:
+
+```ts
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+
+export const Route = createFileRoute('/projects/$projectName/secrets')({
+  validateSearch: parseGridSearch,
+  component: SecretsPage,
+})
+```
+
+Inside the page component, wire the grid to the router:
+
+```ts
+const search = Route.useSearch()
+const navigate = useNavigate({ from: Route.fullPath })
+
+<ResourceGrid
+  search={search}
+  onSearchChange={(updater) =>
+    navigate({ search: updater, replace: true })
+  }
+  ...
+/>
+```
+
+## Extension points
+
+### `extraColumns`
+
+Append TanStack Table `ColumnDef<Row>` entries after the Description column:
+
+```ts
+import { createColumnHelper } from '@tanstack/react-table'
+import type { Row } from '@/components/resource-grid/types'
+
+const col = createColumnHelper<Row>()
+
+const phaseColumn = col.display({
+  id: 'phase',
+  header: 'Phase',
+  cell: ({ row }) => <PhaseBadge phase={row.original.extra?.phase} />,
+})
+
+<ResourceGrid extraColumns={[phaseColumn]} ... />
+```
+
+The `Row.extra` field does not exist on the base interface — attach it via
+module augmentation or pass it out-of-band through closure if needed.
+Deployments uses a local `DeploymentRow` type that extends `Row` for this
+purpose; see `frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx`.
+
+### `onDelete`
+
+Async callback receiving the full `Row`. Throw to surface a toast error.
+
+```ts
+const { mutateAsync } = useDeleteSecret()
+
+const handleDelete = async (row: Row) => {
+  await mutateAsync({ name: row.name, namespace: row.namespace })
+  // queryClient.invalidateQueries(...) if needed
+}
+
+<ResourceGrid onDelete={handleDelete} ... />
+```
+
+### `headerContent`
+
+A `React.ReactNode` rendered inside the Card header below the title, above the
+toolbar. Used by the Deployments page for its description banner.
+
+### `headerActions`
+
+A `React.ReactNode` rendered in the Card header to the left of the "New"
+button. Used by the Templates page for the help-pane toggle (? icon button).
+
+## When to use ResourceGrid v1 vs. the Resource Manager tree
+
+| Situation | Use |
+|---|---|
+| Flat list of resources under one project (Secrets, Deployments, Templates) | ResourceGrid v1 |
+| Cross-scope hierarchical view of all resources (org → folder → project) | Resource Manager tree |
+| A new resource kind that belongs to a single project | ResourceGrid v1 — add a `Kind` entry and map data to `Row` |
+| A new resource kind that spans the org hierarchy | Resource Manager tree — add a node type to `TreeNode` |
+
+## Adding a new kind to an existing grid
+
+Example: adding a hypothetical `TemplateRelease` kind to the Templates grid.
+
+1. Define a new `Kind` entry in the page component:
+
+   ```ts
+   const kinds: Kind[] = [
+     existingKind,
+     { id: 'template-release', label: 'Template Release', newHref: '/...', canCreate: isOwner },
+   ]
+   ```
+
+2. Map API response items to `Row` objects with `kind: 'template-release'`.
+
+3. Merge the two data arrays and pass as `rows` to `ResourceGrid`.
+
+4. Add a unit test asserting the new kind appears in the kind-filter checkboxes
+   and that its rows are visible when the filter is set to `template-release`.
+
+No changes to `ResourceGrid` itself are required.
+
+## Unit-test reference
+
+`frontend/src/components/resource-grid/-resource-grid.test.tsx` — covers:
+
+- Column headers rendered
+- Kind-filter checkboxes (multi-kind scenario)
+- Lineage filter controls
+- Global search filtering
+- Empty state when `rows=[]`
+- Loading skeleton (`data-testid="resource-grid-loading"`)
+- Error card when `error` is set and rows is empty
+- Partial-error inline banner when `error` is set and rows exist
+- Delete-confirm dialog: open on trash icon click, cancel, confirm, error state
+
+See `docs/agents/testing-patterns.md` §"ResourceGrid v1 unit-test pattern" for
+the recommended mock strategy at the page level.

--- a/frontend/src/components/-app-sidebar.tree.test.tsx
+++ b/frontend/src/components/-app-sidebar.tree.test.tsx
@@ -3,14 +3,10 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 
-// HOL-856 integration test: exercise the flat 4-item nav with the real
-// sidebar primitives (no mocks for ui/sidebar). This verifies that
-// SidebarMenuButton asChild correctly forwards the Link child for enabled
-// entries, and that disabled entries render a TooltipProvider-wrapped
-// button instead of an anchor.
-//
-// The Collapsible toggle tests from HOL-604 are intentionally removed: the
-// two-tree Collapsible layout is replaced by a flat SidebarMenu in HOL-856.
+// Integration test: exercise the flat 4-item nav with the real sidebar
+// primitives (no mocks for ui/sidebar). Verifies that SidebarMenuButton
+// asChild correctly forwards the Link child for enabled entries, and that
+// disabled entries render a TooltipProvider-wrapped button instead of an anchor.
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({

--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -3,11 +3,9 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 
-// HOL-856: replaces the two-tree sidebar (HOL-604/HOL-605 Collapsible groups)
-// with a flat 4-item nav: Secrets, Deployments, Templates, Resource Manager.
-// The workspace picker stays in SidebarHeader. The version label moves into
-// SidebarFooter. Legacy routes remain reachable by URL; their cleanup is a
-// separate sibling plan.
+// Tests for the flat 4-item sidebar nav: Secrets, Deployments, Templates,
+// Resource Manager. The workspace picker lives in SidebarHeader; the version
+// label lives in SidebarFooter.
 
 // Configurable per-test so we can drive route-based active-state gating.
 let mockPathname = '/'

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -50,11 +50,10 @@ export function AppSidebar() {
 
   const hasProject = Boolean(selectedProject)
 
-  // HOL-856: flat 4-item nav replacing the two Collapsible trees.
-  // Order: Secrets, Deployments, Templates, Resource Manager.
-  // Resource Manager links to /resource-manager (top-level route added in
-  // Phase 7 / HOL-861). The link is always enabled; it may 404 until Phase 7
-  // merges — this is documented and accepted per the plan sequencing rationale.
+  // Flat 4-item nav: Secrets, Deployments, Templates, Resource Manager.
+  // The first three items are scoped to the selected project and are disabled
+  // until a project is chosen from the WorkspaceMenu. Resource Manager is a
+  // top-level route that is always enabled.
   const navItems: NavItem[] = [
     {
       label: 'Secrets',
@@ -96,17 +95,12 @@ export function AppSidebar() {
   return (
     <Sidebar>
       <SidebarHeader className="px-2 py-2">
-        {/*
-          HOL-603 replaces the previous stacked OrgPicker + ProjectPicker
-          with a single Linear-style workspace menu. Profile / Dev Tools
-          have moved off the footer and into this menu so all "global" nav
-          lives in one place at the top of the sidebar.
-        */}
+          {/* WorkspaceMenu provides org/project selection, profile, and dev tools. */}
         <WorkspaceMenu />
       </SidebarHeader>
 
       <SidebarContent>
-        {/* HOL-856: flat 4-item nav — Secrets, Deployments, Templates, Resource Manager */}
+        {/* Flat 4-item nav — Secrets, Deployments, Templates, Resource Manager */}
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -164,7 +158,7 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
 
-      {/* HOL-856: version label moved from SidebarHeader into footer, bottom-left */}
+      {/* Version label in the footer, bottom-left. */}
       {versionData?.version && (
         <SidebarFooter>
           <div className="px-2 py-2 text-xs text-muted-foreground">

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -10,7 +10,7 @@
  *  - Row-level delete via ConfirmDeleteDialog
  *  - URL sync via TanStack Router useSearch / useNavigate
  *
- * See HOL-855 for the full acceptance criteria.
+ * See docs/ui/resource-grid-v1.md for the design note and extension guide.
  */
 
 import { useState, useMemo, useCallback } from 'react'


### PR DESCRIPTION
## Summary

- Remove HOL-604/605/793/856 issue-number references from `app-sidebar.tsx` and its test files; replace with current functional descriptions.
- Update `ResourceGrid.tsx` header comment to point to `docs/ui/resource-grid-v1.md`.
- Add MVP UI subsection to `AGENTS.md` listing all files added in HOL-855–861.
- Add ResourceGrid v1 unit-test pattern section to `docs/agents/testing-patterns.md`.
- Add new test files from HOL-855–861 to the Existing Test Files table in `docs/testing.md`.
- Create `docs/ui/resource-grid-v1.md`: design note covering columns, Row/Kind interfaces, URL state contract, extension points (`extraColumns`, `onDelete`, `headerContent`, `headerActions`), and when to use ResourceGrid v1 vs the Resource Manager tree.

Fixes HOL-862

## Test plan

- [x] `make test-ui` passes (92 test files, 1172 tests)
- [x] `make test-go` passes (exit 0)
- [x] No code paths changed — docs and comment edits only (plus the `ResourceGrid.tsx` header comment update)

## Notes

- Sibling cleanup plan filed as HOL-863 (removal of legacy sidebar destinations). Not performed in this PR.