### PR TITLE
chore(ui): remove dead references to deleted create-*-dialog files

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -178,8 +178,9 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/queries/-organizations.test.ts` | Organization query hooks: get, update, sharing, default sharing, delete |
 | `src/queries/-projects.test.ts` | useListProjects and useCreateProject hooks |
 | `src/queries/-templatePolicies.test.ts` | `aggregateFanOut` helper: idle/disabled queries, pending while fetching, org-only and org+folder concatenation, partial-failure tolerance, non-Error wrapping, empty input |
-| `src/components/create-org-dialog.test.tsx` | Create organization dialog: validation, submission |
-| `src/components/create-project-dialog.test.tsx` | Create project dialog: validation, submission |
+| `src/routes/_authenticated/organization/-new.test.tsx` | Create organization page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error |
+| `src/routes/_authenticated/folder/-new.test.tsx` | Create folder page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error, orgName guard |
+| `src/routes/_authenticated/project/-new.test.tsx` | Create project page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error, orgName/folderName guards |
 | `src/components/resource-grid/-resource-grid.test.tsx` | ResourceGrid v1: column headers, kind filter, lineage filter, global search, empty/loading/error states, delete-confirm dialog |
 | `src/components/ui/-confirm-delete-dialog.test.tsx` | ConfirmDeleteDialog: open/close, confirm, error, isDeleting state |
 | `src/components/-app-sidebar.tree.test.tsx` | Sidebar integration (real primitives): enabled entries render Link, disabled entries render tooltip-wrapped button |

--- a/scripts/browser-self-service
+++ b/scripts/browser-self-service
@@ -67,56 +67,47 @@ click_link_by_text() {
 }
 
 echo "=== Step 1: Create an organization ==="
-$AB open "$HOLOS_BACKEND_URL/organizations"
+$AB open "$HOLOS_BACKEND_URL/organization/new"
 $AB wait --load networkidle
-$AB wait --text "Organizations" 2>/dev/null || $AB wait 3000
-screenshot "organizations-list"
-
-click_button_by_text "Create Organization"
-$AB wait 1000
-screenshot "create-org-dialog"
+$AB wait --text "Create Organization" 2>/dev/null || $AB wait 3000
+screenshot "org-new-page"
 
 $AB fill "input[placeholder='My Organization']" "$ORG_DISPLAY"
 $AB wait 500
 $AB fill "input[placeholder='my-org']" "$ORG_NAME"
 $AB fill "input[placeholder='What is this organization for?']" "Automated test org"
-screenshot "create-org-filled"
+screenshot "org-new-filled"
 
-click_dialog_button "Create"
+click_button_by_text "Create Organization"
 $AB wait --load networkidle
 $AB wait 2000
 screenshot "org-created"
 
-echo "=== Step 2: Set selected org and navigate to Projects ==="
+echo "=== Step 2: Set selected org and create a project ==="
 $AB eval "sessionStorage.setItem('holos-selected-org', '$ORG_NAME')"
-$AB open "$HOLOS_BACKEND_URL/projects"
+$AB open "$HOLOS_BACKEND_URL/project/new?orgName=$ORG_NAME"
 $AB wait --load networkidle
-$AB wait --text "Projects" 2>/dev/null || $AB wait 3000
-screenshot "projects-list"
-
-echo "=== Step 3: Create a new project ==="
-click_button_by_text "Create Project"
-$AB wait 1000
-screenshot "create-project-dialog"
+$AB wait --text "Create Project" 2>/dev/null || $AB wait 3000
+screenshot "project-new-page"
 
 $AB fill "input[placeholder='My Project']" "$PROJECT_DISPLAY"
 $AB wait 500
 $AB fill "input[placeholder='my-project']" "$PROJECT_NAME"
 $AB fill "input[placeholder='What is this project for?']" "Automated test project"
-screenshot "create-project-filled"
+screenshot "project-new-filled"
 
-click_dialog_button "Create"
+click_button_by_text "Create Project"
 $AB wait --load networkidle
 $AB wait 2000
 screenshot "project-created"
 
-echo "=== Step 4: Navigate to Secrets page ==="
+echo "=== Step 3: Navigate to Secrets page ==="
 click_link_by_text "Secrets"
 $AB wait --load networkidle
 $AB wait 1000
 screenshot "secrets-list"
 
-echo "=== Step 5: Create a new secret ==="
+echo "=== Step 4: Create a new secret ==="
 click_button_by_text "Create Secret"
 $AB wait 1000
 screenshot "create-secret-dialog"
@@ -139,7 +130,7 @@ $AB wait --load networkidle
 $AB wait 2000
 screenshot "secret-created"
 
-echo "=== Step 6: Verify the secret exists ==="
+echo "=== Step 5: Verify the secret exists ==="
 $AB eval "document.querySelector('a[href*=\"$SECRET_NAME\"]')?.click()"
 $AB wait --load networkidle
 $AB wait 1000
@@ -152,7 +143,7 @@ else
   echo "  WARN: Secret key '$SECRET_KEY' not found on detail page (may be masked)."
 fi
 
-echo "=== Step 7: Clean up — delete secret ==="
+echo "=== Step 6: Clean up — delete secret ==="
 click_button_by_text "Delete"
 $AB wait 1000
 screenshot "delete-secret-dialog"
@@ -162,7 +153,7 @@ $AB wait --load networkidle
 $AB wait 2000
 screenshot "secret-deleted"
 
-echo "=== Step 8: Clean up — delete project ==="
+echo "=== Step 7: Clean up — delete project ==="
 $AB open "$HOLOS_BACKEND_URL/projects/$PROJECT_NAME"
 $AB wait --load networkidle
 $AB wait 1000
@@ -176,7 +167,7 @@ $AB wait --load networkidle
 $AB wait 2000
 screenshot "project-deleted"
 
-echo "=== Step 9: Clean up — delete organization ==="
+echo "=== Step 8: Clean up — delete organization ==="
 $AB open "$HOLOS_BACKEND_URL/organizations"
 $AB wait --load networkidle
 $AB wait 1000


### PR DESCRIPTION
## Summary

After HOL-869/870/871 deleted the three modal creation dialog components and their test files, two stale references remained:

- **`docs/testing.md`**: Remove rows for `create-org-dialog.test.tsx` and `create-project-dialog.test.tsx` (files deleted by earlier phases). Add replacement rows for the new page-level tests under `src/routes/_authenticated/{organization,folder,project}/-new.test.tsx`.
- **`scripts/browser-self-service`**: Replace the old modal-dialog creation flow (click "Create Organization" → interact with `[role="dialog"]`) with direct navigation to the new `/organization/new` and `/project/new` routes.

Fixes HOL-874

## Test plan

- [x] `make test-ui` passes (93 test files, 1240 tests)
- [x] Grep for `create-org-dialog|create-folder-dialog|create-project-dialog` in `frontend/` returns only code comments in `*/new.tsx` migration docs and the Vite cache — no live imports or calls remain
- [x] `scripts/browser-self-service` navigates to `/organization/new` and `/project/new` routes instead of opening modal dialogs