### PR TITLE
feat(ui): remove deployments description banner

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
@@ -2,7 +2,6 @@
  * Tests for the Deployments index page (HOL-858) — ResourceGrid v1 implementation.
  *
  * Mocks @/queries/deployments and @/queries/projects. Covers:
- *  - DeploymentsDescription banner (copy-locking assertions)
  *  - ResourceGrid renders project rows
  *  - Delete flow via ConfirmDeleteDialog
  *  - Extra columns: Phase badge and PolicyDrift badge
@@ -62,7 +61,7 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
-import { DeploymentsListPage, DeploymentsDescription } from './index'
+import { DeploymentsListPage } from './index'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -150,36 +149,6 @@ function setupMocks({
 describe('DeploymentsListPage (ResourceGrid v1)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-  })
-
-  // -------------------------------------------------------------------------
-  // Description banner (copy-locking)
-  // -------------------------------------------------------------------------
-
-  describe('DeploymentsDescription banner', () => {
-    it('renders the description banner', () => {
-      render(<DeploymentsDescription />)
-      expect(screen.getByTestId('deployments-description')).toBeInTheDocument()
-    })
-
-    it('contains the three verbatim bullet points', () => {
-      render(<DeploymentsDescription />)
-      expect(
-        screen.getByText('Deployment is a collection of resource declarations (configuration).'),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText('Deploying is applying the configuration to the platform.'),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText('Controllers reconcile current state with desired state.'),
-      ).toBeInTheDocument()
-    })
-
-    it('renders the description banner inside the full page', () => {
-      setupMocks()
-      render(<DeploymentsListPage />)
-      expect(screen.getByTestId('deployments-description')).toBeInTheDocument()
-    })
   })
 
   // -------------------------------------------------------------------------

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -2,7 +2,6 @@
  * Deployments index page — reimplemented on ResourceGrid v1 (HOL-858).
  *
  * Default view: current project as the single parent with Parent column hidden.
- * A static description banner at the top of the Card explains what a Deployment is.
  * Phase and PolicyDrift badges are preserved via the `extraColumns` extension
  * on ResourceGrid v1.
  *
@@ -33,29 +32,6 @@ export const Route = createFileRoute('/_authenticated/projects/$projectName/depl
   validateSearch: parseGridSearch,
   component: DeploymentsListPage,
 })
-
-// ---------------------------------------------------------------------------
-// Description banner
-// ---------------------------------------------------------------------------
-
-/**
- * DeploymentsDescription renders a static three-bullet explanation of what a
- * Deployment is. The copy is verbatim from the HOL-858 acceptance criteria.
- */
-export function DeploymentsDescription() {
-  return (
-    <div
-      className="mb-4 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground"
-      data-testid="deployments-description"
-    >
-      <ul className="list-disc pl-5 space-y-1">
-        <li>Deployment is a collection of resource declarations (configuration).</li>
-        <li>Deploying is applying the configuration to the platform.</li>
-        <li>Controllers reconcile current state with desired state.</li>
-      </ul>
-    </div>
-  )
-}
 
 // ---------------------------------------------------------------------------
 // Extra columns — Phase badge and Policy Drift badge
@@ -183,7 +159,6 @@ export function DeploymentsListPage() {
       search={search}
       onSearchChange={handleSearchChange}
       extraColumns={extraColumns}
-      headerContent={<DeploymentsDescription />}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Remove the `DeploymentsDescription` component from the deployments index page
- Remove `headerContent={<DeploymentsDescription />}` prop from `DeploymentsListPage`
- Remove the corresponding copy-locking unit tests for the banner

Fixes HOL-937

## Test plan
- [x] `make test-ui` passes 94 test files / 1258 tests
- [ ] Verify the Deployments list page no longer shows the three-bullet description banner