### PR TITLE
chore(cleanup): remove stale lineage, scope, and resource-manager references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to holos-console are documented here.
 
 ## [Unreleased]
 
+### Chore — Remove stale lineage, scope, and Resource Manager references (HOL-910 / HOL-919)
+
+The HOL-910 series (HOL-912 through HOL-919) removed the legacy Resource
+Manager tree view, All-Scopes selector, lineage filter, and related
+infrastructure. This final cleanup pass (HOL-919) removed the remaining
+doc/comment references:
+
+- **`docs/ui/resource-grid-v1.md`**: Removed the stale lineage-filter entry
+  from the "What ResourceGrid v1 does" list; removed `lineage` and `recursive`
+  fields from the `ResourceGridSearch` interface example; removed the stale
+  "Resource Manager tree" comparison table row; removed the reference to the
+  deleted `resource-manager/` component directory.
+- **`docs/ui/resource-routing.md`**: Updated the worked example to use
+  `/projects` as the default `returnTo` fallback instead of the deleted
+  `/resource-manager` route.
+- **`docs/testing.md`**: Removed two catalog entries for test files that were
+  deleted with the Resource Manager component
+  (`resource-manager/-resource-tree.test.tsx` and
+  `resource-manager/-index.test.tsx`); updated the ResourceGrid v1 test-catalog
+  entry to remove the mention of the removed lineage filter controls.
+- **`frontend/src/routes/.../templates/index.tsx`** and its test: Updated
+  stale JSDoc comment that still referenced `lineage=descendants` and the
+  removed lineage select control.
+
+### Fixed — Remove All Scopes selector and fix BindingForm policy picker (HOL-917)
+
+- **`BindingForm`**: Removed the unused All-Scopes combobox entry; the policy
+  picker now lists policies from the current scope only, matching the
+  "no policies reachable from this scope" → "no policies exist in this org
+  yet" copy change (HOL-917).
+
+### Added — Template Bindings listing page (`/orgs/$orgName/template-bindings`) (HOL-918)
+
+- New route at `/orgs/$orgName/template-bindings` listing all
+  `TemplatePolicyBinding` objects in the org. Powered by `ResourceGrid v1`
+  with sortable Created At column (HOL-918).
+
 ### Fixed — holos-secret-injector HOL-752 review follow-ups (HOL-839)
 
 - **`holos-secret-injector` CLI now exposes `--mesh-trust-domain`**

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -181,12 +181,10 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/routes/_authenticated/organization/-new.test.tsx` | Create organization page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error |
 | `src/routes/_authenticated/folder/-new.test.tsx` | Create folder page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error, orgName guard |
 | `src/routes/_authenticated/project/-new.test.tsx` | Create project page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error, orgName/folderName guards |
-| `src/components/resource-grid/-resource-grid.test.tsx` | ResourceGrid v1: column headers, kind filter, lineage filter, global search, empty/loading/error states, delete-confirm dialog |
+| `src/components/resource-grid/-resource-grid.test.tsx` | ResourceGrid v1: column headers, kind filter, global search, empty/loading/error states, delete-confirm dialog |
 | `src/components/ui/-confirm-delete-dialog.test.tsx` | ConfirmDeleteDialog: open/close, confirm, error, isDeleting state |
 | `src/components/-app-sidebar.tree.test.tsx` | Sidebar integration (real primitives): enabled entries render Link, disabled entries render tooltip-wrapped button |
 | `src/components/templates/-templates-help-pane.test.tsx` | TemplatesHelpPane: renders help content sections |
-| `src/components/resource-manager/-resource-tree.test.tsx` | ResourceTree: expand/collapse, leaf nodes, empty state |
-| `src/routes/_authenticated/resource-manager/-index.test.tsx` | Resource Manager page: renders ResourceTree, loading/error states |
 | `src/routes/_authenticated/projects/$projectName/templates/-index-help.test.tsx` | Templates index with help pane: ? icon toggle, pane visibility |
 | `src/lib/-template-row-link.test.ts` | templateRowLink helper: namespace/name → detail href mapping |
 | `src/components/template-policy-bindings/BindingForm.test.tsx` | BindingForm: ProjectTemplate / Deployment / ProjectNamespace kind selection, project-name field shown/hidden, wildcard validation, submit / save paths (HOL-814) |

--- a/docs/ui/resource-grid-v1.md
+++ b/docs/ui/resource-grid-v1.md
@@ -19,10 +19,6 @@ frontend/src/components/resource-grid/
 - A **global search** box (`?search=`) using `includesString` filtering.
 - A **multi-kind filter** (`?kind=a,b`) rendered as checkboxes when more than
   one `Kind` is passed. Checking all or none = show everything.
-- A **lineage filter** (`?lineage=ancestors|descendants|both` + `?recursive=1`)
-  — the grid reads these from URL state and exposes them via `search` props so
-  the parent route's data-fetching layer can act on them. The grid itself passes
-  rows through unchanged (data-source-agnostic).
 - A **"New" button** — a single Link when one creatable kind exists, a dropdown
   when multiple exist.
 - **Row-level delete** via `ConfirmDeleteDialog`; callers supply an `onDelete`
@@ -60,11 +56,6 @@ timestamp sourced from `metadata.creationTimestamp` in the API response.
   (UI hardening) to eliminate "Invalid Date" regressions. The only valid
   non-empty value is a parseable RFC 3339 date string.
 
-The Resource Manager tree (`frontend/src/components/resource-manager/`) uses
-`createdAt: undefined` in its synthetic tree-node rows because those rows do
-not correspond 1-to-1 with a single Kubernetes object. This is intentional and
-out of scope for the ResourceGrid v1 contract.
-
 ## The `Row` interface
 
 ```ts
