### PR TITLE
feat(ui): returnTo search-param helper for post-create redirects

### DIFF
--- a/frontend/src/lib/return-to.test.ts
+++ b/frontend/src/lib/return-to.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import { isValidReturnTo, resolveReturnTo, buildReturnTo } from './return-to'
+
+// ---------------------------------------------------------------------------
+// isValidReturnTo
+// ---------------------------------------------------------------------------
+
+describe('isValidReturnTo', () => {
+  // Valid in-app paths
+  it.each([
+    ['/'],
+    ['/organizations'],
+    ['/folders/my-folder'],
+    ['/projects/my-project/settings'],
+    ['/organizations?page=1'],
+    ['/folders/my-folder?tab=secrets'],
+    ['/resource-manager'],
+  ])('accepts valid in-app path: %s', (path) => {
+    expect(isValidReturnTo(path)).toBe(true)
+  })
+
+  // Reject protocol-relative URLs (open-redirect risk)
+  it('rejects protocol-relative URL starting with //', () => {
+    expect(isValidReturnTo('//evil.example.com')).toBe(false)
+  })
+
+  it('rejects protocol-relative URL with path', () => {
+    expect(isValidReturnTo('//evil.example.com/steal?token=1')).toBe(false)
+  })
+
+  // Reject absolute URLs
+  it.each([
+    ['https://evil.example.com'],
+    ['https://evil.example.com/steal'],
+    ['http://evil.example.com'],
+  ])('rejects absolute URL: %s', (url) => {
+    expect(isValidReturnTo(url)).toBe(false)
+  })
+
+  // Reject javascript: and other dangerous schemes
+  it('rejects javascript: URL', () => {
+    expect(isValidReturnTo('javascript:alert(1)')).toBe(false)
+  })
+
+  it('rejects javascript: wrapped in a path prefix attempt', () => {
+    // Does not start with '/', so rejected at first check
+    expect(isValidReturnTo('javascript:void(0)')).toBe(false)
+  })
+
+  it('rejects data: URL', () => {
+    expect(isValidReturnTo('data:text/html,<script>alert(1)</script>')).toBe(false)
+  })
+
+  // Reject backslashes (path traversal tricks)
+  it('rejects path containing backslash', () => {
+    expect(isValidReturnTo('/organizations\\..\\admin')).toBe(false)
+  })
+
+  it('rejects path with backslash at start of segment', () => {
+    expect(isValidReturnTo('/\\')).toBe(false)
+  })
+
+  // Reject empty and non-string values
+  it('rejects empty string', () => {
+    expect(isValidReturnTo('')).toBe(false)
+  })
+
+  it('rejects null', () => {
+    expect(isValidReturnTo(null)).toBe(false)
+  })
+
+  it('rejects undefined', () => {
+    expect(isValidReturnTo(undefined)).toBe(false)
+  })
+
+  it('rejects number', () => {
+    expect(isValidReturnTo(42)).toBe(false)
+  })
+
+  // Reject paths that do not start with /
+  it('rejects relative path without leading slash', () => {
+    expect(isValidReturnTo('organizations')).toBe(false)
+  })
+
+  // Reject invalid percent-encoded sequences
+  it('rejects string with invalid percent encoding', () => {
+    expect(isValidReturnTo('/path/%GG')).toBe(false)
+  })
+
+  // Colon in the first path segment (scheme-like)
+  it('rejects /something:with-colon in first segment', () => {
+    expect(isValidReturnTo('/something:with-colon')).toBe(false)
+  })
+
+  it('allows colon in a later path segment', () => {
+    // A colon after the first slash separator is fine (e.g. a resource name)
+    expect(isValidReturnTo('/projects/my:project')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveReturnTo
+// ---------------------------------------------------------------------------
+
+describe('resolveReturnTo', () => {
+  const FALLBACK = '/organizations'
+
+  it('returns a valid returnTo path', () => {
+    expect(resolveReturnTo('/folders', FALLBACK)).toBe('/folders')
+  })
+
+  it('returns a valid returnTo path with query string', () => {
+    expect(resolveReturnTo('/folders?tab=secrets', FALLBACK)).toBe('/folders?tab=secrets')
+  })
+
+  it('falls back when returnTo is undefined', () => {
+    expect(resolveReturnTo(undefined, FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('falls back when returnTo is null', () => {
+    expect(resolveReturnTo(null, FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('falls back when returnTo is empty string', () => {
+    expect(resolveReturnTo('', FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('falls back when returnTo is an absolute URL', () => {
+    expect(resolveReturnTo('https://evil.example.com', FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('falls back when returnTo is protocol-relative', () => {
+    expect(resolveReturnTo('//evil.example.com', FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('falls back when returnTo is javascript:', () => {
+    expect(resolveReturnTo('javascript:alert(1)', FALLBACK)).toBe(FALLBACK)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildReturnTo
+// ---------------------------------------------------------------------------
+
+describe('buildReturnTo', () => {
+  it('returns pathname only when no search string', () => {
+    expect(buildReturnTo({ pathname: '/organizations' })).toBe('/organizations')
+  })
+
+  it('appends search string when present', () => {
+    expect(buildReturnTo({ pathname: '/folders', search: '?tab=secrets' })).toBe(
+      '/folders?tab=secrets',
+    )
+  })
+
+  it('omits bare "?" as search', () => {
+    expect(buildReturnTo({ pathname: '/folders', search: '?' })).toBe('/folders')
+  })
+
+  it('omits empty-string search', () => {
+    expect(buildReturnTo({ pathname: '/folders', search: '' })).toBe('/folders')
+  })
+
+  it('omits undefined search', () => {
+    expect(buildReturnTo({ pathname: '/folders', search: undefined })).toBe('/folders')
+  })
+
+  it('returns empty string when pathname is empty', () => {
+    expect(buildReturnTo({ pathname: '' })).toBe('')
+  })
+
+  it('produces a value that passes isValidReturnTo for a normal path', () => {
+    const value = buildReturnTo({ pathname: '/folders/my-folder', search: '?page=2' })
+    expect(isValidReturnTo(value)).toBe(true)
+  })
+})

--- a/frontend/src/lib/return-to.ts
+++ b/frontend/src/lib/return-to.ts
@@ -1,0 +1,132 @@
+/**
+ * return-to.ts — open-redirect-safe helpers for the `returnTo` search param.
+ *
+ * Resource-creation routes (`/organization/new`, `/folder/new`,
+ * `/project/new`) need to redirect the user back to the page they launched
+ * the creation from.  This module provides three pure helper functions that
+ * keep the search-param contract consistent across all creation routes.
+ *
+ * ## Security contract
+ *
+ * Only same-origin, in-app paths are allowed.  A valid `returnTo` value:
+ *   - begins with a single `/` (not `//`, which is protocol-relative)
+ *   - contains no `:` in the first path segment (blocks `javascript:`, etc.)
+ *   - contains no backslashes (blocks path-traversal tricks on Windows)
+ *   - is non-empty
+ *   - round-trips through `decodeURIComponent` without throwing (valid UTF-8)
+ *
+ * Any value that fails validation falls back to the caller-supplied default.
+ *
+ * ## Usage
+ *
+ * In a link/button that opens a creation page:
+ *
+ *   import { buildReturnTo } from '@/lib/return-to'
+ *   const search = { returnTo: buildReturnTo(router.state.location) }
+ *   <Link to="/organization/new" search={search}>New Org</Link>
+ *
+ * In the creation route's `onSuccess` handler:
+ *
+ *   import { resolveReturnTo } from '@/lib/return-to'
+ *   const target = resolveReturnTo(search, '/organizations')
+ *   navigate({ to: target })
+ *
+ * @module
+ */
+
+/**
+ * A validated same-origin path.  The branded type lets TypeScript callers
+ * distinguish a trusted, validated path from an arbitrary string.
+ */
+export type SafeReturnPath = string & { readonly __safeReturnPath: unique symbol }
+
+/**
+ * isValidReturnTo returns true when `value` is safe to use as a redirect
+ * destination after a resource-creation action.
+ *
+ * Rules (all must pass):
+ *   1. Non-empty string.
+ *   2. Starts with `/` but NOT `//`.
+ *   3. No colon (`:`) before the first `/` after the leading slash.
+ *      (Blocks `javascript:alert()`, `https://evil.com`, etc.)
+ *   4. No backslash anywhere.  (Blocks Windows-style path tricks.)
+ *   5. `decodeURIComponent` does not throw.  (Ensures valid UTF-8 encoding.)
+ */
+export function isValidReturnTo(value: unknown): value is SafeReturnPath {
+  if (typeof value !== 'string' || value.length === 0) return false
+
+  // Must start with a single '/'.
+  if (!value.startsWith('/')) return false
+
+  // Must NOT start with '//' (protocol-relative URL).
+  if (value.startsWith('//')) return false
+
+  // No backslashes anywhere.
+  if (value.includes('\\')) return false
+
+  // No colon before the first path separator after the leading slash.
+  // Extract the first segment (everything between the leading '/' and the next '/').
+  const afterLeadingSlash = value.slice(1)
+  const firstSegmentEnd = afterLeadingSlash.indexOf('/')
+  const firstSegment =
+    firstSegmentEnd === -1 ? afterLeadingSlash : afterLeadingSlash.slice(0, firstSegmentEnd)
+  if (firstSegment.includes(':')) return false
+
+  // Must round-trip through decodeURIComponent without throwing.
+  try {
+    decodeURIComponent(value)
+  } catch {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * resolveReturnTo returns the redirect target from the `returnTo` search
+ * param when valid, or `fallback` otherwise.
+ *
+ * @param returnTo - The raw `returnTo` value from the URL search params.
+ *   Accepts `string | undefined | null`.
+ * @param fallback - The path to use when `returnTo` is absent or invalid.
+ *   Must be a valid in-app path (the caller is responsible for passing a
+ *   safe default; it is NOT re-validated here to keep the helper simple).
+ *
+ * @returns A path string suitable for TanStack Router's `navigate({ to })`.
+ */
+export function resolveReturnTo(returnTo: string | undefined | null, fallback: string): string {
+  if (isValidReturnTo(returnTo)) return returnTo
+  return fallback
+}
+
+/**
+ * Location represents the minimal subset of a TanStack Router (or browser)
+ * location object needed to build a `returnTo` value.
+ *
+ * TanStack Router's `ParsedLocation` satisfies this interface, as does the
+ * browser's `window.location`.
+ */
+export interface Location {
+  pathname: string
+  search?: string
+}
+
+/**
+ * buildReturnTo encodes `location.pathname` (plus `location.search` when
+ * present) into a single string suitable for use as the `returnTo` search
+ * param.
+ *
+ * The encoded value is the raw path + query string — no additional encoding
+ * is applied at this layer.  TanStack Router serialises search params when
+ * constructing the URL, so callers should pass the plain string returned here
+ * directly into the `search` object:
+ *
+ *   <Link to="/organization/new" search={{ returnTo: buildReturnTo(location) }}>
+ *
+ * Returns an empty string when `location.pathname` is empty or falsy.
+ */
+export function buildReturnTo(location: Location): string {
+  if (!location.pathname) return ''
+  const search = location.search && location.search !== '?' ? location.search : ''
+  return location.pathname + search
+}


### PR DESCRIPTION
## Summary

- Adds `frontend/src/lib/return-to.ts` with three pure, framework-agnostic helpers:
  - `isValidReturnTo(value)` — open-redirect-safe validator (same-origin paths only; rejects `//`, absolute URLs, `javascript:`, backslashes, empty strings, invalid percent-encoding)
  - `resolveReturnTo(returnTo, fallback)` — returns validated path or the supplied fallback
  - `buildReturnTo(location)` — encodes current pathname + search for use as `returnTo` search param
- Adds `frontend/src/lib/return-to.test.ts` with 40 Vitest unit tests covering valid paths, open-redirect attack vectors, and edge cases
- No behavior change visible to users (helper is unused by UI in this phase)

Fixes HOL-868

## Test plan

- [x] `make test-ui` passes — 1212 tests across 93 test files
- [x] All 40 `return-to.test.ts` tests pass
- [x] Valid in-app paths accepted: `/`, `/organizations`, `/folders/f?tab=x`
- [x] Rejected: `//evil.example.com`, `https://evil.example.com`, `javascript:alert(1)`, `data:...`, paths with backslashes, empty strings, null/undefined
- [x] `resolveReturnTo` falls back to default for all invalid inputs
- [x] `buildReturnTo` encodes pathname + search correctly; round-trips through `isValidReturnTo`