### PR TITLE
chore(cleanup): remove AnnotationLinkedTemplates constant and legacy comments

### DIFF
--- a/api/templates/v1alpha1/crd_test.go
+++ b/api/templates/v1alpha1/crd_test.go
@@ -147,8 +147,6 @@ func TestCRDRoundTrip_Template(t *testing.T) {
 			},
 		},
 		{
-			// HOL-908: renamed from "with-defaults-and-links" — LinkedTemplates
-			// was removed from TemplateSpec; this case now covers defaults only.
 			name: "with-defaults",
 			template: &v1alpha1.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "with-defaults", Namespace: nsName},

--- a/api/templates/v1alpha1/template_types.go
+++ b/api/templates/v1alpha1/template_types.go
@@ -59,10 +59,10 @@ type TemplateDefaults struct {
 	Description string `json:"description,omitempty"`
 }
 
-// LinkedTemplateRef is a (namespace, name) reference to another Template
-// used in the explicit linking list. The namespace's
-// `console.holos.run/resource-type` label classifies the linked template's
-// hierarchy kind at render time — callers supply the namespace only.
+// LinkedTemplateRef is a (namespace, name) reference to another Template.
+// The namespace's `console.holos.run/resource-type` label classifies the
+// linked template's hierarchy kind at render time — callers supply the
+// namespace only. Used in TemplatePolicyBinding rules and RenderState.
 type LinkedTemplateRef struct {
 	// Namespace is the Kubernetes namespace that owns the linked template.
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -71,18 +71,6 @@ const (
 	// this label upward to collect templates and resolve permissions (ADR 020
 	// Decision 3 and Decision 6).
 	AnnotationParent = "console.holos.run/parent"
-	// AnnotationLinkedTemplates is the wire format used to bridge
-	// Template CRDs to the deployment handler. Template CRD storage
-	// keeps linked refs in a structured Spec field (HOL-621), but the
-	// deployment handler still consumes deployment-template ConfigMaps
-	// and reads the linked refs off this JSON-annotation. The
-	// templateCRDToConfigMap adapter in console/templates writes the
-	// annotation on the fly so deployments can keep its existing
-	// reader. Once the deployments package is ported off ConfigMaps
-	// (HOL-615 Phase 6 and friends), this constant and its adapter
-	// both go away.
-	// Example: [{"scope":"organization","scope_name":"acme","name":"microservice-v2"}]
-	AnnotationLinkedTemplates = "console.holos.run/linked-templates"
 	// LabelTemplateScope identifies the hierarchy level of a Template.
 	// Values: "organization", "folder", "project" (ADR 021 Decision 4).
 	// Still surfaced on CRD-stored Templates via the scheme label

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -79,19 +79,6 @@
 // Decision 3 and Decision 6).
 #AnnotationParent: "console.holos.run/parent"
 
-// AnnotationLinkedTemplates is the wire format used to bridge
-// Template CRDs to the deployment handler. Template CRD storage
-// keeps linked refs in a structured Spec field (HOL-621), but the
-// deployment handler still consumes deployment-template ConfigMaps
-// and reads the linked refs off this JSON-annotation. The
-// templateCRDToConfigMap adapter in console/templates writes the
-// annotation on the fly so deployments can keep its existing
-// reader. Once the deployments package is ported off ConfigMaps
-// (HOL-615 Phase 6 and friends), this constant and its adapter
-// both go away.
-// Example: [{"scope":"organization","scope_name":"acme","name":"microservice-v2"}]
-#AnnotationLinkedTemplates: "console.holos.run/linked-templates"
-
 // LabelTemplateScope identifies the hierarchy level of a Template.
 // Values: "organization", "folder", "project" (ADR 021 Decision 4).
 // Still surfaced on CRD-stored Templates via the scheme label

--- a/console/console.go
+++ b/console/console.go
@@ -547,13 +547,9 @@ func (s *Server) Serve(ctx context.Context) error {
 		// could be wired; reuse the same client here so there is exactly
 		// one policy reader+writer in the process.
 		//
-		// HOL-600 removed the HOL-570 EXCLUDE-vs-explicit-link guardrail
-		// and its K8sResourceTopology resolver: policies no longer carry
-		// a glob Target, and render-target selection runs entirely
-		// through TemplatePolicyBinding. Any equivalent guardrail now
-		// belongs on the binding create/update path (enforced by
-		// console/templatepolicybindings) rather than on the policy
-		// itself.
+		// Render-target selection runs entirely through TemplatePolicyBinding.
+		// Guardrails belong on the binding create/update path (enforced by
+		// console/templatepolicybindings) rather than on the policy itself.
 		templatePoliciesHandler := templatepolicies.NewHandler(templatePoliciesK8s, nsResolver).
 			WithOrgGrantResolver(orgGrantResolver).
 			WithFolderGrantResolver(folderGrantResolver).

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -256,10 +256,6 @@ func (h *Handler) WithPolicyDriftChecker(c PolicyDriftChecker) *Handler {
 // resolver invocation (HOL-569). Returns (nil, nil, false) when no
 // provider is configured or the walk fails; the caller should fall back to
 // a project-only render in that case.
-//
-// HOL-904: the legacy explicit linkedRefs parameter has been removed.
-// The provider is called with nil, so only the TemplatePolicyBinding-
-// derived effective set contributes to the render.
 func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project, deploymentName string) ([]string, []*consolev1.LinkedTemplateRef, bool) {
 	if h.ancestorTemplateProvider == nil {
 		return nil, nil, false
@@ -279,11 +275,8 @@ func (h *Handler) resolveAncestorTemplateSources(ctx context.Context, project, d
 
 // renderResources renders deployment resources, unifying with platform
 // templates from the full ancestor chain (org + folders) when an
-// AncestorTemplateProvider is configured.
-//
-// The effective template set at render time is derived exclusively from
-// TemplatePolicyBinding resolution. The legacy explicit-link annotation is
-// no longer consulted (HOL-904).
+// AncestorTemplateProvider is configured. The effective template set is
+// derived exclusively from TemplatePolicyBinding resolution.
 //
 // When no AncestorTemplateProvider is configured, falls back to a plain
 // project-level render (deployment template only, no platform template
@@ -319,10 +312,6 @@ func (h *Handler) renderResources(ctx context.Context, project, deploymentName, 
 // ignore it. It is nil when no AncestorTemplateProvider is configured or the
 // provider returned an error (the render falls back to project-only in both
 // cases, so there is no rendered set to record).
-//
-// HOL-904: the legacy explicit linkedRefs parameter has been removed. The
-// effective set is now derived exclusively from TemplatePolicyBinding
-// resolution; the linked-templates annotation is not consulted.
 func (h *Handler) renderResourcesGrouped(ctx context.Context, project, deploymentName, cueSource string, platform v1alpha2.PlatformInput, projectInput v1alpha2.ProjectInput) (*GroupedResources, []*consolev1.LinkedTemplateRef, error) {
 	var ancestorSources []string
 	var effectiveRefs []*consolev1.LinkedTemplateRef
@@ -523,9 +512,6 @@ func (h *Handler) CreateDeployment(
 	}
 
 	// Validate that the referenced template exists and get its CUE source.
-	// The legacy explicit linking list read from the annotation is no longer
-	// consumed here (HOL-904); the render pipeline uses only the
-	// TemplatePolicyBinding-derived effective set.
 	var cueSource string
 	if h.templateResolver != nil {
 		tmplCM, err := h.templateResolver.GetTemplate(ctx, project, req.Msg.Template)
@@ -738,10 +724,7 @@ func (h *Handler) UpdateDeployment(
 		image := updated.Data[ImageKey]
 		tag := updated.Data[TagKey]
 
-		// Look up the template CUE source. The legacy explicit linking list
-		// read from the annotation is no longer consumed here (HOL-904); the
-		// render pipeline uses only the TemplatePolicyBinding-derived effective
-		// set.
+		// Look up the template CUE source.
 		var cueSource string
 		if h.templateResolver != nil && templateName != "" {
 			tmplCM, tmplErr := h.templateResolver.GetTemplate(ctx, project, templateName)
@@ -1057,9 +1040,6 @@ func (h *Handler) GetDeploymentRenderPreview(
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("template %q not found in project %q", templateName, project))
 	}
 	cueTemplate := tmplCM.Data[cueTemplateKey]
-	// The legacy explicit linking list read from the annotation is no longer
-	// consumed here (HOL-904); the render pipeline uses only the
-	// TemplatePolicyBinding-derived effective set.
 
 	// Build platform input from authenticated claims and resolved namespace.
 	ns := h.k8s.Resolver.ProjectNamespace(project)

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -1381,9 +1381,6 @@ func TestRenderResourcesWithAncestorProvider(t *testing.T) {
 		handler := NewHandler(k8s, &stubProjectResolver{}, &stubSettingsResolver{}, &stubTemplateResolver{}, renderer, nil).
 			WithAncestorTemplateProvider(atp)
 
-		// HOL-904: render helpers no longer accept explicit linked-template
-		// refs; the effective set is derived exclusively from
-		// TemplatePolicyBinding resolution.
 		_, err := handler.renderResources(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1457,9 +1454,6 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 		handler := NewHandler(k8s, &stubProjectResolver{}, &stubSettingsResolver{}, &stubTemplateResolver{}, renderer, nil).
 			WithAncestorTemplateProvider(atp)
 
-		// HOL-904: render helpers no longer accept explicit linked-template
-		// refs; the effective set is derived exclusively from
-		// TemplatePolicyBinding resolution.
 		_, _, err := handler.renderResourcesGrouped(context.Background(), "my-project", "test-deployment", "// template", v1alpha2.PlatformInput{}, v1alpha2.ProjectInput{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1500,10 +1494,9 @@ func TestRenderResourcesGroupedWithAncestorProvider(t *testing.T) {
 // TestCreateDeployment_AnnotationIgnored is the HOL-902 regression guard.
 // It asserts that a deployment whose Template ConfigMap carries a populated
 // console.holos.run/linked-templates annotation renders ONLY the resources
-// produced by the deployment template — the annotation must be ignored by the
-// render pipeline (HOL-904). Before HOL-904 the render path read this
-// annotation and merged in unrelated org-level resources (the httproute bug
-// reported in HOL-902).
+// produced by the deployment template — the annotation is ignored by the
+// render pipeline. Before the explicit-linking removal (HOL-902) the render
+// path read this annotation and merged in unrelated org-level resources.
 func TestCreateDeployment_AnnotationIgnored(t *testing.T) {
 	// Build a template ConfigMap that has a non-empty linked-templates annotation.
 	// The annotation lists a fictitious org-level "httproute" template that
@@ -1512,7 +1505,7 @@ func TestCreateDeployment_AnnotationIgnored(t *testing.T) {
 	if tmplCM.Annotations == nil {
 		tmplCM.Annotations = make(map[string]string)
 	}
-	tmplCM.Annotations[v1alpha2.AnnotationLinkedTemplates] = `[{"namespace":"holos-org-acme","name":"httproute"}]`
+	tmplCM.Annotations["console.holos.run/linked-templates"] = `[{"namespace":"holos-org-acme","name":"httproute"}]`
 
 	// stubAncestorTemplateProvider returns no ancestor sources so the render is
 	// project-only. The handler must call it with nil (not the annotation refs).

--- a/console/deployments/policy_state_test.go
+++ b/console/deployments/policy_state_test.go
@@ -53,8 +53,7 @@ func (s *stubPolicyDriftChecker) RecordApplied(_ context.Context, project, name 
 }
 
 // deploymentCMForPolicy builds a minimal deployment ConfigMap for policy-state
-// tests — only the namespace, name, and the v1alpha2 linked-templates
-// annotation matter for the RPC under test.
+// tests.
 func deploymentCMForPolicy(project, name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/console/deployments/record_applied_drift_e2e_test.go
+++ b/console/deployments/record_applied_drift_e2e_test.go
@@ -154,10 +154,6 @@ func TestHandler_CreateDeployment_DriftBecomesFalseAfterRecord(t *testing.T) {
 	fakeClient := fake.NewClientset(projectNS("my-project"))
 	pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
 	k8s := NewK8sClient(fakeClient, testResolver())
-	// Wire a TemplateResolver that surfaces the explicit linked list as
-	// the annotation on the deployment template ConfigMap. The handler
-	// uses this when resolving the deployment's linked-templates
-	// annotation on GetDeploymentPolicyState.
 	templateResolver := &stubTemplateResolver{cm: fakeTemplate("default")}
 
 	h := NewHandler(k8s, pr, &stubSettingsResolver{settings: enabledSettings()}, templateResolver, &stubRenderer{}, &stubApplier{}).

--- a/console/deployments/record_applied_test.go
+++ b/console/deployments/record_applied_test.go
@@ -227,16 +227,13 @@ func TestHandler_CreateDeployment_RecordsEmptyOnDegradedRender(t *testing.T) {
 	}
 }
 
-// TestHandler_CreateDeployment_RecordsEmptyOnZeroExplicitRefs verifies the
-// HOL-569 baseline contract: a successful apply with no explicit linked
+// TestHandler_CreateDeployment_RecordsEmptyOnZeroAncestorRefs verifies the
+// HOL-569 baseline contract: a successful apply with no TPB-resolved ancestor
 // templates still persists an applied set (the empty slice) so
 // GetDeploymentPolicyState reports has_applied_state=true on the very
-// next read. Review round 2 P1a found a gap where the previous guard
-// (effectiveRefs != nil before RecordApplied) conflated "no refs to
-// record" with "degraded render"; the normalization in
-// ListEffectiveTemplateSources plus the empty-slice write-through here
-// keeps the two cases distinct and correct.
-func TestHandler_CreateDeployment_RecordsEmptyOnZeroExplicitRefs(t *testing.T) {
+// next read. The normalization in ListEffectiveTemplateSources plus the
+// empty-slice write-through keeps "no refs" distinct from "degraded render".
+func TestHandler_CreateDeployment_RecordsEmptyOnZeroAncestorRefs(t *testing.T) {
 	// Stub provider returns a non-nil empty effective-ref slice —
 	// mirroring what ListEffectiveTemplateSources now produces on a
 	// successful render whose resolver output is empty.

--- a/console/policyresolver/folder_resolver.go
+++ b/console/policyresolver/folder_resolver.go
@@ -311,9 +311,8 @@ func (r *folderResolver) Resolve(
 	}
 
 	// Apply EXCLUDE rules. EXCLUDE removes any REQUIRE-injected ref that
-	// matches the rule's template. Since there are no owner-linked explicit
-	// refs in the effective set (HOL-905), every ref is eligible for
-	// removal by an EXCLUDE rule.
+	// matches the rule's template. Every ref in the effective set is
+	// eligible for removal by an EXCLUDE rule.
 	if len(excludeRules) == 0 {
 		return effective, nil
 	}

--- a/console/policyresolver/resolver.go
+++ b/console/policyresolver/resolver.go
@@ -3,13 +3,6 @@
 // project-scope templates (create/update/preview), and project creation
 // (REQUIRE-matched templates).
 //
-// The package exists so Phase 5 of HOL-562 (HOL-567) can swap the no-op
-// implementation for a real TemplatePolicy-backed resolver without touching
-// call sites. In Phase 4 (HOL-566) the interface is introduced and wired
-// everywhere with the no-op implementation. Phase 2 of HOL-903 (HOL-905)
-// removed the explicitRefs parameter from the interface so the resolver
-// derives the effective set from TemplatePolicyBinding rules only.
-//
 // Keeping the resolver in its own package (rather than in
 // console/templates/) prevents the PolicyResolver abstraction from leaking
 // into the CUE renderer and related apply/preview machinery. The renderer
@@ -45,9 +38,8 @@ const (
 //	result = REQUIRE-injected − EXCLUDE-removed
 //
 // Only bindings whose target_refs select the current render target contribute.
-// Policies with no covering binding contribute nothing. Callers no longer pass
-// an explicit-refs slice — the resolver derives the effective set purely from
-// policy rules (HOL-905).
+// Policies with no covering binding contribute nothing. The effective set is
+// derived purely from TemplatePolicyBinding rules.
 //
 // Implementations must not mutate any shared state. The returned slice is
 // owned by the caller and may be appended to freely.

--- a/console/templatepolicies/handler.go
+++ b/console/templatepolicies/handler.go
@@ -33,11 +33,9 @@
 //
 // Render-time selection runs exclusively through TemplatePolicyBinding
 // (HOL-590). A rule contributes to a render target only when a matching
-// binding names its owning policy; the legacy glob-based
-// TemplatePolicyTarget path and the HOL-570 EXCLUDE-vs-explicit-link
-// guardrail that operated on it were removed in HOL-600. See
-// console/policyresolver and console/templates/k8s.go for the resolver
-// call sites, and console/templatepolicybindings for the binding CRUD.
+// binding names its owning policy. See console/policyresolver and
+// console/templates/k8s.go for the resolver call sites, and
+// console/templatepolicybindings for the binding CRUD.
 package templatepolicies
 
 import (

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -184,8 +184,7 @@ type ProjectTemplateDriftChecker interface {
 	// PolicyState returns the full TemplatePolicy drift snapshot for a
 	// project-scope template. `project` is the owning project slug;
 	// `templateName` is the template's DNS label within that project.
-	// The effective set is derived purely from TemplatePolicyBinding
-	// resolution (HOL-905); no explicit refs are passed.
+	// The effective set is derived purely from TemplatePolicyBinding resolution.
 	PolicyState(ctx context.Context, project, templateName string) (*consolev1.PolicyState, error)
 	// RecordApplied persists the effective render set for the
 	// project-scope template on successful Create/Update. Idempotent.
@@ -728,8 +727,7 @@ func (h *Handler) CreateTemplate(
 
 	// The `mandatory` annotation and its Go/proto projections were removed in
 	// HOL-565. Ancestor templates that must always apply to every project now
-	// come in via TemplatePolicy REQUIRE rules (HOL-567).
-	// HOL-908: linked_templates was removed from the proto; template composition
+	// come in via TemplatePolicy REQUIRE rules (HOL-567). Template composition
 	// is driven exclusively by TemplatePolicyBinding.
 	ns := scopeNamespace(h.k8s.Resolver, scope, scopeName)
 	_, err = h.k8s.CreateTemplate(ctx, ns, name, tmpl.DisplayName, tmpl.Description, tmpl.CueTemplate, tmpl.Defaults, tmpl.Enabled)
@@ -1282,11 +1280,8 @@ func (h *Handler) ListAncestorTemplates(
 
 // collectAncestorTemplates walks the hierarchy and collects all enabled
 // templates from ancestor scopes (organization and folder). Results are
-// returned in org→folder order for correct CUE unification.
-//
-// HOL-906: the linkedRefs filter was removed. The enabled set is returned
-// unconditionally — template composition is now driven exclusively by
-// TemplatePolicyBinding rather than explicit linked-templates lists.
+// returned in org→folder order for correct CUE unification. Template
+// composition is driven exclusively by TemplatePolicyBinding.
 //
 // Storage-isolation note (HOL-554): the traversal only visits ancestor
 // namespaces — organization and folder — and never reads templates from a
@@ -1713,9 +1708,7 @@ func (h *Handler) GetProjectTemplatePolicyState(
 
 	// Verify the template exists before delegating to the checker so the
 	// handler returns NotFound instead of an empty-state response when the
-	// caller supplies an invalid name. The previous implementation read the
-	// template to extract explicit refs; this read preserves that existence
-	// gate without the now-removed explicit-refs parameter (HOL-905).
+	// caller supplies an invalid name.
 	if _, err := h.k8s.GetTemplate(ctx, namespace, name); err != nil {
 		return nil, mapK8sError(err)
 	}

--- a/console/templates/handler_test.go
+++ b/console/templates/handler_test.go
@@ -136,10 +136,6 @@ func TestConfigMapToTemplate(t *testing.T) {
 		}
 	})
 
-	// NOTE: "linked templates from v1alpha2 annotation" subtest removed in
-	// HOL-908. The LinkedTemplates field was removed from the proto Template
-	// message; configMapToTemplate no longer populates it.
-
 	t.Run("defaults from annotation fallback", func(t *testing.T) {
 		defaultsJSON := `{"image":"ghcr.io/example/app","tag":"v1.0"}`
 		cm := &corev1.ConfigMap{
@@ -261,30 +257,6 @@ func folderLinkedRef(folder, name string) *consolev1.LinkedTemplateRef {
 func projectScopeRef(project string) string {
 	return testResolver.ProjectNamespace(project)
 }
-
-// NOTE: TestCreateTemplate_IgnoresLinkedTemplates and
-// TestUpdateTemplate_IgnoresLinkedTemplates were removed in HOL-908.
-// The linked_templates field on Template, update_linked_templates flag on
-// UpdateTemplateRequest, and LinkedTemplates on TemplateSpec are all gone.
-// Template composition is driven exclusively by TemplatePolicyBinding.
-
-// NOTE: TestCreateTemplateLinkPermissions, TestCreateTemplateLinkedRefsValidation,
-// and TestUpdateTemplateLinkPermissions were removed in HOL-906.
-// Those tests verified that CreateTemplate/UpdateTemplate enforced scoped link
-// permissions and rejected foreign-namespace refs. After HOL-906 the handler
-// silently ignores linked_templates in all requests — permission checks for
-// linking are no longer relevant. TestCreateTemplate_IgnoresLinkedTemplates and
-// TestUpdateTemplate_IgnoresLinkedTemplates guard the new invariant.
-
-// NOTE: TestUpdateTemplateMalformedLinkedAnnotation was removed in HOL-661.
-// Before HOL-661 linked templates were persisted as a JSON annotation on the
-// Template ConfigMap, and the update-path parsed that annotation to enforce
-// scoped link permissions against the pre-existing refs. The test guarded
-// against a silent JSON-parse failure allowing an EDITOR to bypass those
-// checks. After HOL-661 linked templates are a typed field on
-// Template.Spec.LinkedTemplates — there is no JSON parse step to fail, so
-// the invariant the test asserted no longer exists. Permission enforcement
-// still happens via crdLinkedToProto on the typed spec.
 
 // trackingRenderer records which renderer method was called so tests can
 // verify that renderTemplateGrouped dispatches correctly.
@@ -498,8 +470,6 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 
 		msg := &consolev1.RenderTemplateRequest{
 			CueTemplate: validCue,
-			// HOL-908: linked_templates removed from RenderTemplateRequest;
-			// ancestor template resolution is driven by TemplatePolicyBinding.
 		}
 
 		_, err := handler.renderTemplateGrouped(context.Background(), msg)
@@ -573,8 +543,6 @@ func TestRenderTemplateGroupedFolderScoped(t *testing.T) {
 		_, err := handler.renderTemplateGrouped(context.Background(), &consolev1.RenderTemplateRequest{
 			Namespace:   projectScopeRef(project),
 			CueTemplate: validCue,
-			// HOL-908: linked_templates removed from RenderTemplateRequest;
-			// ancestor template resolution is driven by TemplatePolicyBinding.
 		})
 		if err != nil {
 			t.Fatalf("preview render failed: %v", err)

--- a/console/templates/handler_updates_test.go
+++ b/console/templates/handler_updates_test.go
@@ -1,5 +1,0 @@
-// Package templates tests for the CheckUpdates handler were removed in HOL-908.
-// The CheckUpdates RPC, CheckUpdatesRequest / CheckUpdatesResponse messages,
-// and the TemplateUpdate message were removed from templates.proto — explicit
-// linking is superseded by TemplatePolicyBinding.
-package templates

--- a/console/templates/k8s.go
+++ b/console/templates/k8s.go
@@ -139,8 +139,6 @@ func (k *K8sClient) GetTemplate(ctx context.Context, namespace, name string) (*t
 }
 
 // CreateTemplate creates a new Template CRD in the given namespace.
-// HOL-906: the linkedTemplates parameter was removed; template composition
-// is driven exclusively by TemplatePolicyBinding.
 func (k *K8sClient) CreateTemplate(
 	ctx context.Context,
 	namespace, name, displayName, description, cueTemplate string,
@@ -177,9 +175,6 @@ func (k *K8sClient) CreateTemplate(
 //
 // Each optional pointer parameter applies only when non-nil — the helper
 // preserves nil-for-"leave alone" semantics the handler relies on.
-//
-// HOL-908: linkedTemplates and clearLinks parameters were removed — explicit
-// linking is superseded by TemplatePolicyBinding.
 func (k *K8sClient) UpdateTemplate(
 	ctx context.Context,
 	namespace, name string,
@@ -248,8 +243,6 @@ func (k *K8sClient) CloneTemplate(ctx context.Context, namespace, sourceName, ne
 		source.Spec.CueTemplate,
 		crdDefaultsToProto(source.Spec.Defaults),
 		false, // new clones start disabled
-		// HOL-906: linked templates are not propagated to clones; template
-		// composition is driven exclusively by TemplatePolicyBinding.
 	)
 }
 
@@ -288,11 +281,6 @@ func (r *ProjectScopedResolver) GetTemplate(ctx context.Context, project, name s
 // ConfigMap and reads only Name, Namespace, and Data[CueTemplateKey].
 // When the deployments package is rewritten against the CRD this helper can
 // be deleted with ProjectScopedResolver.
-//
-// HOL-906: the AnnotationLinkedTemplates annotation is no longer written.
-// Template composition is driven exclusively by TemplatePolicyBinding; the
-// deployments handler already reads the TPB-derived effective set directly
-// (HOL-904/HOL-905).
 func templateCRDToConfigMap(tmpl *templatesv1alpha1.Template) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/console/templates/k8s_test.go
+++ b/console/templates/k8s_test.go
@@ -11,9 +11,6 @@
 // controller-runtime client because their inputs are still expressed as
 // ConfigMap fixtures and the bridge in testhelpers_test.go materializes
 // them into CRs.
-//
-// HOL-908: LinkedTemplates was removed from TemplateSpec and the
-// LinkedTemplatesAnnotation tests were retired.
 package templates
 
 import (
@@ -50,8 +47,6 @@ var (
 // newLinkedRef builds a proto LinkedTemplateRef for the given scope, scope
 // name, template name, and optional version constraint. Used by
 // ListEffectiveTemplateSources tests to construct policy-effective ref slices.
-// Moved from handler_updates_test.go to this file in HOL-908 when
-// CheckUpdates tests were removed.
 func newLinkedRef(scope scopeKind, scopeName, name, constraint string) *consolev1.LinkedTemplateRef {
 	var ns string
 	switch scope {
@@ -453,7 +448,6 @@ func TestCreateTemplate(t *testing.T) {
 			if tc.defaults != nil && read.Spec.Defaults == nil {
 				t.Errorf("expected defaults to be persisted")
 			}
-			// HOL-908: LinkedTemplates field removed from TemplateSpec entirely.
 		})
 	}
 }
@@ -864,10 +858,6 @@ func TestListEffectiveTemplateSources(t *testing.T) {
 		}
 	})
 }
-
-// NOTE: TestCreateTemplate_NoLinkedTemplates was removed in HOL-908.
-// The LinkedTemplates field was removed from TemplateSpec entirely — there is
-// nothing left to assert against. The invariant was first guarded in HOL-906.
 
 // Ensure defaults serialize through the DefaultsKey JSON path the test
 // helpers use. Covers the DefaultsKey-read path in configMapToTemplateCRD.

--- a/console/templates/record_applied_test.go
+++ b/console/templates/record_applied_test.go
@@ -2,7 +2,6 @@ package templates
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -79,9 +78,7 @@ func ownerCtx() context.Context {
 }
 
 // existingProjectTemplate returns a seeded project-scope template ConfigMap.
-// The refs parameter is accepted for call-site compatibility but ignored —
-// LinkedTemplates was removed from TemplateSpec in HOL-908.
-func existingProjectTemplateWithLinks(project, name string, _ []*consolev1.LinkedTemplateRef) *corev1.ConfigMap {
+func existingProjectTemplate(project, name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -98,30 +95,6 @@ func existingProjectTemplateWithLinks(project, name string, _ []*consolev1.Linke
 			CueTemplateKey: "#Input: { name: string }\n",
 		},
 	}
-}
-
-// marshalLinkedTemplatesForTest is retained for compatibility; callers that
-// existed pre-HOL-908 are gone. The function remains only so any stale
-// test-helper references compile. TODO(HOL-909): remove entirely.
-func marshalLinkedTemplatesForTest(refs []*consolev1.LinkedTemplateRef) (string, error) {
-	type storedRef struct {
-		Namespace         string `json:"namespace"`
-		Name              string `json:"name"`
-		VersionConstraint string `json:"version_constraint,omitempty"`
-	}
-	stored := make([]storedRef, 0, len(refs))
-	for _, r := range refs {
-		stored = append(stored, storedRef{
-			Namespace:         r.GetNamespace(),
-			Name:              r.GetName(),
-			VersionConstraint: r.GetVersionConstraint(),
-		})
-	}
-	b, err := json.Marshal(stored)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
 }
 
 // TestHandler_CreateTemplate_RecordsAppliedOnSuccess verifies that a
@@ -317,12 +290,9 @@ func TestHandler_CreateTemplate_NoRecordOnPersistFailure(t *testing.T) {
 	}
 }
 
-// TestHandler_UpdateTemplate_RecordsAppliedOnSuccess_NewLinks verifies the
 // TestHandler_UpdateTemplate_RecordsAppliedOnSuccess verifies that a
 // successful project-scope UpdateTemplate calls RecordApplied with the
-// policy-resolved effective ref set. HOL-908 removed the update_linked_templates
-// and linked_templates fields; template composition is driven exclusively by
-// TemplatePolicyBinding.
+// policy-resolved effective ref set.
 func TestHandler_UpdateTemplate_RecordsAppliedOnSuccess(t *testing.T) {
 	resolved := []*consolev1.LinkedTemplateRef{
 		folderLinkedRef("payments", "audit"),
@@ -330,7 +300,7 @@ func TestHandler_UpdateTemplate_RecordsAppliedOnSuccess(t *testing.T) {
 	resolver := &recordingResolver{resolved: resolved}
 	checker := &stubProjectTemplateDriftChecker{}
 
-	existing := existingProjectTemplateWithLinks("my-project", "web-app", nil)
+	existing := existingProjectTemplate("my-project", "web-app")
 	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
 
 	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
@@ -386,7 +356,7 @@ func TestHandler_UpdateTemplate_WarnButSucceedOnRecordFailure(t *testing.T) {
 	resolver := &recordingResolver{}
 	checker := &stubProjectTemplateDriftChecker{recordErr: errors.New("applied-state write failed")}
 
-	existing := existingProjectTemplateWithLinks("my-project", "web-app", nil)
+	existing := existingProjectTemplate("my-project", "web-app")
 	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
 
 	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
@@ -409,7 +379,7 @@ func TestHandler_UpdateTemplate_WarnButSucceedOnRecordFailure(t *testing.T) {
 // resolver is not invoked.
 func TestHandler_UpdateTemplate_NilCheckerIsSafe(t *testing.T) {
 	resolver := &recordingResolver{}
-	existing := existingProjectTemplateWithLinks("my-project", "web-app", nil)
+	existing := existingProjectTemplate("my-project", "web-app")
 	h := recordAppliedTemplateHandler(t, resolver, nil, existing)
 
 	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{
@@ -445,7 +415,7 @@ func TestHandler_UpdateTemplate_ResolverFailureIsSwallowed(t *testing.T) {
 	resolver := &recordingResolver{err: errors.New("policy fetch failed")}
 	checker := &stubProjectTemplateDriftChecker{}
 
-	existing := existingProjectTemplateWithLinks("my-project", "web-app", nil)
+	existing := existingProjectTemplate("my-project", "web-app")
 	h := recordAppliedTemplateHandler(t, resolver, checker, existing)
 
 	req := connect.NewRequest(&consolev1.UpdateTemplateRequest{

--- a/console/templates/testhelpers_test.go
+++ b/console/templates/testhelpers_test.go
@@ -69,10 +69,6 @@ func configMapIsTemplate(cm *corev1.ConfigMap) bool {
 // fixture to the equivalent Template CRD. Preserves name, namespace,
 // display/description/enabled fields, CUE payload, and structured defaults
 // (decoded from the DefaultsKey JSON).
-//
-// HOL-908: the linkedTemplates annotation is no longer read — LinkedTemplates
-// was removed from TemplateSpec. Fixtures that carried linked refs via
-// AnnotationLinkedTemplates compile fine; the field is just ignored.
 func configMapToTemplateCRD(cm *corev1.ConfigMap) *templatesv1alpha1.Template {
 	tmpl := &templatesv1alpha1.Template{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -233,8 +233,7 @@ func mustCreateNamespaceWithParent(t *testing.T, c client.Client, name, resource
 // TestTemplate_ObservedGenerationConverges creates a Template, waits for
 // Ready=True, then updates the spec and confirms observedGeneration tracks
 // metadata.generation. Also asserts the condition set contains Accepted,
-// CUEValid, and Ready — the documented HOL-618 surface (LinkedRefsResolved
-// was removed in HOL-908; explicit linking is superseded by TemplatePolicyBinding).
+// CUEValid, and Ready (the documented HOL-618 surface).
 func TestTemplate_ObservedGenerationConverges(t *testing.T) {
 	e := startEnv(t)
 	_, cancel, errCh := startManager(t, e.cfg)
@@ -265,9 +264,6 @@ func TestTemplate_ObservedGenerationConverges(t *testing.T) {
 	}
 
 	// Confirm the full condition set is present.
-	// LinkedRefsResolved was removed in HOL-908 — explicit linking is
-	// superseded by TemplatePolicyBinding. The reconciler now surfaces only
-	// Accepted, CUEValid, and Ready.
 	expected := []string{
 		v1alpha1.TemplateConditionAccepted,
 		v1alpha1.TemplateConditionCUEValid,

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -63,8 +63,6 @@ func (r *TemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //
 //  1. Fetch the object; NotFound -> no-op.
 //  2. Build the Accepted / CUEValid component conditions from the current spec.
-//     LinkedRefsResolved was removed in HOL-908 — explicit linking is
-//     superseded by TemplatePolicyBinding.
 //  3. Aggregate into Ready.
 //  4. Stamp metadata.generation on every condition plus
 //     status.observedGeneration.
@@ -140,9 +138,6 @@ func (r *TemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 // buildTemplateConditions computes the Accepted and CUEValid component
 // conditions from the current spec. The caller aggregates them into Ready
 // and stamps observedGeneration.
-//
-// LinkedRefsResolved was removed in HOL-908 — explicit linking is superseded
-// by TemplatePolicyBinding.
 //
 // Callers receive conditions in the canonical order: Accepted, CUEValid.
 // Keeping a stable order simplifies test assertions.


### PR DESCRIPTION
## Summary

- Removes the `AnnotationLinkedTemplates = "console.holos.run/linked-templates"` constant from `api/v1alpha2/annotations.go` and `api/v1alpha2/schema_gen.cue` — nothing reads or writes this annotation after HOL-904 through HOL-908
- Deletes `console/templates/handler_updates_test.go` (package-only file with no tests; the `CheckUpdates` RPC was removed in HOL-908)
- Strips migration tombstone comments (HOL-904/905/906/908) from handler.go, k8s.go, policyresolver, and test files throughout the codebase
- Removes NOTE: comment blocks in `handler_test.go` and `k8s_test.go` that described tests deleted in prior phases
- Simplifies `existingProjectTemplateWithLinks` → `existingProjectTemplate` (the links param was already ignored) and removes the dead `marshalLinkedTemplatesForTest` helper
- Smoke test: `httpbin-v1` deployment produces only its own resources; the `console.holos.run/linked-templates` annotation on a Template ConfigMap is ignored by the render pipeline (regression test `TestCreateDeployment_AnnotationIgnored` remains in place)

Fixes HOL-909

## Test plan

- [x] `make test-go` green (all packages)
- [x] `make test-ui` green (92 test files, 1235 tests)
- [x] `git grep AnnotationLinkedTemplates` returns zero hits in non-generated source
- [x] `TestCreateDeployment_AnnotationIgnored` passes — annotation is ignored by render pipeline
- [x] `console/templates/examples/` CUE files audited — all already clean (no explicit linking)
- [x] `frontend/src/components/platform-template-copy.ts` audited — all copy is TPB-only