### PR TITLE
feat(ui): add /orgs/$orgName/template-bindings listing page

### DIFF
--- a/frontend/src/components/template-policies/PolicyBindingsSection.tsx
+++ b/frontend/src/components/template-policies/PolicyBindingsSection.tsx
@@ -87,7 +87,7 @@ export function PolicyBindingsSection(props: PolicyBindingsSectionProps) {
             <li key={binding.name}>
               {props.scopeType === 'organization' ? (
                 <Link
-                  to="/orgs/$orgName/template-policy-bindings/$bindingName"
+                  to="/orgs/$orgName/template-bindings/$bindingName"
                   params={{
                     orgName: props.orgName,
                     bindingName: binding.name,

--- a/frontend/src/lib/-template-row-link.test.ts
+++ b/frontend/src/lib/-template-row-link.test.ts
@@ -76,7 +76,7 @@ describe('resolveTemplateRowHref', () => {
     it('resolves org-scope TemplatePolicyBinding link', () => {
       expect(
         resolveTemplateRowHref('TemplatePolicyBinding', 'org-acme', 'my-binding'),
-      ).toBe('/orgs/acme/template-policy-bindings/my-binding')
+      ).toBe('/orgs/acme/template-bindings/my-binding')
     })
 
     it('resolves folder-scope TemplatePolicyBinding link', () => {

--- a/frontend/src/lib/template-row-link.ts
+++ b/frontend/src/lib/template-row-link.ts
@@ -68,7 +68,7 @@ export function resolveTemplateRowHref(
 
     case 'TemplatePolicyBinding': {
       if (scope === 'org') {
-        return `/orgs/${scopeName}/template-policy-bindings/${name}`
+        return `/orgs/${scopeName}/template-bindings/${name}`
       }
       if (scope === 'folder') {
         return `/folders/${scopeName}/template-policy-bindings/${name}`

--- a/frontend/src/routes/-template-policy-bindings-routes.test.ts
+++ b/frontend/src/routes/-template-policy-bindings-routes.test.ts
@@ -1,12 +1,17 @@
-// Route tree guard for HOL-597: TemplatePolicyBindings, like TemplatePolicies,
-// must NEVER be mounted under a project-scoped path. Bindings live only at
-// folder or organization scope — the same storage-isolation guarantee as the
-// policies they reference.
+// Route tree guard for HOL-597 / HOL-918: TemplatePolicyBindings, like
+// TemplatePolicies, must NEVER be mounted under a project-scoped path.
+// Bindings live only at folder or organization scope — the same
+// storage-isolation guarantee as the policies they reference.
+//
+// HOL-918: the org-scoped binding route was renamed from
+// /orgs/$orgName/template-policy-bindings to /orgs/$orgName/template-bindings.
+// The folder-scoped route is unchanged.
 //
 // This test reads the generated route tree and asserts:
 //   1. No path matching `/projects/.+/template-policy-bindings` exists.
-//   2. The folder and org template-policy-bindings trees are present (sanity
-//      check so a stray rename doesn't let the guard pass vacuously).
+//   2. The folder-scoped template-policy-bindings tree is present.
+//   3. The org-scoped template-bindings tree (renamed) is present.
+//   4. No org-scoped template-policy-bindings route exists (old path removed).
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -24,7 +29,12 @@ describe('TemplatePolicyBindings route tree', () => {
     expect(source).toMatch(/\/folders\/\$folderName\/template-policy-bindings/)
   })
 
-  it('includes org-scoped template-policy-bindings route', () => {
-    expect(source).toMatch(/\/orgs\/\$orgName\/template-policy-bindings/)
+  it('includes org-scoped template-bindings route (HOL-918 rename)', () => {
+    expect(source).toMatch(/\/orgs\/\$orgName\/template-bindings/)
+  })
+
+  it('does not include org-scoped template-policy-bindings route (removed by HOL-918)', () => {
+    const removed = /\/orgs\/\$orgName\/template-policy-bindings/
+    expect(source).not.toMatch(removed)
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/$bindingName.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/$bindingName.tsx
@@ -29,22 +29,22 @@ import {
 import { bindingProtoToDraft } from '@/components/template-policy-bindings/binding-draft'
 
 export const Route = createFileRoute(
-  '/_authenticated/orgs/$orgName/template-policy-bindings/$bindingName',
+  '/_authenticated/orgs/$orgName/template-bindings/$bindingName',
 )({
-  component: OrgTemplatePolicyBindingDetailRoute,
+  component: OrgTemplateBindingDetailRoute,
 })
 
-function OrgTemplatePolicyBindingDetailRoute() {
+function OrgTemplateBindingDetailRoute() {
   const { orgName, bindingName } = Route.useParams()
   return (
-    <OrgTemplatePolicyBindingDetailPage
+    <OrgTemplateBindingDetailPage
       orgName={orgName}
       bindingName={bindingName}
     />
   )
 }
 
-export function OrgTemplatePolicyBindingDetailPage({
+export function OrgTemplateBindingDetailPage({
   orgName: propOrgName,
   bindingName: propBindingName,
   forcedScopeType,
@@ -129,11 +129,11 @@ export function OrgTemplatePolicyBindingDetailPage({
               </Link>
               {' / '}
               <Link
-                to="/orgs/$orgName/template-policy-bindings"
+                to="/orgs/$orgName/template-bindings"
                 params={{ orgName }}
                 className="hover:underline"
               >
-                Template Policy Bindings
+                Template Bindings
               </Link>
               {' / '}
               <span>{bindingName}</span>
@@ -172,7 +172,7 @@ export function OrgTemplatePolicyBindingDetailPage({
             }}
             onCancel={() => {
               void navigate({
-                to: '/orgs/$orgName/template-policy-bindings',
+                to: '/orgs/$orgName/template-bindings',
                 params: { orgName },
               })
             }}
@@ -183,7 +183,7 @@ export function OrgTemplatePolicyBindingDetailPage({
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Template Policy Binding</DialogTitle>
+            <DialogTitle>Delete Template Binding</DialogTitle>
             <DialogDescription>
               This will permanently delete the binding &quot;{bindingName}
               &quot;. This action cannot be undone.
@@ -201,7 +201,7 @@ export function OrgTemplatePolicyBindingDetailPage({
                   await deleteMutation.mutateAsync({ name: bindingName })
                   setDeleteOpen(false)
                   await navigate({
-                    to: '/orgs/$orgName/template-policy-bindings',
+                    to: '/orgs/$orgName/template-bindings',
                     params: { orgName },
                   })
                   toast.success('Binding deleted')

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/-detail.test.tsx
@@ -97,7 +97,7 @@ import {
 } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { OrgTemplatePolicyBindingDetailPage } from './$bindingName'
+import { OrgTemplateBindingDetailPage } from './$bindingName'
 
 function makeBinding() {
   return {
@@ -106,7 +106,7 @@ function makeBinding() {
     description: 'Attach require-http to ingress',
     creatorEmail: 'jane@example.com',
     policyRef: {
-      namespace: "holos-org-test-org",
+      namespace: 'holos-org-test-org',
       name: 'require-http',
     },
     targetRefs: [
@@ -143,13 +143,13 @@ function setupMocks(
   })
 }
 
-describe('OrgTemplatePolicyBindingDetailPage', () => {
+describe('OrgTemplateBindingDetailPage', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('shows the Delete Binding button for OWNER', () => {
     setupMocks(Role.OWNER)
     render(
-      <OrgTemplatePolicyBindingDetailPage
+      <OrgTemplateBindingDetailPage
         orgName="test-org"
         bindingName="bind-a"
       />,
@@ -162,7 +162,7 @@ describe('OrgTemplatePolicyBindingDetailPage', () => {
   it('hides the Delete Binding button for EDITOR (DELETE is OWNER-only)', () => {
     setupMocks(Role.EDITOR)
     render(
-      <OrgTemplatePolicyBindingDetailPage
+      <OrgTemplateBindingDetailPage
         orgName="test-org"
         bindingName="bind-a"
       />,
@@ -178,7 +178,7 @@ describe('OrgTemplatePolicyBindingDetailPage', () => {
   it('hides the Delete Binding button for VIEWER', () => {
     setupMocks(Role.VIEWER)
     render(
-      <OrgTemplatePolicyBindingDetailPage
+      <OrgTemplateBindingDetailPage
         orgName="test-org"
         bindingName="bind-a"
       />,
@@ -191,7 +191,7 @@ describe('OrgTemplatePolicyBindingDetailPage', () => {
   it('seeds the form with initial values from the proto binding', () => {
     setupMocks(Role.OWNER)
     render(
-      <OrgTemplatePolicyBindingDetailPage
+      <OrgTemplateBindingDetailPage
         orgName="test-org"
         bindingName="bind-a"
       />,

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/-index.test.tsx
@@ -56,7 +56,7 @@ vi.mock('@/queries/organizations', () => ({
 import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { OrgTemplatePolicyBindingsIndexPage } from './index'
+import { OrgTemplateBindingsIndexPage } from './index'
 
 function makeBinding(
   name: string,
@@ -102,48 +102,51 @@ function setup(
   })
 }
 
-describe('OrgTemplatePolicyBindingsIndexPage', () => {
+describe('OrgTemplateBindingsIndexPage', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('renders empty state when no bindings exist', () => {
     setup(Role.OWNER, [])
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
     expect(
-      screen.getByText(/no template policy bindings yet/i),
+      screen.getByText(/no template bindings yet/i),
     ).toBeInTheDocument()
   })
 
-  it('renders the grid with scope-aware name links, scope badges, and target counts', () => {
+  it('renders the grid with org-scoped name links, scope badges, and target counts', () => {
     setup(Role.OWNER, [
       makeBinding('org-bind', {
         targets: 3,
         policyName: 'require-http',
       }),
+    ])
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
+
+    // Name cell renders as a link to the new template-bindings route.
+    const orgLink = screen.getByRole('link', { name: 'org-bind' })
+    expect(orgLink.getAttribute('href')).toBe(
+      '/orgs/test-org/template-bindings/org-bind',
+    )
+
+    // Scope and targets columns.
+    expect(screen.getByText(/^Organization: test-org$/)).toBeInTheDocument()
+    expect(screen.getByText(/3 targets/)).toBeInTheDocument()
+    expect(screen.getByText('require-http')).toBeInTheDocument()
+  })
+
+  it('renders plain text (no link) for non-org-scoped rows', () => {
+    setup(Role.OWNER, [
       makeBinding('fld-bind', {
         namespace: 'holos-fld-team-alpha',
         targets: 1,
         policyName: 'exclude-http',
       }),
     ])
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
 
-    // Name cells render as links scoped by the binding's namespace.
-    const orgLink = screen.getByRole('link', { name: 'org-bind' })
-    expect(orgLink.getAttribute('href')).toBe(
-      '/orgs/test-org/template-policy-bindings/org-bind',
-    )
-    const fldLink = screen.getByRole('link', { name: 'fld-bind' })
-    expect(fldLink.getAttribute('href')).toBe(
-      '/folders/team-alpha/template-policy-bindings/fld-bind',
-    )
-
-    // Scope and targets columns.
-    expect(screen.getByText(/^Organization: test-org$/)).toBeInTheDocument()
-    expect(screen.getByText(/^Folder: team-alpha$/)).toBeInTheDocument()
-    expect(screen.getByText(/3 targets/)).toBeInTheDocument()
-    expect(screen.getByText(/1 target\b/)).toBeInTheDocument()
-    expect(screen.getByText('require-http')).toBeInTheDocument()
-    expect(screen.getByText('exclude-http')).toBeInTheDocument()
+    // Folder-scoped binding should NOT produce a link (this page is org-only).
+    expect(screen.queryByRole('link', { name: 'fld-bind' })).not.toBeInTheDocument()
+    expect(screen.getByText('fld-bind')).toBeInTheDocument()
   })
 
   it('filters rows by the global search input', () => {
@@ -151,33 +154,29 @@ describe('OrgTemplatePolicyBindingsIndexPage', () => {
       makeBinding('alpha', { policyName: 'p1' }),
       makeBinding('beta', { policyName: 'p2' }),
     ])
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
 
-    const input = screen.getByLabelText('Search template policy bindings')
+    const input = screen.getByLabelText('Search template bindings')
     fireEvent.change(input, { target: { value: 'alph' } })
 
     expect(screen.getByRole('link', { name: 'alpha' })).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'beta' })).not.toBeInTheDocument()
   })
 
-  // HOL-917: the "All scopes / Organization / Folder" Select was removed. The
-  // page is now org-scoped only — no scope filter in the toolbar.
   it('does not render a scope filter select in the toolbar', () => {
     setup(Role.OWNER, [makeBinding('org-bind', { policyName: 'p1' })])
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
     expect(
       screen.queryByRole('combobox', { name: /filter by scope/i }),
     ).not.toBeInTheDocument()
   })
 
-  // HOL-917: prove that org-namespace bindings appear in the listing (the page
-  // now calls useListTemplatePolicyBindings(orgNamespace) directly).
   it('lists bindings returned from the org namespace RPC call', () => {
     setup(Role.OWNER, [
       makeBinding('bind-a', { policyName: 'policy-a' }),
       makeBinding('bind-b', { policyName: 'policy-b' }),
     ])
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
     expect(screen.getByRole('link', { name: 'bind-a' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'bind-b' })).toBeInTheDocument()
   })
@@ -185,7 +184,7 @@ describe('OrgTemplatePolicyBindingsIndexPage', () => {
   it('shows Create Binding for OWNER and EDITOR', () => {
     setup(Role.OWNER, [])
     const { unmount } = render(
-      <OrgTemplatePolicyBindingsIndexPage orgName="test-org" />,
+      <OrgTemplateBindingsIndexPage orgName="test-org" />,
     )
     expect(
       screen.getByRole('link', { name: /create binding/i }),
@@ -193,7 +192,7 @@ describe('OrgTemplatePolicyBindingsIndexPage', () => {
     unmount()
 
     setup(Role.EDITOR, [])
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
     expect(
       screen.getByRole('link', { name: /create binding/i }),
     ).toBeInTheDocument()
@@ -201,7 +200,7 @@ describe('OrgTemplatePolicyBindingsIndexPage', () => {
 
   it('hides Create Binding for VIEWER', () => {
     setup(Role.VIEWER, [])
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
     expect(
       screen.queryByRole('link', { name: /create binding/i }),
     ).not.toBeInTheDocument()
@@ -218,19 +217,19 @@ describe('OrgTemplatePolicyBindingsIndexPage', () => {
       isPending: false,
       error: null,
     })
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
     expect(screen.getByText('backend unreachable')).toBeInTheDocument()
   })
 
-  it('shows a partial-error banner when the fan-out errors but some rows loaded', () => {
+  it('shows a partial-error banner when the query errors but some rows loaded', () => {
     setup(
       Role.OWNER,
       [makeBinding('org-bind', { policyName: 'p1' })],
-      new Error('folder fetch failed'),
+      new Error('fetch failed'),
     )
-    render(<OrgTemplatePolicyBindingsIndexPage orgName="test-org" />)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
     const banner = screen.getByTestId('bindings-partial-error')
-    expect(within(banner).getByText('folder fetch failed')).toBeInTheDocument()
+    expect(within(banner).getByText('fetch failed')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'org-bind' })).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/index.tsx
@@ -33,19 +33,19 @@ import {
 } from '@/lib/scope-labels'
 
 export const Route = createFileRoute(
-  '/_authenticated/orgs/$orgName/template-policy-bindings/',
+  '/_authenticated/orgs/$orgName/template-bindings/',
 )({
-  component: OrgTemplatePolicyBindingsIndexRoute,
+  component: OrgTemplateBindingsIndexRoute,
 })
 
-function OrgTemplatePolicyBindingsIndexRoute() {
+function OrgTemplateBindingsIndexRoute() {
   const { orgName } = Route.useParams()
-  return <OrgTemplatePolicyBindingsIndexPage orgName={orgName} />
+  return <OrgTemplateBindingsIndexPage orgName={orgName} />
 }
 
 const columnHelper = createColumnHelper<TemplatePolicyBinding>()
 
-export function OrgTemplatePolicyBindingsIndexPage({
+export function OrgTemplateBindingsIndexPage({
   orgName: propOrgName,
 }: { orgName?: string } = {}) {
   let routeOrgName: string | undefined
@@ -57,10 +57,10 @@ export function OrgTemplatePolicyBindingsIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
-  // HOL-917: this page is now org-scoped only. The RPC is called with the org
-  // namespace directly so only org-scoped bindings are returned. The previous
-  // fan-out across org+folder namespaces and the "All scopes" Select filter
-  // have been removed.
+  // This page is org-scoped only. The RPC is called with the org namespace
+  // directly so only org-scoped bindings are returned. Folder-scoped bindings
+  // are excluded — the folder-scoped index remains at
+  // /folders/$folderName/template-policy-bindings.
   const orgNamespace = namespaceForOrg(orgName)
   const { data: bindings, isPending, error } =
     useListTemplatePolicyBindings(orgNamespace)
@@ -86,28 +86,13 @@ export function OrgTemplatePolicyBindingsIndexPage({
           const b = row.original
           const label = b.displayName || b.name
           const scope = scopeLabelFromNamespace(b.namespace)
-          // Scope-aware link: bindings live at org or folder scope. A
-          // namespace that fails both prefix checks (stale cache, proto
-          // drift) renders as plain text rather than forging a link that
-          // would 404.
-          if (scope === 'folder') {
-            const folderName = scopeNameFromNamespace(b.namespace)
-            if (folderName) {
-              return (
-                <Link
-                  to="/folders/$folderName/template-policy-bindings/$bindingName"
-                  params={{ folderName, bindingName: b.name }}
-                  title={b.name}
-                  className="hover:underline font-medium"
-                >
-                  {label}
-                </Link>
-              )
-            }
-          } else if (scope === 'org') {
+          // This page shows org-scoped bindings only (namespaceForOrg). Any
+          // row from a folder namespace would indicate stale cache / proto
+          // drift — render as plain text to avoid a broken link.
+          if (scope === 'org') {
             return (
               <Link
-                to="/orgs/$orgName/template-policy-bindings/$bindingName"
+                to="/orgs/$orgName/template-bindings/$bindingName"
                 params={{ orgName, bindingName: b.name }}
                 title={b.name}
                 className="hover:underline font-medium"
@@ -181,7 +166,7 @@ export function OrgTemplatePolicyBindingsIndexPage({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Template Policy Bindings</CardTitle>
+          <CardTitle>Template Bindings</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-2" data-testid="bindings-loading">
@@ -211,13 +196,13 @@ export function OrgTemplatePolicyBindingsIndexPage({
       <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
         <div>
           <p className="text-sm text-muted-foreground">
-            {orgName} / Template Policy Bindings
+            {orgName} / Template Bindings
           </p>
-          <CardTitle className="mt-1">Template Policy Bindings</CardTitle>
+          <CardTitle className="mt-1">Template Bindings</CardTitle>
         </div>
         {canWrite && (
           <Link
-            to="/orgs/$orgName/template-policy-bindings/new"
+            to="/orgs/$orgName/template-bindings/new"
             params={{ orgName }}
           >
             <Button size="sm">Create Binding</Button>
@@ -237,7 +222,7 @@ export function OrgTemplatePolicyBindingsIndexPage({
         {(bindings ?? []).length === 0 ? (
           <div className="rounded-md border border-dashed border-border p-6 text-center">
             <p className="text-sm font-medium">
-              No template policy bindings yet.
+              No template bindings yet.
             </p>
             <p className="mt-1 text-sm text-muted-foreground">
               Bindings attach a single TemplatePolicy to project templates and
@@ -253,7 +238,7 @@ export function OrgTemplatePolicyBindingsIndexPage({
                 value={globalFilter}
                 onChange={(e) => setGlobalFilter(e.target.value)}
                 className="max-w-sm"
-                aria-label="Search template policy bindings"
+                aria-label="Search template bindings"
               />
             </div>
             {rows.length === 0 ? (

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/new.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-bindings/new.tsx
@@ -10,17 +10,17 @@ import {
 } from '@/components/template-policy-bindings/BindingForm'
 
 export const Route = createFileRoute(
-  '/_authenticated/orgs/$orgName/template-policy-bindings/new',
+  '/_authenticated/orgs/$orgName/template-bindings/new',
 )({
-  component: CreateOrgTemplatePolicyBindingRoute,
+  component: CreateOrgTemplateBindingRoute,
 })
 
-function CreateOrgTemplatePolicyBindingRoute() {
+function CreateOrgTemplateBindingRoute() {
   const { orgName } = Route.useParams()
-  return <CreateOrgTemplatePolicyBindingPage orgName={orgName} />
+  return <CreateOrgTemplateBindingPage orgName={orgName} />
 }
 
-export function CreateOrgTemplatePolicyBindingPage({
+export function CreateOrgTemplateBindingPage({
   orgName: propOrgName,
   forcedScopeType,
 }: {
@@ -60,16 +60,16 @@ export function CreateOrgTemplatePolicyBindingPage({
             </Link>
             {' / '}
             <Link
-              to="/orgs/$orgName/template-policy-bindings"
+              to="/orgs/$orgName/template-bindings"
               params={{ orgName }}
               className="hover:underline"
             >
-              Template Policy Bindings
+              Template Bindings
             </Link>
             {' / New'}
           </p>
           <CardTitle className="mt-1">
-            Create Template Policy Binding
+            Create Template Binding
           </CardTitle>
         </div>
       </CardHeader>
@@ -86,13 +86,13 @@ export function CreateOrgTemplatePolicyBindingPage({
           onSubmit={async (values) => {
             await createMutation.mutateAsync(values)
             await navigate({
-              to: '/orgs/$orgName/template-policy-bindings/$bindingName',
+              to: '/orgs/$orgName/template-bindings/$bindingName',
               params: { orgName, bindingName: values.name },
             })
           }}
           onCancel={() => {
             void navigate({
-              to: '/orgs/$orgName/template-policy-bindings',
+              to: '/orgs/$orgName/template-bindings',
               params: { orgName },
             })
           }}

--- a/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/orgs/$orgName/template-policies/-detail.test.tsx
@@ -230,7 +230,7 @@ describe('OrgTemplatePolicyDetailPage', () => {
       // href, so we can assert the route shape without running the router.
       expect(link).toHaveAttribute(
         'href',
-        '/orgs/$orgName/template-policy-bindings/$bindingName',
+        '/orgs/$orgName/template-bindings/$bindingName',
       )
       const params = JSON.parse(link.getAttribute('data-params') ?? '{}')
       expect(params).toEqual({

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -236,7 +236,7 @@ export function ProjectTemplatesIndexPage({
       {
         id: 'TemplatePolicyBinding',
         label: 'Template Policy Binding',
-        newHref: orgName ? `/orgs/${orgName}/template-policy-bindings/new` : undefined,
+        newHref: orgName ? `/orgs/${orgName}/template-bindings/new` : undefined,
         canCreate: canCreateOrgResources,
       },
     ],


### PR DESCRIPTION
## Summary

- Renames the org-scoped `/orgs/$orgName/template-policy-bindings` routes to `/orgs/$orgName/template-bindings` (interpretation 1: URL alias rename)
- New route files: `template-bindings/{index,new,$bindingName}.tsx` — index lists only org-scoped bindings with no scope selector
- Tests renamed and updated accordingly (`-index.test.tsx`, `-detail.test.tsx`)
- Old `orgs/$orgName/template-policy-bindings/` directory deleted
- Internal links updated: `PolicyBindingsSection.tsx`, `template-row-link.ts`, projects `templates/index.tsx`, org template-policies detail test
- Route guard test updated to assert new org-scoped route shape and absence of old path
- Folder-scoped route `folders/$folderName/template-policy-bindings` is unchanged
- `make test-ui` green: 92 test files / 1236 tests pass

Fixes HOL-918

## Test plan

- [x] `make test-ui` passes (92 files, 1236 tests)
- [x] Route tree guard confirms `/orgs/$orgName/template-bindings` present, old `/orgs/$orgName/template-policy-bindings` absent
- [x] No scope filter selector rendered (org-scoped only)
- [x] Create Binding link points to `/orgs/$orgName/template-bindings/new`
- [x] Detail page breadcrumb points back to `/orgs/$orgName/template-bindings`
- [x] Folder-scoped route unchanged