### PR TITLE
chore(ui): remove cuePlatformInput from useRenderTemplate hook

### DIFF
--- a/frontend/src/components/cue-template-editor.tsx
+++ b/frontend/src/components/cue-template-editor.tsx
@@ -145,7 +145,6 @@ export function CueTemplateEditor({
     debouncedCueTemplate,
     debouncedCueInput,
     activeTab === 'preview',
-    undefined,
     linkedTemplates,
   )
 

--- a/frontend/src/components/templates/TemplateCreateForm.test.tsx
+++ b/frontend/src/components/templates/TemplateCreateForm.test.tsx
@@ -605,24 +605,6 @@ describe('TemplateCreateForm — project scope', () => {
     })
   })
 
-  it('useRenderTemplate receives an empty platform input (backend injects authoritative context)', () => {
-    render(
-      <TemplateCreateForm
-        scopeType="project"
-        namespace="holos-prj-test-project"
-        organization="test-org"
-        projectName="test-project"
-        canWrite
-        onSubmit={vi.fn()}
-        onCancel={vi.fn()}
-      />,
-    )
-    const calls = (useRenderTemplate as Mock).mock.calls
-    expect(calls.length).toBeGreaterThan(0)
-    const platformInput = calls[0][4]
-    expect(platformInput).toBe('')
-  })
-
   it('useRenderTemplate receives the project-only input', () => {
     render(
       <TemplateCreateForm
@@ -918,7 +900,7 @@ describe('TemplateCreateForm — project scope', () => {
 
       const calls = (useRenderTemplate as Mock).mock.calls
       const lastCall = calls[calls.length - 1]
-      expect(lastCall[5]).toEqual(
+      expect(lastCall[4]).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: 'httpbin-platform',

--- a/frontend/src/components/templates/TemplateCreateForm.tsx
+++ b/frontend/src/components/templates/TemplateCreateForm.tsx
@@ -52,9 +52,9 @@ export type TemplateCreateFormProps = {
   /** Namespace the new template lives in. Drives the linkable-templates query
    * for project scope. */
   namespace: string
-  /** Organization name. Optional; passed through to callers but no longer used
+  /** Organization name. Optional; passed through to callers but not used
    * to construct preview platform input (the backend injects authoritative
-   * platform context when cuePlatformInput is omitted). */
+   * platform context). */
   organization?: string
   /** Project name. Required for project scope; ignored for org/folder scopes. */
   projectName?: string
@@ -182,7 +182,6 @@ export function TemplateCreateForm({
     debouncedCueTemplate,
     previewCueInput,
     isProject && previewOpen,
-    '',
     previewLinkedTemplates,
   )
 

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -583,7 +583,6 @@ export function useRenderTemplate(
   cueTemplate: string,
   cueInput = '',
   enabled = true,
-  cuePlatformInput = '',
   linkedTemplates: LinkedTemplateRef[] = [],
 ) {
   const { isAuthenticated } = useAuth()
@@ -595,13 +594,12 @@ export function useRenderTemplate(
     .map(t => `${t.namespace}/${t.name}@${t.versionConstraint ?? ''}`)
     .join(',')
   return useQuery({
-    queryKey: ['templates', 'render', namespace, cueTemplate, cueInput, cuePlatformInput, linkedKey] as const,
+    queryKey: ['templates', 'render', namespace, cueTemplate, cueInput, linkedKey] as const,
     queryFn: async () => {
       const response = await client.renderTemplate({
         namespace,
         cueTemplate,
         cueProjectInput: cueInput,
-        cuePlatformInput,
         linkedTemplates,
       })
       return {


### PR DESCRIPTION
## Summary
- Remove `cuePlatformInput` parameter from `useRenderTemplate` signature in `queries/templates.ts`
- Remove `cuePlatformInput` from the `queryKey` array (query key now shrinks by one slot)
- Remove `cuePlatformInput` field from the `renderTemplate` RPC request body
- Drop the empty-string `''` arg from the `TemplateCreateForm.tsx` call site
- Drop the `undefined` arg from the `cue-template-editor.tsx` call site
- Delete the now-stale test that verified the empty-string sentinel was forwarded
- Update the remaining linked-templates test to use the correct argument index (`[4]` instead of `[5]`)

No caller was passing a non-empty `cuePlatformInput` after HOL-892 (removed textarea), HOL-893 (wired template defaults), and HOL-894 (stopped sending from TemplateCreateForm).

Fixes HOL-895

## Test plan
- [x] `make test-ui` passes — 93 test files, 1255 tests, all green
- [x] No non-generated `cuePlatformInput` references remain outside of protobuf `.d.ts` files