### PR TITLE
fix(ui): wire template defaults into Project Input box

### DIFF
--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/$namespace.$name.tsx
@@ -18,17 +18,29 @@ import {
   useGetTemplate,
   useUpdateTemplate,
   useDeleteTemplate,
+  useGetTemplateDefaults,
 } from '@/queries/templates'
-import type { TemplateExample } from '@/queries/templates'
+import type { TemplateExample, TemplateDefaults } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
-const DEFAULT_PROJECT_INPUT = `input: {
-  name:  "example"
-  image: "nginx"
-  tag:   "latest"
-  port:  8080
-}`
+// templateDefaultsToCueInput converts a TemplateDefaults message into a CUE
+// input snippet suitable for pre-populating the Project Input textarea. Only
+// non-empty string and non-zero int32 fields are emitted; complex fields
+// (command, args, env) are skipped in this initial implementation.
+export function templateDefaultsToCueInput(defaults: TemplateDefaults | undefined): string {
+  if (!defaults) return ''
+
+  const lines: string[] = []
+  if (defaults.name) lines.push(`    name:        ${JSON.stringify(defaults.name)}`)
+  if (defaults.image) lines.push(`    image:       ${JSON.stringify(defaults.image)}`)
+  if (defaults.tag) lines.push(`    tag:         ${JSON.stringify(defaults.tag)}`)
+  if (defaults.description) lines.push(`    description: ${JSON.stringify(defaults.description)}`)
+  if (defaults.port !== 0) lines.push(`    port:        ${defaults.port}`)
+
+  if (lines.length === 0) return ''
+  return `input: {\n${lines.join('\n')}\n}`
+}
 
 export const Route = createFileRoute(
   '/_authenticated/orgs/$orgName/templates/$namespace/$name',
@@ -70,6 +82,7 @@ export function ConsolidatedTemplateEditorPage({
 
   const navigate = useNavigate()
   const { data: template, isPending, error } = useGetTemplate(namespace, name)
+  const { data: templateDefaults } = useGetTemplateDefaults({ namespace, name })
   const updateMutation = useUpdateTemplate(namespace, name)
   const deleteMutation = useDeleteTemplate(namespace)
 
@@ -197,7 +210,7 @@ export function ConsolidatedTemplateEditorPage({
             onChange={setCueTemplate}
             onSave={handleSave}
             isSaving={updateMutation.isPending}
-            defaultProjectInput={DEFAULT_PROJECT_INPUT}
+            defaultProjectInput={templateDefaultsToCueInput(templateDefaults)}
             linkedTemplates={template?.linkedTemplates ?? []}
             namespace={namespace}
           />

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-$namespace.$name.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-$namespace.$name.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/queries/templates', () => ({
   useUpdateTemplate: vi.fn(),
   useDeleteTemplate: vi.fn(),
   useListTemplateExamples: vi.fn(),
+  useGetTemplateDefaults: vi.fn(),
   useRenderTemplate: vi.fn().mockReturnValue({
     data: undefined,
     error: null,
@@ -46,9 +47,11 @@ import {
   useUpdateTemplate,
   useDeleteTemplate,
   useListTemplateExamples,
+  useGetTemplateDefaults,
 } from '@/queries/templates'
+import type { TemplateDefaults } from '@/queries/templates'
 import { toast } from 'sonner'
-import { ConsolidatedTemplateEditorPage } from './$namespace.$name'
+import { ConsolidatedTemplateEditorPage, templateDefaultsToCueInput } from './$namespace.$name'
 
 const EXAMPLE_HTTPROUTE = {
   name: 'httproute-v1',
@@ -103,11 +106,16 @@ function setupMocks(
     isPending: false,
     error: null,
   })
+  ;(useGetTemplateDefaults as Mock).mockReturnValue({
+    data: undefined,
+  })
 }
 
 describe('ConsolidatedTemplateEditorPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: no template defaults loaded (covers tests that don't call setupMocks).
+    ;(useGetTemplateDefaults as Mock).mockReturnValue({ data: undefined })
   })
 
   it('renders skeletons while loading', () => {
@@ -293,6 +301,96 @@ describe('ConsolidatedTemplateEditorPage', () => {
         const textarea = screen.getByRole('textbox', { name: /cue template/i }) as HTMLTextAreaElement
         expect(textarea.value).toBe(originalCue)
       })
+    })
+  })
+
+  // HOL-893: templateDefaultsToCueInput unit tests
+  describe('templateDefaultsToCueInput', () => {
+    it('returns empty string when defaults is undefined', () => {
+      expect(templateDefaultsToCueInput(undefined)).toBe('')
+    })
+
+    it('builds a CUE input snippet from non-empty fields', () => {
+      const defaults: TemplateDefaults = {
+        name: 'httpbin',
+        image: 'ghcr.io/mccutchen/go-httpbin',
+        tag: '2.21.0',
+        description: 'A simple HTTP Request & Response Service',
+        port: 8080,
+        command: [],
+        args: [],
+        env: [],
+      } as unknown as TemplateDefaults
+      const result = templateDefaultsToCueInput(defaults)
+      expect(result).toContain('input: {')
+      expect(result).toContain('"httpbin"')
+      expect(result).toContain('"ghcr.io/mccutchen/go-httpbin"')
+      expect(result).toContain('"2.21.0"')
+      expect(result).toContain('"A simple HTTP Request & Response Service"')
+      expect(result).toContain('8080')
+    })
+
+    it('omits fields with zero/empty values', () => {
+      const defaults: TemplateDefaults = {
+        name: 'myapp',
+        image: '',
+        tag: '',
+        description: '',
+        port: 0,
+        command: [],
+        args: [],
+        env: [],
+      } as unknown as TemplateDefaults
+      const result = templateDefaultsToCueInput(defaults)
+      expect(result).toContain('"myapp"')
+      expect(result).not.toContain('image')
+      expect(result).not.toContain('tag')
+      expect(result).not.toContain('port')
+    })
+
+    it('returns empty string when all fields are zero/empty', () => {
+      const defaults: TemplateDefaults = {
+        name: '',
+        image: '',
+        tag: '',
+        description: '',
+        port: 0,
+        command: [],
+        args: [],
+        env: [],
+      } as unknown as TemplateDefaults
+      expect(templateDefaultsToCueInput(defaults)).toBe('')
+    })
+  })
+
+  // HOL-893: integration — Project Input textarea pre-populated from defaults
+  describe('template defaults pre-population', () => {
+    it('pre-populates the Project Input textarea with values from useGetTemplateDefaults', async () => {
+      setupMocks()
+      ;(useGetTemplateDefaults as Mock).mockReturnValue({
+        data: {
+          name: 'httpbin',
+          image: 'ghcr.io/mccutchen/go-httpbin',
+          tag: '2.21.0',
+          description: 'A simple HTTP Request & Response Service',
+          port: 8080,
+          command: [],
+          args: [],
+          env: [],
+        } as unknown as TemplateDefaults,
+      })
+
+      const user = userEvent.setup()
+      render(<ConsolidatedTemplateEditorPage />)
+
+      // Switch to the Preview tab to reveal the Project Input textarea.
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+
+      const textarea = screen.getByRole('textbox', { name: /project input/i }) as HTMLTextAreaElement
+      expect(textarea.value).toContain('"httpbin"')
+      expect(textarea.value).toContain('"ghcr.io/mccutchen/go-httpbin"')
+      expect(textarea.value).toContain('"2.21.0"')
+      expect(textarea.value).toContain('8080')
     })
   })
 

--- a/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/templates/-cross-scope.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@/queries/templates', () => ({
   useUpdateTemplate: vi.fn(),
   useDeleteTemplate: vi.fn(),
   useListTemplateExamples: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+  useGetTemplateDefaults: vi.fn(),
   useRenderTemplate: vi.fn().mockReturnValue({
     data: undefined,
     error: null,
@@ -52,6 +53,7 @@ import {
   useGetTemplate,
   useUpdateTemplate,
   useDeleteTemplate,
+  useGetTemplateDefaults,
 } from '@/queries/templates'
 import { ConsolidatedTemplateEditorPage } from './$namespace.$name'
 
@@ -64,6 +66,7 @@ const cases = [
 describe('ConsolidatedTemplateEditorPage cross-scope equivalence (HOL-607)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(useGetTemplateDefaults as Mock).mockReturnValue({ data: undefined })
   })
 
   it.each(cases)(


### PR DESCRIPTION
## Summary

- Removes the hardcoded `DEFAULT_PROJECT_INPUT` constant (`nginx:latest` placeholder) from the template detail route
- Adds `useGetTemplateDefaults({ namespace, name })` call in `ConsolidatedTemplateEditorPage`
- Adds exported `templateDefaultsToCueInput(defaults)` helper that converts `TemplateDefaults` fields (name, image, tag, description, port) into a CUE `input: { ... }` snippet; complex fields (command, args, env) are skipped per the issue spec
- Passes the dynamically-fetched snippet as `defaultProjectInput` to `CueTemplateEditor`, so templates like `httpbin-v1` pre-populate the Preview tab with their actual values
- Adds `useGetTemplateDefaults` to the vi.mock in `-$namespace.$name.test.tsx` and `-cross-scope.test.tsx`; initialises it to `{ data: undefined }` in `beforeEach`
- Adds 4 unit tests for `templateDefaultsToCueInput` and 1 integration test that activates the Preview tab and asserts the textarea contains the fetched defaults

Fixes HOL-893

## Test plan

- [x] `make test-ui` — 93 files, 1256 tests, all pass
- [x] New `templateDefaultsToCueInput` unit tests cover: undefined → `""`, non-empty fields included, zero/empty fields omitted, all-zero → `""`
- [x] Integration test verifies Project Input textarea value after clicking Preview tab
- [x] Cross-scope test updated to not error on missing `useGetTemplateDefaults` export