@@ -99,10 +90,8 @@ All search params flow through `ResourceGridSearch`:
 
 ```ts
 interface ResourceGridSearch {
-  kind?: string          // comma-separated Kind.id list; absent = show all
-  search?: string        // global filter string
-  lineage?: 'ancestors' | 'descendants' | 'both'
-  recursive?: '0' | '1' // '0' / absent = non-recursive (default)
+  kind?: string   // comma-separated Kind.id list; absent = show all
+  search?: string // global filter string
 }
 ```
 
@@ -184,14 +173,12 @@ toolbar. Used by the Deployments page for its description banner.
 A `React.ReactNode` rendered in the Card header to the left of the "New"
 button. Used by the Templates page for the help-pane toggle (? icon button).
 
-## When to use ResourceGrid v1 vs. the Resource Manager tree
+## When to use ResourceGrid v1
 
 | Situation | Use |
 |---|---|
 | Flat list of resources under one project (Secrets, Deployments, Templates) | ResourceGrid v1 |
-| Cross-scope hierarchical view of all resources (org → folder → project) | Resource Manager tree |
 | A new resource kind that belongs to a single project | ResourceGrid v1 — add a `Kind` entry and map data to `Row` |
-| A new resource kind that spans the org hierarchy | Resource Manager tree — add a node type to `TreeNode` |
 
 ## Adding a new kind to an existing grid
 
@@ -221,7 +208,6 @@ No changes to `ResourceGrid` itself are required.
 
 - Column headers rendered
 - Kind-filter checkboxes (multi-kind scenario)
-- Lineage filter controls
 - Global search filtering
 - Empty state when `rows=[]`
 - Loading skeleton (`data-testid="resource-grid-loading"`)

--- a/docs/ui/resource-routing.md
+++ b/docs/ui/resource-routing.md
@@ -67,7 +67,7 @@ URL-encoding when it serialises the `search` object.
 import { resolveReturnTo } from '@/lib/return-to'
 
 // In the onSuccess / navigate call after the resource is created:
