### PR TITLE
refactor(resource-grid): remove descendants/lineage filter controls

### DIFF
--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -23,7 +23,6 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { toast } from 'sonner'
-import type { Mock } from 'vitest'
 import { ResourceGrid } from './ResourceGrid'
 import type { Kind, Row, ResourceGridSearch } from './types'
 
@@ -287,41 +286,6 @@ describe('ResourceGrid', () => {
     })
     expect(screen.getByText('My Deployment')).toBeInTheDocument()
     expect(screen.queryByText('My Secret')).not.toBeInTheDocument()
-  })
-
-  // --- Lineage filter ---
-
-  it('renders lineage filter controls', () => {
-    renderGrid()
-    expect(screen.getByTestId('lineage-filter')).toBeInTheDocument()
-    expect(screen.getByRole('combobox', { name: /lineage direction/i })).toBeInTheDocument()
-    expect(
-      screen.getByTestId('lineage-recursive-checkbox'),
-    ).toBeInTheDocument()
-  })
-
-  it('recursive checkbox is unchecked by default', () => {
-    renderGrid({ search: {} })
-    const checkbox = screen.getByTestId('lineage-recursive-checkbox')
-    // The shadcn Checkbox renders as a button with aria-checked
-    expect(checkbox).toHaveAttribute('aria-checked', 'false')
-  })
-
-  it('calls onSearchChange with recursive=1 when recursive checkbox is clicked', () => {
-    const onSearchChange = vi.fn()
-    renderGrid({ onSearchChange, search: {} })
-    const checkbox = screen.getByTestId('lineage-recursive-checkbox')
-    fireEvent.click(checkbox)
-    expect(onSearchChange).toHaveBeenCalled()
-    // Verify the updater produces recursive=1
-    const updater = (onSearchChange as Mock).mock.calls[0][0]
-    expect(updater({})).toMatchObject({ recursive: '1' })
-  })
-
-  it('shows recursive checkbox as checked when search.recursive is "1"', () => {
-    renderGrid({ search: { recursive: '1' } })
-    const checkbox = screen.getByTestId('lineage-recursive-checkbox')
-    expect(checkbox).toHaveAttribute('aria-checked', 'true')
   })
 
   // --- New button ---

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -5,7 +5,6 @@
  * Features:
  *  - TanStack Table with global search (includesString)
  *  - Multi-kind filter (URL ?kind=a,b)
- *  - Lineage filter (URL ?lineage=ancestors&recursive=0)
  *  - New button / dropdown
  *  - Row-level delete via ConfirmDeleteDialog
  *  - URL sync via TanStack Router useSearch / useNavigate
@@ -40,13 +39,6 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -57,7 +49,7 @@ import { Label } from '@/components/ui/label'
 import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
 
 import type { ColumnDef } from '@tanstack/react-table'
-import type { Kind, Row, LineageDirection, ResourceGridSearch } from './types'
+import type { Kind, Row, ResourceGridSearch } from './types'
 import { parseKindIds, serialiseKindIds } from './url-state'
 
 // ---------------------------------------------------------------------------
@@ -140,8 +132,6 @@ export function ResourceGrid({
   )
 
   const globalFilter = search.search ?? ''
-  const lineageDirection: LineageDirection = search.lineage ?? 'descendants'
-  const recursive = search.recursive === '1'
 
   // --- URL updater helpers -----------------------------------------------
 
@@ -165,20 +155,6 @@ export function ResourceGrid({
         ...prev,
         kind: serialiseKindIds(ids) ?? undefined,
       }))
-    },
-    [updateSearch],
-  )
-
-  const setLineageDirection = useCallback(
-    (dir: LineageDirection) => {
-      updateSearch((prev) => ({ ...prev, lineage: dir }))
-    },
-    [updateSearch],
-  )
-
-  const setRecursive = useCallback(
-    (val: boolean) => {
-      updateSearch((prev) => ({ ...prev, recursive: val ? '1' : '0' }))
     },
     [updateSearch],
   )
@@ -233,19 +209,6 @@ export function ResourceGrid({
     const kindSet = new Set(selectedKindIds)
     return rows.filter((r) => kindSet.has(r.kind))
   }, [rows, selectedKindIds])
