### PR TITLE
chore(ui): audit raw-anchor regressions and document SPA nav contract

### DIFF
--- a/docs/ui/resource-grid-v1.md
+++ b/docs/ui/resource-grid-v1.md
@@ -202,6 +202,40 @@ Example: adding a hypothetical `TemplateRelease` kind to the Templates grid.
 
 No changes to `ResourceGrid` itself are required.
 
+## SPA navigation contract
+
+The Display Name cell **must** use TanStack Router `Link` for all intra-app
+navigation. Raw `<a href>` anchors are forbidden for in-app routes because they
+trigger a full-page reload, which re-authenticates the user and discards client
+state (the root cause of HOL-920 / HOL-921).
+
+**Invariant**: when `row.detailHref` is set, `ResourceGrid` renders a `<Link
+to={row.detailHref}>` (from `@tanstack/react-router`), never a bare `<a href>`.
+
+**Audit procedure**: run the following from the repo root after any change to
+`ResourceGrid.tsx` or its callers:
+
+```bash
+grep -rn '<a href=' frontend/src --include='*.tsx' | grep -v '\.test\.tsx'
+```
+
+The only permitted results are inside `frontend/src/test/` (test infrastructure
+mocks). Any hit in a production file is a regression and must be converted to
+`<Link>`.
+
+**Test coverage**: the `links display name to detailHref` case in
+`-resource-grid.test.tsx` asserts both `href` and `data-testid="router-link"`
+on the rendered element. The `data-testid` guard ensures a future regression to
+a bare anchor is caught by the test mock (which sets `data-testid="router-link"`
+on the `<Link>` stub). This test was hardened as part of HOL-921.
+
+**Rationale**: HOL-920 tracked the original regression where the Secrets list
+used a raw `<a href>` for row-click navigation. HOL-921 decomposed the fix into
+three phases: HOL-922 (replace the raw anchor with `<Link>`), HOL-923 (E2E
+regression guard), and HOL-924 (this audit + doc update). The contract is
+captured here so future agents adding new `detailHref` sources are aware of the
+requirement without having to trace the issue history.
+
 ## Unit-test reference
 
 `frontend/src/components/resource-grid/-resource-grid.test.tsx` — covers:


### PR DESCRIPTION
## Summary

- Audited `frontend/src/` for raw `<a href>` anchors used for intra-app navigation; found zero regressions — all occurrences are in test mock helpers (`*.test.tsx` and `frontend/src/test/link-mock.tsx`), which is intentional
- `ResourceGrid.tsx` has no stale comments referencing old anchor paths; the `Link` import and usage are already correct
- Added a **SPA navigation contract** subsection to `docs/ui/resource-grid-v1.md` that explicitly states the invariant, provides the grep audit command, explains the `data-testid="router-link"` test guard, and cites HOL-920 / HOL-921 as rationale

Fixes HOL-924

## Test plan

- [x] `make test-ui` — 92 test files, 1239 tests, all pass
- [x] Grep audit: `grep -rn '<a href=' frontend/src --include='*.tsx' | grep -v '\.test\.tsx'` — only `frontend/src/test/link-mock.tsx` (test infrastructure, intentional)
- [x] `docs/ui/resource-grid-v1.md` contains "SPA navigation contract" section with HOL-920 / HOL-921 references