### PR TITLE
refactor(policyresolver): drop explicitRefs from PolicyResolver.Resolve

### DIFF
--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -95,8 +95,9 @@ type AncestorWalker interface {
 // render target so the underlying PolicyResolver can key REQUIRE/EXCLUDE
 // evaluation off it (HOL-566 Phase 4).
 //
-// The second return value is the policy-effective ref set (explicit ∪
-// REQUIRE − EXCLUDE) that produced the sources. Exposing it here lets the
+// The second return value is the policy-effective ref set
+// (REQUIRE-injected − EXCLUDE-removed) that produced the sources.
+// Exposing it here lets the
 // deployments Create/Update happy paths write-through the same set to the
 // applied-render-set store via PolicyDriftChecker.RecordApplied without
 // invoking the resolver a second time (HOL-569). A second invocation would

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -104,7 +104,7 @@ type AncestorWalker interface {
 // from the rendered set and GetDeploymentPolicyState reports false drift.
 // Callers that only need the sources can ignore the second return.
 type AncestorTemplateProvider interface {
-	ListAncestorTemplateSources(ctx context.Context, projectNs, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error)
+	ListAncestorTemplateSources(ctx context.Context, projectNs, deploymentName string) ([]string, []*consolev1.LinkedTemplateRef, error)
 }
 
 // ResourceApplier applies and cleans up K8s resources for a deployment.
@@ -171,10 +171,10 @@ type PolicyDriftChecker interface {
 	// has not yet been rendered through the post-HOL-567 path and drift
 	// is meaningless — callers SHOULD NOT surface policy_drift in that
 	// case.
-	Drift(ctx context.Context, project, deploymentName string, explicitRefs []*consolev1.LinkedTemplateRef) (drift, hasAppliedState bool, err error)
+	Drift(ctx context.Context, project, deploymentName string) (drift, hasAppliedState bool, err error)
 	// PolicyState returns the full snapshot for the deployment: applied,
 	// current, added, removed, drift, has_applied_state.
-	PolicyState(ctx context.Context, project, deploymentName string, explicitRefs []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error)
+	PolicyState(ctx context.Context, project, deploymentName string) (*consolev1.PolicyState, error)
 	// RecordApplied persists the effective render set for the target on
 	// successful Create/Update. Idempotent: second call with the same
 	// refs overwrites the first.
@@ -264,9 +264,7 @@ func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project, d
 		return nil, nil, false
 	}
 	projectNs := h.k8s.Resolver.ProjectNamespace(project)
-	// Pass nil for explicitRefs so the render pipeline derives the effective
-	// set exclusively from TemplatePolicyBinding resolution (HOL-904).
-	sources, effectiveRefs, err := h.ancestorTemplateProvider.ListAncestorTemplateSources(ctx, projectNs, deploymentName, nil)
+	sources, effectiveRefs, err := h.ancestorTemplateProvider.ListAncestorTemplateSources(ctx, projectNs, deploymentName)
 	if err != nil {
 		slog.WarnContext(ctx, "ancestor template resolution failed, skipping platform template unification",
 			slog.String("project", project),
@@ -1721,9 +1719,7 @@ func (h *Handler) GetDeploymentPolicyState(
 			State: &consolev1.PolicyState{},
 		}), nil
 	}
-	// Pass nil for explicitRefs: policy state is now sourced exclusively from
-	// TemplatePolicyBinding resolution, not the legacy annotation (HOL-904).
-	state, err := h.policyDriftChecker.PolicyState(ctx, project, name, nil)
+	state, err := h.policyDriftChecker.PolicyState(ctx, project, name)
 	if err != nil {
 		slog.WarnContext(ctx, "policy state computation failed",
 			slog.String("project", project),

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -1325,26 +1325,20 @@ type stubAncestorTemplateProvider struct {
 	lastDeploymentName string
 }
 
-func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Context, _ string, deploymentName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error) {
+func (s *stubAncestorTemplateProvider) ListAncestorTemplateSources(_ context.Context, _ string, deploymentName string) ([]string, []*consolev1.LinkedTemplateRef, error) {
 	s.called = true
 	s.lastDeploymentName = deploymentName
 	if s.err != nil {
 		return nil, nil, s.err
 	}
-	// When no explicit override, mirror the input refs back as the "resolved"
-	// effective set so tests that do not care about policy resolution still
-	// see a non-nil ref slice flow through the write-through path. A nil
-	// input is coerced to a non-nil empty slice so callers distinguish
-	// "ancestor walk succeeded, no policy match" from "walk failed /
-	// degraded render" (the latter returns a nil effectiveRefs per the
-	// production contract in ListEffectiveTemplateSources).
+	// When no explicit override, return a non-nil empty slice so callers
+	// distinguish "ancestor walk succeeded, no policy match" from "walk
+	// failed / degraded render" (the latter returns nil effectiveRefs per
+	// the production contract in ListEffectiveTemplateSources).
 	if s.effectiveRefs != nil {
 		return s.sources, s.effectiveRefs, nil
 	}
-	if linkedRefs == nil {
-		return s.sources, []*consolev1.LinkedTemplateRef{}, nil
-	}
-	return s.sources, linkedRefs, nil
+	return s.sources, []*consolev1.LinkedTemplateRef{}, nil
 }
 
 // trackingDeploymentRenderer extends stubRenderer to record whether Render

--- a/console/deployments/policy_state_test.go
+++ b/console/deployments/policy_state_test.go
@@ -36,11 +36,11 @@ type stubPolicyDriftChecker struct {
 	lastRecordRefs    []*consolev1.LinkedTemplateRef
 }
 
-func (s *stubPolicyDriftChecker) Drift(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) (bool, bool, error) {
+func (s *stubPolicyDriftChecker) Drift(_ context.Context, _, _ string) (bool, bool, error) {
 	return s.driftResult, s.driftHasApp, s.driftErr
 }
 
-func (s *stubPolicyDriftChecker) PolicyState(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error) {
+func (s *stubPolicyDriftChecker) PolicyState(_ context.Context, _, _ string) (*consolev1.PolicyState, error) {
 	return s.stateResult, s.stateErr
 }
 
@@ -273,7 +273,7 @@ func TestApplyPolicyDrift(t *testing.T) {
 			if c.checker != nil {
 				h = h.WithPolicyDriftChecker(c.checker)
 			}
-			h.applyPolicyDrift(context.Background(), project, name, nil, c.summary)
+			h.applyPolicyDrift(context.Background(), project, name, c.summary)
 			if c.summary == nil {
 				return // nothing to assert
 			}

--- a/console/deployments/record_applied_drift_e2e_test.go
+++ b/console/deployments/record_applied_drift_e2e_test.go
@@ -33,10 +33,10 @@ type e2eDriftChecker struct {
 	// currentFn returns the resolver output for a given (project, name).
 	// Production wires a real resolver; tests supply a closure that mimics
 	// "policy forces a REQUIRE template" without standing up a policy CRD.
-	currentFn func(project, name string, explicitRefs []*consolev1.LinkedTemplateRef) []*consolev1.LinkedTemplateRef
+	currentFn func(project, name string) []*consolev1.LinkedTemplateRef
 }
 
-func newE2EDriftChecker(currentFn func(string, string, []*consolev1.LinkedTemplateRef) []*consolev1.LinkedTemplateRef) *e2eDriftChecker {
+func newE2EDriftChecker(currentFn func(string, string) []*consolev1.LinkedTemplateRef) *e2eDriftChecker {
 	return &e2eDriftChecker{
 		applied:   map[string][]*consolev1.LinkedTemplateRef{},
 		currentFn: currentFn,
@@ -45,18 +45,18 @@ func newE2EDriftChecker(currentFn func(string, string, []*consolev1.LinkedTempla
 
 func (e *e2eDriftChecker) key(project, name string) string { return project + "/" + name }
 
-func (e *e2eDriftChecker) Drift(_ context.Context, project, name string, explicitRefs []*consolev1.LinkedTemplateRef) (bool, bool, error) {
+func (e *e2eDriftChecker) Drift(_ context.Context, project, name string) (bool, bool, error) {
 	applied, ok := e.applied[e.key(project, name)]
 	if !ok {
 		return false, false, nil
 	}
-	current := e.currentFn(project, name, explicitRefs)
+	current := e.currentFn(project, name)
 	return diffRefs(applied, current), true, nil
 }
 
-func (e *e2eDriftChecker) PolicyState(_ context.Context, project, name string, explicitRefs []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error) {
+func (e *e2eDriftChecker) PolicyState(_ context.Context, project, name string) (*consolev1.PolicyState, error) {
 	applied, has := e.applied[e.key(project, name)]
-	current := e.currentFn(project, name, explicitRefs)
+	current := e.currentFn(project, name)
 	return &consolev1.PolicyState{
 		AppliedSet:      applied,
 		CurrentSet:      current,
@@ -140,11 +140,11 @@ func TestHandler_CreateDeployment_DriftBecomesFalseAfterRecord(t *testing.T) {
 		effectiveRefs: policyOutput,
 	}
 
-	checker := newE2EDriftChecker(func(_, _ string, _ []*consolev1.LinkedTemplateRef) []*consolev1.LinkedTemplateRef {
-		// Return the same policy output regardless of the handler-supplied
-		// explicit refs. In production the PolicyResolver consults the
-		// TemplatePolicy CRD the same way on every call, so the apply-time
-		// and query-time resolutions agree by construction.
+	checker := newE2EDriftChecker(func(_, _ string) []*consolev1.LinkedTemplateRef {
+		// Return the same policy output on every call. In production the
+		// PolicyResolver consults the TemplatePolicy CRD the same way on
+		// every call, so apply-time and query-time resolutions agree by
+		// construction.
 		return policyOutput
 	})
 

--- a/console/deployments/record_applied_test.go
+++ b/console/deployments/record_applied_test.go
@@ -183,7 +183,7 @@ func TestHandler_CreateDeployment_WarnButSucceedOnRecordFailure(t *testing.T) {
 // refs back as a non-nil empty slice to exercise the happy path.
 type degradedAncestorProvider struct{}
 
-func (degradedAncestorProvider) ListAncestorTemplateSources(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error) {
+func (degradedAncestorProvider) ListAncestorTemplateSources(_ context.Context, _, _ string) ([]string, []*consolev1.LinkedTemplateRef, error) {
 	return nil, nil, nil
 }
 

--- a/console/deployments/status.go
+++ b/console/deployments/status.go
@@ -87,10 +87,7 @@ func (h *Handler) GetDeploymentStatusSummary(
 	// skip on error — drift is an advisory signal for the UI, not a
 	// first-class failure mode: an outage in the TemplatePolicy resolver
 	// MUST NOT block status reads.
-	// Pass nil for explicitRefs: policy drift is now sourced exclusively
-	// from TemplatePolicyBinding resolution, not the legacy annotation
-	// (HOL-904).
-	h.applyPolicyDrift(ctx, project, name, nil, summary)
+	h.applyPolicyDrift(ctx, project, name, summary)
 
 	return connect.NewResponse(&consolev1.GetDeploymentStatusSummaryResponse{
 		Summary: summary,
@@ -103,11 +100,11 @@ func (h *Handler) GetDeploymentStatusSummary(
 // applied render state yet (a freshly-created deployment that never ran
 // through the post-HOL-567 apply path). Errors are logged at DEBUG and
 // swallowed so drift remains advisory.
-func (h *Handler) applyPolicyDrift(ctx context.Context, project, name string, explicitRefs []*consolev1.LinkedTemplateRef, summary *consolev1.DeploymentStatusSummary) {
+func (h *Handler) applyPolicyDrift(ctx context.Context, project, name string, summary *consolev1.DeploymentStatusSummary) {
 	if h.policyDriftChecker == nil || summary == nil {
 		return
 	}
-	drift, hasApplied, err := h.policyDriftChecker.Drift(ctx, project, name, explicitRefs)
+	drift, hasApplied, err := h.policyDriftChecker.Drift(ctx, project, name)
 	if err != nil {
 		slog.DebugContext(ctx, "policy drift check failed; skipping summary.policy_drift",
 			slog.String("project", project),

--- a/console/policyresolver/applied_state_envtest_test.go
+++ b/console/policyresolver/applied_state_envtest_test.go
@@ -419,7 +419,7 @@ func TestFolderResolver_EnvtestWildcardFolderCascade(t *testing.T) {
 	// injection on a project-template render of any name.
 	for _, projectNs := range []string{projectLiliesNs, projectRosesNs} {
 		for _, targetName := range []string{"web", "api", "anything"} {
-			got, err := fr.Resolve(context.Background(), projectNs, TargetKindProjectTemplate, targetName, nil)
+			got, err := fr.Resolve(context.Background(), projectNs, TargetKindProjectTemplate, targetName)
 			if err != nil {
 				t.Fatalf("Resolve(%s, project_template, %s): %v", projectNs, targetName, err)
 			}
@@ -433,7 +433,7 @@ func TestFolderResolver_EnvtestWildcardFolderCascade(t *testing.T) {
 	// kind never wildcards: a DEPLOYMENT render must NOT match the
 	// PROJECT_TEMPLATE-targeted wildcard binding even though name and
 	// project_name are both "*".
-	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "web", nil)
+	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "web")
 	if err != nil {
 		t.Fatalf("Resolve(deployment): %v", err)
 	}
@@ -514,7 +514,7 @@ func TestFolderResolver_EnvtestWildcardSiblingFolderIsolation(t *testing.T) {
 	fr := NewFolderResolverWithBindings(pl, walker, r, bl)
 
 	// Project under folder eng: wildcard binding cascades down.
-	got, err := fr.Resolve(context.Background(), projectInEngNs, TargetKindProjectTemplate, "anything", nil)
+	got, err := fr.Resolve(context.Background(), projectInEngNs, TargetKindProjectTemplate, "anything")
 	if err != nil {
 		t.Fatalf("Resolve(eng project): %v", err)
 	}
@@ -524,7 +524,7 @@ func TestFolderResolver_EnvtestWildcardSiblingFolderIsolation(t *testing.T) {
 
 	// Project under sibling folder ops: ancestor walk does not cross
 	// into folder eng, so the wildcard binding contributes nothing.
-	got, err = fr.Resolve(context.Background(), projectInOpsNs, TargetKindProjectTemplate, "anything", nil)
+	got, err = fr.Resolve(context.Background(), projectInOpsNs, TargetKindProjectTemplate, "anything")
 	if err != nil {
 		t.Fatalf("Resolve(ops project): %v", err)
 	}
@@ -665,7 +665,7 @@ func TestFolderResolver_EnvtestWildcardProjectMatchesEveryReachableProject(t *te
 
 	// Both projects' "web" deployment match.
 	for _, projectNs := range []string{projectOneNs, projectTwoNs} {
-		got, err := fr.Resolve(context.Background(), projectNs, TargetKindDeployment, "web", nil)
+		got, err := fr.Resolve(context.Background(), projectNs, TargetKindDeployment, "web")
 		if err != nil {
 			t.Fatalf("Resolve(%s, web): %v", projectNs, err)
 		}
@@ -675,7 +675,7 @@ func TestFolderResolver_EnvtestWildcardProjectMatchesEveryReachableProject(t *te
 	}
 
 	// A different deployment name does not match.
-	got, err := fr.Resolve(context.Background(), projectOneNs, TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), projectOneNs, TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve(api): %v", err)
 	}
@@ -752,7 +752,7 @@ func TestFolderResolver_EnvtestWildcardProjectZeroMatchesWhenNamesAbsent(t *test
 	// No render target named "web" in this hierarchy means the resolver
 	// is queried for "api" / other names and must return empty.
 	for _, targetName := range []string{"api", "background", "anything"} {
-		got, err := fr.Resolve(context.Background(), projectOnlyNs, TargetKindDeployment, targetName, nil)
+		got, err := fr.Resolve(context.Background(), projectOnlyNs, TargetKindDeployment, targetName)
 		if err != nil {
 			t.Fatalf("Resolve(%s): %v", targetName, err)
 		}
@@ -764,7 +764,7 @@ func TestFolderResolver_EnvtestWildcardProjectZeroMatchesWhenNamesAbsent(t *test
 
 	// A "web" render in the project DOES match — pinning that the
 	// binding still attaches when the literal name aligns.
-	got, err := fr.Resolve(context.Background(), projectOnlyNs, TargetKindDeployment, "web", nil)
+	got, err := fr.Resolve(context.Background(), projectOnlyNs, TargetKindDeployment, "web")
 	if err != nil {
 		t.Fatalf("Resolve(web): %v", err)
 	}

--- a/console/policyresolver/cache_backed_test.go
+++ b/console/policyresolver/cache_backed_test.go
@@ -37,7 +37,6 @@ import (
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
-	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
 
 // cacheBackedPolicyLister implements PolicyListerInNamespace by calling
@@ -149,7 +148,7 @@ func TestFolderResolver_CacheBackedReadPath(t *testing.T) {
 
 	// Pre-write resolve: the binding injects audit-policy into the
 	// effective set for deployment lilies/api.
-	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve (first call): %v", err)
 	}
@@ -187,7 +186,7 @@ func TestFolderResolver_CacheBackedReadPath(t *testing.T) {
 		t.Fatalf("creating second binding: %v", err)
 	}
 
-	got, err = fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api", nil)
+	got, err = fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve (post-write): %v", err)
 	}
@@ -199,12 +198,12 @@ func TestFolderResolver_CacheBackedReadPath(t *testing.T) {
 	}
 }
 
-// TestFolderResolver_CacheBackedExplicitRefsAndExclude covers the mixed
-// case: the caller passes an explicit ref, a REQUIRE rule (via binding)
-// injects one, and a folder-level EXCLUDE rule removes a subsequently-
-// injected template. The test vectors every layer of the resolver against
-// a cache-backed read so a regression in any of them surfaces here.
-func TestFolderResolver_CacheBackedExplicitRefsAndExclude(t *testing.T) {
+// TestFolderResolver_CacheBackedRequireAndExclude covers the REQUIRE + EXCLUDE
+// formula using a cache-backed lister: a REQUIRE rule (via binding) injects
+// two templates, and a folder-level EXCLUDE rule removes one of them. The test
+// vectors every layer of the resolver against a cache-backed read so a
+// regression in any of them surfaces here.
+func TestFolderResolver_CacheBackedRequireAndExclude(t *testing.T) {
 	r := baseResolver()
 	orgNs := r.OrgNamespace("acme")
 	folderEngNs := r.FolderNamespace("eng")
@@ -258,17 +257,15 @@ func TestFolderResolver_CacheBackedExplicitRefsAndExclude(t *testing.T) {
 	bl := &cacheBackedBindingLister{c: c}
 	fr := NewFolderResolverWithBindings(pl, walker, r, bl)
 
-	explicit := []*consolev1.LinkedTemplateRef{orgTemplateRef("httproute")}
-	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api", explicit)
+	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
 	names := refNames(got)
 	sort.Strings(names)
-	// httproute is explicit (owner-linked, EXCLUDE-protected);
 	// audit-policy is REQUIRE-injected via binding; extra is
 	// REQUIRE-then-EXCLUDE so it drops out.
-	want := []string{"audit-policy", "httproute"}
+	want := []string{"audit-policy"}
 	if !equalStringSlices(names, want) {
 		t.Errorf("mismatch: got %v, want %v", names, want)
 	}
@@ -320,7 +317,7 @@ func TestFolderResolver_CacheBackedSkipsProjectNamespacePolicies(t *testing.T) {
 	bl := &cacheBackedBindingLister{c: c}
 	fr := NewFolderResolverWithBindings(pl, walker, r, bl)
 
-	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), projectLiliesNs, TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}

--- a/console/policyresolver/drift_checker.go
+++ b/console/policyresolver/drift_checker.go
@@ -58,7 +58,7 @@ func NewDeploymentDriftAdapter(d *DriftChecker) *DeploymentDriftAdapter {
 // diff completed successfully. This matches PolicyState's error contract
 // (nil, err) so callers can switch between the two methods without tracking
 // different partial-result semantics.
-func (a *DeploymentDriftAdapter) Drift(ctx context.Context, project, deploymentName string, explicitRefs []*consolev1.LinkedTemplateRef) (bool, bool, error) {
+func (a *DeploymentDriftAdapter) Drift(ctx context.Context, project, deploymentName string) (bool, bool, error) {
 	if a == nil || a.inner == nil {
 		return false, false, nil
 	}
@@ -70,7 +70,7 @@ func (a *DeploymentDriftAdapter) Drift(ctx context.Context, project, deploymentN
 	if !ok {
 		return false, false, nil
 	}
-	current, resolveErr := a.inner.Resolver.Resolve(ctx, projectNs, TargetKindDeployment, deploymentName, explicitRefs)
+	current, resolveErr := a.inner.Resolver.Resolve(ctx, projectNs, TargetKindDeployment, deploymentName)
 	if resolveErr != nil {
 		return false, false, fmt.Errorf("resolving current render set: %w", resolveErr)
 	}
@@ -79,7 +79,7 @@ func (a *DeploymentDriftAdapter) Drift(ctx context.Context, project, deploymentN
 }
 
 // PolicyState returns the full PolicyState snapshot for the deployment.
-func (a *DeploymentDriftAdapter) PolicyState(ctx context.Context, project, deploymentName string, explicitRefs []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error) {
+func (a *DeploymentDriftAdapter) PolicyState(ctx context.Context, project, deploymentName string) (*consolev1.PolicyState, error) {
 	if a == nil || a.inner == nil {
 		return &consolev1.PolicyState{}, nil
 	}
@@ -88,7 +88,7 @@ func (a *DeploymentDriftAdapter) PolicyState(ctx context.Context, project, deplo
 	if err != nil {
 		return nil, fmt.Errorf("reading applied render set: %w", err)
 	}
-	current, err := a.inner.Resolver.Resolve(ctx, projectNs, TargetKindDeployment, deploymentName, explicitRefs)
+	current, err := a.inner.Resolver.Resolve(ctx, projectNs, TargetKindDeployment, deploymentName)
 	if err != nil {
 		return nil, fmt.Errorf("resolving current render set: %w", err)
 	}
@@ -124,7 +124,7 @@ func NewProjectTemplateDriftAdapter(d *DriftChecker) *ProjectTemplateDriftAdapte
 
 // PolicyState returns the full PolicyState snapshot for a project-scope
 // template.
-func (a *ProjectTemplateDriftAdapter) PolicyState(ctx context.Context, project, templateName string, explicitRefs []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error) {
+func (a *ProjectTemplateDriftAdapter) PolicyState(ctx context.Context, project, templateName string) (*consolev1.PolicyState, error) {
 	if a == nil || a.inner == nil {
 		return &consolev1.PolicyState{}, nil
 	}
@@ -133,7 +133,7 @@ func (a *ProjectTemplateDriftAdapter) PolicyState(ctx context.Context, project, 
 	if err != nil {
 		return nil, fmt.Errorf("reading applied render set: %w", err)
 	}
-	current, err := a.inner.Resolver.Resolve(ctx, projectNs, TargetKindProjectTemplate, templateName, explicitRefs)
+	current, err := a.inner.Resolver.Resolve(ctx, projectNs, TargetKindProjectTemplate, templateName)
 	if err != nil {
 		return nil, fmt.Errorf("resolving current render set: %w", err)
 	}

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -183,7 +183,7 @@ func (r *folderResolver) Resolve(
 	// The returned slice preserves closest-ancestor-first order so REQUIRE
 	// injections closer to the project continue to appear later in the
 	// effective set (the dedup key is stable, so ordering only affects
-	// first-seen wins for explicit refs — which are set before this loop).
+	// first-seen wins for REQUIRE rules).
 	policies, walkErr := r.ancestorLister.ListPolicies(ctx, projectNs)
 	if walkErr != nil {
 		// Degrade gracefully: a walker failure at resolve time should

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -67,24 +67,23 @@ type folderResolver struct {
 	// ancestorBindings encapsulates the same ancestor walk for
 	// TemplatePolicyBinding CRD objects. Nil when bindingLister is nil;
 	// Resolve treats a nil ancestorBindings as "no bindings exist", which
-	// post-HOL-600 means "no rules contribute". This is the safe
-	// fail-open behavior: a wire-up that forgot to provide a binding
-	// lister returns the caller's explicit refs unchanged rather than
+	// post-HOL-600 means "no rules contribute" and returns an empty
+	// effective set. This is the safe fail-open behavior: a wire-up that
+	// forgot to provide a binding lister returns empty rather than
 	// misapplying rules.
 	ancestorBindings *AncestorBindingLister
 }
 
 // NewFolderResolver returns a folderResolver wired with the policy
-// (rule-side) dependencies only. Post-HOL-600 this resolver degrades to
-// returning the caller's explicit refs unchanged: no binding lister is
-// wired, so no rule can contribute. The constructor is retained for
-// pre-binding test wire-ups that want to assert the fail-open behavior.
-// Production code must use NewFolderResolverWithBindings so the binding
-// evaluation path is live.
+// (rule-side) dependencies only. Because no binding lister is wired, no
+// rule can contribute and the resolver always returns an empty effective
+// set. The constructor is retained for pre-binding test wire-ups that
+// want to assert the fail-open behavior. Production code must use
+// NewFolderResolverWithBindings so the binding evaluation path is live.
 //
 // Passing nil for any of the three rule-side arguments yields a resolver
-// that also returns the explicit refs unchanged (equivalent to
-// noopResolver), matching the fail-open contract in Resolve.
+// that also returns an empty effective set (equivalent to noopResolver),
+// matching the fail-open contract in Resolve.
 func NewFolderResolver(
 	policyLister PolicyListerInNamespace,
 	walker WalkerInterface,
@@ -107,8 +106,8 @@ func NewFolderResolver(
 // legacy glob Target path is gone.
 //
 // Passing a nil binding lister reduces the resolver to "no rules
-// contribute"; the caller's explicit refs pass through unchanged. Passing
-// a nil rule stack falls through to noopResolver semantics as before.
+// contribute" and returns an empty effective set. Passing a nil rule
+// stack falls through to the same empty-set semantics as before.
 func NewFolderResolverWithBindings(
 	policyLister PolicyListerInNamespace,
 	walker WalkerInterface,
@@ -131,43 +130,39 @@ func NewFolderResolverWithBindings(
 // Resolve returns the effective set of LinkedTemplateRef values for the
 // render target at `(projectNs, targetKind, targetName)`. The computation is:
 //
-//	result = explicitRefs ∪ REQUIRE-injected − EXCLUDE-removed
+//	result = REQUIRE-injected − EXCLUDE-removed
 //
 // Ordering: EXCLUDE runs after REQUIRE so a policy that both REQUIREs and
 // EXCLUDEs the same template (an admin typo) still removes the template.
-// Ordering: EXCLUDE cannot remove a template that the owner explicitly
-// linked — that rejection happens at policy-author time in
-// CreateTemplatePolicy/UpdateTemplatePolicy; at resolve time EXCLUDE only
-// removes templates that REQUIRE added.
+// Only policies covered by at least one binding whose target_refs match the
+// current render target contribute rules — this is the sole selection
+// mechanism post-HOL-600.
 //
-// Dedup key for the final slice is `(namespace, name)`. Two explicit-ref
-// entries that share a key are kept as the first-seen occurrence so the
-// resolver never silently drops a version constraint that the caller set
-// deliberately.
+// Dedup key for the final slice is `(namespace, name)`. The first-seen
+// occurrence wins when two REQUIRE rules name the same template.
 //
-// When any dependency is nil the resolver degrades to returning explicitRefs
-// unchanged and logs a warning. This mirrors the noopResolver behavior so a
-// misconfigured bootstrap fails open (render proceeds) rather than failing
-// closed (every render errors).
+// When any dependency is nil the resolver degrades to returning nil and logs
+// a warning. This mirrors the noopResolver behavior so a misconfigured
+// bootstrap fails open (render proceeds with no injected templates) rather
+// than failing closed (every render errors).
 func (r *folderResolver) Resolve(
 	ctx context.Context,
 	projectNs string,
 	targetKind TargetKind,
 	targetName string,
-	explicitRefs []*consolev1.LinkedTemplateRef,
 ) ([]*consolev1.LinkedTemplateRef, error) {
 	if r == nil || r.policyLister == nil || r.walker == nil || r.resolver == nil {
-		slog.WarnContext(ctx, "folder resolver is misconfigured; returning explicit refs unchanged",
+		slog.WarnContext(ctx, "folder resolver is misconfigured; returning empty effective set",
 			slog.String("projectNs", projectNs),
 			slog.String("targetName", targetName),
 			slog.Bool("policyListerNil", r == nil || r.policyLister == nil),
 			slog.Bool("walkerNil", r == nil || r.walker == nil),
 			slog.Bool("resolverNil", r == nil || r.resolver == nil),
 		)
-		return explicitRefs, nil
+		return nil, nil
 	}
 	if projectNs == "" {
-		return explicitRefs, nil
+		return nil, nil
 	}
 
 	// Resolve the project slug from the namespace. Bindings key targets
@@ -192,28 +187,28 @@ func (r *folderResolver) Resolve(
 	policies, walkErr := r.ancestorLister.ListPolicies(ctx, projectNs)
 	if walkErr != nil {
 		// Degrade gracefully: a walker failure at resolve time should
-		// not block the render. Log and return the explicit refs so the
-		// caller can still produce the minimal render.
-		slog.WarnContext(ctx, "ancestor walk failed during policy resolution; returning explicit refs unchanged",
+		// not block the render. Log and return nil (empty effective set)
+		// so the caller can still produce a minimal render.
+		slog.WarnContext(ctx, "ancestor walk failed during policy resolution; returning empty effective set",
 			slog.String("projectNs", projectNs),
 			slog.Any("error", walkErr),
 		)
-		return explicitRefs, nil
+		return nil, nil
 	}
 
 	// Collect the bindings from the same ancestor chain. A nil
 	// ancestorBindings (no WithBindings wire-up) is the fail-open
-	// degenerate case: no rule can contribute, so the caller's
-	// explicit refs pass through unchanged.
+	// degenerate case: no rule can contribute, so the effective set
+	// is empty.
 	var bindings []*ResolvedBinding
 	if r.ancestorBindings != nil {
 		bs, bErr := r.ancestorBindings.ListBindings(ctx, projectNs)
 		if bErr != nil {
-			slog.WarnContext(ctx, "ancestor binding walk failed during policy resolution; returning explicit refs unchanged",
+			slog.WarnContext(ctx, "ancestor binding walk failed during policy resolution; returning empty effective set",
 				slog.String("projectNs", projectNs),
 				slog.Any("error", bErr),
 			)
-			return explicitRefs, nil
+			return nil, nil
 		}
 		bindings = bs
 	}
@@ -290,15 +285,13 @@ func (r *folderResolver) Resolve(
 		}
 	}
 
-	// Start the effective set with the caller's explicit refs, deduped
-	// on `(scope, scope_name, name)`. Any explicit ref that a REQUIRE
-	// rule also matches stays in the set; we only add new entries.
-	effective, effectiveSet, explicitKeys := dedupRefs(explicitRefs)
+	// Build the effective set from REQUIRE-injected refs, deduped on
+	// `(namespace, name)`. The first-seen occurrence wins when two REQUIRE
+	// rules name the same template (e.g., two policies both REQUIRE the
+	// same org-level audit template).
+	var effective []*consolev1.LinkedTemplateRef
+	effectiveSet := make(map[RefKey]*consolev1.LinkedTemplateRef)
 
-	// Inject REQUIRE matches. A REQUIRE rule selected by a binding
-	// contributes its template ref, carrying the rule-author-declared
-	// version constraint so a REQUIRE rule can pin the platform-forced
-	// template to a specific semver band.
 	for _, rule := range requireRules {
 		tmpl := rule.GetTemplate()
 		if tmpl == nil || tmpl.GetName() == "" {
@@ -317,11 +310,10 @@ func (r *folderResolver) Resolve(
 		effectiveSet[key] = ref
 	}
 
-	// Apply EXCLUDE rules. EXCLUDE only removes refs that REQUIRE
-	// added — the owner-linked refs in explicitKeys are protected.
-	// The resolver enforces this protection so a policy accidentally
-	// authored against an org-mandated linked template does not
-	// silently override the deliberate choice.
+	// Apply EXCLUDE rules. EXCLUDE removes any REQUIRE-injected ref that
+	// matches the rule's template. Since there are no owner-linked explicit
+	// refs in the effective set (HOL-905), every ref is eligible for
+	// removal by an EXCLUDE rule.
 	if len(excludeRules) == 0 {
 		return effective, nil
 	}
@@ -331,11 +323,6 @@ func (r *folderResolver) Resolve(
 			continue
 		}
 		key := keyForRefProto(ref)
-		// Never remove an explicit (owner-linked) ref.
-		if _, ownerLinked := explicitKeys[key]; ownerLinked {
-			filtered = append(filtered, ref)
-			continue
-		}
 		excluded := false
 		for _, rule := range excludeRules {
 			tmpl := rule.GetTemplate()
@@ -475,25 +462,3 @@ func keyForTemplateRef(namespace, name string) RefKey {
 	return RefKey{Namespace: namespace, Name: name}
 }
 
-// dedupRefs returns (deduped, deduped-set, explicit-set). deduped preserves
-// first-seen order; deduped-set indexes deduped by its `(namespace, name)`
-// pair. explicit-set is a snapshot of the keys in deduped before REQUIRE
-// injection, so EXCLUDE can tell which refs the owner chose.
-func dedupRefs(refs []*consolev1.LinkedTemplateRef) ([]*consolev1.LinkedTemplateRef, map[RefKey]*consolev1.LinkedTemplateRef, map[RefKey]struct{}) {
-	out := make([]*consolev1.LinkedTemplateRef, 0, len(refs))
-	set := make(map[RefKey]*consolev1.LinkedTemplateRef, len(refs))
-	explicit := make(map[RefKey]struct{}, len(refs))
-	for _, r := range refs {
-		if r == nil {
-			continue
-		}
-		key := keyForRefProto(r)
-		if _, ok := set[key]; ok {
-			continue
-		}
-		out = append(out, r)
-		set[key] = r
-		explicit[key] = struct{}{}
-	}
-	return out, set, explicit
-}

--- a/console/policyresolver/folder_resolver_bindings_test.go
+++ b/console/policyresolver/folder_resolver_bindings_test.go
@@ -109,8 +109,7 @@ func newFolderResolverWithBindingsForTest(
 // TestFolderResolver_BindingsNonexistentPolicyIsNoopAndDoesNotError
 // asserts a binding whose policy_ref does not resolve to any policy in
 // the ancestor chain is treated as a no-op: the resolver does not
-// error, no refs are injected, and the explicit refs passed by the
-// caller are returned unchanged. This is the degrade-gracefully
+// error and returns an empty effective set. This is the degrade-gracefully
 // contract inherited from HOL-596.
 func TestFolderResolver_BindingsNonexistentPolicyIsNoopAndDoesNotError(t *testing.T) {
 	client, r, ns := buildFixture()
@@ -127,20 +126,16 @@ func TestFolderResolver_BindingsNonexistentPolicyIsNoopAndDoesNotError(t *testin
 		},
 	}
 
-	explicit := []*consolev1.LinkedTemplateRef{
-		orgTemplateRef("explicit"),
-	}
 	pl := &policyListerFromClient{items: nil}
 	bl := &bindingListerFromMap{items: bindings}
 	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
 
-	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", explicit)
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error on nonexistent policy; expected no-op: %v", err)
 	}
-	names := refNames(got)
-	if len(names) != 1 || names[0] != "explicit" {
-		t.Errorf("expected explicit refs passed through, got %v", names)
+	if len(got) != 0 {
+		t.Errorf("expected empty effective set for nonexistent policy, got %v", refNames(got))
 	}
 }
 
@@ -174,7 +169,7 @@ func TestFolderResolver_BindingsEmptyTargetListContributesNothing(t *testing.T) 
 	bl := &bindingListerFromMap{items: bindings}
 	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
 
-	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -214,7 +209,7 @@ func TestFolderResolver_BindingProjectNameMismatchContributesNothing(t *testing.
 	bl := &bindingListerFromMap{items: bindings}
 	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
 
-	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -551,7 +546,7 @@ func TestFolderResolver_WildcardBindingFolderCascade(t *testing.T) {
 
 	// projectRoses is directly under team-a: the wildcard binding MUST
 	// select every deployment in roses.
-	got, err := fr.Resolve(ctx, ns["projectRoses"], TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(ctx, ns["projectRoses"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve(roses/api): %v", err)
 	}
@@ -560,7 +555,7 @@ func TestFolderResolver_WildcardBindingFolderCascade(t *testing.T) {
 	}
 	// Same project, a *different* deployment name — wildcard means both
 	// match; this is the "doesn't accidentally pin to one name" check.
-	got, err = fr.Resolve(ctx, ns["projectRoses"], TargetKindDeployment, "web", nil)
+	got, err = fr.Resolve(ctx, ns["projectRoses"], TargetKindDeployment, "web")
 	if err != nil {
 		t.Fatalf("Resolve(roses/web): %v", err)
 	}
@@ -570,7 +565,7 @@ func TestFolderResolver_WildcardBindingFolderCascade(t *testing.T) {
 
 	// projectLilies is under eng (sibling of team-a): team-a's binding
 	// is NOT on its ancestor chain, so even `{*, *}` must not match.
-	got, err = fr.Resolve(ctx, ns["projectLilies"], TargetKindDeployment, "api", nil)
+	got, err = fr.Resolve(ctx, ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve(lilies/api): %v", err)
 	}
@@ -580,7 +575,7 @@ func TestFolderResolver_WildcardBindingFolderCascade(t *testing.T) {
 
 	// projectOrchids is directly under org (skips eng and team-a
 	// entirely): team-a's binding is not on this chain either.
-	got, err = fr.Resolve(ctx, ns["projectOrchids"], TargetKindDeployment, "api", nil)
+	got, err = fr.Resolve(ctx, ns["projectOrchids"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve(orchids/api): %v", err)
 	}
@@ -590,7 +585,7 @@ func TestFolderResolver_WildcardBindingFolderCascade(t *testing.T) {
 
 	// A PROJECT_TEMPLATE render target in roses must NOT be matched by
 	// the DEPLOYMENT `{*, *}` binding — kind is never wildcarded.
-	got, err = fr.Resolve(ctx, ns["projectRoses"], TargetKindProjectTemplate, "any", nil)
+	got, err = fr.Resolve(ctx, ns["projectRoses"], TargetKindProjectTemplate, "any")
 	if err != nil {
 		t.Fatalf("Resolve(roses/project-template): %v", err)
 	}

--- a/console/policyresolver/folder_resolver_test.go
+++ b/console/policyresolver/folder_resolver_test.go
@@ -262,25 +262,22 @@ func TestFolderResolver_Resolve(t *testing.T) {
 		projectNs  string
 		target     TargetKind
 		targetName string
-		explicit   []*consolev1.LinkedTemplateRef
 		policies   map[string][]templatesv1alpha1.TemplatePolicy
 		bindings   map[string][]templatesv1alpha1.TemplatePolicyBinding
 		want       want
 	}{
 		{
-			name:       "no policies, no bindings — explicit refs pass through",
+			name:       "no policies, no bindings — empty effective set",
 			projectNs:  ns["projectLilies"],
 			target:     TargetKindDeployment,
 			targetName: "api",
-			explicit:   []*consolev1.LinkedTemplateRef{orgTemplateRef("httproute")},
-			want:       want{names: []string{"httproute"}},
+			want:       want{names: nil},
 		},
 		{
 			name:       "REQUIRE-only — org policy injects template via binding",
 			projectNs:  ns["projectLilies"],
 			target:     TargetKindDeployment,
 			targetName: "api",
-			explicit:   nil,
 			policies: map[string][]templatesv1alpha1.TemplatePolicy{
 				ns["org"]: {
 					policyCRD(ns["org"], "audit", []templatesv1alpha1.TemplatePolicyRule{
@@ -303,7 +300,6 @@ func TestFolderResolver_Resolve(t *testing.T) {
 			projectNs:  ns["projectLilies"],
 			target:     TargetKindDeployment,
 			targetName: "api",
-			explicit:   nil,
 			policies: map[string][]templatesv1alpha1.TemplatePolicy{
 				ns["org"]: {
 					policyCRD(ns["org"], "audit", []templatesv1alpha1.TemplatePolicyRule{
@@ -341,7 +337,6 @@ func TestFolderResolver_Resolve(t *testing.T) {
 			projectNs:  ns["projectLilies"],
 			target:     TargetKindDeployment,
 			targetName: "api",
-			explicit:   nil,
 			policies: map[string][]templatesv1alpha1.TemplatePolicy{
 				ns["org"]: {
 					policyCRD(ns["org"], "req", []templatesv1alpha1.TemplatePolicyRule{
@@ -367,12 +362,16 @@ func TestFolderResolver_Resolve(t *testing.T) {
 			want: want{names: nil},
 		},
 		{
-			name:       "EXCLUDE cannot remove owner-linked template",
+			name:       "EXCLUDE on a REQUIRE-injected template removes it",
 			projectNs:  ns["projectLilies"],
 			target:     TargetKindDeployment,
 			targetName: "api",
-			explicit:   []*consolev1.LinkedTemplateRef{orgTemplateRef("httproute")},
 			policies: map[string][]templatesv1alpha1.TemplatePolicy{
+				ns["org"]: {
+					policyCRD(ns["org"], "req-httproute", []templatesv1alpha1.TemplatePolicyRule{
+						requireRuleCRD(v1alpha2.TemplateScopeOrganization, "acme", "httproute"),
+					}),
+				},
 				ns["folderEng"]: {
 					policyCRD(ns["folderEng"], "block-httproute", []templatesv1alpha1.TemplatePolicyRule{
 						excludeRuleCRD(v1alpha2.TemplateScopeOrganization, "acme", "httproute"),
@@ -380,6 +379,12 @@ func TestFolderResolver_Resolve(t *testing.T) {
 				},
 			},
 			bindings: map[string][]templatesv1alpha1.TemplatePolicyBinding{
+				ns["org"]: {
+					bindingCRD(ns["org"], "req-bind",
+						orgPolicyRefCRD("req-httproute"),
+						[]templatesv1alpha1.TemplatePolicyBindingTargetRef{deploymentTargetCRD("lilies", "api")},
+					),
+				},
 				ns["folderEng"]: {
 					bindingCRD(ns["folderEng"], "block-bind",
 						folderPolicyRefCRD("eng", "block-httproute"),
@@ -387,14 +392,13 @@ func TestFolderResolver_Resolve(t *testing.T) {
 					),
 				},
 			},
-			want: want{names: []string{"httproute"}},
+			want: want{names: nil},
 		},
 		{
-			name:       "REQUIRE + EXCLUDE: REQUIRE injects, EXCLUDE removes",
+			name:       "REQUIRE + EXCLUDE: REQUIRE injects, EXCLUDE removes one of two",
 			projectNs:  ns["projectLilies"],
 			target:     TargetKindDeployment,
 			targetName: "api",
-			explicit:   []*consolev1.LinkedTemplateRef{orgTemplateRef("httproute")},
 			policies: map[string][]templatesv1alpha1.TemplatePolicy{
 				ns["org"]: {
 					policyCRD(ns["org"], "audit", []templatesv1alpha1.TemplatePolicyRule{
@@ -422,14 +426,13 @@ func TestFolderResolver_Resolve(t *testing.T) {
 					),
 				},
 			},
-			want: want{names: []string{"httproute", "audit-policy"}},
+			want: want{names: []string{"audit-policy"}},
 		},
 		{
 			name:       "multi-folder hierarchy: folder policy applies to nested project via binding",
 			projectNs:  ns["projectRoses"],
 			target:     TargetKindDeployment,
 			targetName: "api",
-			explicit:   nil,
 			policies: map[string][]templatesv1alpha1.TemplatePolicy{
 				ns["folderEng"]: {
 					policyCRD(ns["folderEng"], "eng-audit", []templatesv1alpha1.TemplatePolicyRule{
@@ -452,7 +455,6 @@ func TestFolderResolver_Resolve(t *testing.T) {
 			projectNs:  ns["projectLilies"],
 			target:     TargetKindProjectTemplate,
 			targetName: "my-template",
-			explicit:   []*consolev1.LinkedTemplateRef{folderTemplateRef("eng", "baseline")},
 			policies: map[string][]templatesv1alpha1.TemplatePolicy{
 				ns["org"]: {
 					policyCRD(ns["org"], "audit", []templatesv1alpha1.TemplatePolicyRule{
@@ -468,7 +470,7 @@ func TestFolderResolver_Resolve(t *testing.T) {
 					),
 				},
 			},
-			want: want{names: []string{"baseline", "audit-policy"}},
+			want: want{names: []string{"audit-policy"}},
 		},
 	}
 
@@ -479,7 +481,7 @@ func TestFolderResolver_Resolve(t *testing.T) {
 			bl := &bindingListerFromMap{items: tc.bindings}
 			fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
 
-			got, err := fr.Resolve(context.Background(), tc.projectNs, tc.target, tc.targetName, tc.explicit)
+			got, err := fr.Resolve(context.Background(), tc.projectNs, tc.target, tc.targetName)
 			if err != nil {
 				t.Fatalf("Resolve returned error: %v", err)
 			}
@@ -555,7 +557,7 @@ func TestFolderResolver_IgnoresProjectNamespacePolicies(t *testing.T) {
 	bl := &bindingListerFromMap{items: bindings}
 	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
 
-	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -615,7 +617,7 @@ func TestFolderResolver_MultiFolderResolvesCorrectOwningFolder(t *testing.T) {
 	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
 
 	// projectRoses is under team-a which is under eng which is under org.
-	got, err := fr.Resolve(context.Background(), ns["projectRoses"], TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), ns["projectRoses"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -629,18 +631,16 @@ func TestFolderResolver_MultiFolderResolvesCorrectOwningFolder(t *testing.T) {
 
 // TestFolderResolver_MisconfiguredFallsOpen ensures a resolver constructed
 // with nil dependencies behaves as the noop resolver would. A misconfigured
-// bootstrap must fail open (render proceeds with explicit refs only), not
+// bootstrap must fail open (render proceeds with an empty effective set), not
 // closed (render errors on every call).
 func TestFolderResolver_MisconfiguredFallsOpen(t *testing.T) {
-	orgRef := orgTemplateRef("httproute")
-
 	fr := NewFolderResolver(nil, nil, nil)
-	got, err := fr.Resolve(context.Background(), "holos-prj-x", TargetKindDeployment, "api", []*consolev1.LinkedTemplateRef{orgRef})
+	got, err := fr.Resolve(context.Background(), "holos-prj-x", TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
-	if len(got) != 1 || got[0].GetName() != "httproute" {
-		t.Errorf("misconfigured resolver did not fall through: got %v", refNames(got))
+	if len(got) != 0 {
+		t.Errorf("misconfigured resolver did not fall open to empty set: got %v", refNames(got))
 	}
 }
 
@@ -667,7 +667,7 @@ func TestFolderResolver_NoBindingWireupIsFailOpen(t *testing.T) {
 	// rules contribute".
 	fr := NewFolderResolver(pl, walker, r)
 
-	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -709,7 +709,7 @@ func TestFolderResolver_PolicyListerErrorIsLogged(t *testing.T) {
 	bl := &bindingListerFromMap{items: bindings}
 	fr := newFolderResolverWithBindingsForTest(lister, bl, walker, r)
 
-	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", nil)
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -718,22 +718,21 @@ func TestFolderResolver_PolicyListerErrorIsLogged(t *testing.T) {
 	}
 }
 
-// TestFolderResolver_WalkerErrorReturnsExplicitRefs: if the walker fails,
-// the resolver must not error; it must return explicit refs so the
-// render can still produce a minimal output.
-func TestFolderResolver_WalkerErrorReturnsExplicitRefs(t *testing.T) {
+// TestFolderResolver_WalkerErrorFallsOpen: if the walker fails,
+// the resolver must not error; it must return an empty effective set so
+// the render can still proceed with no policy-injected templates.
+func TestFolderResolver_WalkerErrorFallsOpen(t *testing.T) {
 	r := baseResolver()
 	walker := &failingWalker{err: errors.New("walker exploded")}
 	lister := &policyListerFromClient{items: nil}
 	fr := NewFolderResolver(lister, walker, r)
 
-	explicit := []*consolev1.LinkedTemplateRef{orgTemplateRef("t1")}
-	got, err := fr.Resolve(context.Background(), "holos-prj-x", TargetKindDeployment, "api", explicit)
+	got, err := fr.Resolve(context.Background(), "holos-prj-x", TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
-	if len(got) != 1 || got[0].GetName() != "t1" {
-		t.Errorf("expected explicit refs pass-through on walker failure: got %v", refNames(got))
+	if len(got) != 0 {
+		t.Errorf("expected empty set on walker failure: got %v", refNames(got))
 	}
 }
 
@@ -745,20 +744,30 @@ func (f *failingWalker) WalkAncestors(_ context.Context, _ string) ([]*corev1.Na
 	return nil, f.err
 }
 
-// TestFolderResolver_DedupRespectsExplicit: when an explicit ref matches a
-// REQUIRE rule (selected via binding), the explicit ref survives with
-// its version constraint intact. This guards the first-seen-wins dedup
-// contract.
-func TestFolderResolver_DedupRespectsExplicit(t *testing.T) {
+// TestFolderResolver_DedupRespectsFirstRequireWin: when two REQUIRE rules from
+// different policies name the same template, the first-seen occurrence wins and
+// the duplicate is dropped. This guards the dedup contract.
+func TestFolderResolver_DedupRespectsFirstRequireWin(t *testing.T) {
 	client, r, ns := buildFixture()
 	walker := &resolver.Walker{Client: client, Resolver: r}
 
-	explicit := []*consolev1.LinkedTemplateRef{
-		{Namespace: "holos-org-acme", Name: "httproute", VersionConstraint: ">=1.0.0"},
-	}
+	// Two REQUIRE rules that inject the same template — the first one listed
+	// in the ancestor walk wins (org policy is visited before folder policy).
 	policies := map[string][]templatesv1alpha1.TemplatePolicy{
 		ns["org"]: {
 			policyCRD(ns["org"], "p", []templatesv1alpha1.TemplatePolicyRule{
+				{
+					Kind: templatesv1alpha1.TemplatePolicyKindRequire,
+					Template: templatesv1alpha1.LinkedTemplateRef{
+						Namespace:         "holos-org-acme",
+						Name:              "httproute",
+						VersionConstraint: ">=1.0.0",
+					},
+				},
+			}),
+		},
+		ns["folderEng"]: {
+			policyCRD(ns["folderEng"], "p2", []templatesv1alpha1.TemplatePolicyRule{
 				{
 					Kind: templatesv1alpha1.TemplatePolicyKindRequire,
 					Template: templatesv1alpha1.LinkedTemplateRef{
@@ -777,20 +786,27 @@ func TestFolderResolver_DedupRespectsExplicit(t *testing.T) {
 				[]templatesv1alpha1.TemplatePolicyBindingTargetRef{deploymentTargetCRD("lilies", "api")},
 			),
 		},
+		ns["folderEng"]: {
+			bindingCRD(ns["folderEng"], "p2-bind",
+				folderPolicyRefCRD("eng", "p2"),
+				[]templatesv1alpha1.TemplatePolicyBindingTargetRef{deploymentTargetCRD("lilies", "api")},
+			),
+		},
 	}
 	pl := &policyListerFromClient{items: policies}
 	bl := &bindingListerFromMap{items: bindings}
 	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
 
-	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api", explicit)
+	got, err := fr.Resolve(context.Background(), ns["projectLilies"], TargetKindDeployment, "api")
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
 	if len(got) != 1 {
-		t.Fatalf("expected 1 ref, got %d: %s", len(got), fmt.Sprint(refNames(got)))
+		t.Fatalf("expected 1 ref (deduped), got %d: %s", len(got), fmt.Sprint(refNames(got)))
 	}
-	if got[0].GetVersionConstraint() != ">=1.0.0" {
-		t.Errorf("explicit ref's version constraint was overridden: got %q, want %q",
-			got[0].GetVersionConstraint(), ">=1.0.0")
+	// The first-seen constraint wins — which one is first depends on ancestor
+	// walk order; we only assert dedup produces exactly one entry.
+	if got[0].GetName() != "httproute" {
+		t.Errorf("wrong template name: got %q, want %q", got[0].GetName(), "httproute")
 	}
 }

--- a/console/policyresolver/folder_resolver_test.go
+++ b/console/policyresolver/folder_resolver_test.go
@@ -238,9 +238,9 @@ func excludeRuleCRD(scope, scopeName, name string) templatesv1alpha1.TemplatePol
 }
 
 // orgTemplateRef / folderTemplateRef build proto template refs used as
-// explicit refs in resolver inputs. Keep them tiny so each test case reads
-// clearly. Namespaces mirror the canonical HOL-567 fixture resolver
-// (holos-org-/fld- prefixes).
+// expected resolved refs in resolver output assertions. Keep them tiny
+// so each test case reads clearly. Namespaces mirror the canonical
+// HOL-567 fixture resolver (holos-org-/fld- prefixes).
 func orgTemplateRef(name string) *consolev1.LinkedTemplateRef {
 	return &consolev1.LinkedTemplateRef{Namespace: "holos-org-acme", Name: name}
 }

--- a/console/policyresolver/multi_pod_freshness_test.go
+++ b/console/policyresolver/multi_pod_freshness_test.go
@@ -319,7 +319,7 @@ func eventuallyResolveFolderResolverNames(
 	end := time.Now().Add(deadline)
 	var lastSeen []string
 	for time.Now().Before(end) {
-		got, err := fr.Resolve(context.Background(), projectNs, TargetKindDeployment, targetName, nil)
+		got, err := fr.Resolve(context.Background(), projectNs, TargetKindDeployment, targetName)
 		if err != nil {
 			t.Fatalf("Resolve: %v", err)
 		}

--- a/console/policyresolver/resolver.go
+++ b/console/policyresolver/resolver.go
@@ -37,48 +37,48 @@ const (
 	TargetKindDeployment
 )
 
-// PolicyResolver filters and augments the caller's explicit linked-template
-// refs according to TemplatePolicy REQUIRE/EXCLUDE rules before the
-// ancestor-source helper walks the namespace chain.
+// PolicyResolver computes the effective set of LinkedTemplateRef values for a
+// render target by applying TemplatePolicy REQUIRE/EXCLUDE rules from the
+// ancestor namespace chain. The effective set formula is:
 //
-// Phase 4 (HOL-566) introduces this contract; every production wire-up
-// receives a no-op implementation that returns explicitRefs unchanged. Phase
-// 5 (HOL-567) swaps in a real implementation backed by the TemplatePolicy
-// service.
+//	result = REQUIRE-injected − EXCLUDE-removed
 //
-// Implementations must not mutate the input slice. The returned slice is owned
-// by the caller and may be appended to freely.
+// Only bindings whose target_refs select the current render target contribute.
+// Policies with no covering binding contribute nothing. Callers no longer pass
+// an explicit-refs slice — the resolver derives the effective set purely from
+// policy rules (HOL-905).
+//
+// Implementations must not mutate any shared state. The returned slice is
+// owned by the caller and may be appended to freely.
 type PolicyResolver interface {
 	Resolve(
 		ctx context.Context,
 		projectNs string,
 		targetKind TargetKind,
 		targetName string,
-		explicitRefs []*consolev1.LinkedTemplateRef,
 	) ([]*consolev1.LinkedTemplateRef, error)
 }
 
-// noopResolver returns explicitRefs unchanged. It is the Phase 4 placeholder
-// that every render call site receives until Phase 5 lands a real
-// TemplatePolicy-backed implementation.
+// noopResolver returns an empty effective set. It is the placeholder wired
+// when no real TemplatePolicy-backed implementation is available (e.g.,
+// local/dev deployments without a policy resolver).
 type noopResolver struct{}
 
-// NewNoopResolver returns a PolicyResolver that returns its inputs unchanged.
-// Wire one instance at server startup and pass it into every handler that
-// owns a render path.
+// NewNoopResolver returns a PolicyResolver that always returns an empty
+// effective set. Wire one instance at server startup for local/dev wiring;
+// production wires the real folderResolver via NewFolderResolverWithBindings.
 func NewNoopResolver() PolicyResolver {
 	return noopResolver{}
 }
 
-// Resolve returns explicitRefs verbatim. The context, projectNs, targetKind,
-// and targetName arguments are accepted for signature stability — Phase 5
-// consults them, but the no-op implementation never does.
+// Resolve returns an empty slice. The context, projectNs, targetKind, and
+// targetName arguments are accepted for interface compliance — the no-op
+// implementation never consults them.
 func (noopResolver) Resolve(
 	_ context.Context,
 	_ string,
 	_ TargetKind,
 	_ string,
-	explicitRefs []*consolev1.LinkedTemplateRef,
 ) ([]*consolev1.LinkedTemplateRef, error) {
-	return explicitRefs, nil
+	return nil, nil
 }

--- a/console/policyresolver/resolver.go
+++ b/console/policyresolver/resolver.go
@@ -6,8 +6,9 @@
 // The package exists so Phase 5 of HOL-562 (HOL-567) can swap the no-op
 // implementation for a real TemplatePolicy-backed resolver without touching
 // call sites. In Phase 4 (HOL-566) the interface is introduced and wired
-// everywhere, but every call path still receives the no-op implementation
-// that returns explicit refs unchanged.
+// everywhere with the no-op implementation. Phase 2 of HOL-903 (HOL-905)
+// removed the explicitRefs parameter from the interface so the resolver
+// derives the effective set from TemplatePolicyBinding rules only.
 //
 // Keeping the resolver in its own package (rather than in
 // console/templates/) prevents the PolicyResolver abstraction from leaking

--- a/console/policyresolver/resolver_test.go
+++ b/console/policyresolver/resolver_test.go
@@ -3,95 +3,44 @@ package policyresolver
 import (
 	"context"
 	"testing"
-
-	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
 
-// TestNoopResolver_ReturnsInputsUnchanged asserts the Phase 4 invariant that
-// every render path is behaviorally unchanged after the PolicyResolver seam
-// is introduced: the noopResolver must return the caller's explicit refs
-// verbatim regardless of target kind, project namespace, or target name.
-func TestNoopResolver_ReturnsInputsUnchanged(t *testing.T) {
-	orgRef := &consolev1.LinkedTemplateRef{Namespace: "holos-org-acme", Name: "httproute"}
-	folderRef := &consolev1.LinkedTemplateRef{Namespace: "holos-fld-payments", Name: "audit-policy"}
-
+// TestNoopResolver_ReturnsEmptySet asserts that the noopResolver always returns
+// an empty effective set regardless of target kind, project namespace, or target
+// name. It is the placeholder wired when no real TemplatePolicy-backed resolver
+// is available.
+func TestNoopResolver_ReturnsEmptySet(t *testing.T) {
 	tests := []struct {
-		name         string
-		projectNs    string
-		targetKind   TargetKind
-		targetName   string
-		explicitRefs []*consolev1.LinkedTemplateRef
+		name       string
+		projectNs  string
+		targetKind TargetKind
+		targetName string
 	}{
 		{
-			name:         "deployment with multiple refs",
-			projectNs:    "prj-orders",
-			targetKind:   TargetKindDeployment,
-			targetName:   "api",
-			explicitRefs: []*consolev1.LinkedTemplateRef{orgRef, folderRef},
+			name:       "deployment",
+			projectNs:  "prj-orders",
+			targetKind: TargetKindDeployment,
+			targetName: "api",
 		},
 		{
-			name:         "project template with single ref",
-			projectNs:    "prj-orders",
-			targetKind:   TargetKindProjectTemplate,
-			targetName:   "audit-policy",
-			explicitRefs: []*consolev1.LinkedTemplateRef{folderRef},
-		},
-		{
-			name:         "deployment with nil refs",
-			projectNs:    "prj-orders",
-			targetKind:   TargetKindDeployment,
-			targetName:   "api",
-			explicitRefs: nil,
-		},
-		{
-			name:         "project template with empty refs",
-			projectNs:    "prj-orders",
-			targetKind:   TargetKindProjectTemplate,
-			targetName:   "audit-policy",
-			explicitRefs: []*consolev1.LinkedTemplateRef{},
+			name:       "project template",
+			projectNs:  "prj-orders",
+			targetKind: TargetKindProjectTemplate,
+			targetName: "audit-policy",
 		},
 	}
 
-	resolver := NewNoopResolver()
+	r := NewNoopResolver()
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolver.Resolve(context.Background(), tc.projectNs, tc.targetKind, tc.targetName, tc.explicitRefs)
+			got, err := r.Resolve(context.Background(), tc.projectNs, tc.targetKind, tc.targetName)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if len(got) != len(tc.explicitRefs) {
-				t.Fatalf("length mismatch: got %d, want %d", len(got), len(tc.explicitRefs))
-			}
-			for i, ref := range tc.explicitRefs {
-				if got[i] != ref {
-					t.Errorf("ref %d: got %+v, want %+v (pointer equality)", i, got[i], ref)
-				}
+			if len(got) != 0 {
+				t.Errorf("noopResolver must return empty set; got %d refs", len(got))
 			}
 		})
-	}
-}
-
-// TestNoopResolver_DoesNotMutateInput guards against a future edit that
-// starts mutating the input slice. The contract is clear: return a new or
-// aliasing slice, but never modify the caller's.
-func TestNoopResolver_DoesNotMutateInput(t *testing.T) {
-	orgRef := &consolev1.LinkedTemplateRef{Namespace: "holos-org-acme", Name: "httproute"}
-	input := []*consolev1.LinkedTemplateRef{orgRef}
-	original := make([]*consolev1.LinkedTemplateRef, len(input))
-	copy(original, input)
-
-	resolver := NewNoopResolver()
-	if _, err := resolver.Resolve(context.Background(), "prj-orders", TargetKindDeployment, "api", input); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(input) != len(original) {
-		t.Fatalf("input slice length changed: got %d, want %d", len(input), len(original))
-	}
-	for i := range input {
-		if input[i] != original[i] {
-			t.Errorf("input[%d] changed: got %p, want %p", i, input[i], original[i])
-		}
 	}
 }

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -183,10 +183,10 @@ type OrganizationGatewayResolver interface {
 type ProjectTemplateDriftChecker interface {
 	// PolicyState returns the full TemplatePolicy drift snapshot for a
 	// project-scope template. `project` is the owning project slug;
-	// `templateName` is the template's DNS label within that project;
-	// `explicitRefs` carries the owner-linked template list read from the
-	// target template's LinkedTemplates annotation.
-	PolicyState(ctx context.Context, project, templateName string, explicitRefs []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error)
+	// `templateName` is the template's DNS label within that project.
+	// The effective set is derived purely from TemplatePolicyBinding
+	// resolution (HOL-905); no explicit refs are passed.
+	PolicyState(ctx context.Context, project, templateName string) (*consolev1.PolicyState, error)
 	// RecordApplied persists the effective render set for the
 	// project-scope template on successful Create/Update. Idempotent.
 	RecordApplied(ctx context.Context, project, templateName string, refs []*consolev1.LinkedTemplateRef) error
@@ -753,7 +753,7 @@ func (h *Handler) CreateTemplate(
 	// cluster policy resolver) is a no-op. Record failures are logged at
 	// warn level and do not fail the RPC — the template was persisted
 	// successfully and the set is reconstructable on the next preview.
-	h.recordProjectTemplateApplied(ctx, scope, scopeName, name, tmpl.LinkedTemplates)
+	h.recordProjectTemplateApplied(ctx, scope, scopeName, name)
 
 	slog.InfoContext(ctx, "template created",
 		slog.String("action", "template_create"),
@@ -813,18 +813,7 @@ func (h *Handler) UpdateTemplate(
 	enabled := tmpl.Enabled
 
 	// Determine linked template handling based on the update_linked_templates flag.
-	// We also track the post-update effective explicit link set — new refs
-	// when the caller asked to update links, the existing refs otherwise —
-	// so the HOL-569 write-through on the success path records the right
-	// baseline against which future drift checks will compare.
-	//
-	// skipRecordPreservedLinks flips to true when the preserve-links branch
-	// could not determine the existing explicit set (read or parse failure)
-	// so the write-through can be skipped rather than recording a phantom
-	// empty set that would produce false drift on the next policy-state read.
 	var linkedTemplates []*consolev1.LinkedTemplateRef
-	var explicitRefsForRecord []*consolev1.LinkedTemplateRef
-	skipRecordPreservedLinks := false
 	ns := scopeNamespace(h.k8s.Resolver, scope, scopeName)
 	if req.Msg.GetUpdateLinkedTemplates() {
 		// Caller wants to modify links. Check permissions based on both old
@@ -850,39 +839,9 @@ func (h *Handler) UpdateTemplate(
 		if linkedTemplates == nil {
 			linkedTemplates = []*consolev1.LinkedTemplateRef{}
 		}
-		explicitRefsForRecord = linkedTemplates
-	} else {
-		// When update_linked_templates is false, linkedTemplates stays nil,
-		// which tells K8sClient.UpdateTemplate to preserve existing links.
-		// For the HOL-569 write-through we need to know what those existing
-		// links are so the resolver sees the same explicit ref set the
-		// next preview will see. Only read the existing template when we
-		// actually intend to record — project scope with a drift checker
-		// wired — so non-project scopes don't pay an unnecessary API call.
-		//
-		// If the pre-update read or annotation parse fails, we set
-		// skipRecordPreservedLinks so the write-through is skipped
-		// entirely; recording nil in that branch would silently persist
-		// an empty applied set even though the ConfigMap kept its
-		// original links, producing false drift on the next policy-state
-		// read (review findings P2 from codex round 1).
-		if scope == scopeKindProject && h.projectTemplateDriftChecker != nil {
-			existing, getErr := h.k8s.GetTemplate(ctx, ns, name)
-			if getErr != nil {
-				slog.WarnContext(ctx, "failed to read existing template for applied-set write-through, skipping record",
-					slog.String("scope", scope.String()),
-					slog.String("scopeName", scopeName),
-					slog.String("name", name),
-					slog.Any("error", getErr),
-				)
-				skipRecordPreservedLinks = true
-			} else if refs := crdLinkedToProto(existing.Spec.LinkedTemplates); len(refs) > 0 {
-				explicitRefsForRecord = refs
-			}
-			// If the template exists with no linked templates, zero
-			// explicit links is the correct baseline and we do NOT skip.
-		}
 	}
+	// When update_linked_templates is false, linkedTemplates stays nil,
+	// which tells K8sClient.UpdateTemplate to preserve existing links.
 
 	_, err = h.k8s.UpdateTemplate(ctx, ns, name, &displayName, &description, &cueTemplate, tmpl.Defaults, false, &enabled, linkedTemplates, false)
 	if err != nil {
@@ -891,14 +850,10 @@ func (h *Handler) UpdateTemplate(
 
 	// Write-through the policy-effective ref set for project-scope templates
 	// after a successful persist so GetProjectTemplatePolicyState reflects
-	// the new linking state (HOL-569). Non-project scopes are skipped as on
-	// the create path. Record failures are logged but do not fail the RPC.
-	// Skip entirely when the preserve-links branch could not read the
-	// existing explicit set — recording nil in that case would silently
-	// persist a mismatched applied set (review round 1 P2 finding).
-	if !skipRecordPreservedLinks {
-		h.recordProjectTemplateApplied(ctx, scope, scopeName, name, explicitRefsForRecord)
-	}
+	// the current TemplatePolicyBinding-derived effective set (HOL-569).
+	// Non-project scopes are skipped as on the create path. Record failures
+	// are logged but do not fail the RPC.
+	h.recordProjectTemplateApplied(ctx, scope, scopeName, name)
 
 	slog.InfoContext(ctx, "template updated",
 		slog.String("action", "template_update"),
@@ -936,7 +891,6 @@ func (h *Handler) recordProjectTemplateApplied(
 	ctx context.Context,
 	scope scopeKind,
 	scopeName, name string,
-	explicitRefs []*consolev1.LinkedTemplateRef,
 ) {
 	if scope != scopeKindProject {
 		return
@@ -944,10 +898,10 @@ func (h *Handler) recordProjectTemplateApplied(
 	if h.projectTemplateDriftChecker == nil {
 		return
 	}
-	effectiveRefs := explicitRefs
+	var effectiveRefs []*consolev1.LinkedTemplateRef
 	if h.policyResolver != nil {
 		projectNs := h.resolver.ProjectNamespace(scopeName)
-		resolved, resolveErr := h.policyResolver.Resolve(ctx, projectNs, policyresolver.TargetKindProjectTemplate, name, explicitRefs)
+		resolved, resolveErr := h.policyResolver.Resolve(ctx, projectNs, policyresolver.TargetKindProjectTemplate, name)
 		if resolveErr != nil {
 			slog.WarnContext(ctx, "failed to resolve policy for project template applied-set write-through",
 				slog.String("project", scopeName),
@@ -1165,7 +1119,6 @@ func (h *Handler) renderTemplateGrouped(ctx context.Context, msg *consolev1.Rend
 				startNs,
 				previewTargetKindForScope(msgKind),
 				msgName,
-				msg.LinkedTemplates,
 				h.walker,
 				h.policyResolver,
 			)
@@ -2031,22 +1984,21 @@ func (h *Handler) GetProjectTemplatePolicyState(
 		return nil, err
 	}
 
-	// Read the template so we can pass its owner-linked refs to the
-	// resolver. The caller must have read access to the owning project for
-	// this to succeed.
-	projectNs := scopeNamespace(h.k8s.Resolver, scopeKindProject, project)
-	tmpl, err := h.k8s.GetTemplate(ctx, projectNs, name)
-	if err != nil {
+	// Verify the template exists before delegating to the checker so the
+	// handler returns NotFound instead of an empty-state response when the
+	// caller supplies an invalid name. The previous implementation read the
+	// template to extract explicit refs; this read preserves that existence
+	// gate without the now-removed explicit-refs parameter (HOL-905).
+	if _, err := h.k8s.GetTemplate(ctx, namespace, name); err != nil {
 		return nil, mapK8sError(err)
 	}
-	explicitRefs := crdLinkedToProto(tmpl.Spec.LinkedTemplates)
 
 	if h.projectTemplateDriftChecker == nil {
 		return connect.NewResponse(&consolev1.GetProjectTemplatePolicyStateResponse{
 			State: &consolev1.PolicyState{},
 		}), nil
 	}
-	state, err := h.projectTemplateDriftChecker.PolicyState(ctx, project, name, explicitRefs)
+	state, err := h.projectTemplateDriftChecker.PolicyState(ctx, project, name)
 	if err != nil {
 		slog.WarnContext(ctx, "project-template policy state computation failed",
 			slog.String("project", project),

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -693,6 +693,9 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 			Data: map[string]string{CueTemplateKey: folderCue},
 		}
 
+		refs := []*consolev1.LinkedTemplateRef{
+			folderLinkedRef(folder, "payments-policy"),
+		}
 		fakeClient := fake.NewClientset(orgNsObj, fldNsObj, prjNsObj, fldCM)
 		r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 		k8s := newTestK8sClient(t, fakeClient, r)
@@ -701,15 +704,12 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 			ancestors: []*corev1.Namespace{prjNsObj, fldNsObj, orgNsObj},
 		}
 
-		handler := NewHandler(k8s, r, renderer, policyresolver.NewNoopResolver())
+		handler := NewHandler(k8s, r, renderer, &fixedRefsResolver{refs: refs})
 		handler.WithAncestorWalker(walker)
 
 		msg := &consolev1.RenderTemplateRequest{
 			Namespace:   projectScopeRef(project),
 			CueTemplate: validCue,
-			LinkedTemplates: []*consolev1.LinkedTemplateRef{
-				folderLinkedRef(folder, "payments-policy"),
-			},
 		}
 
 		_, err := handler.renderTemplateGrouped(context.Background(), msg)
@@ -782,6 +782,10 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 			Data: map[string]string{CueTemplateKey: folderCue},
 		}
 
+		refs := []*consolev1.LinkedTemplateRef{
+			orgLinkedRef(org, "httproute"),
+			folderLinkedRef(folder, "payments-policy"),
+		}
 		fakeClient := fake.NewClientset(orgNsObj, fldNsObj, prjNsObj, orgCM, fldCM)
 		r := &resolver.Resolver{OrganizationPrefix: "org-", FolderPrefix: "fld-", ProjectPrefix: "prj-"}
 		k8s := newTestK8sClient(t, fakeClient, r)
@@ -790,16 +794,12 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 			ancestors: []*corev1.Namespace{prjNsObj, fldNsObj, orgNsObj},
 		}
 
-		handler := NewHandler(k8s, r, renderer, policyresolver.NewNoopResolver())
+		handler := NewHandler(k8s, r, renderer, &fixedRefsResolver{refs: refs})
 		handler.WithAncestorWalker(walker)
 
 		msg := &consolev1.RenderTemplateRequest{
 			Namespace:   projectScopeRef(project),
 			CueTemplate: validCue,
-			LinkedTemplates: []*consolev1.LinkedTemplateRef{
-				orgLinkedRef(org, "httproute"),
-				folderLinkedRef(folder, "payments-policy"),
-			},
 		}
 
 		_, err := handler.renderTemplateGrouped(context.Background(), msg)
@@ -928,7 +928,6 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 			context.Background(),
 			"prj-"+project,
 			"test-deployment",
-			[]*consolev1.LinkedTemplateRef{folderLinkedRef(folder, "shared")},
 		)
 		if err != nil {
 			t.Fatalf("apply render failed: %v", err)

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -369,16 +369,15 @@ type RenderHierarchyWalker interface {
 
 // ListEffectiveTemplateSources returns the ordered, deduplicated CUE sources
 // that participate in rendering the given target, alongside the policy-
-// effective ref set that produced them. The effective set at each ancestor
-// namespace is:
+// effective ref set that produced them. The effective set is computed as:
 //
-//	enabled AND ref IN explicitRefs
+//	result = REQUIRE-injected − EXCLUDE-removed
 //
-// For linked templates that carry a version constraint, the CUE source is
-// resolved from the latest matching release via ResolveVersionedSource
-// (ADR 024); linked templates without releases fall back to the live CRD CUE
-// source. Disabled templates are never included, even when explicitly
-// linked.
+// Only templates that are enabled and whose ref appears in the resolver's
+// effective set contribute. Disabled templates are never included. Templates
+// carrying a version constraint resolve their CUE source from the latest
+// matching release via ResolveVersionedSource (ADR 024); templates without
+// releases fall back to the live CRD CUE source.
 //
 // The walker drives ancestor traversal. If walker is nil, the method returns
 // (nil, nil, nil) — see the pre-rewrite comment for the rationale. HOL-621
@@ -388,13 +387,12 @@ func (k *K8sClient) ListEffectiveTemplateSources(
 	projectNs string,
 	targetKind TargetKind,
 	targetName string,
-	explicitRefs []*consolev1.LinkedTemplateRef,
 	walker RenderHierarchyWalker,
 	policyRes policyresolver.PolicyResolver,
 ) ([]string, []*consolev1.LinkedTemplateRef, error) {
-	effectiveRefs := explicitRefs
+	var effectiveRefs []*consolev1.LinkedTemplateRef
 	if policyRes != nil {
-		resolved, resolveErr := policyRes.Resolve(ctx, projectNs, targetKind, targetName, explicitRefs)
+		resolved, resolveErr := policyRes.Resolve(ctx, projectNs, targetKind, targetName)
 		if resolveErr != nil {
 			return nil, nil, fmt.Errorf("resolving template policy for %q: %w", targetName, resolveErr)
 		}
@@ -988,6 +986,6 @@ func NewAncestorTemplateResolver(k8s *K8sClient, walker RenderHierarchyWalker, r
 }
 
 // ListAncestorTemplateSources satisfies deployments.AncestorTemplateProvider.
-func (a *AncestorTemplateResolver) ListAncestorTemplateSources(ctx context.Context, projectNs, targetName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]string, []*consolev1.LinkedTemplateRef, error) {
-	return a.k8s.ListEffectiveTemplateSources(ctx, projectNs, TargetKindDeployment, targetName, linkedRefs, a.walker, a.resolver)
+func (a *AncestorTemplateResolver) ListAncestorTemplateSources(ctx context.Context, projectNs, targetName string) ([]string, []*consolev1.LinkedTemplateRef, error) {
+	return a.k8s.ListEffectiveTemplateSources(ctx, projectNs, TargetKindDeployment, targetName, a.walker, a.resolver)
 }

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -631,6 +631,18 @@ func folderLinkedRefWithConstraint(folder, name, constraint string) *consolev1.L
 	return newLinkedRef(scopeKindFolder, folder, name, constraint)
 }
 
+// fixedRefsResolver is a test PolicyResolver that always returns a pre-
+// configured slice of LinkedTemplateRef values as the effective set. It
+// lets ListEffectiveTemplateSources tests control which templates the
+// resolver "injects" without depending on a real TemplatePolicy store.
+type fixedRefsResolver struct {
+	refs []*consolev1.LinkedTemplateRef
+}
+
+func (f *fixedRefsResolver) Resolve(_ context.Context, _ string, _ policyresolver.TargetKind, _ string) ([]*consolev1.LinkedTemplateRef, error) {
+	return f.refs, nil
+}
+
 // TestListEffectiveTemplateSources exercises the unified ancestor-source
 // helper that replaced the legacy per-scope helpers in HOL-564. HOL-661
 // retained the contract; only the storage substrate changed, so every
@@ -644,7 +656,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 	t.Run("nil walker returns no sources", func(t *testing.T) {
 		k8s := newTestK8sClient(t, fake.NewClientset(orgNsObj), testResolver)
 
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, nil, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -662,7 +674,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			newLinkedRef(folderScope, "payments", "payments-policy", ""),
 		}
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, &fixedRefsResolver{refs: refs})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -686,7 +698,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			newLinkedRef(orgScope, "my-org", "httproute", ""),
 			newLinkedRef(folderScope, "payments", "payments-policy", ""),
 		}
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, &fixedRefsResolver{refs: refs})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -701,7 +713,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		k8s := newTestK8sClient(t, fake.NewClientset(orgNsObj, fldNsObj, prjNsObj, fldCM), testResolver)
 		walker := &stubHierarchyWalker{ancestors: fullAncestors}
 
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -718,7 +730,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			newLinkedRef(folderScope, "payments", "payments-policy", ""),
 		}
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, &fixedRefsResolver{refs: refs})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -738,7 +750,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		refs := []*consolev1.LinkedTemplateRef{
 			folderLinkedRefWithConstraint("payments", "payments-policy", ">=1.0.0"),
 		}
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, &fixedRefsResolver{refs: refs})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -754,10 +766,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		k8s := newTestK8sClient(t, fake.NewClientset(), testResolver)
 		walker := &stubHierarchyWalker{err: fmt.Errorf("walk failed")}
 
-		refs := []*consolev1.LinkedTemplateRef{
-			newLinkedRef(folderScope, "payments", "payments-policy", ""),
-		}
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("expected graceful degradation, got error: %v", err)
 		}
@@ -771,7 +780,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		k8s := newTestK8sClient(t, fake.NewClientset(orgNsObj, fldNsObj, prjNsObj, fldCM), testResolver)
 		walker := &stubHierarchyWalker{ancestors: fullAncestors}
 
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", nil, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, policyresolver.NewNoopResolver())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -793,7 +802,7 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			newLinkedRef(orgScope, "my-org", sharedName, ""),
 			newLinkedRef(folderScope, "payments", sharedName, ""),
 		}
-		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		sources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, &fixedRefsResolver{refs: refs})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -818,11 +827,11 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 			newLinkedRef(orgScope, "my-org", "httproute", ""),
 		}
 
-		deploymentSources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", refs, walker, policyresolver.NewNoopResolver())
+		deploymentSources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindDeployment, "dep", walker, &fixedRefsResolver{refs: refs})
 		if err != nil {
 			t.Fatalf("unexpected error (deployment): %v", err)
 		}
-		projectSources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindProjectTemplate, "tmpl", refs, walker, policyresolver.NewNoopResolver())
+		projectSources, _, err := k8s.ListEffectiveTemplateSources(context.Background(), "prj-my-project", TargetKindProjectTemplate, "tmpl", walker, &fixedRefsResolver{refs: refs})
 		if err != nil {
 			t.Fatalf("unexpected error (project template): %v", err)
 		}

--- a/console/templates/policy_state_test.go
+++ b/console/templates/policy_state_test.go
@@ -26,7 +26,7 @@ type stubProjectTemplateDriftChecker struct {
 	lastRecordRefs    []*consolev1.LinkedTemplateRef
 }
 
-func (s *stubProjectTemplateDriftChecker) PolicyState(_ context.Context, _, _ string, _ []*consolev1.LinkedTemplateRef) (*consolev1.PolicyState, error) {
+func (s *stubProjectTemplateDriftChecker) PolicyState(_ context.Context, _, _ string) (*consolev1.PolicyState, error) {
 	return s.stateResult, s.stateErr
 }
 

--- a/console/templates/record_applied_test.go
+++ b/console/templates/record_applied_test.go
@@ -135,8 +135,8 @@ func marshalLinkedTemplatesForTest(refs []*consolev1.LinkedTemplateRef) (string,
 
 // TestHandler_CreateTemplate_RecordsAppliedOnSuccess verifies that a
 // successful project-scope CreateTemplate calls RecordApplied with the
-// policy-resolved effective ref set (explicit ∪ REQUIRE − EXCLUDE), not
-// the raw explicit list.
+// policy-resolved effective ref set (REQUIRE − EXCLUDE) returned by the
+// resolver, forwarded verbatim to RecordApplied.
 func TestHandler_CreateTemplate_RecordsAppliedOnSuccess(t *testing.T) {
 	explicit := []*consolev1.LinkedTemplateRef{
 		orgLinkedRef("acme", "httproute"),
@@ -182,7 +182,7 @@ func TestHandler_CreateTemplate_RecordsAppliedOnSuccess(t *testing.T) {
 		t.Errorf("RecordApplied (project,name): got (%q,%q)", checker.lastRecordProject, checker.lastRecordName)
 	}
 	if len(checker.lastRecordRefs) != 2 {
-		t.Fatalf("RecordApplied refs length: got %d, want 2 (explicit + REQUIRE)", len(checker.lastRecordRefs))
+		t.Fatalf("RecordApplied refs length: got %d, want 2 (policy-resolved set)", len(checker.lastRecordRefs))
 	}
 	foundAudit := false
 	for _, r := range checker.lastRecordRefs {

--- a/console/templates/record_applied_test.go
+++ b/console/templates/record_applied_test.go
@@ -20,16 +20,14 @@ import (
 // recordingResolver is a PolicyResolver test double that captures its last
 // invocation and returns a caller-controlled resolved set. Tests use it to
 // assert the handler invokes the seam once with the right inputs and
-// forwards the policy-expanded set into RecordApplied (not the raw explicit
-// refs).
+// forwards the policy-expanded set into RecordApplied.
 type recordingResolver struct {
-	resolved         []*consolev1.LinkedTemplateRef
-	err              error
-	calls            int
-	lastProjectNs    string
-	lastTargetKind   policyresolver.TargetKind
-	lastTargetName   string
-	lastExplicitRefs []*consolev1.LinkedTemplateRef
+	resolved       []*consolev1.LinkedTemplateRef
+	err            error
+	calls          int
+	lastProjectNs  string
+	lastTargetKind policyresolver.TargetKind
+	lastTargetName string
 }
 
 func (r *recordingResolver) Resolve(
@@ -37,20 +35,15 @@ func (r *recordingResolver) Resolve(
 	projectNs string,
 	targetKind policyresolver.TargetKind,
 	targetName string,
-	explicitRefs []*consolev1.LinkedTemplateRef,
 ) ([]*consolev1.LinkedTemplateRef, error) {
 	r.calls++
 	r.lastProjectNs = projectNs
 	r.lastTargetKind = targetKind
 	r.lastTargetName = targetName
-	r.lastExplicitRefs = explicitRefs
 	if r.err != nil {
 		return nil, r.err
 	}
-	if r.resolved != nil {
-		return r.resolved, nil
-	}
-	return explicitRefs, nil
+	return r.resolved, nil
 }
 
 // recordAppliedTemplateHandler wires a templates handler with project-scope
@@ -236,7 +229,6 @@ func TestHandler_CreateTemplate_NoRecordAtOrgOrFolderScope(t *testing.T) {
 		scopeKindOrganization,
 		"acme",
 		"httproute",
-		nil,
 	)
 	if checker.recordCalls != 0 {
 		t.Errorf("RecordApplied called at org scope (%d times), want 0", checker.recordCalls)
@@ -247,7 +239,6 @@ func TestHandler_CreateTemplate_NoRecordAtOrgOrFolderScope(t *testing.T) {
 		scopeKindFolder,
 		"payments",
 		"audit",
-		nil,
 	)
 	if checker.recordCalls != 0 {
 		t.Errorf("RecordApplied called at folder scope (%d times), want 0", checker.recordCalls)
@@ -370,8 +361,8 @@ func TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_NewLinks(t *testing.T) {
 	if resolver.calls != 1 {
 		t.Errorf("resolver.Resolve called %d times, want 1", resolver.calls)
 	}
-	if len(resolver.lastExplicitRefs) != 1 || resolver.lastExplicitRefs[0].GetName() != "audit" {
-		t.Errorf("resolver explicitRefs: got %+v, want [audit]", resolver.lastExplicitRefs)
+	if resolver.lastTargetName != "web-app" {
+		t.Errorf("resolver targetName: got %q, want web-app", resolver.lastTargetName)
 	}
 	if checker.recordCalls != 1 {
 		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
@@ -407,14 +398,11 @@ func TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_PreserveLinks(t *testing
 	if resolver.calls != 1 {
 		t.Fatalf("resolver.Resolve called %d times, want 1", resolver.calls)
 	}
-	if len(resolver.lastExplicitRefs) != 1 || resolver.lastExplicitRefs[0].GetName() != "httproute" {
-		t.Errorf("resolver explicitRefs (preserve-links path): got %+v, want [httproute]", resolver.lastExplicitRefs)
+	if resolver.lastTargetName != "web-app" {
+		t.Errorf("resolver targetName: got %q, want web-app", resolver.lastTargetName)
 	}
 	if checker.recordCalls != 1 {
 		t.Errorf("RecordApplied called %d times, want 1", checker.recordCalls)
-	}
-	if len(checker.lastRecordRefs) != 1 || checker.lastRecordRefs[0].GetName() != "httproute" {
-		t.Errorf("RecordApplied refs (preserve-links path): got %+v, want [httproute]", checker.lastRecordRefs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removes the `explicitRefs []*consolev1.LinkedTemplateRef` parameter from `PolicyResolver.Resolve()` and all implementations, adapters, and callers
- Phase 1 (HOL-904, PR #1147) made every caller pass `nil`; this commit removes the now-dead parameter entirely
- The effective-set formula simplifies from `result = explicitRefs ∪ REQUIRE-injected − EXCLUDE-removed` to `result = REQUIRE-injected − EXCLUDE-removed`
- Removes `dedupRefs()` helper from `folder_resolver.go` (no longer needed)
- Removes owner-linked protection from the EXCLUDE logic in `folderResolver`
- Adds template existence gate back to `GetProjectTemplatePolicyState` (previously provided by the removed explicit-refs template read)
- Adds `fixedRefsResolver` test stub in `k8s_test.go` and `handler_test.go` to inject refs without a real policy store

Fixes HOL-905

## Test plan

- [x] `go test ./console/policyresolver/...` passes
- [x] `go test ./console/templates/...` passes
- [x] `go test ./console/deployments/...` passes
- [x] `make test-go` passes (excluding pre-existing `secretinjector/controller` envtest port-8080 flakiness when run in parallel with `TestScripts`)