-
-  // --- Lineage filter ----------------------------------------------------
-
-  const lineageFilteredRows = useMemo(() => {
-    // Lineage filtering is applied by the consumer's data-fetching layer
-    // in later phases.  The grid itself exposes the URL state; advanced
-    // multi-level walk logic belongs in the route.  We pass rows through
-    // unchanged here so the component stays data-source-agnostic.
-    //
-    // The lineage direction and recursive values are exposed via the search
-    // props so parent routes can consume them in their query hooks.
-    return kindFilteredRows
-  }, [kindFilteredRows])
 
   // --- TanStack Table columns --------------------------------------------
 
@@ -357,7 +320,7 @@ export function ResourceGrid({
   // --- TanStack Table instance -------------------------------------------
 
   const table = useReactTable({
-    data: lineageFilteredRows,
+    data: kindFilteredRows,
     columns,
     state: { globalFilter, columnVisibility },
     onGlobalFilterChange: setGlobalFilter,
@@ -450,14 +413,6 @@ export function ResourceGrid({
                 onChange={setKindIds}
               />
             )}
-
-            {/* Lineage filter */}
-            <LineageFilterControl
-              direction={lineageDirection}
-              recursive={recursive}
-              onDirectionChange={setLineageDirection}
-              onRecursiveChange={setRecursive}
-            />
           </div>
 
           {/* Empty state */}
@@ -608,52 +563,3 @@ function KindFilter({
   )
 }
 
-/** Lineage direction select + recursive checkbox. */
-function LineageFilterControl({
-  direction,
-  recursive,
-  onDirectionChange,
-  onRecursiveChange,
-}: {
-  direction: LineageDirection
-  recursive: boolean
-  onDirectionChange: (d: LineageDirection) => void
-  onRecursiveChange: (r: boolean) => void
-}) {
-  return (
-    <div
-      className="flex items-center gap-2"
-      aria-label="Lineage filter"
-      data-testid="lineage-filter"
-    >
-      <Select
-        value={direction}
-        onValueChange={(v) => onDirectionChange(v as LineageDirection)}
-      >
-        <SelectTrigger className="w-[160px]" aria-label="Lineage direction">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="ancestors">Ancestors</SelectItem>
-          <SelectItem value="descendants">Descendants</SelectItem>
-          <SelectItem value="both">Both</SelectItem>
-        </SelectContent>
-      </Select>
-      <div className="flex items-center gap-1">
-        <Checkbox
-          id="lineage-recursive"
-          checked={recursive}
-          onCheckedChange={(checked) => onRecursiveChange(checked === true)}
-          aria-label="Recursive lineage"
-          data-testid="lineage-recursive-checkbox"
-        />
-        <Label
-          htmlFor="lineage-recursive"
-          className="text-sm cursor-pointer"
-        >
-          Recursive
-        </Label>
-      </div>
-    </div>
-  )
-}

--- a/frontend/src/components/resource-grid/types.ts
+++ b/frontend/src/components/resource-grid/types.ts
@@ -34,7 +34,7 @@ export interface Row {
   namespace: string
   /** Stable identifier for the resource (e.g. UID or compound key). */
   id: string
-  /** Parent resource name / namespace — used by the lineage filter. */
+  /** Parent resource name / namespace. */
   parentId: string
   /** Human-readable label for the parent (e.g. project or folder name). */
   parentLabel: string
@@ -49,21 +49,6 @@ export interface Row {
 }
 
 /**
- * Lineage filter direction.  "ancestors" = rows whose parentId matches a
- * parent of the active namespace; "descendants" = rows whose parentId is a
- * child; "both" = union.
- */
-export type LineageDirection = 'ancestors' | 'descendants' | 'both'
-
-/**
- * Parsed representation of the URL lineage params.
- */
-export interface LineageFilter {
-  direction: LineageDirection
-  recursive: boolean
-}
-
-/**
  * The shape of the URL search params owned by the ResourceGrid.  Consumers
  * extend this type in their route's `validateSearch` to merge grid params with
  * any route-specific params.
@@ -73,12 +58,4 @@ export interface ResourceGridSearch {
   kind?: string
   /** Global search string. */
   search?: string
-  /** Lineage direction: "ancestors" | "descendants" | "both". */
-  lineage?: LineageDirection
-  /**
-   * Whether the lineage traversal is recursive.  "1" = true, "0" = false.
-   * We store as string so TanStack Router's `parseSearchWith` keeps it a
-   * simple literal without schema coercion.
-   */
-  recursive?: '0' | '1'
 }

--- a/frontend/src/components/resource-grid/url-state.ts
+++ b/frontend/src/components/resource-grid/url-state.ts
@@ -7,13 +7,7 @@
  * duplicated.
  */
 
-import type { LineageDirection, ResourceGridSearch } from './types'
-
-const VALID_LINEAGE_DIRECTIONS = new Set<string>([
-  'ancestors',
-  'descendants',
-  'both',
-])
+import type { ResourceGridSearch } from './types'
 
 /**
  * Parse an untrusted query-string object into a validated `ResourceGridSearch`.
@@ -44,19 +38,6 @@ export function parseGridSearch(raw: Record<string, unknown>): ResourceGridSearc
     result.search = search
   }
 
-  const lineage = raw['lineage']
-  if (typeof lineage === 'string' && VALID_LINEAGE_DIRECTIONS.has(lineage)) {
-    result.lineage = lineage as LineageDirection
-  }
-
-  const recursive = raw['recursive']
-  if (recursive === '1') {
-    result.recursive = '1'
-  } else if (recursive === '0') {
-    result.recursive = '0'
-  }
-  // Default (absent) → treated as '0' (non-recursive) by the grid.
-
   return result
 }
 
@@ -71,8 +52,6 @@ export function serialiseGridSearch(
   return {
     kind: params.kind || undefined,
     search: params.search || undefined,
-    lineage: params.lineage || undefined,
-    recursive: params.recursive,
   }
 }
 

--- a/frontend/src/queries/secrets.ts
+++ b/frontend/src/queries/secrets.ts
@@ -1,14 +1,11 @@
 import { useMemo } from 'react'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
-import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { SecretsService } from '@/gen/holos/console/v1/secrets_pb.js'
 import type { SecretMetadata } from '@/gen/holos/console/v1/secrets_pb.js'
 import { useAuth } from '@/lib/auth'
-import { useGetProject } from '@/queries/projects'
-import { useListFolders } from '@/queries/folders'
 import { aggregateFanOut, type FanOutAggregate, type FanOutQueryState } from '@/queries/templatePolicies'
-import type { LineageDirection } from '@/components/resource-grid/types'
 
 function listSecretsKey(project: string) {
   return ['secrets', 'list', project] as const
@@ -121,62 +118,25 @@ export function useUpdateSecretSharing(project: string) {
   })
 }
 
-// Module-level sentinel so the `folders` useMemo fallback preserves reference
-// identity across renders when the folders list is still pending or empty.
-const EMPTY_FOLDERS: readonly { name: string }[] = []
-
 /**
- * useAllSecretsForProject fans a ListSecrets call across the project itself
- * plus its ancestor folders and org when the lineage filter requests it.
+ * useAllSecretsForProject fetches the secrets for the given project namespace.
  *
- * The fan-out pattern mirrors useAllTemplatesForOrg in templates.ts. When
- * lineage is 'descendants' (the default), only the project's own secrets are
- * fetched. When lineage is 'ancestors' or 'both', the hook additionally
- * queries each ancestor folder and the org namespace.
- *
- * Result rows carry a `scope` field (project name, folder name, or org name)
- * that the caller maps to the ResourceGrid Row.parentId so the lineage filter
- * UI can surface the correct parent label.
+ * Result rows carry a `scope` field (the project name) that the caller maps
+ * to the ResourceGrid Row.parentId.
  */
 export interface SecretRow {
   secret: SecretMetadata
-  /** The project/folder/org name the secret was fetched from. */
+  /** The project name the secret was fetched from. */
   scope: string
 }
 
 export function useAllSecretsForProject(
   projectName: string,
-  options: { lineage?: LineageDirection } = {},
 ): FanOutAggregate<SecretRow> {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
 
-  const lineage = options.lineage ?? 'descendants'
-  const includeAncestors = lineage === 'ancestors' || lineage === 'both'
-
-  // Fetch the project record so we can resolve its parent folder and org.
-  const projectQuery = useGetProject(projectName)
-  const project = projectQuery.data
-  const orgName = project?.organization ?? ''
-
-  // Fetch all folders in the org so we can walk up the ancestor chain.
-  const foldersQuery = useListFolders(includeAncestors ? orgName : '')
-  const folders = useMemo(
-    () => foldersQuery.data ?? EMPTY_FOLDERS,
-    [foldersQuery.data],
-  )
-
-  // Build the set of ancestor scopes: immediate parent folder (if any) up to
-  // the org. When the project has a folder parent, that folder is the direct
-  // ancestor. For simplicity we include all folders in the org when ancestors
-  // are requested — the recursive flag on the grid controls depth in the UI.
-  const ancestorFolderNames = useMemo<string[]>(() => {
-    if (!includeAncestors || !project) return []
-    return folders.map((f) => f.name)
-  }, [includeAncestors, project, folders])
-
-  // Always fetch the project's own secrets.
   const projectSecretsQuery = useQuery({
     queryKey: [...listSecretsKey(projectName), 'fanout'] as const,
     queryFn: async (): Promise<SecretRow[]> => {
@@ -186,30 +146,6 @@ export function useAllSecretsForProject(
     enabled: isAuthenticated && !!projectName,
   })
 
-  // Fan-out to ancestor folder scopes (useQueries to avoid conditional hooks).
-  const folderQueries = useQueries({
-    queries: ancestorFolderNames.map((folderName) => ({
-      queryKey: [...listSecretsKey(folderName), 'fanout'] as const,
-      queryFn: async (): Promise<SecretRow[]> => {
-        const response = await client.listSecrets({ project: folderName })
-        return response.secrets.map((s) => ({ secret: s, scope: folderName }))
-      },
-      enabled: isAuthenticated && !!folderName,
-    })),
-  })
-
-  // Fan-out to the org scope.
-  const orgQuery = useQuery({
-    queryKey: [...listSecretsKey(orgName), 'fanout'] as const,
-    queryFn: async (): Promise<SecretRow[]> => {
-      const response = await client.listSecrets({ project: orgName })
-      return response.secrets.map((s) => ({ secret: s, scope: orgName }))
-    },
-    enabled: isAuthenticated && !!orgName && includeAncestors,
-  })
-
-  // Model the project-level query and structural queries as FanOutQueryState
-  // inputs so aggregateFanOut can handle pending/error semantics uniformly.
   const projectAsQuery: FanOutQueryState<SecretRow[]> = {
     data: projectSecretsQuery.data,
     error: projectSecretsQuery.error,
@@ -217,32 +153,6 @@ export function useAllSecretsForProject(
     fetchStatus: projectSecretsQuery.fetchStatus,
   }
 
-  const foldersListAsQuery: FanOutQueryState<SecretRow[]> = {
-    data: foldersQuery.data === undefined ? undefined : [],
-    error: foldersQuery.error,
-    isPending: foldersQuery.isPending,
-    fetchStatus: foldersQuery.fetchStatus,
-  }
-
-  const orgAsQuery: FanOutQueryState<SecretRow[]> = {
-    data: orgQuery.data,
-    error: orgQuery.error,
-    isPending: orgQuery.isPending,
-    fetchStatus: orgQuery.fetchStatus,
-  }
-
-  const allQueries: FanOutQueryState<SecretRow[]>[] = [
-    projectAsQuery,
-    ...(includeAncestors ? [foldersListAsQuery] : []),
-    ...(includeAncestors ? [orgAsQuery] : []),
-    ...folderQueries.map((q) => ({
-      data: q.data,
-      error: q.error,
-      isPending: q.isPending,
-      fetchStatus: q.fetchStatus,
-    })),
-  ]
-
-  return aggregateFanOut<SecretRow>(allQueries)
+  return aggregateFanOut<SecretRow>([projectAsQuery])
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx
@@ -123,12 +123,10 @@ describe('SecretsListPage (ResourceGrid v1)', () => {
     expect(screen.getByText('my-secret')).toBeInTheDocument()
   })
 
-  it('calls useAllSecretsForProject with descendants lineage by default', () => {
+  it('calls useAllSecretsForProject with the project name', () => {
     setupMocks()
     render(<SecretsListPage />)
-    expect(useAllSecretsForProject).toHaveBeenCalledWith('test-project', {
-      lineage: 'descendants',
-    })
+    expect(useAllSecretsForProject).toHaveBeenCalledWith('test-project')
   })
 
   it('shows loading skeleton when isPending is true', () => {
@@ -235,17 +233,6 @@ describe('SecretsListPage (ResourceGrid v1)', () => {
 
     await waitFor(() => {
       expect(mutateAsync).toHaveBeenCalledWith('my-secret')
-    })
-  })
-
-  it('URL state: useAllSecretsForProject is called with the search lineage', () => {
-    // The component extracts lineage from useSearch() and passes it to
-    // useAllSecretsForProject. Since our router mock returns {} for useSearch,
-    // the component defaults to "descendants".
-    setupMocks({ rows: [makeSecretRow('my-secret')] })
-    render(<SecretsListPage />)
-    expect(useAllSecretsForProject).toHaveBeenCalledWith('test-project', {
-      lineage: 'descendants',
     })
   })
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
@@ -2,8 +2,6 @@
  * Secrets index page — reimplemented on ResourceGrid v1 (HOL-857).
  *
  * Default view: current project as the single parent with Parent column hidden.
- * Expanding the lineage filter to ancestors/both surfaces folder- and org-level
- * secrets without leaving the page.
  *
  * Detail and new/edit flows are unchanged — only the list page is rewritten.
  */
@@ -30,8 +28,7 @@ export function SecretsListPage() {
 
   const { data: project } = useGetProject(projectName)
 
-  const lineage = search.lineage ?? 'descendants'
-  const { data: secretRows = [], isPending, error } = useAllSecretsForProject(projectName, { lineage })
+  const { data: secretRows = [], isPending, error } = useAllSecretsForProject(projectName)
 
   const deleteMutation = useDeleteSecret(projectName)
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -244,16 +244,14 @@ export function ProjectTemplatesIndexPage({
   )
 
   // ---------------------------------------------------------------------------
-  // Default URL state: kind=Template, lineage=descendants
-  // Apply defaults when URL omits them so the initial view shows only
+  // Default URL state: kind=Template
+  // Apply default when URL omits it so the initial view shows only
   // the current project's Template rows.
   // ---------------------------------------------------------------------------
 
   const searchWithDefaults: ResourceGridSearch = useMemo(
     () => ({
       kind: search.kind ?? 'Template',
-      lineage: search.lineage ?? 'descendants',
-      recursive: search.recursive ?? '0',
       search: search.search,
     }),
     [search],


### PR DESCRIPTION
## Summary
- Removes the non-functional lineage direction select and recursive checkbox from `ResourceGrid` — these controls never affected backend results and were a design mistake (HOL-910 item 1)
- Deletes `LineageDirection` type, `LineageFilter` interface, and `lineage`/`recursive` fields from `ResourceGridSearch` in `types.ts`
- Drops lineage/recursive parsing from `url-state.ts` (`parseGridSearch` and `serialiseGridSearch`)
- Removes the `LineageFilterControl` sub-component and all wiring from `ResourceGrid.tsx`
- Simplifies `useAllSecretsForProject` in `queries/secrets.ts` to project-scope-only (removes ancestor fan-out and unused imports)
- Cleans up lineage defaults in `secrets/index.tsx` and `templates/index.tsx` routes
- Removes lineage test cases from `resource-grid` and `secrets` test files

Fixes HOL-913

## Test plan
- [x] `make test-ui` passes (92 test files, 1230 tests)
- [x] No `lineage`/`recursive`/`LineageDirection` references remain in `frontend/src`