### PR TITLE
fix(ui): vertical persona list and $TOKEN placeholder in /dev-tools

### DIFF
--- a/frontend/src/routes/_authenticated/-dev-tools.test.tsx
+++ b/frontend/src/routes/_authenticated/-dev-tools.test.tsx
@@ -34,11 +34,16 @@ import { useAuth } from '@/lib/auth'
 import { getConsoleConfig } from '@/lib/console-config'
 import { DevToolsPage } from './dev-tools'
 
+// JWT-shaped fixture: real ID tokens start with "eyJ". Using a realistic
+// shape lets tests assert the curl snippet does NOT embed the live token.
+const TEST_ID_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature'
+
 function mockAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
   ;(useAuth as Mock).mockReturnValue({
     user: {
       access_token: 'test-access-token',
-      id_token: 'test-id-token',
+      id_token: TEST_ID_TOKEN,
       profile: {
         email: 'platform@localhost',
         sub: 'test-platform-001',
@@ -124,6 +129,32 @@ describe('DevToolsPage', () => {
     render(<DevToolsPage />)
     const card = getCardByTitle('Quick Token')
     expect(within(card).getByText(/curl example/i)).toBeInTheDocument()
+  })
+
+  it('curl snippet uses $TOKEN placeholder and does not embed the live ID token', () => {
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Quick Token')
+    const snippet = within(card).getByText(/holos\.console\.v1\.OrganizationService/)
+    expect(snippet.textContent).toContain('Bearer $TOKEN')
+    // Live ID tokens are JWTs (start with "eyJ"). The snippet must not embed one.
+    expect(snippet.textContent).not.toMatch(/eyJ[A-Za-z0-9_-]+/)
+  })
+
+  it('documents where to obtain a real token via /api/dev/token', () => {
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Quick Token')
+    expect(within(card).getByText('/api/dev/token')).toBeInTheDocument()
+  })
+
+  it('renders persona cards in a vertical layout (no horizontal grid)', () => {
+    render(<DevToolsPage />)
+    const card = getCardByTitle('Persona Switcher')
+    const platformLabel = within(card).getByText('Platform Engineer')
+    // Walk up to the container that wraps the persona buttons.
+    let container: HTMLElement | null = platformLabel.closest('button')?.parentElement ?? null
+    expect(container).not.toBeNull()
+    expect(container!.className).toMatch(/flex-col/)
+    expect(container!.className).not.toMatch(/grid-cols-/)
   })
 
   it('renders the current user email and role for a different persona', () => {

--- a/frontend/src/routes/_authenticated/dev-tools.tsx
+++ b/frontend/src/routes/_authenticated/dev-tools.tsx
@@ -112,7 +112,7 @@ export function DevToolsPage() {
     `  ${origin}/holos.console.v1.OrganizationService/ListOrganizations \\\n` +
     `  -H "Content-Type: application/json" \\\n` +
     `  -H "Connect-Protocol-Version: 1" \\\n` +
-    `  -H "Authorization: Bearer ${idToken}" \\\n` +
+    `  -H "Authorization: Bearer $TOKEN" \\\n` +
     `  -d '{}'`
 
   const handleCopyCurl = () => {
@@ -214,7 +214,7 @@ function PersonaSwitcherCard({
         <CardTitle>Persona Switcher</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="flex flex-col gap-3">
           {personas.map((persona) => {
             const isCurrent = persona.email === currentEmail
             const isSwitching = switching === persona.id
@@ -310,6 +310,13 @@ function QuickTokenCard({
         <div className="space-y-2">
           <p className="text-xs uppercase tracking-wider text-muted-foreground">
             curl example (Connect protocol)
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Set <code className="font-mono">$TOKEN</code> to an ID token before running.
+            Obtain one from the{' '}
+            <code className="font-mono">/api/dev/token</code> endpoint (see{' '}
+            <code className="font-mono">CONTRIBUTING.md</code> &rarr; Dev Tools and
+            Persona Switching).
           </p>
           <div className="relative">
             <pre className="rounded-md bg-muted p-4 text-xs font-mono overflow-auto whitespace-pre">


### PR DESCRIPTION
## Summary
- Persona switcher at `/dev-tools` now stacks vertically (`flex flex-col gap-3`) so persona cards no longer overflow the viewport on narrow widths; name, email, and role all remain visible.
- The Quick Token curl snippet now uses the literal placeholder `$TOKEN` instead of embedding the live `${idToken}` value, with inline copy pointing readers at the `/api/dev/token` endpoint documented in `CONTRIBUTING.md`.
- Tests upgraded: mock ID token is now JWT-shaped, and new assertions verify the snippet contains `$TOKEN`, does not contain a JWT-shaped string, documents `/api/dev/token`, and the persona container uses a vertical layout.

Fixes HOL-916

## Test plan
- [x] `make test-ui` green (1261/1261)
- [x] 13/13 tests pass in `frontend/src/routes/_authenticated/-dev-tools.test.tsx`
- [ ] Manual: open `/dev-tools` at <=640px wide and confirm persona cards stack vertically with no horizontal overflow
- [ ] Manual: copy the curl snippet — confirm it contains `Bearer $TOKEN` (not a real JWT) and the surrounding text directs the reader to `/api/dev/token`