### PR TITLE
fix(ui): add /organizations/$orgName layout that syncs URL org to useOrg store

### DIFF
--- a/frontend/src/routes/_authenticated/organizations/$orgName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { useEffect } from 'react'
+import { useOrg } from '@/lib/org-context'
+
+export const Route = createFileRoute('/_authenticated/organizations/$orgName')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const { orgName } = Route.useParams()
+  return <OrgLayout orgName={orgName} />
+}
+
+export function OrgLayout({ orgName }: { orgName: string }) {
+  const { setSelectedOrg } = useOrg()
+
+  useEffect(() => {
+    setSelectedOrg(orgName)
+  }, [orgName, setSelectedOrg])
+
+  return <Outlet />
+}

--- a/frontend/src/routes/_authenticated/organizations/-$orgName.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/-$orgName.test.tsx
@@ -1,0 +1,50 @@
+import { render, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+
+const mockSetSelectedOrg = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({}),
+    Outlet: () => null,
+  }
+})
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: () => ({
+    selectedOrg: null,
+    setSelectedOrg: mockSetSelectedOrg,
+    organizations: [],
+    isLoading: false,
+  }),
+}))
+
+import { OrgLayout } from './$orgName'
+
+describe('OrgLayout — URL sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls setSelectedOrg with the orgName param on mount', async () => {
+    render(<OrgLayout orgName="my-org" />)
+    await waitFor(() => {
+      expect(mockSetSelectedOrg).toHaveBeenCalledWith('my-org')
+    })
+  })
+
+  it('calls setSelectedOrg again when orgName param changes', async () => {
+    const { rerender } = render(<OrgLayout orgName="org-a" />)
+    await waitFor(() => {
+      expect(mockSetSelectedOrg).toHaveBeenCalledWith('org-a')
+    })
+
+    rerender(<OrgLayout orgName="org-b" />)
+    await waitFor(() => {
+      expect(mockSetSelectedOrg).toHaveBeenCalledWith('org-b')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `frontend/src/routes/_authenticated/organizations/$orgName.tsx` layout route that mirrors the proven `orgs/$orgName.tsx` pattern
- On mount and `orgName` param change, calls `useOrg().setSelectedOrg(orgName)` so the WorkspaceMenu stays in sync with the URL
- Export `OrgLayout` component for unit testing (same pattern as `ProjectLayout` and `OrgLayout` in `orgs/`)
- Add unit test `frontend/src/routes/_authenticated/organizations/-$orgName.test.tsx` asserting `setSelectedOrg` is called with the route param on mount and on re-render with new param
- TanStack route tree regenerated: `organizations/$orgName/projects/` now nests under the new layout as confirmed in `routeTree.gen.ts`

Fixes HOL-928

## Test plan
- [x] `make test-ui` passes — 93 test files, 1241 tests all green
- [x] `make build` passes — route tree regenerated with `organizations/$orgName` as parent of `organizations/$orgName/projects/`
- [x] New unit test asserts `setSelectedOrg('my-org')` called on mount
- [x] New unit test asserts `setSelectedOrg('org-b')` called when param changes from `'org-a'`