### PR TITLE
fix(ui): harden ResourceGrid Created At cell against empty/invalid values

### DIFF
--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -145,6 +145,27 @@ describe('ResourceGrid', () => {
     expect(screen.getByText('A test secret')).toBeInTheDocument()
   })
 
+  // --- Created At cell ---
+
+  it('renders a localized date string when createdAt is a valid ISO string', () => {
+    // Use a fixed RFC3339 timestamp and assert the cell is non-empty and not
+    // the placeholder.
+    renderGrid({ rows: [makeRow({ createdAt: '2025-01-15T12:00:00Z' })] })
+    // new Date('2025-01-15T12:00:00Z').toLocaleDateString() in jsdom is '1/15/2025'
+    const cell = screen.getByText(/\d+\/\d+\/\d+/)
+    expect(cell).toBeInTheDocument()
+  })
+
+  it('renders em-dash placeholder when createdAt is an empty string', () => {
+    renderGrid({ rows: [makeRow({ createdAt: '' })] })
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders em-dash placeholder when createdAt is an unparseable string', () => {
+    renderGrid({ rows: [makeRow({ createdAt: 'not-a-date' })] })
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
   it('links display name to detailHref', () => {
     renderGrid()
     const link = screen.getByRole('link', { name: /my secret/i })

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -315,15 +315,22 @@ export function ResourceGrid({
         header: 'Created At',
         cell: ({ getValue }) => {
           const raw = getValue()
-          try {
+          if (!raw) {
             return (
-              <span className="text-muted-foreground text-sm whitespace-nowrap">
-                {new Date(raw).toLocaleDateString()}
-              </span>
+              <span className="text-muted-foreground text-sm">—</span>
             )
-          } catch {
-            return <span className="text-muted-foreground text-sm">{raw}</span>
           }
+          const date = new Date(raw)
+          if (Number.isNaN(date.getTime())) {
+            return (
+              <span className="text-muted-foreground text-sm">—</span>
+            )
+          }
+          return (
+            <span className="text-muted-foreground text-sm whitespace-nowrap">
+              {date.toLocaleDateString()}
+            </span>
+          )
         },
       }),
       // Actions column — no accessor, uses the full row


### PR DESCRIPTION
## Summary
- Replace the `try/catch`-around-`toLocaleDateString()` in `ResourceGrid`'s Created At cell with an explicit `Number.isNaN(date.getTime())` validity check
- Render `—` (em-dash) when `row.createdAt` is empty (`''`), falsy, or an unparseable string; render `toLocaleDateString()` only for valid dates
- Add three Vitest tests covering valid ISO string, empty string, and garbage string branches

Fixes HOL-876

## Test plan
- [x] `make test-ui` passes all 1243 tests
- [x] New test: valid date renders localized string
- [x] New test: empty `createdAt` renders `—`
- [x] New test: garbage string renders `—`