### PR TITLE
fix(ui): wire Resource Manager + New dropdown to new creation routes

### DIFF
--- a/frontend/src/routes/_authenticated/resource-manager/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/resource-manager/-index.test.tsx
@@ -51,7 +51,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     },
     useNavigate: () => mockNavigate,
     useRouter: () => ({
-      state: { location: { pathname: '/resource-manager', search: '?expanded=folder-a' } },
+      state: { location: { pathname: '/resource-manager', searchStr: '?expanded=folder-a' } },
     }),
   }
 })

--- a/frontend/src/routes/_authenticated/resource-manager/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/resource-manager/-index.test.tsx
@@ -28,10 +28,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
       children,
       to,
       params,
+      search,
     }: {
       children: React.ReactNode
       to?: string
       params?: Record<string, string>
+      search?: Record<string, string>
     }) => {
       let href = to ?? '#'
       if (params) {
@@ -39,10 +41,18 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
           href = href.replace(new RegExp(`\\$${k}`), v)
         }
       }
+      if (search && Object.keys(search).length > 0) {
+        const qs = Object.entries(search)
+          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+          .join('&')
+        href = `${href}?${qs}`
+      }
       return <a href={href}>{children}</a>
     },
     useNavigate: () => mockNavigate,
-    useRouter: () => ({ state: { location: { pathname: '/resource-manager' } } }),
+    useRouter: () => ({
+      state: { location: { pathname: '/resource-manager', search: '?expanded=folder-a' } },
+    }),
   }
 })
 
@@ -159,6 +169,43 @@ describe('ResourceManagerPage', () => {
     if (orgEntry) expect(orgEntry).toBeInTheDocument()
     if (folderEntry) expect(folderEntry).toBeInTheDocument()
     if (projectEntry) expect(projectEntry).toBeInTheDocument()
+  })
+
+  it('New dropdown links point to the dedicated creation routes with returnTo', () => {
+    // useRouter mock returns pathname=/resource-manager search=?expanded=folder-a
+    // buildReturnTo produces "/resource-manager?expanded=folder-a"
+    const expectedReturnTo = encodeURIComponent('/resource-manager?expanded=folder-a')
+    const encodedOrgName = encodeURIComponent('my-org')
+
+    setupMocks({ selectedOrg: 'my-org' })
+    render(<ResourceManagerPage />)
+
+    const orgLink = screen.queryByTestId('new-menu-organization')
+    const folderLink = screen.queryByTestId('new-menu-folder')
+    const projectLink = screen.queryByTestId('new-menu-project')
+
+    if (orgLink) {
+      const anchor = orgLink.querySelector('a') ?? orgLink
+      const href = anchor.getAttribute('href') ?? ''
+      expect(href).toContain('/organization/new')
+      expect(href).toContain(`returnTo=${expectedReturnTo}`)
+    }
+
+    if (folderLink) {
+      const anchor = folderLink.querySelector('a') ?? folderLink
+      const href = anchor.getAttribute('href') ?? ''
+      expect(href).toContain('/folder/new')
+      expect(href).toContain(`orgName=${encodedOrgName}`)
+      expect(href).toContain(`returnTo=${expectedReturnTo}`)
+    }
+
+    if (projectLink) {
+      const anchor = projectLink.querySelector('a') ?? projectLink
+      const href = anchor.getAttribute('href') ?? ''
+      expect(href).toContain('/project/new')
+      expect(href).toContain(`orgName=${encodedOrgName}`)
+      expect(href).toContain(`returnTo=${expectedReturnTo}`)
+    }
   })
 
   it('renders the Resource Manager card title', () => {

--- a/frontend/src/routes/_authenticated/resource-manager/index.tsx
+++ b/frontend/src/routes/_authenticated/resource-manager/index.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useCallback, useMemo } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { ChevronDown, Plus } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -30,6 +30,7 @@ import {
 import { useOrg } from '@/lib/org-context'
 import { useListResources } from '@/queries/resources'
 import { ResourceTree } from '@/components/resource-manager/ResourceTree'
+import { buildReturnTo } from '@/lib/return-to'
 
 // ---------------------------------------------------------------------------
 // Route search params schema
@@ -208,13 +209,15 @@ export function ResourceManagerPage() {
 /**
  * NewDropdown — top-right dropdown for creating new resources.
  *
- * Organization → /organizations (existing org-create landing page)
- * Folder → /orgs/$orgName/settings (deferred; no standalone create-folder
- *           route exists yet — follow-up in sibling cleanup plan)
- * Project → /organizations (deferred; no standalone create-project route
- *            exists yet — follow-up in sibling cleanup plan)
+ * Each item links to the dedicated creation route for that resource type.
+ * A `returnTo` search param is included so the creation page can redirect
+ * the user back to Resource Manager (preserving the current `?expanded=…`
+ * state) after the resource is created.
  */
 function NewDropdown({ orgName }: { orgName: string }) {
+  const router = useRouter()
+  const returnTo = buildReturnTo(router.state.location)
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -226,17 +229,25 @@ function NewDropdown({ orgName }: { orgName: string }) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" data-testid="resource-manager-new-menu">
         <DropdownMenuItem asChild data-testid="new-menu-organization">
-          <Link to="/organizations">Organization</Link>
+          <Link to="/organization/new" search={{ returnTo }}>
+            Organization
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild data-testid="new-menu-folder">
-          {/* Route to org settings until a dedicated create-folder page exists. */}
-          <Link to="/orgs/$orgName/settings" params={{ orgName }}>
+          <Link
+            to="/folder/new"
+            search={orgName ? { orgName, returnTo } : { returnTo }}
+          >
             Folder
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild data-testid="new-menu-project">
-          {/* Route to organizations until a dedicated create-project page exists. */}
-          <Link to="/organizations">Project</Link>
+          <Link
+            to="/project/new"
+            search={orgName ? { orgName, returnTo } : { returnTo }}
+          >
+            Project
+          </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/frontend/src/routes/_authenticated/resource-manager/index.tsx
+++ b/frontend/src/routes/_authenticated/resource-manager/index.tsx
@@ -216,7 +216,8 @@ export function ResourceManagerPage() {
  */
 function NewDropdown({ orgName }: { orgName: string }) {
   const router = useRouter()
-  const returnTo = buildReturnTo(router.state.location)
+  const { pathname, searchStr } = router.state.location
+  const returnTo = buildReturnTo({ pathname, search: searchStr })
 
   return (
     <DropdownMenu>


### PR DESCRIPTION
## Summary

- Update `NewDropdown` in `/resource-manager` to link each item to its dedicated creation route (`/organization/new`, `/folder/new`, `/project/new`) instead of placeholder fallback routes
- Each link includes a `returnTo` search param built via `buildReturnTo(router.state.location)` so the user returns to Resource Manager with `?expanded=…` state preserved
- Pass `orgName` on folder/project links when an org context is active; omit it otherwise (the creation form will prompt)
- Remove stale placeholder comments (lines 211–215) that noted the wrong URLs
- Extend the test mock to serialize `search` params into link hrefs
- Add a dedicated unit test asserting correct href (route path + `orgName` + `returnTo`) for all three dropdown items

Fixes HOL-872

## Test plan

- [x] `make test-ui` — all 93 test files / 1240 tests pass
- [x] New test `New dropdown links point to the dedicated creation routes with returnTo` verifies each link href
- [ ] Manual: open `/resource-manager?expanded=folder-a` with an active org, click + New — each item should navigate to the correct creation page and a successful submit should return to `/resource-manager?expanded=folder-a`