### PR TITLE
docs(ui): add Created At section to ResourceGrid v1 design note

### DIFF
--- a/docs/ui/resource-grid-v1.md
+++ b/docs/ui/resource-grid-v1.md
@@ -42,6 +42,29 @@ frontend/src/components/resource-grid/
 | Created At | `row.createdAt` | ISO-8601 string, rendered via `toLocaleDateString()` |
 | Actions | — | Delete icon button; triggers ConfirmDeleteDialog |
 
+## Created At
+
+The `createdAt` field on `Row` carries the Kubernetes resource creation
+timestamp sourced from `metadata.creationTimestamp` in the API response.
+
+- **Type**: `string` — RFC 3339 / ISO-8601 (e.g. `"2025-01-15T12:00:00Z"`).
+  Every row mapper should read `metadata.creationTimestamp` from the
+  Kubernetes object and pass it verbatim; do not coerce it to a `Date` or
+  leave it as `""`.
+- **Backend source**: `ObjectMeta.creationTimestamp` from the Kubernetes API
+  response. The field is always present on persisted objects; it is safe to
+  read without a nil-guard.
+- **Fallback behavior**: When `createdAt` is an empty string, `undefined`, or
+  any value that `new Date(value).getTime()` returns as `NaN`, the cell
+  renders an em-dash (`—`) placeholder. This guard was introduced in HOL-876
+  (UI hardening) to eliminate "Invalid Date" regressions. The only valid
+  non-empty value is a parseable RFC 3339 date string.
+
+The Resource Manager tree (`frontend/src/components/resource-manager/`) uses
+`createdAt: undefined` in its synthetic tree-node rows because those rows do
+not correspond 1-to-1 with a single Kubernetes object. This is intentional and
+out of scope for the ResourceGrid v1 contract.
+
 ## The `Row` interface
 
 ```ts


### PR DESCRIPTION
## Summary

- Adds a dedicated **Created At** section to `docs/ui/resource-grid-v1.md` documenting:
  - Expected type: `string`, RFC 3339 / ISO-8601
  - Backend source: `metadata.creationTimestamp` from the Kubernetes API response
  - Fallback behavior: em-dash (`—`) placeholder when the value is empty, `undefined`, or unparseable (introduced in HOL-876)
- Calls out that the Resource Manager tree intentionally uses `createdAt: undefined` on synthetic tree-node rows (out of scope for ResourceGrid v1)

## Audit result

`rg "createdAt: ''"` across `frontend/src/` finds **4 occurrences**, all deliberate test fixtures:

| File | Purpose |
|---|---|
| `frontend/src/components/resource-grid/-resource-grid.test.tsx` | Tests em-dash placeholder branch |
| `frontend/src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx` | Tests em-dash placeholder in Templates page |
| `frontend/src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx` | Tests "Unknown" fallback in project settings |
| `frontend/src/routes/_authenticated/orgs/$orgName/settings/-settings.test.tsx` | Tests "Unknown" fallback in org settings |

No non-test source code passes `createdAt: ''` to any ResourceGrid row mapper.

**Resource Manager tree**: `frontend/src/components/resource-manager/ResourceTree.tsx` uses `createdAt: undefined` on three synthetic tree-node rows. This is intentional — those rows render in a tree view, not a ResourceGrid, and are tracked separately.

## Smoke test (automated coverage)

The automated guard is the unit tests added in phases 1–4 (HOL-876 through HOL-879), which cover the em-dash fallback for all three kinds. `make test-ui` passes: **1251/1251 tests**. CI E2E also passes.

`make test-go` has two pre-existing failures on `main` before this patch:
- `TestHotLoopGuards_HoldAcrossReconcilers` — port conflict in envtest environment
- `TestTemplate_InvalidCUEConditionSurface` — pre-existing flake

Both failures reproduce identically on `main` with no changes, confirming they are not introduced by this PR.

Fixes HOL-880

## Test plan

- [x] `rg "createdAt: ''"` audit across `frontend/src/` — all occurrences are deliberate test fixtures
- [x] `make test-ui` passes (1251/1251)
- [x] CI: Lint, Unit Tests, E2E Tests all pass

## Deferred Acceptance Criteria

- [ ] Manual smoke test in demo environment: create Secret, Deployment, and Template — each row should show a formatted date immediately (no "Invalid Date", no "—"). Requires a running cluster (`make run` + `make dev`).