### PR TITLE
feat(ui): add Project Settings above Organization Settings in workspace menu

### DIFF
--- a/frontend/src/components/workspace-menu.test.tsx
+++ b/frontend/src/components/workspace-menu.test.tsx
@@ -186,15 +186,35 @@ describe('WorkspaceMenu — items', () => {
     expect(link.getAttribute('href')).toBe('/profile')
   })
 
-  it('renders Settings disabled (not a link) when no org is selected', () => {
+  it('renders Project Settings disabled (not a link) when no project is selected', () => {
     render(<WorkspaceMenu />)
-    const settings = screen.getByTestId('workspace-menu-item-settings')
+    const settings = screen.getByTestId('workspace-menu-item-project-settings')
     expect(settings.tagName).toBe('DIV')
     expect(settings.getAttribute('aria-disabled')).toBe('true')
-    expect(settings.textContent).toContain('Settings')
+    expect(settings.textContent).toContain('Project Settings')
   })
 
-  it('renders Settings → /orgs/$orgName/settings when an org is selected', () => {
+  it('renders Project Settings → /projects/$projectName/settings when a project is selected', () => {
+    ;(useProject as Mock).mockReturnValue({
+      projects: [{ name: 'my-project', displayName: 'My Project' }],
+      selectedProject: 'my-project',
+      setSelectedProject: vi.fn(),
+      isLoading: false,
+    })
+    render(<WorkspaceMenu />)
+    const link = screen.getByTestId('workspace-menu-item-project-settings')
+    expect(link.getAttribute('href')).toBe('/projects/my-project/settings')
+  })
+
+  it('renders Organization Settings disabled (not a link) when no org is selected', () => {
+    render(<WorkspaceMenu />)
+    const settings = screen.getByTestId('workspace-menu-item-org-settings')
+    expect(settings.tagName).toBe('DIV')
+    expect(settings.getAttribute('aria-disabled')).toBe('true')
+    expect(settings.textContent).toContain('Organization Settings')
+  })
+
+  it('renders Organization Settings → /orgs/$orgName/settings when an org is selected', () => {
     ;(useOrg as Mock).mockReturnValue({
       organizations: [{ name: 'my-org', displayName: 'My Org' }],
       selectedOrg: 'my-org',
@@ -202,7 +222,7 @@ describe('WorkspaceMenu — items', () => {
       isLoading: false,
     })
     render(<WorkspaceMenu />)
-    const link = screen.getByTestId('workspace-menu-item-settings')
+    const link = screen.getByTestId('workspace-menu-item-org-settings')
     expect(link.getAttribute('href')).toBe('/orgs/my-org/settings')
   })
 
@@ -238,11 +258,17 @@ describe('WorkspaceMenu — items', () => {
     expect(switchProjects.textContent).toContain('Switch Projects')
   })
 
-  it('renders items in the canonical order: About, Settings, Switch Projects, Switch organization, Profile, Dev Tools', () => {
+  it('renders items in the canonical order: About, Project Settings, Organization Settings, Switch Projects, Switch Organization, Profile, Dev Tools', () => {
     ;(useOrg as Mock).mockReturnValue({
       organizations: [{ name: 'my-org', displayName: 'My Org' }],
       selectedOrg: 'my-org',
       setSelectedOrg: vi.fn(),
+      isLoading: false,
+    })
+    ;(useProject as Mock).mockReturnValue({
+      projects: [{ name: 'my-project', displayName: 'My Project' }],
+      selectedProject: 'my-project',
+      setSelectedProject: vi.fn(),
       isLoading: false,
     })
     ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
@@ -255,7 +281,8 @@ describe('WorkspaceMenu — items', () => {
 
     expect(labels).toEqual([
       'workspace-menu-item-about',
-      'workspace-menu-item-settings',
+      'workspace-menu-item-project-settings',
+      'workspace-menu-item-org-settings',
       'workspace-menu-item-switch-projects',
       'workspace-menu-item-switch-organization',
       'workspace-menu-item-profile',
@@ -263,7 +290,7 @@ describe('WorkspaceMenu — items', () => {
     ])
   })
 
-  it('keeps the canonical order when no org is selected (Settings and Switch Projects are disabled but present)', () => {
+  it('keeps the canonical order when no org/project selected (Project Settings and Org Settings are disabled but present)', () => {
     ;(getConsoleConfig as Mock).mockReturnValue({ devToolsEnabled: true })
     render(<WorkspaceMenu />)
 
@@ -274,7 +301,8 @@ describe('WorkspaceMenu — items', () => {
 
     expect(labels).toEqual([
       'workspace-menu-item-about',
-      'workspace-menu-item-settings',
+      'workspace-menu-item-project-settings',
+      'workspace-menu-item-org-settings',
       'workspace-menu-item-switch-projects',
       'workspace-menu-item-switch-organization',
       'workspace-menu-item-profile',

--- a/frontend/src/components/workspace-menu.test.tsx
+++ b/frontend/src/components/workspace-menu.test.tsx
@@ -174,7 +174,7 @@ describe('WorkspaceMenu — items', () => {
     expect(link.getAttribute('href')).toBe('/about')
   })
 
-  it('renders Switch organization → /organizations', () => {
+  it('renders Switch Organization → /organizations', () => {
     render(<WorkspaceMenu />)
     const link = screen.getByTestId('workspace-menu-item-switch-organization')
     expect(link.getAttribute('href')).toBe('/organizations')
@@ -256,6 +256,21 @@ describe('WorkspaceMenu — items', () => {
     expect(switchProjects.tagName).toBe('DIV')
     expect(switchProjects.getAttribute('aria-disabled')).toBe('true')
     expect(switchProjects.textContent).toContain('Switch Projects')
+  })
+
+  it('renders Project Settings as a link but Organization Settings disabled when project is selected without an org (stale localStorage state)', () => {
+    ;(useProject as Mock).mockReturnValue({
+      projects: [{ name: 'my-project', displayName: 'My Project' }],
+      selectedProject: 'my-project',
+      setSelectedProject: vi.fn(),
+      isLoading: false,
+    })
+    render(<WorkspaceMenu />)
+    const projectSettings = screen.getByTestId('workspace-menu-item-project-settings')
+    expect(projectSettings.getAttribute('href')).toBe('/projects/my-project/settings')
+    const orgSettings = screen.getByTestId('workspace-menu-item-org-settings')
+    expect(orgSettings.tagName).toBe('DIV')
+    expect(orgSettings.getAttribute('aria-disabled')).toBe('true')
   })
 
   it('renders items in the canonical order: About, Project Settings, Organization Settings, Switch Projects, Switch Organization, Profile, Dev Tools', () => {

--- a/frontend/src/components/workspace-menu.tsx
+++ b/frontend/src/components/workspace-menu.tsx
@@ -16,14 +16,16 @@ import { getConsoleConfig } from '@/lib/console-config'
  * of the sidebar. It replaces the previous stacked OrgPicker + ProjectPicker
  * dropdowns. Menu items appear in the canonical order:
  *
- *   About, Settings, Switch Projects, Switch organization, separator, Profile, Dev Tools
+ *   About, Project Settings, Organization Settings, Switch Projects,
+ *   Switch Organization, separator, Profile, Dev Tools
  *
  * Dev Tools is only visible when the server gates it on via `--enable-dev-tools`
  * (mirrored to the frontend via `getConsoleConfig().devToolsEnabled`). The
- * `Settings` item routes to org settings when an org is selected; when no org
- * is selected it is rendered disabled (there is no global settings route) so
- * the canonical item order stays visible in every state. `Switch Projects`
- * links to the org-scoped projects list and is disabled when no org is selected.
+ * `Project Settings` item routes to project settings when a project is selected;
+ * `Organization Settings` routes to org settings when an org is selected. Both
+ * are rendered disabled when the respective scope is not selected so the
+ * canonical item order stays visible in every state. `Switch Projects` links to
+ * the org-scoped projects list and is disabled when no org is selected.
  */
 export function WorkspaceMenu() {
   const { selectedOrg, organizations } = useOrg()
@@ -75,21 +77,38 @@ export function WorkspaceMenu() {
               <span>About</span>
             </Link>
           </DropdownMenuItem>
+          {selectedProject ? (
+            <DropdownMenuItem asChild>
+              <Link
+                to="/projects/$projectName/settings"
+                params={{ projectName: selectedProject }}
+                data-testid="workspace-menu-item-project-settings"
+              >
+                <Settings className="h-4 w-4" />
+                <span>Project Settings</span>
+              </Link>
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem disabled data-testid="workspace-menu-item-project-settings">
+              <Settings className="h-4 w-4" />
+              <span>Project Settings</span>
+            </DropdownMenuItem>
+          )}
           {selectedOrg ? (
             <DropdownMenuItem asChild>
               <Link
                 to="/orgs/$orgName/settings"
                 params={{ orgName: selectedOrg }}
-                data-testid="workspace-menu-item-settings"
+                data-testid="workspace-menu-item-org-settings"
               >
                 <Settings className="h-4 w-4" />
-                <span>Settings</span>
+                <span>Organization Settings</span>
               </Link>
             </DropdownMenuItem>
           ) : (
-            <DropdownMenuItem disabled data-testid="workspace-menu-item-settings">
+            <DropdownMenuItem disabled data-testid="workspace-menu-item-org-settings">
               <Settings className="h-4 w-4" />
-              <span>Settings</span>
+              <span>Organization Settings</span>
             </DropdownMenuItem>
           )}
           {selectedOrg ? (
@@ -114,7 +133,7 @@ export function WorkspaceMenu() {
           <DropdownMenuItem asChild>
             <Link to="/organizations" data-testid="workspace-menu-item-switch-organization">
               <ArrowRightLeft className="h-4 w-4" />
-              <span>Switch organization</span>
+              <span>Switch Organization</span>
             </Link>
           </DropdownMenuItem>
           <DropdownMenuSeparator />


### PR DESCRIPTION
## Summary
- Add **Project Settings** entry above **Organization Settings** in the top-left workspace dropdown menu, linking to `/projects/$projectName/settings` when a project is selected (disabled otherwise)
- Rename **Settings** → **Organization Settings** with updated `data-testid` (`workspace-menu-item-org-settings`)
- Fix **Switch organization** → **Switch Organization** (capitalization)
- Update all affected tests to cover new items and canonical menu order

Fixes HOL-925

## Test plan
- [ ] Open workspace menu with a project selected — "Project Settings" appears and links to the project's settings page
- [ ] Open workspace menu with no project selected — "Project Settings" is disabled (greyed out)
- [ ] Open workspace menu with an org selected — "Organization Settings" appears and links to the org's settings page
- [ ] Open workspace menu with no org selected — "Organization Settings" is disabled
- [ ] Confirm "Switch Organization" appears with correct capitalization
- [ ] All unit tests pass: `make test-ui`