### PR TITLE
refactor(templates): stop persisting and serving explicit linked-templates (HOL-906)

### DIFF
--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -716,9 +716,6 @@ func (h *Handler) CreateTemplate(
 			return nil, err
 		}
 	}
-	if err := h.validateLinkedRefs(tmpl.LinkedTemplates); err != nil {
-		return nil, err
-	}
 
 	claims := rpc.ClaimsFromContext(ctx)
 	if claims == nil {
@@ -729,18 +726,13 @@ func (h *Handler) CreateTemplate(
 		return nil, err
 	}
 
-	// Enforce scoped link permissions when linked templates are provided.
-	if len(tmpl.LinkedTemplates) > 0 {
-		if err := h.checkLinkPermissions(ctx, claims, scope, scopeName, tmpl.LinkedTemplates); err != nil {
-			return nil, err
-		}
-	}
-
 	// The `mandatory` annotation and its Go/proto projections were removed in
 	// HOL-565. Ancestor templates that must always apply to every project now
 	// come in via TemplatePolicy REQUIRE rules (HOL-567).
+	// HOL-906: linked_templates in the request is silently ignored; template
+	// composition is driven exclusively by TemplatePolicyBinding.
 	ns := scopeNamespace(h.k8s.Resolver, scope, scopeName)
-	_, err = h.k8s.CreateTemplate(ctx, ns, name, tmpl.DisplayName, tmpl.Description, tmpl.CueTemplate, tmpl.Defaults, tmpl.Enabled, tmpl.LinkedTemplates)
+	_, err = h.k8s.CreateTemplate(ctx, ns, name, tmpl.DisplayName, tmpl.Description, tmpl.CueTemplate, tmpl.Defaults, tmpl.Enabled)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -792,11 +784,6 @@ func (h *Handler) UpdateTemplate(
 			return nil, err
 		}
 	}
-	if req.Msg.GetUpdateLinkedTemplates() {
-		if err := h.validateLinkedRefs(tmpl.LinkedTemplates); err != nil {
-			return nil, err
-		}
-	}
 
 	claims := rpc.ClaimsFromContext(ctx)
 	if claims == nil {
@@ -812,38 +799,13 @@ func (h *Handler) UpdateTemplate(
 	cueTemplate := tmpl.CueTemplate
 	enabled := tmpl.Enabled
 
-	// Determine linked template handling based on the update_linked_templates flag.
-	var linkedTemplates []*consolev1.LinkedTemplateRef
+	// HOL-906: update_linked_templates and linked_templates are silently
+	// ignored; template composition is driven exclusively by
+	// TemplatePolicyBinding. Pass nil for linkedTemplates so K8sClient
+	// preserves (rather than clears) any links that exist on the CRD from
+	// before this phase — they are harmless until Phase 5 removes the field.
 	ns := scopeNamespace(h.k8s.Resolver, scope, scopeName)
-	if req.Msg.GetUpdateLinkedTemplates() {
-		// Caller wants to modify links. Check permissions based on both old
-		// (being removed) and new (being added) linked template scopes.
-		existing, getErr := h.k8s.GetTemplate(ctx, ns, name)
-		if getErr != nil {
-			return nil, mapK8sError(getErr)
-		}
-		existingRefs := crdLinkedToProto(existing.Spec.LinkedTemplates)
-		// Merge old and new refs to check all affected scopes.
-		allRefs := append(existingRefs, tmpl.LinkedTemplates...)
-		if len(allRefs) > 0 {
-			if err := h.checkLinkPermissions(ctx, claims, scope, scopeName, allRefs); err != nil {
-				return nil, err
-			}
-		}
-		linkedTemplates = tmpl.LinkedTemplates
-		// Protobuf binary encoding cannot distinguish an omitted repeated
-		// field from an empty one — both arrive as nil.  When the caller
-		// explicitly asked to update links, nil means "clear all links,"
-		// so normalize to a non-nil empty slice.  K8sClient.UpdateTemplate
-		// treats nil as "preserve existing" and empty as "delete annotation."
-		if linkedTemplates == nil {
-			linkedTemplates = []*consolev1.LinkedTemplateRef{}
-		}
-	}
-	// When update_linked_templates is false, linkedTemplates stays nil,
-	// which tells K8sClient.UpdateTemplate to preserve existing links.
-
-	_, err = h.k8s.UpdateTemplate(ctx, ns, name, &displayName, &description, &cueTemplate, tmpl.Defaults, false, &enabled, linkedTemplates, false)
+	_, err = h.k8s.UpdateTemplate(ctx, ns, name, &displayName, &description, &cueTemplate, tmpl.Defaults, false, &enabled, nil, false)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -1313,7 +1275,7 @@ func (h *Handler) ListAncestorTemplates(
 		return nil, err
 	}
 
-	templates, err := h.collectAncestorTemplates(ctx, scope, scopeName, nil)
+	templates, err := h.collectAncestorTemplates(ctx, scope, scopeName)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -1323,18 +1285,13 @@ func (h *Handler) ListAncestorTemplates(
 	}), nil
 }
 
