### PR TITLE
feat(ui): Projects listing page, Created At column, sortable columns

### DIFF
--- a/frontend/src/lib/format-created-at.test.ts
+++ b/frontend/src/lib/format-created-at.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { formatCreatedAt } from './format-created-at'
+
+// Pin "now" to 2026-04-23T12:00:00Z so relative-time assertions are stable.
+const FIXED_NOW = new Date('2026-04-23T12:00:00Z').getTime()
+
+describe('formatCreatedAt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns empty string for an empty input', () => {
+    expect(formatCreatedAt('')).toBe('')
+  })
+
+  it('returns empty string for an invalid timestamp', () => {
+    expect(formatCreatedAt('not-a-date')).toBe('')
+  })
+
+  it('formats a timestamp from today as "YYYY-MM-DD (today)"', () => {
+    expect(formatCreatedAt('2026-04-23T08:00:00Z')).toBe('2026-04-23 (today)')
+  })
+
+  it('formats a timestamp from yesterday as "YYYY-MM-DD (1 day ago)"', () => {
+    expect(formatCreatedAt('2026-04-22T10:00:00Z')).toBe('2026-04-22 (1 day ago)')
+  })
+
+  it('formats a timestamp from 2 days ago as "YYYY-MM-DD (2 days ago)"', () => {
+    expect(formatCreatedAt('2026-04-21T00:00:00Z')).toBe('2026-04-21 (2 days ago)')
+  })
+
+  it('formats a timestamp from 30 days ago correctly', () => {
+    expect(formatCreatedAt('2026-03-24T06:00:00Z')).toBe('2026-03-24 (30 days ago)')
+  })
+
+  it('formats a timestamp from 365 days ago correctly', () => {
+    expect(formatCreatedAt('2025-04-23T12:00:00Z')).toBe('2025-04-23 (365 days ago)')
+  })
+})

