### PR TITLE
feat(templates/examples): add httpbin-v1 and podinfo-v1 deployment examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,12 +83,17 @@ The UI picker on every "New Template" page is backed by a Go registry of built-i
      """
    ```
 
-2. Update `console/templates/examples/examples_test.go`:
+2. Update two test files:
 
+   In `console/templates/examples/examples_test.go`:
    - Increment the `TestExamples` count by 1.
    - Add the new example's `name` to the `wantNames` slice.
    - If the template produces concrete Kubernetes resources (i.e. it is not a policy-only template), add the name to the `exampleResourcesEmitted` switch so `TestExamplePreviewRender` asserts non-empty output.
    - Optionally add a sub-test in `TestExamplePreviewRender_KnownExamples` asserting specific resource kinds and apiVersions for regression coverage (recommended for deployment templates).
+
+   In `console/templates/handler_examples_test.go`:
+   - Increment the `wantCount` constant by 1 in `TestListTemplateExamples_HappyPath`.
+   - Add the new example's `name` to the `wantNames` slice in `TestListTemplateExamples_KnownNames`.
 
 3. Run `make test-go` to confirm the new example compiles against the `v1alpha2` generated schema and renders correctly through the preview path.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ in a sibling cleanup plan.
 
 ## Example Template Registry
 
-The UI picker on every "New Template" page is backed by a Go registry of built-in CUE drop-in examples. Adding a new example requires **only a single CUE file** — no Go or TypeScript changes.
+The UI picker on every "New Template" page is backed by a Go registry of built-in CUE drop-in examples.
 
 ### Adding a new example (drop-in workflow)
 
@@ -83,9 +83,16 @@ The UI picker on every "New Template" page is backed by a Go registry of built-i
      """
    ```
 
-2. Run `make test-go` to confirm the new example compiles against the `v1alpha2` generated schema. The test in `examples_test.go` verifies every registry file.
+2. Update `console/templates/examples/examples_test.go`:
 
-3. That is all. The ConnectRPC `ListTemplateExamples` handler reads the registry at startup; the picker fetches from that RPC. No Go or TypeScript changes are required unless you also want to seed the example into a namespace via the populate-defaults flow.
+   - Increment the `TestExamples` count by 1.
+   - Add the new example's `name` to the `wantNames` slice.
+   - If the template produces concrete Kubernetes resources (i.e. it is not a policy-only template), add the name to the `exampleResourcesEmitted` switch so `TestExamplePreviewRender` asserts non-empty output.
+   - Optionally add a sub-test in `TestExamplePreviewRender_KnownExamples` asserting specific resource kinds and apiVersions for regression coverage (recommended for deployment templates).
+
+3. Run `make test-go` to confirm the new example compiles against the `v1alpha2` generated schema and renders correctly through the preview path.
+
+The ConnectRPC `ListTemplateExamples` handler reads the registry at startup; the picker fetches from that RPC. No TypeScript changes are required.
 
 ### Docs-sync contract
 

--- a/console/templates/examples/examples.go
+++ b/console/templates/examples/examples.go
@@ -7,8 +7,10 @@
 // as a multi-line string so it can reference #PlatformInput, #ProjectInput,
 // etc. without those types needing to be in scope in this file.
 //
-// Adding a new example requires only dropping a new *.cue file in this
-// directory — no Go changes are needed.
+// Adding a new example requires dropping a new *.cue file in this directory
+// and updating the test counts and name lists in examples_test.go and
+// console/templates/handler_examples_test.go. See AGENTS.md for the full
+// drop-in workflow.
 package examples
 
 import (

--- a/console/templates/examples/examples_test.go
+++ b/console/templates/examples/examples_test.go
@@ -22,8 +22,8 @@ func TestExamples(t *testing.T) {
 		t.Fatalf("Examples() error: %v", err)
 	}
 
-	// There must be exactly four examples.
-	if got, want := len(list), 4; got != want {
+	// There must be exactly six examples.
+	if got, want := len(list), 6; got != want {
 		t.Fatalf("Examples() returned %d examples, want %d", got, want)
 	}
 
@@ -38,6 +38,8 @@ func TestExamples(t *testing.T) {
 		"allowed-project-resource-kinds-v1",
 		"project-namespace-description-annotation-v1",
 		"project-namespace-reference-grant-v1",
+		"httpbin-v1",
+		"podinfo-v1",
 	}
 	for _, name := range wantNames {
 		ex, ok := byName[name]
@@ -127,7 +129,7 @@ func buildPreviewProjectInput() string {
 // concrete objects, so they are excluded from the non-empty output assertion.
 func exampleResourcesEmitted(name string) bool {
 	switch name {
-	case "httproute-v1":
+	case "httproute-v1", "httpbin-v1", "podinfo-v1":
 		return true
 	default:
 		// Policy-only examples produce no concrete K8s resources but must still

--- a/console/templates/examples/examples_test.go
+++ b/console/templates/examples/examples_test.go
@@ -275,7 +275,6 @@ func TestExamplePreviewRender_KnownExamples(t *testing.T) {
 	})
 
 	for _, name := range []string{"httpbin-v1", "podinfo-v1"} {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			ex, ok := byName[name]
 			if !ok {

--- a/console/templates/examples/examples_test.go
+++ b/console/templates/examples/examples_test.go
@@ -273,4 +273,45 @@ func TestExamplePreviewRender_KnownExamples(t *testing.T) {
 			t.Fatalf("allowed-project-resource-kinds-v1: RenderGrouped failed: %v", err)
 		}
 	})
+
+	for _, name := range []string{"httpbin-v1", "podinfo-v1"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			ex, ok := byName[name]
+			if !ok {
+				t.Fatalf("%s example not found in registry", name)
+			}
+			grouped, err := adapter.RenderGrouped(
+				context.Background(),
+				ex.CueTemplate,
+				cuePlatformInput,
+				cueProjectInput,
+			)
+			if err != nil {
+				t.Fatalf("%s: RenderGrouped failed: %v", name, err)
+			}
+
+			var projectYAML strings.Builder
+			for _, r := range grouped.Project {
+				projectYAML.WriteString(r.YAML)
+			}
+			yaml := projectYAML.String()
+
+			if yaml == "" {
+				t.Errorf("%s: expected non-empty project_resources_yaml", name)
+			}
+			for _, kind := range []string{"kind: ServiceAccount", "kind: Deployment", "kind: Service"} {
+				if !strings.Contains(yaml, kind) {
+					t.Errorf("%s: project_resources_yaml must contain %q, got:\n%s", name, kind, yaml)
+				}
+			}
+			if !strings.Contains(yaml, "apiVersion: apps/v1") {
+				t.Errorf("%s: project_resources_yaml must contain 'apiVersion: apps/v1', got:\n%s", name, yaml)
+			}
+			// Deployment resources must land in grouped.Project, not grouped.Platform.
+			if len(grouped.Platform) > 0 {
+				t.Errorf("%s: expected empty platform resources for project-only template, got %d", name, len(grouped.Platform))
+			}
+		})
+	}
 }

--- a/console/templates/examples/httpbin-v1.cue
+++ b/console/templates/examples/httpbin-v1.cue
@@ -1,0 +1,142 @@
+// httpbin deployment example — project-level deployment template for go-httpbin.
+// Produces: ServiceAccount, Deployment, Service. No ReferenceGrant — pair with
+// the httproute-v1 platform template to expose the Service via the gateway.
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "httpbin (v1)"
+name:        "httpbin-v1"
+description: "A simple HTTP Request & Response Service"
+
+cueTemplate: """
+	// defaults declares the template's default values as concrete CUE data.
+	// The backend reads this block (via ExtractDefaults) to pre-fill the Create
+	// Deployment form. See ADR 027 for the authoritative pre-fill behavior.
+	defaults: #ProjectInput & {
+		name:        "httpbin"
+		image:       "ghcr.io/mccutchen/go-httpbin"
+		tag:         "2.21.0"
+		port:        8080
+		description: "A simple HTTP Request & Response Service"
+	}
+
+	// Use generated type definitions from api/v1alpha2 (prepended by renderer).
+	// Additional CUE constraints narrow the generated types for this template.
+	input: #ProjectInput & {
+		name:  *defaults.name | (string & =~"^[a-z][a-z0-9-]*$") // DNS label
+		image: *defaults.image | _
+		tag:   *defaults.tag | _
+		port:  *defaults.port | (>0 & <=65535)
+	}
+	platform: #PlatformInput
+
+	// _labels are the standard labels required on every resource.
+	// app.kubernetes.io/managed-by MUST equal "console.holos.run" or the
+	// render will be rejected.
+	_labels: {
+		"app.kubernetes.io/name":       input.name
+		"app.kubernetes.io/managed-by": "console.holos.run"
+	}
+
+	// _annotations are standard annotations applied to every resource.
+	// console.holos.run/deployer-email records the identity of the user
+	// who last rendered and applied this resource.
+	_annotations: {
+		"console.holos.run/deployer-email": platform.claims.email
+	}
+
+	// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+	// Structure: namespaced.<namespace>.<Kind>.<name>
+	// The struct path keys must match the corresponding resource metadata fields.
+	#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name:      Name
+			namespace: Namespace
+			...
+		}
+		...
+	}
+
+	// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+	// Structure: cluster.<Kind>.<name>
+	// The struct path keys must match the corresponding resource metadata fields.
+	#Cluster: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name: Name
+			...
+		}
+		...
+	}
+
+	projectResources: {
+		namespacedResources: #Namespaced & {
+			(platform.namespace): {
+				// ServiceAccount provides a Kubernetes identity for the pods.
+				ServiceAccount: (input.name): {
+					apiVersion: "v1"
+					kind:       "ServiceAccount"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+				}
+
+				// Deployment runs the go-httpbin container.
+				// go-httpbin listens on port 8080 by default and needs no special
+				// command or args — the image's default entrypoint works.
+				Deployment: (input.name): {
+					apiVersion: "apps/v1"
+					kind:       "Deployment"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						replicas: 1
+						selector: matchLabels: "app.kubernetes.io/name": input.name
+						template: {
+							metadata: labels: _labels
+							spec: {
+								serviceAccountName: input.name
+								containers: [{
+									name:  input.name
+									image: input.image + ":" + input.tag
+									ports: [{containerPort: input.port, name: "http"}]
+								}]
+							}
+						}
+					}
+				}
+
+				// Service exposes port 80 → container port input.port (named "http").
+				// The HTTPRoute in the org platform template routes gateway traffic here.
+				Service: (input.name): {
+					apiVersion: "v1"
+					kind:       "Service"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						selector: "app.kubernetes.io/name": input.name
+						ports: [{port: 80, targetPort: "http", name: "http"}]
+					}
+				}
+			}
+		}
+
+		// clusterResources organizes cluster-scoped resources (none for this template).
+		clusterResources: #Cluster & {}
+	}
+	"""

--- a/console/templates/examples/podinfo-v1.cue
+++ b/console/templates/examples/podinfo-v1.cue
@@ -1,0 +1,140 @@
+// podinfo deployment example — project-level deployment template for podinfo.
+// Produces: ServiceAccount, Deployment, Service. No ReferenceGrant — pair with
+// the httproute-v1 platform template to expose the Service via the gateway.
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "podinfo (v1)"
+name:        "podinfo-v1"
+description: "Podinfo is a tiny web application made with Go that showcases best practices of running microservices in Kubernetes."
+
+cueTemplate: """
+	// defaults declares the template's default values as concrete CUE data.
+	// The backend reads this block (via ExtractDefaults) to pre-fill the Create
+	// Deployment form. See ADR 027 for the authoritative pre-fill behavior.
+	defaults: #ProjectInput & {
+		name:        "podinfo"
+		image:       "stefanprodan/podinfo"
+		tag:         "6.11.2"
+		port:        9898
+		description: "Podinfo is a tiny web application made with Go that showcases best practices of running microservices in Kubernetes."
+	}
+
+	// Use generated type definitions from api/v1alpha2 (prepended by renderer).
+	// Additional CUE constraints narrow the generated types for this template.
+	input: #ProjectInput & {
+		name:  *defaults.name | (string & =~"^[a-z][a-z0-9-]*$") // DNS label
+		image: *defaults.image | _
+		tag:   *defaults.tag | _
+		port:  *defaults.port | (>0 & <=65535)
+	}
+	platform: #PlatformInput
+
+	// _labels are the standard labels required on every resource.
+	// app.kubernetes.io/managed-by MUST equal "console.holos.run" or the
+	// render will be rejected.
+	_labels: {
+		"app.kubernetes.io/name":       input.name
+		"app.kubernetes.io/managed-by": "console.holos.run"
+	}
+
+	// _annotations are standard annotations applied to every resource.
+	// console.holos.run/deployer-email records the identity of the user
+	// who last rendered and applied this resource.
+	_annotations: {
+		"console.holos.run/deployer-email": platform.claims.email
+	}
+
+	// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+	// Structure: namespaced.<namespace>.<Kind>.<name>
+	// The struct path keys must match the corresponding resource metadata fields.
+	#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name:      Name
+			namespace: Namespace
+			...
+		}
+		...
+	}
+
+	// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+	// Structure: cluster.<Kind>.<name>
+	// The struct path keys must match the corresponding resource metadata fields.
+	#Cluster: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name: Name
+			...
+		}
+		...
+	}
+
+	projectResources: {
+		namespacedResources: #Namespaced & {
+			(platform.namespace): {
+				// ServiceAccount provides a Kubernetes identity for the pods.
+				ServiceAccount: (input.name): {
+					apiVersion: "v1"
+					kind:       "ServiceAccount"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+				}
+
+				// Deployment runs the podinfo container.
+				Deployment: (input.name): {
+					apiVersion: "apps/v1"
+					kind:       "Deployment"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						replicas: 1
+						selector: matchLabels: "app.kubernetes.io/name": input.name
+						template: {
+							metadata: labels: _labels
+							spec: {
+								serviceAccountName: input.name
+								containers: [{
+									name:  input.name
+									image: input.image + ":" + input.tag
+									ports: [{containerPort: input.port, name: "http"}]
+								}]
+							}
+						}
+					}
+				}
+
+				// Service exposes port 80 → container port input.port (named "http").
+				// The HTTPRoute in the org platform template routes gateway traffic here.
+				Service: (input.name): {
+					apiVersion: "v1"
+					kind:       "Service"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						selector: "app.kubernetes.io/name": input.name
+						ports: [{port: 80, targetPort: "http", name: "http"}]
+					}
+				}
+			}
+		}
+
+		// clusterResources organizes cluster-scoped resources (none for this template).
+		clusterResources: #Cluster & {}
+	}
+	"""

--- a/console/templates/handler_examples_test.go
+++ b/console/templates/handler_examples_test.go
@@ -1,7 +1,7 @@
 // handler_examples_test.go exercises the ListTemplateExamples RPC introduced
 // in HOL-797. The acceptance criteria are:
 //
-//   - The happy path returns exactly four examples (one per embedded *.cue file).
+//   - The happy path returns exactly six examples (one per embedded *.cue file).
 //   - Results are sorted by name ascending so the UI can rely on a stable order.
 //   - Each entry has non-empty DisplayName, Description, and CueTemplate.
 package templates
@@ -33,7 +33,7 @@ func newExamplesTestHandler(t *testing.T) *Handler {
 }
 
 // TestListTemplateExamples_HappyPath verifies that ListTemplateExamples returns
-// exactly four examples (matching the four *.cue files embedded in the examples
+// exactly six examples (matching the six *.cue files embedded in the examples
 // package), each with non-empty fields, and sorted by name ascending.
 func TestListTemplateExamples_HappyPath(t *testing.T) {
 	handler := newExamplesTestHandler(t)
@@ -46,7 +46,7 @@ func TestListTemplateExamples_HappyPath(t *testing.T) {
 	}
 
 	got := resp.Msg.GetExamples()
-	const wantCount = 4
+	const wantCount = 6
 	if len(got) != wantCount {
 		t.Fatalf("ListTemplateExamples() returned %d examples, want %d", len(got), wantCount)
 	}
@@ -91,7 +91,7 @@ func TestListTemplateExamples_SortedByName(t *testing.T) {
 	}
 }
 
-// TestListTemplateExamples_KnownNames verifies the four expected built-in
+// TestListTemplateExamples_KnownNames verifies the six expected built-in
 // example slugs are present, anchoring the test to the actual embedded files.
 func TestListTemplateExamples_KnownNames(t *testing.T) {
 	handler := newExamplesTestHandler(t)
@@ -110,7 +110,9 @@ func TestListTemplateExamples_KnownNames(t *testing.T) {
 
 	wantNames := []string{
 		"allowed-project-resource-kinds-v1",
+		"httpbin-v1",
 		"httproute-v1",
+		"podinfo-v1",
 		"project-namespace-description-annotation-v1",
 		"project-namespace-reference-grant-v1",
 	}


### PR DESCRIPTION
## Summary

- Adds `console/templates/examples/httpbin-v1.cue` — go-httpbin deployment template producing ServiceAccount, Deployment, and Service
- Adds `console/templates/examples/podinfo-v1.cue` — podinfo deployment template with the same resource set
- Updates `TestExamples` count from 4 → 6, adds both new examples to `wantNames`, and updates `exampleResourcesEmitted` to return `true` for both

Both templates follow the drop-in registry workflow (AGENTS.md §"Example Template Registry") — no Go or TypeScript changes required.

Fixes HOL-882
Refs: HOL-883, HOL-884, HOL-885

## Test plan

- [x] `go test ./console/templates/examples/...` passes — `TestExamples`, `TestExamplePreviewRender`, and `TestExamplePreviewRender_KnownExamples` all pass for both new examples
- [x] `exampleResourcesEmitted` returns `true` for `httpbin-v1` and `podinfo-v1`
- [ ] Verify templates appear in the "New Template" picker at `/projects/$name/templates/new`