-// collectAncestorTemplates walks the hierarchy and collects templates from all
-// ancestor scopes plus the current scope itself. The render-set formula is:
+// collectAncestorTemplates walks the hierarchy and collects all enabled
+// templates from ancestor scopes (organization and folder). Results are
+// returned in org→folder order for correct CUE unification.
 //
-//	enabled AND ref IN linkedRefs
-//
-// Results are returned in org→folders→project order for correct CUE
-// unification. If linkedRefs is empty, no ancestor templates are returned.
-// The "mandatory" annotation branch of the effective set was removed in
-// HOL-565; TemplatePolicy REQUIRE rules (wired in HOL-567) reintroduce
-// unconditional ancestor inclusion at render time via the policy resolver
-// that sits in front of ListEffectiveTemplateSources — not via this
-// helper, which only surfaces the caller's explicit linkedRefs.
+// HOL-906: the linkedRefs filter was removed. The enabled set is returned
+// unconditionally — template composition is now driven exclusively by
+// TemplatePolicyBinding rather than explicit linked-templates lists.
 //
 // Storage-isolation note (HOL-554): the traversal only visits ancestor
 // namespaces — organization and folder — and never reads templates from a
@@ -1343,7 +1300,7 @@ func (h *Handler) ListAncestorTemplates(
 // in folder/organization namespaces precisely because project owners can
 // write to their project namespace and would otherwise be able to tamper
 // with the constraints the platform is enforcing.
-func (h *Handler) collectAncestorTemplates(ctx context.Context, scope scopeKind, scopeName string, linkedRefs []*consolev1.LinkedTemplateRef) ([]*consolev1.Template, error) {
+func (h *Handler) collectAncestorTemplates(ctx context.Context, scope scopeKind, scopeName string) ([]*consolev1.Template, error) {
 	if h.walker == nil {
 		return nil, nil
 	}
@@ -1355,16 +1312,8 @@ func (h *Handler) collectAncestorTemplates(ctx context.Context, scope scopeKind,
 		return nil, fmt.Errorf("walking ancestors for %s/%s: %w", scope, scopeName, err)
 	}
 
-	// Build a set of linked refs for O(1) lookup.
-	linkedSet := make(map[linkedRef]bool, len(linkedRefs))
-	for _, ref := range linkedRefs {
-		if ref != nil {
-			linkedSet[linkedRefFromProto(ref)] = true
-		}
-	}
-
-	// Collect templates from each ancestor, in reverse (org first, child last).
-	// ancestors is child→parent order; reverse to get org→child.
+	// Collect enabled templates from each ancestor, in reverse (org first,
+	// child last). ancestors is child→parent order; reverse to get org→child.
 	var result []*consolev1.Template
 	for i := len(ancestors) - 1; i >= 0; i-- {
 		ns := ancestors[i]
@@ -1387,13 +1336,6 @@ func (h *Handler) collectAncestorTemplates(ctx context.Context, scope scopeKind,
 			if !crd.Spec.Enabled {
 				continue
 			}
-			ref := linkedRef{
-				namespace: ns.Name,
-				name:      crd.Name,
-			}
-			if !linkedSet[ref] {
-				continue
-			}
 			result = append(result, templateCRDToProto(crd, ancestorKind == scopeKindProject))
 		}
 	}
@@ -1401,67 +1343,6 @@ func (h *Handler) collectAncestorTemplates(ctx context.Context, scope scopeKind,
 	return result, nil
 }
 
-// validateLinkedRefs rejects linked template references whose namespace does
-// not classify as a console-managed organization/folder/project namespace.
-// HOL-619 collapsed the scope enum and HOL-723 retired the scopeshim; this
-// check preserves the guardrail the old (scope, scopeName) enum gave us for
-// free — render-time resolution only searches console-managed ancestor
-// namespaces, so a link to `default` or any other foreign namespace would
-// silently never resolve.
-func (h *Handler) validateLinkedRefs(refs []*consolev1.LinkedTemplateRef) error {
-	for i, ref := range refs {
-		if ref == nil {
-			continue
-		}
-		ns := ref.GetNamespace()
-		if ns == "" {
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("linked_templates[%d].namespace is required", i))
-		}
-		if ref.GetName() == "" {
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("linked_templates[%d].name is required", i))
-		}
-		if kind, _ := classifyNamespace(h.resolver, ns); kind == scopeKindUnspecified {
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("linked_templates[%d].namespace %q is not a console-managed organization, folder, or project namespace", i, ns))
-		}
-	}
-	return nil
-}
-
-// checkLinkPermissions verifies the caller has the scoped link permissions
-// required by the provided linked template references. If any ref targets an
-// org-scope template, PermissionTemplatesLinkOrgWrite is checked. If any ref
-// targets a folder-scope template, PermissionTemplatesLinkFolderWrite is checked.
-// Both checks are performed at the template's owning scope.
-func (h *Handler) checkLinkPermissions(ctx context.Context, claims *rpc.Claims, scope scopeKind, scopeName string, linkedTemplates []*consolev1.LinkedTemplateRef) error {
-	hasOrg := false
-	hasFolder := false
-	for _, ref := range linkedTemplates {
-		if ref == nil {
-			continue
-		}
-		refKind, _ := classifyNamespace(h.resolver, ref.GetNamespace())
-		switch refKind {
-		case scopeKindOrganization:
-			hasOrg = true
-		case scopeKindFolder:
-			hasFolder = true
-		}
-	}
-	if hasOrg {
-		if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesLinkOrgWrite); err != nil {
-			return err
-		}
-	}
-	if hasFolder {
-		if err := h.checkAccess(ctx, claims, scope, scopeName, rbac.PermissionTemplatesLinkFolderWrite); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 // checkAccess verifies the caller has the given permission for the requested scope.
 // All scope levels (org, folder, project) use the unified TemplateCascadePerms

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -298,80 +297,46 @@ func projectScopeRef(project string) string {
 	return testResolver.ProjectNamespace(project)
 }
 
-// TestCreateTemplateLinkPermissions verifies that CreateTemplate enforces scoped
-// link permissions: OWNER can create with org and folder links, EDITOR cannot.
-func TestCreateTemplateLinkPermissions(t *testing.T) {
+// TestCreateTemplate_IgnoresLinkedTemplates guards the HOL-906 invariant:
+// CreateTemplate silently ignores any linked_templates in the request and never
+// writes the console.holos.run/linked-templates annotation to the Template CRD.
+// Template composition is driven exclusively by TemplatePolicyBinding.
+func TestCreateTemplate_IgnoresLinkedTemplates(t *testing.T) {
 	const project = "my-project"
 	const ownerEmail = "platform@localhost"
-	const editorEmail = "product@localhost"
 
 	tests := []struct {
 		name            string
-		email           string
 		linkedTemplates []*consolev1.LinkedTemplateRef
-		wantErr         bool
-		wantCode        connect.Code
 	}{
 		{
-			name:            "OWNER creates template with org-linked templates succeeds",
-			email:           ownerEmail,
+			name:            "linked templates with foreign namespace are silently ignored",
+			linkedTemplates: []*consolev1.LinkedTemplateRef{{Namespace: "default", Name: "rogue"}},
+		},
+		{
+			name:            "linked templates with org namespace are silently ignored",
 			linkedTemplates: []*consolev1.LinkedTemplateRef{orgLinkedRef("acme", "httproute")},
-			wantErr:         false,
 		},
 		{
-			name:            "OWNER creates template with folder-linked templates succeeds",
-			email:           ownerEmail,
+			name:            "linked templates with folder namespace are silently ignored",
 			linkedTemplates: []*consolev1.LinkedTemplateRef{folderLinkedRef("payments", "payments-policy")},
-			wantErr:         false,
 		},
 		{
-			name:  "OWNER creates template with both org and folder links succeeds",
-			email: ownerEmail,
-			linkedTemplates: []*consolev1.LinkedTemplateRef{
-				orgLinkedRef("acme", "httproute"),
-				folderLinkedRef("payments", "payments-policy"),
-			},
-			wantErr: false,
-		},
-		{
-			name:            "EDITOR creates template with org-linked templates fails",
-			email:           editorEmail,
-			linkedTemplates: []*consolev1.LinkedTemplateRef{orgLinkedRef("acme", "httproute")},
-			wantErr:         true,
-			wantCode:        connect.CodePermissionDenied,
-		},
-		{
-			name:            "EDITOR creates template with folder-linked templates fails",
-			email:           editorEmail,
-			linkedTemplates: []*consolev1.LinkedTemplateRef{folderLinkedRef("payments", "payments-policy")},
-			wantErr:         true,
-			wantCode:        connect.CodePermissionDenied,
-		},
-		{
-			name:            "EDITOR creates template with no linked templates succeeds",
-			email:           editorEmail,
+			name:            "nil linked templates succeeds",
 			linkedTemplates: nil,
-			wantErr:         false,
 		},
 	}
 
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "prj-" + project,
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "prj-" + project},
 			}
 			fakeClient := fake.NewClientset(ns)
-			shareUsers := map[string]string{
-				ownerEmail:  "owner",
-				editorEmail: "editor",
-			}
-			handler := newTestHandler(t, fakeClient, shareUsers)
+			handler, k8s := newTestHandlerAndK8s(t, fakeClient, map[string]string{ownerEmail: "owner"})
 
-			// Use a unique template name per test to avoid AlreadyExists.
 			templateName := fmt.Sprintf("tmpl-%d", i)
-			ctx := authedCtx(tt.email, nil)
+			ctx := authedCtx(ownerEmail, nil)
 			req := connect.NewRequest(&consolev1.CreateTemplateRequest{
 				Namespace: projectScopeRef(project),
 				Template: &consolev1.Template{
@@ -382,72 +347,35 @@ func TestCreateTemplateLinkPermissions(t *testing.T) {
 			})
 
 			_, err := handler.CreateTemplate(ctx, req)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if connectErr := new(connect.Error); connect.CodeOf(err) != tt.wantCode {
-					t.Errorf("expected code %v, got %v (%v)", tt.wantCode, connect.CodeOf(err), connectErr)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			// HOL-906: the stored CRD must not carry any linked-templates
+			// annotation, regardless of what the request contained.
+			got, getErr := k8s.GetTemplate(context.Background(), "prj-"+project, templateName)
+			if getErr != nil {
+				t.Fatalf("GetTemplate after create: %v", getErr)
+			}
+			if len(got.Spec.LinkedTemplates) != 0 {
+				t.Errorf("HOL-906: expected no linked templates in CRD spec, got %d entries: %+v",
+					len(got.Spec.LinkedTemplates), got.Spec.LinkedTemplates)
 			}
 		})
 	}
 }
 
