### PR TITLE
fix(ui): remove Platform Input textarea from CueTemplateEditor preview tab

### DIFF
--- a/frontend/src/components/cue-template-editor.test.tsx
+++ b/frontend/src/components/cue-template-editor.test.tsx
@@ -106,7 +106,7 @@ describe('CueTemplateEditor', () => {
     expect(onSave).toHaveBeenCalledTimes(1)
   })
 
-  it('renders preview tab with platform input, project input, and rendered YAML sections', async () => {
+  it('renders preview tab with project input and rendered YAML sections', async () => {
     const user = userEvent.setup()
     ;(useRenderTemplate as Mock).mockReturnValue({
       data: { renderedYaml: 'apiVersion: v1\nkind: ReferenceGrant', renderedJson: '' },
@@ -117,7 +117,6 @@ describe('CueTemplateEditor', () => {
       <CueTemplateEditor
         cueTemplate="content"
         onChange={vi.fn()}
-        defaultPlatformInput="platform: {}"
         defaultProjectInput="input: {}"
         namespace={testNamespace}
       />
@@ -126,7 +125,7 @@ describe('CueTemplateEditor', () => {
     // Switch to preview tab
     await user.click(screen.getByRole('tab', { name: /preview/i }))
 
-    expect(screen.getByRole('textbox', { name: /platform input/i })).toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: /platform input/i })).not.toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: /project input/i })).toBeInTheDocument()
     expect(screen.getByLabelText('Rendered YAML')).toBeInTheDocument()
     expect(screen.getByLabelText('Rendered YAML')).toHaveTextContent('ReferenceGrant')
@@ -285,7 +284,7 @@ describe('CueTemplateEditor', () => {
       expect(screen.getByLabelText('Project Resources YAML')).toHaveTextContent('ConfigMap')
     })
 
-    it('pretty-prints JSON default inputs in textareas', async () => {
+    it('pretty-prints JSON default project input in textarea', async () => {
       const user = userEvent.setup()
       ;(useRenderTemplate as Mock).mockReturnValue({
         data: undefined,
@@ -297,7 +296,6 @@ describe('CueTemplateEditor', () => {
         <CueTemplateEditor
           cueTemplate="content"
           onChange={vi.fn()}
-          defaultPlatformInput={compactJson}
           defaultProjectInput={compactJson}
           namespace={testNamespace}
         />
@@ -305,11 +303,10 @@ describe('CueTemplateEditor', () => {
       await user.click(screen.getByRole('tab', { name: /preview/i }))
 
       const expectedPretty = JSON.stringify(JSON.parse(compactJson), null, 2)
-      expect(screen.getByRole('textbox', { name: /platform input/i })).toHaveValue(expectedPretty)
       expect(screen.getByRole('textbox', { name: /project input/i })).toHaveValue(expectedPretty)
     })
 
-    it('passes CUE default inputs through unchanged', async () => {
+    it('passes CUE default project input through unchanged', async () => {
       const user = userEvent.setup()
       ;(useRenderTemplate as Mock).mockReturnValue({
         data: undefined,
@@ -321,7 +318,6 @@ describe('CueTemplateEditor', () => {
         <CueTemplateEditor
           cueTemplate="content"
           onChange={vi.fn()}
-          defaultPlatformInput={cueInput}
           defaultProjectInput={cueInput}
           namespace={testNamespace}
         />
@@ -329,7 +325,6 @@ describe('CueTemplateEditor', () => {
       await user.click(screen.getByRole('tab', { name: /preview/i }))
 
       // CUE is not valid JSON, so it should pass through unchanged
-      expect(screen.getByRole('textbox', { name: /platform input/i })).toHaveValue(cueInput)
       expect(screen.getByRole('textbox', { name: /project input/i })).toHaveValue(cueInput)
     })
 

--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -91,8 +91,6 @@ export interface CueTemplateEditorProps {
   onSave?: () => Promise<void>
   /** Whether a save operation is in progress */
   isSaving?: boolean
-  /** Default platform input for the preview tab */
-  defaultPlatformInput?: string
   /** Default project input for the preview tab */
   defaultProjectInput?: string
   /** Namespace used to resolve ancestor platform templates when rendering the preview */
@@ -112,13 +110,11 @@ export function CueTemplateEditor({
   readOnly = false,
   onSave,
   isSaving = false,
-  defaultPlatformInput = '',
   defaultProjectInput = '',
   namespace,
   linkedTemplates = [],
 }: CueTemplateEditorProps) {
   const [activeTab, setActiveTab] = useState('editor')
-  const [cuePlatformInput, setCuePlatformInput] = useState(() => prettyPrintJson(defaultPlatformInput))
   const [cueInput, setCueInput] = useState(() => prettyPrintJson(defaultProjectInput))
 
   // The defaults can change after first render when async data (such as the
@@ -126,17 +122,7 @@ export function CueTemplateEditor({
   // textarea state to the new default value only if the user has not edited
   // it — track the last applied default in a ref and compare with current
   // state to detect that case.
-  const lastPlatformDefaultRef = useRef(prettyPrintJson(defaultPlatformInput))
   const lastProjectDefaultRef = useRef(prettyPrintJson(defaultProjectInput))
-  useEffect(() => {
-    const next = prettyPrintJson(defaultPlatformInput)
-    if (next !== lastPlatformDefaultRef.current) {
-      setCuePlatformInput((current) =>
-        current === lastPlatformDefaultRef.current ? next : current,
-      )
-      lastPlatformDefaultRef.current = next
-    }
-  }, [defaultPlatformInput])
   useEffect(() => {
     const next = prettyPrintJson(defaultProjectInput)
     if (next !== lastProjectDefaultRef.current) {
@@ -148,12 +134,10 @@ export function CueTemplateEditor({
   }, [defaultProjectInput])
 
   const debouncedCueInput = useDebouncedValue(cueInput, 500)
-  const debouncedCuePlatformInput = useDebouncedValue(cuePlatformInput, 500)
   const debouncedCueTemplate = useDebouncedValue(cueTemplate, 500)
 
   const isStale =
     cueInput !== debouncedCueInput ||
-    cuePlatformInput !== debouncedCuePlatformInput ||
     cueTemplate !== debouncedCueTemplate
 
   const { data: renderData, error: renderError, isFetching: isRendering } = useRenderTemplate(
@@ -161,7 +145,7 @@ export function CueTemplateEditor({
     debouncedCueTemplate,
     debouncedCueInput,
     activeTab === 'preview',
-    debouncedCuePlatformInput,
+    undefined,
     linkedTemplates,
   )
 
@@ -201,20 +185,6 @@ export function CueTemplateEditor({
         )}
       </TabsContent>
       <TabsContent value="preview" className="mt-4 space-y-4 min-w-0">
-        <div className="space-y-2 min-w-0">
-          <Label htmlFor="cue-platform-input-editor">Platform Input</Label>
-          <p className="text-xs text-muted-foreground">
-            These values are set by the console at deployment time and include the authenticated user&apos;s OIDC claims.
-          </p>
-          <Textarea
-            id="cue-platform-input-editor"
-            aria-label="Platform Input"
-            value={cuePlatformInput}
-            onChange={(e) => setCuePlatformInput(e.target.value)}
-            rows={10}
-            className="font-mono text-sm field-sizing-normal max-h-64 overflow-y-auto overflow-x-auto"
-          />
-        </div>
         <div className="space-y-2 min-w-0">
           <Label htmlFor="cue-input-editor">Project Input (deployment parameters)</Label>
           <Textarea

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
@@ -23,27 +23,6 @@ import type { TemplateExample } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
-// DEFAULT_PLATFORM_INPUT seeds the preview pane with cosmetic placeholder
-// values for the user-editable fields of #PlatformInput (project, namespace,
-// claims). The backend always injects the authoritative platform-owned fields
-// before evaluating the user-supplied input, so values like gatewayNamespace
-// (HOL-526) and organization are resolved server-side and must not be set here.
-// CUE unification merges the backend values with these seeds: fields present in
-// both must agree (identical strings unify; conflicting strings surface a CUE
-// error, which is the correct behavior for pinned vs. resolved mismatches).
-const DEFAULT_PLATFORM_INPUT = `platform: {
-  project:          "example-project"
-  namespace:        "prj-example-project"
-  claims: {
-    iss:            "https://login.example.com"
-    sub:            "user-abc123"
-    iat:            1743868800
-    exp:            1743872400
-    email:          "developer@example.com"
-    email_verified: true
-  }
-}`
-
 const DEFAULT_PROJECT_INPUT = `input: {
   name:  "example"
   image: "nginx"

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
@@ -218,7 +218,6 @@ export function ConsolidatedTemplateEditorPage({
             onChange={setCueTemplate}
             onSave={handleSave}
             isSaving={updateMutation.isPending}
-            defaultPlatformInput={DEFAULT_PLATFORM_INPUT}
             defaultProjectInput={DEFAULT_PROJECT_INPUT}
             linkedTemplates={template?.linkedTemplates ?? []}
             namespace={namespace}


### PR DESCRIPTION
## Summary

- Remove Platform Input label, description paragraph, and textarea from the Preview tab in `CueTemplateEditor`
- Remove `defaultPlatformInput` prop from `CueTemplateEditorProps` interface and function signature
- Remove `cuePlatformInput` state, `useRef`, and `useEffect` sync for platform input
- Remove `cuePlatformInput` from `isStale` computation and `debouncedCuePlatformInput` debounce
- Pass `undefined` (not a stale string) as the cuePlatformInput arg to `useRenderTemplate`, letting the hook's `''` default tell the backend to use its own injected values
- Remove `defaultPlatformInput={DEFAULT_PLATFORM_INPUT}` from the caller in the template detail route
- Update tests: assert platform input textbox is absent, trim pretty-print and CUE pass-through tests to project input only

Fixes HOL-892

## Test plan

- [x] `make test-ui` passes (1251 tests)
- [ ] Manually open the Preview tab on a template detail page and verify it still renders YAML correctly without the Platform Input textarea