### PR TITLE
fix(ui): stop sending cuePlatformInput from TemplateCreateForm

### DIFF
--- a/frontend/src/components/templates/TemplateCreateForm.test.tsx
+++ b/frontend/src/components/templates/TemplateCreateForm.test.tsx
@@ -48,6 +48,8 @@ vi.mock('@/queries/templates', () => ({
   },
 }))
 
+// @/queries/organizations is no longer imported by TemplateCreateForm; the mock
+// is kept for safety in case any indirect import path references it during tests.
 vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
@@ -61,7 +63,6 @@ import {
   useListLinkableTemplates,
   useListTemplateExamples,
 } from '@/queries/templates'
-import { useGetOrganization } from '@/queries/organizations'
 import { TemplateCreateForm } from './TemplateCreateForm'
 
 const EXAMPLE_HTTPROUTE = {
@@ -84,7 +85,6 @@ function setupQueryMocks({
   linkable = [],
   linkablePending = false,
   examples = [EXAMPLE_HTTPROUTE, EXAMPLE_SECOND],
-  gatewayNamespace = '',
 }: {
   renderData?: { renderedJson?: string; platformResourcesJson?: string; projectResourcesJson?: string }
   renderError?: Error
@@ -98,7 +98,6 @@ function setupQueryMocks({
   }>
   linkablePending?: boolean
   examples?: typeof EXAMPLE_HTTPROUTE[]
-  gatewayNamespace?: string
 } = {}) {
   ;(useRenderTemplate as Mock).mockReturnValue({
     data: renderData ?? undefined,
@@ -112,11 +111,6 @@ function setupQueryMocks({
   })
   ;(useListTemplateExamples as Mock).mockReturnValue({
     data: examples,
-    isPending: false,
-    error: null,
-  })
-  ;(useGetOrganization as Mock).mockReturnValue({
-    data: { name: 'test-org', gatewayNamespace },
     isPending: false,
     error: null,
   })
@@ -611,7 +605,7 @@ describe('TemplateCreateForm — project scope', () => {
     })
   })
 
-  it('useRenderTemplate receives the mock platform input including claims', () => {
+  it('useRenderTemplate receives an empty platform input (backend injects authoritative context)', () => {
     render(
       <TemplateCreateForm
         scopeType="project"
@@ -626,9 +620,7 @@ describe('TemplateCreateForm — project scope', () => {
     const calls = (useRenderTemplate as Mock).mock.calls
     expect(calls.length).toBeGreaterThan(0)
     const platformInput = calls[0][4]
-    expect(platformInput).toContain('platform:')
-    expect(platformInput).toContain('claims')
-    expect(platformInput).toContain('email')
+    expect(platformInput).toBe('')
   })
 
   it('useRenderTemplate receives the project-only input', () => {

--- a/frontend/src/components/templates/TemplateCreateForm.tsx
+++ b/frontend/src/components/templates/TemplateCreateForm.tsx
@@ -104,8 +104,6 @@ projectResources: {
 export function TemplateCreateForm({
   scopeType,
   namespace,
-  organization,
-  projectName,
   canWrite,
   canLink,
   isPending = false,

--- a/frontend/src/components/templates/TemplateCreateForm.tsx
+++ b/frontend/src/components/templates/TemplateCreateForm.tsx
@@ -33,7 +33,6 @@ import type {
 } from '@/queries/templates'
 import { LinkedTemplateRefSchema } from '@/gen/holos/console/v1/policy_state_pb.js'
 import { scopeLabelFromNamespace } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 
@@ -53,11 +52,11 @@ export type TemplateCreateFormProps = {
   /** Namespace the new template lives in. Drives the linkable-templates query
    * for project scope. */
   namespace: string
-  /** Organization name. Required for project scope (drives preview
-   * gatewayNamespace lookup); ignored for org/folder scopes. */
+  /** Organization name. Optional; passed through to callers but no longer used
+   * to construct preview platform input (the backend injects authoritative
+   * platform context when cuePlatformInput is omitted). */
   organization?: string
-  /** Project name. Required for project scope (drives preview platform-input
-   * project/namespace); ignored for org/folder scopes. */
+  /** Project name. Required for project scope; ignored for org/folder scopes. */
   projectName?: string
   /** Whether the user may fill/submit the form. */
   canWrite: boolean
@@ -99,8 +98,8 @@ projectResources: {
  *    (HOL-789 AC 5). Enabled label carries a tooltip pointing at
  *    TemplatePolicyBinding.
  *  - project:      Deployment template. No Enabled toggle. Adds the
- *    Linked Platform Templates picker and the Preview pane, which render the
- *    CUE against mock platform input + mock project input.
+ *    Linked Platform Templates picker and the Preview pane, which renders the
+ *    CUE with project input; platform context is injected by the backend.
  */
 export function TemplateCreateForm({
   scopeType,
@@ -140,8 +139,6 @@ export function TemplateCreateForm({
 
   // Project-scope preview queries. Gated by the `enabled` flag on the render
   // hook (passing previewOpen) so the org/folder forms don't fire them.
-  const { data: org, isPending: orgPending, error: orgError } =
-    useGetOrganization(isProject ? (organization ?? '') : '')
   const { data: linkableTemplates = [], isPending: linkablePending } =
     useListLinkableTemplates(isProject ? namespace : '')
 
@@ -159,33 +156,6 @@ export function TemplateCreateForm({
       ),
     [linkableTemplates],
   )
-
-  // Mirror the org-configured gatewayNamespace (HOL-526/HOL-644) in the
-  // preview platform input so previews line up with the backend's injected
-  // value. Wait for a successful org load before picking a default — a
-  // project EDITOR who cannot read the org should not see a misleading
-  // fallback value; the preview simply omits the field and the backend
-  // fills it in.
-  const orgLoaded =
-    (organization ?? '').length > 0 && !orgPending && !orgError
-  const gatewayNamespace = orgLoaded
-    ? org?.gatewayNamespace || 'istio-ingress'
-    : ''
-  const gatewayNamespaceLine = gatewayNamespace
-    ? `\tgatewayNamespace: "${gatewayNamespace}"\n`
-    : ''
-  const previewCuePlatformInput = `platform: {
-\tproject:          "${projectName ?? ''}"
-\tnamespace:        "holos-prj-${projectName ?? ''}"
-${gatewayNamespaceLine}\tclaims: {
-\t\tiss:            "https://login.example.com"
-\t\tsub:            "user-abc123"
-\t\tiat:            1743868800
-\t\texp:            1743872400
-\t\temail:          "developer@example.com"
-\t\temail_verified: true
-\t}
-}`
 
   const previewCueInput = `input: {
 \tname:  "go-httpbin"
@@ -214,7 +184,7 @@ ${gatewayNamespaceLine}\tclaims: {
     debouncedCueTemplate,
     previewCueInput,
     isProject && previewOpen,
-    previewCuePlatformInput,
+    '',
     previewLinkedTemplates,
   )
 


### PR DESCRIPTION
## Summary

- Removes `previewCuePlatformInput` constant and the `orgLoaded`, `gatewayNamespace`, `gatewayNamespaceLine` variables from `TemplateCreateForm.tsx` — they were only used to build the hardcoded platform input
- Removes the `useGetOrganization` import/query since it was solely consumed by the deleted platform-input construction logic
- Passes `''` (empty string) for `cuePlatformInput` in the `useRenderTemplate` call so the backend injects authoritative platform context instead of a frontend-constructed value
- Updates `TemplateCreateForm.test.tsx`: removes `useGetOrganization` mock/import, removes `gatewayNamespace` from `setupQueryMocks`, and updates the platform-input assertion to verify `''` is passed

Fixes HOL-894

## Test plan

- [x] `make test-ui` — all 1256 tests pass
- [ ] Manual: open a project-scope create form and toggle Preview — verify the preview renders without error (backend fills in platform context)