-// TestCreateTemplateLinkedRefsValidation covers the HOL-723 guardrail: a
-// LinkedTemplateRef whose namespace does not classify as a console-managed
-// org/folder/project namespace must be rejected before persistence, because
-// render-time resolution only walks ancestor namespaces and would silently
-// drop such a ref. HOL-619 flattened the scope enum off the wire; HOL-723
-// retired the (scope, scopeName) CRD fields that previously caught this at
-// decode time.
-func TestCreateTemplateLinkedRefsValidation(t *testing.T) {
-	const project = "my-project"
-	const ownerEmail = "platform@localhost"
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "prj-" + project,
-		},
-	}
-	fakeClient := fake.NewClientset(ns)
-	handler := newTestHandler(t, fakeClient, map[string]string{ownerEmail: "owner"})
-	ctx := authedCtx(ownerEmail, nil)
-
-	req := connect.NewRequest(&consolev1.CreateTemplateRequest{
-		Namespace: projectScopeRef(project),
-		Template: &consolev1.Template{
-			Name:        "foreign-linked",
-			CueTemplate: validCue,
-			LinkedTemplates: []*consolev1.LinkedTemplateRef{
-				{Namespace: "default", Name: "rogue"},
-			},
-		},
-	})
-
-	_, err := handler.CreateTemplate(ctx, req)
-	if err == nil {
-		t.Fatal("expected validation error for foreign linked namespace, got nil")
-	}
-	if connect.CodeOf(err) != connect.CodeInvalidArgument {
-		t.Errorf("expected CodeInvalidArgument, got %v", connect.CodeOf(err))
-	}
-	if !strings.Contains(err.Error(), "not a console-managed") {
-		t.Errorf("expected 'not a console-managed' in error, got: %v", err)
-	}
-}
-
-// TestUpdateTemplateLinkPermissions verifies that UpdateTemplate honors the
-// update_linked_templates flag and enforces scoped link permissions.
-func TestUpdateTemplateLinkPermissions(t *testing.T) {
+// TestUpdateTemplate_IgnoresLinkedTemplates guards the HOL-906 invariant:
+// UpdateTemplate silently ignores update_linked_templates=true and any
+// linked_templates payload — the flag is a no-op for the annotation.
+// Template composition is driven exclusively by TemplatePolicyBinding.
+func TestUpdateTemplate_IgnoresLinkedTemplates(t *testing.T) {
 	const project = "my-project"
 	const ownerEmail = "platform@localhost"
 	const editorEmail = "product@localhost"
 
-	// Pre-seed a template with org-linked templates for update tests.
+	// Pre-seed a template with existing linked templates in spec so the
+	// preservation check has something to observe.
 	existingLinkedJSON := `[{"scope":"organization","scope_name":"acme","name":"httproute"}]`
 
 	makeExistingTemplate := func() *corev1.ConfigMap {
@@ -466,92 +394,49 @@ func TestUpdateTemplateLinkPermissions(t *testing.T) {
 					v1alpha2.AnnotationLinkedTemplates: existingLinkedJSON,
 				},
 			},
-			Data: map[string]string{
-				CueTemplateKey: validCue,
-			},
+			Data: map[string]string{CueTemplateKey: validCue},
 		}
 	}
 
 	tests := []struct {
-		name               string
-		email              string
-		updateLinkedTmpl   bool
-		linkedTemplates    []*consolev1.LinkedTemplateRef
-		wantErr            bool
-		wantCode           connect.Code
-		wantLinksPreserved bool // When true, verify existing links are still present after update.
-		wantLinksCleared   bool // When true, verify linked-templates annotation is removed after update.
+		name             string
+		email            string
+		updateLinkedTmpl bool
+		linkedTemplates  []*consolev1.LinkedTemplateRef
 	}{
 		{
-			name:             "OWNER updates linked templates with update_linked_templates=true succeeds",
+			name:             "OWNER with update_linked_templates=true and non-empty list succeeds without error",
 			email:            ownerEmail,
 			updateLinkedTmpl: true,
 			linkedTemplates: []*consolev1.LinkedTemplateRef{
 				orgLinkedRef("acme", "httproute"),
 				folderLinkedRef("payments", "payments-policy"),
 			},
-			wantErr: false,
 		},
 		{
-			name:             "EDITOR updates linked templates with update_linked_templates=true fails",
+			name:             "EDITOR with update_linked_templates=true succeeds (flag is now a no-op)",
 			email:            editorEmail,
 			updateLinkedTmpl: true,
-			linkedTemplates: []*consolev1.LinkedTemplateRef{
-				orgLinkedRef("acme", "new-route"),
-			},
-			wantErr:  true,
-			wantCode: connect.CodePermissionDenied,
+			linkedTemplates:  []*consolev1.LinkedTemplateRef{orgLinkedRef("acme", "new-route")},
 		},
 		{
-			name:             "EDITOR updates folder-linked templates with update_linked_templates=true fails",
-			email:            editorEmail,
-			updateLinkedTmpl: true,
-			linkedTemplates: []*consolev1.LinkedTemplateRef{
-				folderLinkedRef("payments", "payments-policy"),
-			},
-			wantErr:  true,
-			wantCode: connect.CodePermissionDenied,
-		},
-		{
-			name:               "EDITOR updates CUE only with update_linked_templates=false succeeds and preserves links",
-			email:              editorEmail,
-			updateLinkedTmpl:   false,
-			linkedTemplates:    nil,
-			wantErr:            false,
-			wantLinksPreserved: true,
-		},
-		{
-			name:             "OWNER clears all linked templates with update_linked_templates=true empty list succeeds",
+			name:             "OWNER with update_linked_templates=true and nil list does not clear existing",
 			email:            ownerEmail,
 			updateLinkedTmpl: true,
-			linkedTemplates:  []*consolev1.LinkedTemplateRef{}, // empty list clears links
-			wantErr:          false,
-			wantLinksCleared: true,
+			linkedTemplates:  nil,
 		},
 		{
-			name:             "OWNER clears linked templates with update_linked_templates=true nil list succeeds",
-			email:            ownerEmail,
-			updateLinkedTmpl: true,
-			linkedTemplates:  nil, // protobuf binary encoding delivers nil for empty repeated fields
-			wantErr:          false,
-			wantLinksCleared: true,
-		},
-		{
-			name:             "EDITOR clears linked templates with update_linked_templates=true empty list fails",
+			name:             "EDITOR CUE-only update with update_linked_templates=false succeeds",
 			email:            editorEmail,
-			updateLinkedTmpl: true,
-			linkedTemplates:  []*consolev1.LinkedTemplateRef{}, // clearing requires permission on existing scopes
-			wantErr:          true,
-			wantCode:         connect.CodePermissionDenied,
+			updateLinkedTmpl: false,
+			linkedTemplates:  nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "prj-" + project,
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "prj-" + project},
 			}
 			cm := makeExistingTemplate()
 			fakeClient := fake.NewClientset(ns, cm)