-const target = resolveReturnTo(search.returnTo, '/resource-manager')
+const target = resolveReturnTo(search.returnTo, '/projects')
 navigate({ to: target })
 ```
 
@@ -86,15 +86,14 @@ Only same-origin, in-app paths are accepted. A valid `returnTo` value:
 
 See `frontend/src/lib/return-to.ts` for the full implementation and JSDoc.
 
-## Worked Example — Resource Manager's New Dropdown
+## Worked Example — Projects Page New Dropdown
 
-The Resource Manager page (`/resource-manager`) shows a single **New ▾**
-dropdown that navigates to all three creation routes. Each `Link` encodes the
-current URL (including the `?expanded=…` tree state) as `returnTo` so the user
-lands back on the same Resource Manager view after creating a resource.
+A page with a **New ▾** dropdown navigates to creation routes while encoding
+the current URL (including any search params) as `returnTo` so the user lands
+back on the same page after creating a resource.
 
 ```tsx
-// frontend/src/routes/_authenticated/resource-manager/index.tsx
+// Example: a page that lets the user create a new folder or project
 
 function NewDropdown({ orgName }: { orgName: string }) {
   const router = useRouter()
@@ -111,13 +110,6 @@ function NewDropdown({ orgName }: { orgName: string }) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {/* Singular prefix → /organization/new */}
-        <DropdownMenuItem asChild>
-          <Link to="/organization/new" search={{ returnTo }}>
-            Organization
-          </Link>
-        </DropdownMenuItem>
-
         {/* Singular prefix → /folder/new */}
         <DropdownMenuItem asChild>
           <Link to="/folder/new" search={orgName ? { orgName, returnTo } : { returnTo }}>
@@ -140,12 +132,11 @@ function NewDropdown({ orgName }: { orgName: string }) {
 After the resource is created, each creation page calls:
 
 ```ts
-const target = resolveReturnTo(search.returnTo, '/resource-manager')
+const target = resolveReturnTo(search.returnTo, '/projects')
 navigate({ to: target })
 ```
 
-…which returns the user to `/resource-manager?expanded=…` with the tree state
-intact.
+…which returns the user to the originating page with search state intact.
 
 ## File Map
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-index.test.tsx
@@ -218,7 +218,7 @@ describe('ProjectTemplatesIndexPage (ResourceGrid v1)', () => {
   // -------------------------------------------------------------------------
 
   it('renders default view showing only Template rows from the current project', () => {
-    // Default URL: kind=Template, lineage=descendants → only Template rows visible.
+    // Default URL state: kind=Template → only Template rows visible.
     setupMocks({
       templates: [makeTemplate('web-template', 'project-test-project')],
       policies: [makePolicy('strict-policy', 'org-acme')],

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -7,9 +7,8 @@
  *
  * The grid fans out across the whole org tree via the three useAll*ForOrg
  * hooks so ancestor-scope templates/policies/bindings are discoverable.
- * Default URL state: kind=Template, lineage=descendants — effectively the
- * current project's own templates only, but the user can widen by toggling
- * the kind filter or lineage select.
+ * Default URL state: kind=Template — only Template rows visible. The user
+ * can widen to other kinds by toggling the kind filter checkboxes.
  *
  * orgName is derived from the OrgContext (useOrg()), not the URL, because
  * this route is project-scoped.


### PR DESCRIPTION
## Summary
- Removed stale `lineage`/`lineage=descendants` references from `docs/ui/resource-grid-v1.md`, the ResourceGridSearch interface example, and TSDoc comments in the Templates route
- Updated `docs/ui/resource-routing.md` worked example: replaced the deleted `/resource-manager` route with a generic Projects-page example
- Removed two stale test-catalog rows in `docs/testing.md` for deleted resource-manager test files
- Updated the ResourceGrid v1 test-catalog entry to drop the mention of the removed lineage filter controls
- Added a CHANGELOG entry summarising the nine HOL-910 cleanup phases

Fixes HOL-919

## Test plan
- [x] `make test-ui` — 92 test files / 1236 tests pass
- [x] `make test-go` — all packages pass
- [x] `grep -r "lineage" docs/` returns only unrelated hits (ADR narrative prose)
- [x] `grep -r "resource-manager\|ResourceManager" docs/` returns no hits