### PR TITLE
fix(ui): replace raw anchor with TanStack Router Link in ResourceGrid

### DIFF
--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     }: {
       children: React.ReactNode
       to?: string
-    }) => <a href={to ?? '#'}>{children}</a>,
+    }) => <a href={to ?? '#'} data-testid="router-link">{children}</a>,
     useNavigate: () => vi.fn(),
   }
 })
@@ -169,6 +169,9 @@ describe('ResourceGrid', () => {
     renderGrid()
     const link = screen.getByRole('link', { name: /my secret/i })
     expect(link).toHaveAttribute('href', '/secrets/my-secret')
+    // Assert the link comes from the TanStack Router Link component (via mock
+    // data-testid) so a future regression to a raw <a href> is caught here.
+    expect(link).toHaveAttribute('data-testid', 'router-link')
   })
 
   // --- Parent ID column hiding ---

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -241,13 +241,13 @@ export function ResourceGrid({
             const label = row.original.displayName || row.original.name
             if (row.original.detailHref) {
               return (
-                <a
-                  href={row.original.detailHref}
+                <Link
+                  to={row.original.detailHref}
                   className="font-medium hover:underline"
                   title={row.original.name}
                 >
                   {label}
-                </a>
+                </Link>
               )
             }
             return (

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
@@ -30,11 +30,13 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     }),
     Link: ({
       children,
+      to,
       className,
     }: {
       children: React.ReactNode
+      to?: string
       className?: string
-    }) => <a href="#" className={className}>{children}</a>,
+    }) => <a href={to ?? '#'} className={className}>{children}</a>,
     useNavigate: () => vi.fn(),
   }
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx
@@ -26,11 +26,13 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     }),
     Link: ({
       children,
+      to,
       className,
     }: {
       children: React.ReactNode
+      to?: string
       className?: string
-    }) => <a href="#" className={className}>{children}</a>,
+    }) => <a href={to ?? '#'} className={className}>{children}</a>,
     useNavigate: () => vi.fn(),
   }
 })


### PR DESCRIPTION
## Summary

- Replace the raw `<a href={row.original.detailHref}>` in `ResourceGrid`'s display-name cell with `<Link to={row.original.detailHref}>` from TanStack Router, making secret/deployment/template row clicks client-side SPA transitions instead of full-document GETs that re-enter the OIDC login redirect
- Strengthen the `Link` mock in the resource-grid unit test with `data-testid="router-link"` and assert its presence in the "links display name to detailHref" test, catching any future regression back to a raw anchor
- Fix the `Link` mock stubs in the deployments and secrets index tests to forward the `to` prop as `href`, keeping those tests accurate with the new Link-based rendering

Fixes HOL-922

## Test plan

- [x] `make test-ui` passes (92 files, 1236 tests)
- [x] `ResourceGrid` test "links display name to detailHref" asserts both `href` and `data-testid="router-link"`
- [x] Deployments index test "deployment name links to detail page" correctly resolves `href` through forwarded `to` prop
- [x] No eslint `no-unused-vars` regression — the existing `Link` import on line 16 remains in use