@@ -573,48 +458,34 @@ func TestUpdateTemplateLinkPermissions(t *testing.T) {
 			})
 
 			_, err := handler.UpdateTemplate(ctx, req)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if connect.CodeOf(err) != tt.wantCode {
-					t.Errorf("expected code %v, got %v", tt.wantCode, connect.CodeOf(err))
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
 
-			// Post-HOL-661 linked templates live on Template.Spec.LinkedTemplates
-			// (typed), not on the legacy ConfigMap annotation. Read through the
-			// K8sClient so the assertions observe production storage.
+			// HOL-906: update_linked_templates is a no-op — the spec should
+			// be unchanged (any existing links from before this phase are
+			// preserved by passing nil to K8sClient.UpdateTemplate).
 			updated, getErr := k8s.GetTemplate(context.Background(), "prj-"+project, "web-app")
 			if getErr != nil {
-				t.Fatalf("failed to get updated Template: %v", getErr)
+				t.Fatalf("GetTemplate after update: %v", getErr)
 			}
-
-			// Verify link preservation when update_linked_templates=false.
-			if tt.wantLinksPreserved {
-				if len(updated.Spec.LinkedTemplates) == 0 {
-					t.Fatal("expected linked templates to be preserved, but spec.linkedTemplates is empty")
-				}
-				got := updated.Spec.LinkedTemplates[0]
-				if got.Namespace != testResolver.OrgNamespace("acme") || got.Name != "httproute" {
-					t.Errorf("expected preserved org/acme/httproute link, got %+v", got)
-				}
-			}
-
-			// Verify link clearing when update_linked_templates=true with empty or nil list.
-			if tt.wantLinksCleared {
-				if len(updated.Spec.LinkedTemplates) != 0 {
-					t.Errorf("expected linked templates to be cleared, but found %d entries: %+v", len(updated.Spec.LinkedTemplates), updated.Spec.LinkedTemplates)
-				}
+			// The existing links were seeded via the ConfigMap annotation
+			// bridge, so they should still be present on the CRD.
+			if len(updated.Spec.LinkedTemplates) == 0 {
+				t.Errorf("HOL-906: expected existing linked templates to be preserved (nil pass-through), got 0")
 			}
 		})
 	}
 	_ = existingLinkedJSON
 }