--- a/frontend/src/lib/format-created-at.ts
+++ b/frontend/src/lib/format-created-at.ts
@@ -1,0 +1,29 @@
+// formatCreatedAt formats an RFC3339 timestamp string as "YYYY-MM-DD (N days ago)".
+// The relative suffix uses plain English: "today", "1 day ago", or "N days ago".
+// Callers should handle an empty string by returning an empty string (no timestamp available).
+export function formatCreatedAt(ts: string): string {
+  if (!ts) return ''
+  const date = new Date(ts)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const isoDate = date.toISOString().slice(0, 10)
+  const now = new Date()
+
+  // Compute calendar-day difference in the user's local timezone by comparing
+  // midnight-aligned date values. Using UTC midnight for both avoids DST skew.
+  const msPerDay = 86_400_000
+  const startOfToday = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const startOfCreated = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  const daysDiff = Math.round((startOfToday - startOfCreated) / msPerDay)
+
+  let relative: string
+  if (daysDiff === 0) {
+    relative = 'today'
+  } else if (daysDiff === 1) {
+    relative = '1 day ago'
+  } else {
+    relative = `${daysDiff} days ago`
+  }
+
+  return `${isoDate} (${relative})`
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({}),
+    Link: ({
+      children,
+      to,
+      search,
+      className,
+    }: {
+      children: React.ReactNode
+      to?: string
+      search?: Record<string, unknown>
+      className?: string
+    }) => (
+      <a href={to} data-search={JSON.stringify(search)} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@/queries/projects', () => ({
+  useListProjects: vi.fn(),
+}))
+
+// Pin "now" to 2026-04-23T12:00:00Z so Created At column assertions are stable.
+const FIXED_NOW = new Date('2026-04-23T12:00:00Z').getTime()
+
+import { useListProjects } from '@/queries/projects'
+import { OrgProjectsIndexPage } from './index'
+
+type ProjectFixture = {
+  name: string
+  displayName?: string
+  description?: string
+  createdAt?: string
+}
+
+function makeProject(
+  name: string,
+  displayName = '',
+  description = '',
+  createdAt = '2026-04-20T10:00:00Z',
+): ProjectFixture {
+  return { name, displayName, description, createdAt }
+}
+
+function setupMocks(projects: ProjectFixture[] = [makeProject('test-project', 'Test Project')]) {
+  ;(useListProjects as Mock).mockReturnValue({
+    data: { projects },
+    isLoading: false,
+    error: null,
+  })
+}
+
+describe('OrgProjectsIndexPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders loading skeletons while query is pending', () => {
+    ;(useListProjects as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    })
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders empty-state prompt when project list is empty', () => {
+    setupMocks([])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    expect(screen.getByText(/no projects in this organization/i)).toBeInTheDocument()
+  })
+
+  it('renders a table row for each project returned by the mock query', () => {
+    setupMocks([
+      makeProject('alpha', 'Alpha Project'),
+      makeProject('beta', 'Beta Project'),
+    ])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    expect(screen.getByText('Alpha Project')).toBeInTheDocument()
+    expect(screen.getByText('Beta Project')).toBeInTheDocument()
+  })
+
+  it('renders the Created At column for each project', () => {
+    // 2026-04-20 is 3 days before the fixed "now" of 2026-04-23
+    setupMocks([makeProject('alpha', 'Alpha Project', '', '2026-04-20T10:00:00Z')])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    expect(screen.getByText('2026-04-20 (3 days ago)')).toBeInTheDocument()
+  })
+
+  it('renders the "Created At" column header', () => {
+    setupMocks([makeProject('alpha', 'Alpha')])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    expect(screen.getByText('Created At')).toBeInTheDocument()
+  })
+
+  it('clicking the Created At column header toggles sort asc/desc', () => {
+    setupMocks([
+      makeProject('alpha', 'Alpha', '', '2026-04-20T10:00:00Z'),
+      makeProject('beta', 'Beta', '', '2026-04-22T10:00:00Z'),
+    ])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+
+    // Default sort is desc (newest first), so beta appears before alpha.
+    const rows = screen.getAllByRole('row').slice(1) // skip header
+    expect(rows[0]).toHaveTextContent('Beta')
+    expect(rows[1]).toHaveTextContent('Alpha')
+
+    // Click Created At header to switch to ascending (oldest first).
+    fireEvent.click(screen.getByText('Created At'))
+    const rowsAsc = screen.getAllByRole('row').slice(1)
+    expect(rowsAsc[0]).toHaveTextContent('Alpha')
+    expect(rowsAsc[1]).toHaveTextContent('Beta')
+  })
+
+  it('projects list is scoped to $orgName via useListProjects', () => {
+    setupMocks([])
+    render(<OrgProjectsIndexPage orgName="acme-corp" />)
+    expect(useListProjects).toHaveBeenCalledWith('acme-corp')
+  })
+
+  it('search input filters visible rows', () => {
+    setupMocks([
+      makeProject('alpha', 'Alpha Project'),
+      makeProject('beta', 'Beta Project'),
+    ])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    const searchInput = screen.getByPlaceholderText(/search projects/i)
+    fireEvent.change(searchInput, { target: { value: 'alpha' } })
+    expect(screen.getByText('Alpha Project')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Project')).not.toBeInTheDocument()
+  })
+
+  it('clicking a project row navigates to the project detail page', () => {
+    setupMocks([makeProject('my-project', 'My Project')])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    const row = screen.getByText('My Project').closest('tr')!
+    fireEvent.click(row)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/projects/$projectName',
+      params: { projectName: 'my-project' },
+    })
+  })
+
+  it('renders error alert when query fails', () => {
+    ;(useListProjects as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('failed to load projects'),
+    })
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    expect(screen.getByText(/failed to load projects/i)).toBeInTheDocument()
+  })
+
+  it('renders breadcrumb linking back to /organizations', () => {
+    setupMocks([])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    const orgLink = screen.getByRole('link', { name: 'Organizations' })
+    expect(orgLink).toHaveAttribute('href', '/organizations')
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import {
   useReactTable,
   getCoreRowModel,
@@ -25,14 +25,20 @@ import {
 } from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ChevronUp, ChevronDown, ChevronsUpDown, Plus } from 'lucide-react'
-import { useListOrganizations } from '@/queries/organizations'
-import { useOrg } from '@/lib/org-context'
+import { useListProjects } from '@/queries/projects'
 import { formatCreatedAt } from '@/lib/format-created-at'
-import type { Organization } from '@/gen/holos/console/v1/organizations_pb'
+import type { Project } from '@/gen/holos/console/v1/projects_pb'
 
-export const Route = createFileRoute('/_authenticated/organizations/')({
-  component: OrganizationsIndexPage,
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/projects/',
+)({
+  component: OrgProjectsIndexRoute,
 })
+
+function OrgProjectsIndexRoute() {
+  const { orgName } = Route.useParams()
+  return <OrgProjectsIndexPage orgName={orgName} />
+}
 
 // SortIcon renders a chevron indicator for a sortable column header.
 function SortIcon({ isSorted }: { isSorted: false | 'asc' | 'desc' }) {
@@ -45,9 +51,9 @@ function SortIcon({ isSorted }: { isSorted: false | 'asc' | 'desc' }) {
 
 // columnHelper and columns are defined at module scope so they are stable
 // across re-renders and do not trigger unnecessary TanStack Table updates.
-const columnHelper = createColumnHelper<Organization>()
+const columnHelper = createColumnHelper<Project>()
 
-const columns: ColumnDef<Organization, string>[] = [
+const columns: ColumnDef<Project, string>[] = [
   columnHelper.accessor((row) => row.displayName || row.name, {
     id: 'displayName',
     header: ({ column }) => (
@@ -126,11 +132,21 @@ const columns: ColumnDef<Organization, string>[] = [
   }),
 ]
 
-export function OrganizationsIndexPage() {
+export function OrgProjectsIndexPage({
+  orgName: propOrgName,
+}: { orgName?: string } = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
   const navigate = useNavigate()
-  const { setSelectedOrg } = useOrg()
-  const { data, isLoading, error } = useListOrganizations()
-  const organizations = data?.organizations ?? []
+  const { data, isLoading, error } = useListProjects(orgName)
+  const projects = data?.projects ?? []
 
   const [globalFilter, setGlobalFilter] = useState('')
   // Default sort: Created At descending (newest first).
@@ -139,7 +155,7 @@ export function OrganizationsIndexPage() {
   ])
 
   const table = useReactTable({
-    data: organizations,
+    data: projects,
     columns,
     state: { globalFilter, sorting },
     onGlobalFilterChange: setGlobalFilter,
@@ -152,29 +168,15 @@ export function OrganizationsIndexPage() {
     initialState: { pagination: { pageSize: 25 } },
   })
 
-  const handleRowClick = (org: Organization) => {
-    // Switching organizations from this page sets the selected org and lands
-    // on the org's Resources listing (the unified folders + projects view,
-    // introduced in HOL-606). Reusing OrgContext keeps the selection
-    // persistent across reloads.
-    setSelectedOrg(org.name)
-    navigate({
-      to: '/orgs/$orgName/resources',
-      params: { orgName: org.name },
-    })
-  }
-
   if (isLoading) {
     return (
       <Card>
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-          <CardTitle>Organizations</CardTitle>
-          <Link to="/organization/new" search={{ returnTo: '/organizations' }}>
-            <Button size="sm" disabled>
-              <Plus className="h-4 w-4 mr-1" />
-              Create Organization
-            </Button>
-          </Link>
+          <CardTitle>Projects</CardTitle>
+          <Button size="sm" disabled>
+            <Plus className="h-4 w-4 mr-1" />
+            Create Project
+          </Button>
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
@@ -203,29 +205,45 @@ export function OrganizationsIndexPage() {
     <>
       <Card>
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-          <CardTitle>Organizations</CardTitle>
-          <Link to="/organization/new" search={{ returnTo: '/organizations' }}>
+          <div>
+            <p className="text-sm text-muted-foreground">
+              <Link to="/organizations" className="hover:underline">
+                Organizations
+              </Link>
+              {' / '}
+              {orgName}
+              {' / Projects'}
+            </p>
+            <CardTitle className="mt-1">Projects</CardTitle>
+          </div>
+          <Link
+            to="/project/new"
+            search={{ returnTo: `/organizations/${orgName}/projects` }}
+          >
             <Button size="sm">
               <Plus className="h-4 w-4 mr-1" />
-              Create Organization
+              Create Project
             </Button>
           </Link>
         </CardHeader>
         <CardContent>
-          {organizations.length === 0 ? (
+          {projects.length === 0 ? (
             <div className="flex flex-col items-center gap-3 py-8 text-center">
-              <p className="text-muted-foreground">No organizations yet. Create one.</p>
-              <Link to="/organization/new" search={{ returnTo: '/organizations' }}>
-                <Button size="sm">
-                  Create Organization
-                </Button>
+              <p className="text-muted-foreground">
+                No projects in this organization yet.
+              </p>
+              <Link
+                to="/project/new"
+                search={{ returnTo: `/organizations/${orgName}/projects` }}
+              >
+                <Button size="sm">Create Project</Button>
               </Link>
             </div>
           ) : (
             <>
               <div className="mb-3">
                 <Input
-                  placeholder="Search organizations…"
+                  placeholder="Search projects…"
                   value={globalFilter}
                   onChange={(e) => setGlobalFilter(e.target.value)}
                   className="max-w-sm"
@@ -239,7 +257,10 @@ export function OrganizationsIndexPage() {
                         <TableHead key={header.id}>
                           {header.isPlaceholder
                             ? null
-                            : flexRender(header.column.columnDef.header, header.getContext())}
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
                         </TableHead>
                       ))}
                     </TableRow>
@@ -250,11 +271,19 @@ export function OrganizationsIndexPage() {
                     <TableRow
                       key={row.id}
                       className="cursor-pointer"
-                      onClick={() => handleRowClick(row.original)}
+                      onClick={() =>
+                        navigate({
+                          to: '/projects/$projectName',
+                          params: { projectName: row.original.name },
+                        })
+                      }
                     >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
                         </TableCell>
                       ))}
                     </TableRow>

--- a/frontend/src/routes/_authenticated/organizations/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/-index.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { vi } from 'vitest'
+import { vi, beforeEach, afterEach } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 
@@ -39,16 +39,20 @@ vi.mock('@/lib/org-context', () => ({
   useOrg: vi.fn(),
 }))
 
+// Pin "now" to 2026-04-23T12:00:00Z so Created At column assertions are stable.
+const FIXED_NOW = new Date('2026-04-23T12:00:00Z').getTime()
+
 import { useListOrganizations } from '@/queries/organizations'
 import { useOrg } from '@/lib/org-context'
 import { OrganizationsIndexPage } from './index'
 
-function makeOrg(name: string, displayName = '', description = '') {
-  return {
-    name,
-    displayName,
-    description,
-  }
+function makeOrg(
+  name: string,
+  displayName = '',
+  description = '',
+  createdAt = '2026-04-20T10:00:00Z',
+) {
+  return { name, displayName, description, createdAt }
 }
 
 function setupMocks(organizations = [makeOrg('test-org', 'Test Org')]) {
@@ -68,6 +72,12 @@ function setupMocks(organizations = [makeOrg('test-org', 'Test Org')]) {
 describe('OrganizationsIndexPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('renders loading skeletons while query is pending', () => {
@@ -106,6 +116,38 @@ describe('OrganizationsIndexPage', () => {
     setupMocks([makeOrg('my-slug', 'My Org')])
     render(<OrganizationsIndexPage />)
     expect(screen.getByText('my-slug')).toBeInTheDocument()
+  })
+
+  it('renders the "Created At" column header', () => {
+    setupMocks([makeOrg('test-org', 'Test Org')])
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByText('Created At')).toBeInTheDocument()
+  })
+
+  it('renders the Created At column formatted as YYYY-MM-DD (N days ago)', () => {
+    // 2026-04-20 is 3 days before the fixed "now" of 2026-04-23
+    setupMocks([makeOrg('test-org', 'Test Org', '', '2026-04-20T10:00:00Z')])
+    render(<OrganizationsIndexPage />)
+    expect(screen.getByText('2026-04-20 (3 days ago)')).toBeInTheDocument()
+  })
+
+  it('clicking the Created At header toggles sort between desc and asc', () => {
+    setupMocks([
+      makeOrg('alpha', 'Alpha Org', '', '2026-04-20T10:00:00Z'),
+      makeOrg('beta', 'Beta Org', '', '2026-04-22T10:00:00Z'),
+    ])
+    render(<OrganizationsIndexPage />)
+
+    // Default sort is desc (newest first): beta should appear before alpha.
+    const rows = screen.getAllByRole('row').slice(1) // skip header
+    expect(rows[0]).toHaveTextContent('Beta Org')
+    expect(rows[1]).toHaveTextContent('Alpha Org')
+
+    // Click Created At to switch to ascending (oldest first).
+    fireEvent.click(screen.getByText('Created At'))
+    const rowsAsc = screen.getAllByRole('row').slice(1)
+    expect(rowsAsc[0]).toHaveTextContent('Alpha Org')
+    expect(rowsAsc[1]).toHaveTextContent('Beta Org')
   })
 
   it('search input filters visible rows by display name', () => {


### PR DESCRIPTION
## Summary
- Adds new route `frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx` that lists all projects scoped to the org, fixing the broken Projects sidebar link added in HOL-914
- Adds shared `formatCreatedAt(ts)` helper in `frontend/src/lib/format-created-at.ts` that formats RFC3339 timestamps as `YYYY-MM-DD (N days ago)` with unit tests
- Adds Created At column (formatted) to both the Organizations table and the new Projects table, with default sort descending (newest first)
- Makes all columns on both tables sortable via TanStack Table's `getSortedRowModel()` with clickable column headers and `SortIcon` indicators
- Both proto messages (`Organization` and `Project`) already carried `created_at` as a string field populated from Kubernetes namespace `creationTimestamp` — no proto or Go changes needed

Fixes HOL-915

## Test plan
- [x] `make test-ui` — 92 test files, 1231 tests, all pass
- [x] 11 new Vitest/RTL tests for `OrgProjectsIndexPage`: loading, empty state, table rows, Created At column render, default sort order (desc), sort toggle asc/desc, orgName-scoped query assertion, search filter, row click navigation, error alert, breadcrumb link
- [x] 3 new tests added to `OrganizationsIndexPage` suite: Created At header visible, formatted value, sort toggle
- [x] 7 unit tests for `formatCreatedAt` helper: empty string, invalid input, today, yesterday, N days ago, 30 days, 365 days