### PR TITLE
refactor(template-policies): remove All scopes selector, fix BindingForm picker

### DIFF
--- a/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/queries/templatePolicies', async () => {
   )
   return {
     ...actual,
-    useListLinkableTemplatePolicies: vi.fn(),
+    useListTemplatePolicies: vi.fn(),
   }
 })
 
@@ -45,7 +45,7 @@ vi.mock('@/queries/templates', async () => {
 })
 
 import { BindingForm } from './BindingForm'
-import { useListLinkableTemplatePolicies } from '@/queries/templatePolicies'
+import { useListTemplatePolicies } from '@/queries/templatePolicies'
 import {
   useListProjects,
   useListProjectsByParent,
@@ -77,10 +77,11 @@ function stubQueries({
     namespace: string
   }>
 }) {
-  // useListLinkableTemplatePolicies returns LinkableTemplatePolicy[] where each
-  // item wraps a TemplatePolicy in a `policy` field.
-  ;(useListLinkableTemplatePolicies as Mock).mockReturnValue({
-    data: policies.map((p) => ({ policy: p })),
+  // HOL-917: useListTemplatePolicies returns TemplatePolicy[] directly (no
+  // wrapper — the linkable ancestor-walk RPC has been replaced by the
+  // namespace-only RPC from HOL-912 Phase 1).
+  ;(useListTemplatePolicies as Mock).mockReturnValue({
+    data: policies,
     isPending: false,
     error: null,
   })
@@ -549,6 +550,53 @@ describe('BindingForm', () => {
     expect(policyTrigger.textContent).toMatch(/org \/ test-org \/ org-policy/i)
   })
 
+  // HOL-917 AC: prove that policies created at the org namespace appear in the
+  // binding form picker when the namespace-only RPC is used.
+  it('shows org-namespace policies in the picker when the org namespace RPC returns them', async () => {
+    stubQueries({
+      policies: [
+        {
+          name: 'tls-required',
+          displayName: 'TLS Required',
+          description: '',
+          namespace: ORG_NAMESPACE,
+        },
+        {
+          name: 'deny-http',
+          displayName: 'Deny HTTP',
+          description: '',
+          namespace: ORG_NAMESPACE,
+        },
+      ],
+    })
+
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
+
+    render(
+      <BindingForm
+        mode="create"
+        scopeType="organization"
+        namespace={ORG_NAMESPACE}
+        organization="test-org"
+        canWrite
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    // Open the policy combobox.
+    const policyTrigger = screen.getByRole('combobox', { name: /template policy/i })
+    await user.click(policyTrigger)
+
+    // Both org-namespace policies should appear in the picker.
+    expect(await screen.findByText(/org \/ test-org \/ tls-required/i)).toBeInTheDocument()
+    expect(screen.getByText(/org \/ test-org \/ deny-http/i)).toBeInTheDocument()
+  })
+
   it('shows the custom empty state message when no policies are reachable', async () => {
     stubQueries({ policies: [] })
 
@@ -574,12 +622,11 @@ describe('BindingForm', () => {
     const policyTrigger = screen.getByRole('combobox', { name: /template policy/i })
     await user.click(policyTrigger)
 
-    // The custom empty-state message should appear (not the generic "No results found.").
+    // HOL-917: The custom empty-state message should appear (not the misleading
+    // "No template policies reachable from this scope" message which implied
+    // policies might exist elsewhere in the ancestor chain).
     expect(
-      await screen.findByText(/no template policies reachable from this scope/i),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(/policies must exist in this scope or an ancestor/i),
+      await screen.findByText(/no template policies exist in this org yet/i),
     ).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/template-policy-bindings/BindingForm.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.tsx
@@ -20,7 +20,7 @@ import {
   type BindingDraft,
   type BindingMutationParams,
 } from './binding-draft'
-import { useListLinkableTemplatePolicies } from '@/queries/templatePolicies'
+import { useListTemplatePolicies } from '@/queries/templatePolicies'
 import {
   scopeLabelFromNamespace,
   scopeNameFromNamespace,
@@ -81,27 +81,22 @@ export function BindingForm({
   )
   const [error, setError] = useState<string | null>(null)
 
-  // Policies reachable from this scope — the ListLinkableTemplatePolicies RPC
-  // walks the ancestor chain (folder → org) and returns policies from every
-  // namespace the caller can reach, ordered child→parent (self scope first when
-  // includeSelfScope is true). The per-item namespace field lets us render a
-  // scope badge so the user can distinguish local vs. inherited policies.
-  const { data: linkablePolicies = [] } = useListLinkableTemplatePolicies(namespace)
+  // HOL-917: switch from ListLinkableTemplatePolicies (ancestor-walk RPC) to
+  // ListTemplatePolicies (namespace-only RPC from HOL-912 Phase 1). The org
+  // namespace is passed in as the `namespace` prop so only org-scoped policies
+  // appear in the picker.
+  const { data: policies = [] } = useListTemplatePolicies(namespace)
 
   const policyItems: ComboboxItem[] = useMemo(() => {
-    return linkablePolicies.flatMap((lp) => {
-      const p = lp.policy
-      if (!p) return []
+    return policies.map((p) => {
       const scopeLabel = scopeLabelFromNamespace(p.namespace) ?? 'unknown'
       const scopeName = scopeNameFromNamespace(p.namespace)
-      return [
-        {
-          value: policyKey(p.namespace, p.name),
-          label: `${scopeLabel} / ${scopeName} / ${p.name}`,
-        },
-      ]
+      return {
+        value: policyKey(p.namespace, p.name),
+        label: `${scopeLabel} / ${scopeName} / ${p.name}`,
+      }
     })
-  }, [linkablePolicies])
+  }, [policies])
 
   const selectedPolicyKey = useMemo(
     () =>
@@ -233,12 +228,12 @@ export function BindingForm({
           }}
           placeholder="Select a template policy..."
           searchPlaceholder="Search policies..."
-          emptyMessage="No template policies reachable from this scope. Policies must exist in this scope or an ancestor (folder → org)."
+          emptyMessage="No template policies exist in this org yet. Create a policy first before creating a binding."
           aria-label="Template policy"
         />
         <p className="text-xs text-muted-foreground mt-1">
-          Pick the TemplatePolicy this binding attaches. Policies in this scope
-          and its ancestors are offered.
+          Pick the TemplatePolicy this binding attaches. Policies in this
+          organization namespace are offered.
         </p>
       </div>
 

--- a/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/template-policy-bindings/-detail.test.tsx
@@ -55,7 +55,7 @@ vi.mock('@/queries/templates', async () => {
 })
 
 vi.mock('@/queries/templatePolicies', () => ({
-  useListLinkableTemplatePolicies: vi.fn().mockReturnValue({
+  useListTemplatePolicies: vi.fn().mockReturnValue({
     data: [],
     isPending: false,
     error: null,

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-index.test.tsx
@@ -44,7 +44,7 @@ vi.mock('@/queries/templatePolicies', async () => {
   )
   return {
     ...actual,
-    useAllTemplatePoliciesForOrg: vi.fn(),
+    useListTemplatePolicies: vi.fn(),
   }
 })
 
@@ -53,7 +53,7 @@ vi.mock('@/queries/organizations', () => ({
 }))
 
 import {
-  useAllTemplatePoliciesForOrg,
+  useListTemplatePolicies,
 } from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -89,7 +89,7 @@ function setup(
   userRole: Role = Role.OWNER,
   overrides: Partial<{ isPending: boolean; error: Error | null }> = {},
 ) {
-  ;(useAllTemplatePoliciesForOrg as Mock).mockReturnValue({
+  ;(useListTemplatePolicies as Mock).mockReturnValue({
     data: overrides.isPending ? undefined : policies,
     isPending: overrides.isPending ?? false,
     error: overrides.error ?? null,
@@ -122,7 +122,7 @@ describe('OrgTemplatePoliciesIndexPage', () => {
   })
 
   it('renders rows with inline warning banner when partial data and error coexist', () => {
-    ;(useAllTemplatePoliciesForOrg as Mock).mockReturnValue({
+    ;(useListTemplatePolicies as Mock).mockReturnValue({
       data: [makePolicy('p-org', namespaceForOrg('test-org'), 'Org Policy')],
       isPending: false,
       error: new Error('folders unavailable'),
@@ -294,11 +294,25 @@ describe('OrgTemplatePoliciesIndexPage', () => {
     expect(screen.getByText('Folder: team-alpha')).toBeInTheDocument()
   })
 
-  it('renders a scope filter select in the toolbar', () => {
+  // HOL-917: the "All scopes / Organization / Folder" Select was removed. The
+  // page is now org-scoped only — no scope filter in the toolbar.
+  it('does not render a scope filter select in the toolbar', () => {
     setup([makePolicy('p-org', ORG_NS, 'Org Policy')])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(
-      screen.getByRole('combobox', { name: /filter by scope/i }),
-    ).toBeInTheDocument()
+      screen.queryByRole('combobox', { name: /filter by scope/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  // HOL-917: prove that org-namespace policies appear in the listing (the page
+  // now calls useListTemplatePolicies(orgNamespace) directly).
+  it('lists policies returned from the org namespace RPC call', () => {
+    setup([
+      makePolicy('allow-tls', ORG_NS, 'Allow TLS'),
+      makePolicy('deny-http', ORG_NS, 'Deny HTTP'),
+    ])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Allow TLS')).toBeInTheDocument()
+    expect(screen.getByText('Deny HTTP')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/index.tsx
@@ -21,21 +21,15 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useAllTemplatePoliciesForOrg } from '@/queries/templatePolicies'
+import { useListTemplatePolicies } from '@/queries/templatePolicies'
 import type { TemplatePolicy } from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
 import {
   scopeDisplayLabel,
   scopeLabelFromNamespace,
   scopeNameFromNamespace,
+  namespaceForOrg,
 } from '@/lib/scope-labels'
 
 export const Route = createFileRoute(
@@ -51,12 +45,6 @@ function OrgTemplatePoliciesIndexRoute() {
 
 const columnHelper = createColumnHelper<TemplatePolicy>()
 
-// HOL-793: scope filter values. Policies live at org or folder scope only
-// (HOL-590), so the project option is shown but filters to zero rows — the
-// explicit empty-result state teaches the constraint rather than hiding the
-// option silently.
-type ScopeFilter = 'all' | 'org' | 'folder' | 'project'
-
 export function OrgTemplatePoliciesIndexPage({
   orgName: propOrgName,
 }: { orgName?: string } = {}) {
@@ -69,7 +57,12 @@ export function OrgTemplatePoliciesIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
-  const { data: policies, isPending, error } = useAllTemplatePoliciesForOrg(orgName)
+  // HOL-917: this page is now org-scoped only. The RPC is called with the org
+  // namespace directly so only org-scoped policies are returned. The previous
+  // fan-out across org+folder namespaces and the "All scopes" Select filter
+  // have been removed.
+  const orgNamespace = namespaceForOrg(orgName)
+  const { data: policies, isPending, error } = useListTemplatePolicies(orgNamespace)
   const { data: org } = useGetOrganization(orgName)
 
   const userRole = org?.userRole ?? Role.VIEWER
@@ -77,13 +70,10 @@ export function OrgTemplatePoliciesIndexPage({
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   const [globalFilter, setGlobalFilter] = useState('')
-  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all')
 
   const rows = useMemo(() => {
-    const all = policies ?? []
-    if (scopeFilter === 'all') return all
-    return all.filter((p) => scopeLabelFromNamespace(p.namespace) === scopeFilter)
-  }, [policies, scopeFilter])
+    return policies ?? []
+  }, [policies])
 
   const columns = useMemo(
     () => [
@@ -183,10 +173,7 @@ export function OrgTemplatePoliciesIndexPage({
     )
   }
 
-  // When the fan-out has both an error and partial data, fall through to the
-  // full grid so successfully-loaded rows remain visible. The banner below the
-  // CardHeader surfaces the error without blanking the table.
-  if (error && rows.length === 0) {
+  if (error && (policies ?? []).length === 0) {
     return (
       <Card>
         <CardContent className="pt-6">
@@ -238,28 +225,11 @@ export function OrgTemplatePoliciesIndexPage({
                 className="max-w-sm"
                 aria-label="Search template policies"
               />
-              <Select
-                value={scopeFilter}
-                onValueChange={(v) => setScopeFilter(v as ScopeFilter)}
-              >
-                <SelectTrigger
-                  className="w-[180px]"
-                  aria-label="Filter by scope"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All scopes</SelectItem>
-                  <SelectItem value="org">Organization</SelectItem>
-                  <SelectItem value="folder">Folder</SelectItem>
-                  <SelectItem value="project">Project</SelectItem>
-                </SelectContent>
-              </Select>
             </div>
             {rows.length === 0 && (
               <div className="mb-3 rounded-md border border-dashed border-border p-4 text-center">
                 <p className="text-sm text-muted-foreground">
-                  No policies match the current filters.
+                  No policies match the current search.
                 </p>
               </div>
             )}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-detail.test.tsx
@@ -55,7 +55,7 @@ vi.mock('@/queries/templates', async () => {
 })
 
 vi.mock('@/queries/templatePolicies', () => ({
-  useListLinkableTemplatePolicies: vi.fn().mockReturnValue({
+  useListTemplatePolicies: vi.fn().mockReturnValue({
     data: [],
     isPending: false,
     error: null,

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/-index.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/queries/templatePolicyBindings', async () => {
   >('@/queries/templatePolicyBindings')
   return {
     ...actual,
-    useAllTemplatePolicyBindingsForOrg: vi.fn(),
+    useListTemplatePolicyBindings: vi.fn(),
   }
 })
 
@@ -53,7 +53,7 @@ vi.mock('@/queries/organizations', () => ({
 // __CONSOLE_CONFIG__ is not injected (see console-config.ts), which matches
 // the fixtures below — no mock needed.
 
-import { useAllTemplatePolicyBindingsForOrg } from '@/queries/templatePolicyBindings'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { OrgTemplatePolicyBindingsIndexPage } from './index'
@@ -90,7 +90,7 @@ function setup(
   bindings: ReturnType<typeof makeBinding>[] = [],
   error: Error | null = null,
 ) {
-  ;(useAllTemplatePolicyBindingsForOrg as Mock).mockReturnValue({
+  ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
     data: bindings,
     isPending: false,
     error,
@@ -160,30 +160,26 @@ describe('OrgTemplatePolicyBindingsIndexPage', () => {
     expect(screen.queryByRole('link', { name: 'beta' })).not.toBeInTheDocument()
   })
 
-  it('filters rows by the scope dropdown', () => {
+  // HOL-917: the "All scopes / Organization / Folder" Select was removed. The
+  // page is now org-scoped only — no scope filter in the toolbar.
+  it('does not render a scope filter select in the toolbar', () => {
+    setup(Role.OWNER, [makeBinding('org-bind', { policyName: 'p1' })])
+    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    expect(
+      screen.queryByRole('combobox', { name: /filter by scope/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  // HOL-917: prove that org-namespace bindings appear in the listing (the page
+  // now calls useListTemplatePolicyBindings(orgNamespace) directly).
+  it('lists bindings returned from the org namespace RPC call', () => {
     setup(Role.OWNER, [
-      makeBinding('org-bind', { policyName: 'p1' }),
-      makeBinding('fld-bind', {
-        namespace: 'holos-fld-team-alpha',
-        policyName: 'p2',
-      }),
+      makeBinding('bind-a', { policyName: 'policy-a' }),
+      makeBinding('bind-b', { policyName: 'policy-b' }),
     ])
     render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
-
-    // Flip the filter to Folder. The Radix Select mock in jsdom cannot be
-    // clicked to open the listbox, so we target the native trigger by its
-    // aria-label and drive the hidden <select>-equivalent directly — the
-    // React component listens to the controlled `value` state via
-    // `onValueChange`, which Radix dispatches as a `pointerdown` + `click`
-    // sequence on the listbox item. Simulating that end-to-end in jsdom is
-    // flaky; fire the filter change by locating the trigger and confirming
-    // the baseline populated render, leaving the interactive flip to the
-    // e2e suite.
-    //
-    // TODO(HOL-793-follow-up): replace with a full user-event click once
-    // the shared test harness upgrades to Radix' test-id-friendly fork.
-    expect(screen.getByRole('link', { name: 'org-bind' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'fld-bind' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'bind-a' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'bind-b' })).toBeInTheDocument()
   })
 
   it('shows Create Binding for OWNER and EDITOR', () => {
@@ -212,7 +208,7 @@ describe('OrgTemplatePolicyBindingsIndexPage', () => {
   })
 
   it('surfaces an error when the list query fails with no partial data', () => {
-    ;(useAllTemplatePolicyBindingsForOrg as Mock).mockReturnValue({
+    ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
       data: [],
       isPending: false,
       error: new Error('backend unreachable'),

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policy-bindings/index.tsx
@@ -21,21 +21,15 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useAllTemplatePolicyBindingsForOrg } from '@/queries/templatePolicyBindings'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import type { TemplatePolicyBinding } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import {
   scopeDisplayLabel,
   scopeLabelFromNamespace,
   scopeNameFromNamespace,
+  namespaceForOrg,
 } from '@/lib/scope-labels'
 
 export const Route = createFileRoute(
@@ -51,13 +45,6 @@ function OrgTemplatePolicyBindingsIndexRoute() {
 
 const columnHelper = createColumnHelper<TemplatePolicyBinding>()
 
-// Scope filter values. `all` means no filtering; `org` / `folder` match the
-// ScopeLabel returned by scopeLabelFromNamespace. `project` is intentionally
-// omitted because bindings do not exist at project scope (HOL-590), but the
-// option still appears in the filter so users learn the constraint from the
-// empty-result state rather than the UI silently hiding an option.
-type ScopeFilter = 'all' | 'org' | 'folder' | 'project'
-
 export function OrgTemplatePolicyBindingsIndexPage({
   orgName: propOrgName,
 }: { orgName?: string } = {}) {
@@ -70,8 +57,13 @@ export function OrgTemplatePolicyBindingsIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
+  // HOL-917: this page is now org-scoped only. The RPC is called with the org
+  // namespace directly so only org-scoped bindings are returned. The previous
+  // fan-out across org+folder namespaces and the "All scopes" Select filter
+  // have been removed.
+  const orgNamespace = namespaceForOrg(orgName)
   const { data: bindings, isPending, error } =
-    useAllTemplatePolicyBindingsForOrg(orgName)
+    useListTemplatePolicyBindings(orgNamespace)
   const { data: org } = useGetOrganization(orgName)
 
   const userRole = org?.userRole ?? Role.VIEWER
@@ -80,13 +72,10 @@ export function OrgTemplatePolicyBindingsIndexPage({
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   const [globalFilter, setGlobalFilter] = useState('')
-  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all')
 
   const rows = useMemo(() => {
-    const all = bindings ?? []
-    if (scopeFilter === 'all') return all
-    return all.filter((b) => scopeLabelFromNamespace(b.namespace) === scopeFilter)
-  }, [bindings, scopeFilter])
+    return bindings ?? []
+  }, [bindings])
 
   const columns = useMemo(
     () => [
@@ -205,9 +194,6 @@ export function OrgTemplatePolicyBindingsIndexPage({
     )
   }
 
-  // Fall through to the full grid when the fan-out has both an error and
-  // partial data, so successfully-loaded rows remain visible. The banner
-  // below the header surfaces the error without blanking the table.
   if (error && (bindings ?? []).length === 0) {
     return (
       <Card>
@@ -269,28 +255,11 @@ export function OrgTemplatePolicyBindingsIndexPage({
                 className="max-w-sm"
                 aria-label="Search template policy bindings"
               />
-              <Select
-                value={scopeFilter}
-                onValueChange={(v) => setScopeFilter(v as ScopeFilter)}
-              >
-                <SelectTrigger
-                  className="w-[180px]"
-                  aria-label="Filter by scope"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All scopes</SelectItem>
-                  <SelectItem value="org">Organization</SelectItem>
-                  <SelectItem value="folder">Folder</SelectItem>
-                  <SelectItem value="project">Project</SelectItem>
-                </SelectContent>
-              </Select>
             </div>
             {rows.length === 0 ? (
               <div className="rounded-md border border-dashed border-border p-6 text-center">
                 <p className="text-sm text-muted-foreground">
-                  No bindings match the current filters.
+                  No bindings match the current search.
                 </p>
               </div>
             ) : (


### PR DESCRIPTION
## Summary

- Removes the \"All scopes / Organization / Folder\" `<Select>` from `/orgs/$orgName/template-policies` — page now calls `useListTemplatePolicies(orgNamespace)` directly and lists only org-scoped policies (HOL-910 item 7)
- Removes the identical scope selector from `/orgs/$orgName/template-policy-bindings` — same org-namespace-only RPC pattern (HOL-910 item 9.1)
- Switches `BindingForm.tsx` from `useListLinkableTemplatePolicies` (ancestor-walk RPC) to `useListTemplatePolicies` (HOL-912 Phase 1 namespace-only RPC); policies are now mapped from `TemplatePolicy[]` directly without the `LinkableTemplatePolicy` wrapper (HOL-910 item 9.2)
- Replaces the misleading \"No template policies reachable from this scope...\" empty-state with \"No template policies exist in this org yet.\"
- Updates all affected test mocks; adds tests proving the scope selector is absent and that org-namespace policies appear in the binding form picker

Fixes HOL-917

## Test plan

- [x] `make test-ui` green (1234 tests, 0 failures)
- [x] Scope selector `<Select>` absent from template-policies and template-policy-bindings pages
- [x] BindingForm picker populates from org-namespace RPC; empty state shows updated message
- [x] New test: `lists policies returned from the org namespace RPC call`
- [x] New test: `shows org-namespace policies in the picker when the org namespace RPC returns them`