+
+// NOTE: TestCreateTemplateLinkPermissions, TestCreateTemplateLinkedRefsValidation,
+// and TestUpdateTemplateLinkPermissions were removed in HOL-906.
+// Those tests verified that CreateTemplate/UpdateTemplate enforced scoped link
+// permissions and rejected foreign-namespace refs. After HOL-906 the handler
+// silently ignores linked_templates in all requests — permission checks for
+// linking are no longer relevant. TestCreateTemplate_IgnoresLinkedTemplates and
+// TestUpdateTemplate_IgnoresLinkedTemplates guard the new invariant.
 
 // NOTE: TestUpdateTemplateMalformedLinkedAnnotation was removed in HOL-661.
 // Before HOL-661 linked templates were persisted as a JSON annotation on the

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -140,12 +140,13 @@ func (k *K8sClient) GetTemplate(ctx context.Context, namespace, name string) (*t
 }
 
 // CreateTemplate creates a new Template CRD in the given namespace.
+// HOL-906: the linkedTemplates parameter was removed; template composition
+// is driven exclusively by TemplatePolicyBinding.
 func (k *K8sClient) CreateTemplate(
 	ctx context.Context,
 	namespace, name, displayName, description, cueTemplate string,
 	defaults *consolev1.TemplateDefaults,
 	enabled bool,
-	linkedTemplates []*consolev1.LinkedTemplateRef,
 ) (*templatesv1alpha1.Template, error) {
 	slog.DebugContext(ctx, "creating template in kubernetes",
 		slog.String("namespace", namespace),
@@ -160,12 +161,11 @@ func (k *K8sClient) CreateTemplate(
 			},
 		},
 		Spec: templatesv1alpha1.TemplateSpec{
-			DisplayName:     displayName,
-			Description:     description,
-			CueTemplate:     cueTemplate,
-			Defaults:        protoDefaultsToCRD(defaults),
-			Enabled:         enabled,
-			LinkedTemplates: protoLinkedToCRD(linkedTemplates),
+			DisplayName: displayName,
+			Description: description,
+			CueTemplate: cueTemplate,
+			Defaults:    protoDefaultsToCRD(defaults),
+			Enabled:     enabled,
 		},
 	}
 	if err := k.client.Create(ctx, tmpl); err != nil {
@@ -272,7 +272,8 @@ func (k *K8sClient) CloneTemplate(ctx context.Context, namespace, sourceName, ne
 		source.Spec.CueTemplate,
 		crdDefaultsToProto(source.Spec.Defaults),
 		false, // new clones start disabled
-		crdLinkedToProto(source.Spec.LinkedTemplates),
+		// HOL-906: linked templates are not propagated to clones; template
+		// composition is driven exclusively by TemplatePolicyBinding.
 	)
 }
 
@@ -308,12 +309,16 @@ func (r *ProjectScopedResolver) GetTemplate(ctx context.Context, project, name s
 // templateCRDToConfigMap converts a Template CRD to the ConfigMap shape the
 // deployments handler still expects. This is a transitional adapter: the
 // only consumer is deployments.TemplateResolver, which receives the
-// ConfigMap and reads only Name, Namespace, Data[CueTemplateKey], and the
-// v1alpha2.AnnotationLinkedTemplates annotation. When the deployments
-// package is rewritten against the CRD this helper can be deleted with
-// ProjectScopedResolver.
+// ConfigMap and reads only Name, Namespace, and Data[CueTemplateKey].
+// When the deployments package is rewritten against the CRD this helper can
+// be deleted with ProjectScopedResolver.
+//
+// HOL-906: the AnnotationLinkedTemplates annotation is no longer written.
+// Template composition is driven exclusively by TemplatePolicyBinding; the
+// deployments handler already reads the TPB-derived effective set directly
+// (HOL-904/HOL-905).
 func templateCRDToConfigMap(tmpl *templatesv1alpha1.Template) *corev1.ConfigMap {
-	cm := &corev1.ConfigMap{
+	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        tmpl.Name,
 			Namespace:   tmpl.Namespace,
@@ -323,13 +328,6 @@ func templateCRDToConfigMap(tmpl *templatesv1alpha1.Template) *corev1.ConfigMap 
 			CueTemplateKey: tmpl.Spec.CueTemplate,
 		},
 	}
-	if len(tmpl.Spec.LinkedTemplates) > 0 {
-		refs := crdLinkedToProto(tmpl.Spec.LinkedTemplates)
-		if b, err := marshalLinkedTemplates(refs); err == nil {
-			cm.Annotations[v1alpha2.AnnotationLinkedTemplates] = string(b)
-		}
-	}
-	return cm
 }
 
 // ListTemplatesInNamespace returns every Template CRD in the given namespace.
@@ -515,7 +513,6 @@ func (k *K8sClient) SeedOrgTemplate(ctx context.Context, org string) error {
 		DefaultReferenceGrantTemplate,
 		nil,
 		true, // enabled for populate_defaults flow
-		nil,
 	)
 	return err
 }
@@ -533,7 +530,6 @@ func (k *K8sClient) SeedProjectTemplate(ctx context.Context, project string) err
 		ExampleHttpbinTemplate,
 		nil,
 		true, // enabled for populate_defaults flow
-		nil,
 	)
 	return err
 }

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -369,14 +369,13 @@ func TestCreateTemplate(t *testing.T) {
 	ensureNamespace(t, e.Direct, ns)
 
 	cases := []struct {
-		name            string
-		resourceName    string
-		displayName     string
-		description     string
-		cueTemplate     string
-		defaults        *consolev1.TemplateDefaults
-		enabled         bool
-		linkedTemplates []*consolev1.LinkedTemplateRef
+		name         string
+		resourceName string
+		displayName  string
+		description  string
+		cueTemplate  string
+		defaults     *consolev1.TemplateDefaults
+		enabled      bool
 	}{
 		{
 			name:         "minimal fields persisted",
@@ -395,21 +394,18 @@ func TestCreateTemplate(t *testing.T) {
 			},
 		},
 		{
-			name:         "enabled + linked refs stored in spec",
+			name:         "enabled flag stored in spec",
 			resourceName: "enabled",
 			displayName:  "Enabled",
 			cueTemplate:  "package holos\n",
 			enabled:      true,
-			linkedTemplates: []*consolev1.LinkedTemplateRef{
-				newLinkedRef(orgScope, "acme", "httproute", ""),
-			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := k.CreateTemplate(
 				context.Background(), ns, tc.resourceName, tc.displayName, tc.description,
-				tc.cueTemplate, tc.defaults, tc.enabled, tc.linkedTemplates,
+				tc.cueTemplate, tc.defaults, tc.enabled,
 			)
 			if err != nil {
 				t.Fatalf("CreateTemplate: %v", err)
@@ -432,8 +428,9 @@ func TestCreateTemplate(t *testing.T) {
 			if tc.defaults != nil && read.Spec.Defaults == nil {
 				t.Errorf("expected defaults to be persisted")
 			}
-			if len(tc.linkedTemplates) != len(read.Spec.LinkedTemplates) {
-				t.Errorf("linkedTemplates len=%d want %d", len(read.Spec.LinkedTemplates), len(tc.linkedTemplates))
+			// HOL-906: CreateTemplate never writes LinkedTemplates.
+			if len(read.Spec.LinkedTemplates) != 0 {
+				t.Errorf("expected no linked templates in spec (HOL-906), got %d", len(read.Spec.LinkedTemplates))
 			}
 		})
 	}
@@ -541,7 +538,7 @@ func TestK8sClient_ListReflectsCreate(t *testing.T) {
 
 	if _, err := k.CreateTemplate(
 		context.Background(), ns, "fresh", "Fresh", "", "package holos\n",
-		nil, false, nil,
+		nil, false,
 	); err != nil {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
@@ -846,43 +843,33 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 	})
 }
 
-// TestLinkedTemplatesAnnotation covers CreateTemplate's linked-refs handling
-// through the CRD spec (post-HOL-661 the annotation round-trip is gone, but
-// the bridged fixtures make the same assertions). The bridge still round-
-// trips through the JSON annotation path to make sure
-// unmarshalLinkedTemplates retains its public shape — the Release-rendering
-// path depends on it.
-func TestLinkedTemplatesAnnotation(t *testing.T) {
+// TestCreateTemplate_NoLinkedTemplates guards the HOL-906 invariant:
+// CreateTemplate never writes spec.linkedTemplates regardless of what the
+// caller passes. Template composition is driven exclusively by
+// TemplatePolicyBinding (HOL-903 Phase 3).
+func TestCreateTemplate_NoLinkedTemplates(t *testing.T) {
 	e, k := newEnvtestK8sClient(t)
 
 	ns := "prj-links"
 	ctx := context.Background()
 	ensureNamespace(t, e.Direct, ns)
 
-	t.Run("CreateTemplate stores linked refs in spec", func(t *testing.T) {
-		linked := []*consolev1.LinkedTemplateRef{
-			newLinkedRef(orgScope, "acme", "httproute", ""),
-			newLinkedRef(orgScope, "acme", "policy-floor", ""),
-		}
-		tmpl, err := k.CreateTemplate(ctx, ns, "web-app", "Web App", "desc", "package holos\n", nil, false, linked)
+	t.Run("CreateTemplate never writes spec.linkedTemplates", func(t *testing.T) {
+		tmpl, err := k.CreateTemplate(ctx, ns, "web-app", "Web App", "desc", "package holos\n", nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(tmpl.Spec.LinkedTemplates) != 2 {
-			t.Fatalf("expected 2 linked templates, got %d", len(tmpl.Spec.LinkedTemplates))
-		}
-		if tmpl.Spec.LinkedTemplates[0].Name != "httproute" {
-			t.Errorf("expected 'httproute', got %q", tmpl.Spec.LinkedTemplates[0].Name)
-		}
-	})
-
-	t.Run("CreateTemplate with nil linked list leaves spec empty", func(t *testing.T) {
-		tmpl, err := k.CreateTemplate(ctx, ns, "no-links", "No Links", "desc", "package holos\n", nil, false, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		// HOL-906: CreateTemplate must not write any linked templates.
 		if len(tmpl.Spec.LinkedTemplates) != 0 {
-			t.Errorf("expected empty linked list, got %d entries", len(tmpl.Spec.LinkedTemplates))
+			t.Errorf("HOL-906: expected no linked templates in spec, got %d", len(tmpl.Spec.LinkedTemplates))
+		}
+		// Read-your-own-write via direct client Get to confirm storage.
+		read := &templatesv1alpha1.Template{}
+		if err := e.Direct.Get(ctx, types.NamespacedName{Namespace: ns, Name: "web-app"}, read); err != nil {
+			t.Fatalf("Get after Create: %v", err)
+		}
+		if len(read.Spec.LinkedTemplates) != 0 {
+			t.Errorf("HOL-906: expected no linked templates on stored CRD, got %d", len(read.Spec.LinkedTemplates))
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `CreateTemplate` silently ignores `linked_templates` in the request and never writes `console.holos.run/linked-templates` to the Template CRD. The `validateLinkedRefs` and `checkLinkPermissions` functions are removed.
- `UpdateTemplate` ignores `update_linked_templates` and any `linked_templates` payload; passes `nil` to `K8sClient.UpdateTemplate` so existing links on the CRD are preserved harmlessly until Phase 5.
- `collectAncestorTemplates` removes the `linkedRefs` filter parameter and returns all enabled ancestor templates unconditionally.
- `templateCRDToConfigMap` no longer writes `AnnotationLinkedTemplates` — the deployments handler reads TPB-derived effective sets directly (HOL-904/HOL-905).
- Legacy tests (`TestCreateTemplateLinkPermissions`, `TestCreateTemplateLinkedRefsValidation`, `TestUpdateTemplateLinkPermissions`) removed; new regression tests (`TestCreateTemplate_IgnoresLinkedTemplates`, `TestUpdateTemplate_IgnoresLinkedTemplates`) guard the new invariant.

Fixes HOL-906

## Test plan

- [x] `make test-go` passes (all Go tests green)
- [x] `TestCreateTemplate_IgnoresLinkedTemplates` asserts CreateTemplate with any `linked_templates` produces a CRD with no `spec.linkedTemplates`
- [x] `TestUpdateTemplate_IgnoresLinkedTemplates` asserts UpdateTemplate with `update_linked_templates=true` is a no-op for links
- [x] `TestListLinkableTemplates` still passes (ListLinkableTemplates is kept)
- [x] Proto fields (`linked_templates`, `update_linked_templates`) remain on the wire — Phase 4 (frontend) and Phase 5 (proto removal) handle their deletion