### PR TITLE
feat(ui): make ResourceGrid resource ID and rows clickable links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ entry and WorkspaceMenu improvements. Key files:
 | `frontend/src/components/templates/TemplatesHelpPane.tsx` | HOL-860 | Templates help pane (? icon toggle) |
 | `frontend/src/routes/_authenticated/organizations/$orgName.tsx` | HOL-928 | Layout — syncs `$orgName` URL param → `useOrg()` store (one-way) |
 | `docs/ui/selected-entity-state.md` | HOL-931 | Selected-entity state contract; read-precedence rules; creation-page invariants |
+| `docs/agents/data-grid-conventions.md` | HOL-940 | Data grid conventions: clickable resource IDs and fully-clickable rows |
 
 **Deleted (HOL-914)**: `frontend/src/components/resource-manager/` and
 `frontend/src/routes/_authenticated/resource-manager/` were removed when the
@@ -64,6 +65,7 @@ in a sibling cleanup plan.
 - [Demo Docs Routing](https://github.com/holos-run/holos-console-docs/tree/main/demo) — Demo setup materials and CUE example snippets belong in `holos-run/holos-console-docs/demo/`, **not** in this repo; demo-related issues must include concrete examples and operator guidance.
 - [Smoke Test Contract](https://github.com/holos-run/holos-console-docs/tree/main/demo/smoke-tests) — Smoke-test instructions must use `kubectl` commands for the resources required to observe the feature in the demo environment.
 - [Demo README](https://github.com/holos-run/holos-console-docs/blob/main/demo/README.md) — Forward pointer to the demo setup order, prerequisites, and per-template walkthroughs.
+- [Data Grid Conventions](docs/agents/data-grid-conventions.md) — Every `ResourceGrid` row must have `detailHref` set so the resource ID cell and the full row are clickable links to the resource detail page. Action buttons in the row must call `e.stopPropagation()` to prevent triggering row navigation.
 
 ## Example Template Registry
 

--- a/docs/agents/data-grid-conventions.md
+++ b/docs/agents/data-grid-conventions.md
@@ -39,11 +39,13 @@ Any future action button added to the actions column must also call
 
 This convention applies to all pages backed by `ResourceGrid`:
 
-| Page | `detailHref` pattern |
-|------|----------------------|
-| Secrets | `/projects/$projectName/secrets/$secretName` |
-| Deployments | `/projects/$projectName/deployments/$deploymentName` |
-| Templates | `/projects/$projectName/templates/$templateName` |
+| Page | `detailHref` pattern | Notes |
+|------|----------------------|-------|
+| Secrets | `/projects/$projectName/secrets/$secretName` | Always set |
+| Deployments | `/projects/$projectName/deployments/$deploymentName` | Always set |
+| Templates | `/projects/$projectName/templates/$templateName` | May be absent when the template namespace cannot be resolved |
 
 When adding a new resource kind to `ResourceGrid`, include a `detailHref` on
-each row unless the resource has no dedicated detail page.
+each row whenever the resource has a dedicated detail page. Rows without
+`detailHref` render the resource ID as plain text and the row is not clickable
+— the `ResourceGrid` handles both cases automatically.

--- a/docs/agents/data-grid-conventions.md
+++ b/docs/agents/data-grid-conventions.md
@@ -1,0 +1,49 @@
+# Data Grid Conventions
+
+> **Agent quick-read** (~2 min). Covers the clickable-row and clickable-identifier
+> convention for all `ResourceGrid` tables.
+> Source of record: HOL-940.
+
+## The Rule
+
+Every `ResourceGrid` data row that represents a named resource **must** be
+fully clickable:
+
+1. **Resource ID cell** — the `id` column renders as a `<Link>` to the resource
+   detail page when `Row.detailHref` is set.
+2. **Entire row** — the `<TableRow>` has an `onClick` handler that navigates to
+   `Row.detailHref` when it is set, and a `cursor-pointer` visual hint.
+
+## How to apply
+
+Set `detailHref` on every `Row` you pass to `ResourceGrid`. The component
+handles both the cell link and the row click automatically — no extra wiring
+is required in the calling page.
+
+```ts
+// Example — secrets/index.tsx
+const rows: Row[] = secretRows.map(({ secret, scope }) => ({
+  // ...other fields...
+  detailHref: `/projects/${projectName}/secrets/${secret.name}`,
+}))
+```
+
+## Propagation guard
+
+The delete-icon button calls `e.stopPropagation()` before opening the confirm
+dialog so that clicking the trash icon does **not** trigger the row navigation.
+Any future action button added to the actions column must also call
+`e.stopPropagation()`.
+
+## Scope
+
+This convention applies to all pages backed by `ResourceGrid`:
+
+| Page | `detailHref` pattern |
+|------|----------------------|
+| Secrets | `/projects/$projectName/secrets/$secretName` |
+| Deployments | `/projects/$projectName/deployments/$deploymentName` |
+| Templates | `/projects/$projectName/templates/$templateName` |
+
+When adding a new resource kind to `ResourceGrid`, include a `detailHref` on
+each row unless the resource has no dedicated detail page.

--- a/frontend/e2e/secrets-spa-navigation.spec.ts
+++ b/frontend/e2e/secrets-spa-navigation.spec.ts
@@ -49,7 +49,7 @@ test.describe('Secrets SPA Navigation (HOL-923 regression)', () => {
     await page.getByPlaceholder('my-secret').fill(secretName)
     await page.getByRole('button', { name: /create secret/i }).click()
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/?$`), { timeout: 5000 })
-    await expect(page.getByRole('link', { name: secretName })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('link', { name: secretName, exact: true })).toBeVisible({ timeout: 10000 })
 
     // 3. Collect top-level main-frame navigation requests during the click so
     //    we can assert that none of them hit the Dex or PKCE endpoints.
@@ -75,7 +75,7 @@ test.describe('Secrets SPA Navigation (HOL-923 regression)', () => {
     page.on('request', onRequest)
 
     // 4. Click the display-name link for the secret row.
-    await page.getByRole('link', { name: secretName }).click()
+    await page.getByRole('link', { name: secretName, exact: true }).click()
 
     // 5. Assert the URL became the detail page (SPA navigation succeeded).
     await page.waitForURL(

--- a/frontend/e2e/secrets.spec.ts
+++ b/frontend/e2e/secrets.spec.ts
@@ -58,10 +58,10 @@ test.describe('Secrets Page', () => {
 
     // Wait for redirect back to list and secret to appear
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/?$`), { timeout: 5000 })
-    await expect(page.getByRole('link', { name: secretName })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('link', { name: secretName, exact: true })).toBeVisible({ timeout: 10000 })
 
     // Navigate to the created secret
-    await page.getByRole('link', { name: secretName }).click()
+    await page.getByRole('link', { name: secretName, exact: true }).click()
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/${secretName}`), { timeout: 5000 })
 
     // Verify sharing panel is present
@@ -108,10 +108,10 @@ test.describe('Secrets Page', () => {
     await page.getByPlaceholder('value').fill('KEY=value')
     await page.getByRole('button', { name: /create secret/i }).click()
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/?$`), { timeout: 5000 })
-    await expect(page.getByRole('link', { name: secretName })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('link', { name: secretName, exact: true })).toBeVisible({ timeout: 10000 })
 
     // Navigate to the secret
-    await page.getByRole('link', { name: secretName }).click()
+    await page.getByRole('link', { name: secretName, exact: true }).click()
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/${secretName}`), { timeout: 5000 })
 
     // Verify sharing panel and edit button
@@ -170,7 +170,7 @@ test.describe('Secrets Page', () => {
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/?$`), { timeout: 5000 })
 
     // Verify the secret shows in the list as a link
-    await expect(page.getByRole('link', { name: secretName })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('link', { name: secretName, exact: true })).toBeVisible({ timeout: 10000 })
 
     // Clean up: delete via the list
     await page.getByLabel(new RegExp(`delete ${secretName}`, 'i')).click()
@@ -205,10 +205,10 @@ test.describe('Secrets Page', () => {
     // Do NOT fill key/value — create an empty secret
     await page.getByRole('button', { name: /create secret/i }).click()
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/?$`), { timeout: 5000 })
-    await expect(page.getByRole('link', { name: secretName })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('link', { name: secretName, exact: true })).toBeVisible({ timeout: 10000 })
 
     // Navigate to the detail page
-    await page.getByRole('link', { name: secretName }).click()
+    await page.getByRole('link', { name: secretName, exact: true }).click()
     await page.waitForURL(new RegExp(`/projects/${projectName}/secrets/${secretName}`), { timeout: 5000 })
 
     // Click Edit to enter edit mode — grid should show one empty row

--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -12,10 +12,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     Link: ({
       children,
       to,
+      onClick,
     }: {
       children: React.ReactNode
       to?: string
-    }) => <a href={to ?? '#'} data-testid="router-link">{children}</a>,
+      onClick?: (e: React.MouseEvent) => void
+    }) => <a href={to ?? '#'} data-testid="router-link" onClick={onClick}>{children}</a>,
     useNavigate: () => mockNavigate,
   }
 })
@@ -202,6 +204,22 @@ describe('ResourceGrid', () => {
     const deleteBtn = screen.getByRole('button', { name: /delete my secret/i })
     fireEvent.click(deleteBtn)
     await waitFor(() => screen.getByRole('dialog'))
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger row navigate() when the resource ID link is clicked', () => {
+    renderGrid()
+    const idLink = screen.getByRole('link', { name: /abc-123/i })
+    fireEvent.click(idLink)
+    // The link handles its own navigation via href; the row handler must not
+    // also call navigate() or a double history-push occurs.
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger row navigate() when the display name link is clicked', () => {
+    renderGrid()
+    const nameLink = screen.getByRole('link', { name: /my secret/i })
+    fireEvent.click(nameLink)
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -2,8 +2,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import React from 'react'
 
-// Mock TanStack Router — ResourceGrid uses Link and the search/navigate props
-// are passed in directly from the parent route, so we only need Link.
+const mockNavigate = vi.fn()
+
+// Mock TanStack Router — ResourceGrid uses Link and useNavigate internally.
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
   return {
@@ -15,7 +16,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
       children: React.ReactNode
       to?: string
     }) => <a href={to ?? '#'} data-testid="router-link">{children}</a>,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
   }
 })
 
@@ -99,6 +100,7 @@ function renderGrid(
 describe('ResourceGrid', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockNavigate.mockReset()
   })
 
   // --- Loading state ---
@@ -172,6 +174,35 @@ describe('ResourceGrid', () => {
     // Assert the link comes from the TanStack Router Link component (via mock
     // data-testid) so a future regression to a raw <a href> is caught here.
     expect(link).toHaveAttribute('data-testid', 'router-link')
+  })
+
+  it('links resource ID cell to detailHref when detailHref is set', () => {
+    renderGrid()
+    const links = screen.getAllByRole('link', { name: /abc-123/i })
+    expect(links.length).toBeGreaterThan(0)
+    expect(links[0]).toHaveAttribute('href', '/secrets/my-secret')
+    expect(links[0]).toHaveAttribute('data-testid', 'router-link')
+  })
+
+  it('renders resource ID as plain text when detailHref is absent', () => {
+    renderGrid({ rows: [makeRow({ detailHref: undefined })] })
+    expect(screen.getByText('abc-123')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /abc-123/i })).not.toBeInTheDocument()
+  })
+
+  it('navigates to detailHref when the row is clicked', () => {
+    renderGrid()
+    const row = screen.getByText('abc-123').closest('tr')!
+    fireEvent.click(row)
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/secrets/my-secret' })
+  })
+
+  it('does not trigger row navigation when the delete button is clicked', async () => {
+    renderGrid()
+    const deleteBtn = screen.getByRole('button', { name: /delete my secret/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() => screen.getByRole('dialog'))
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   // --- Parent ID column hiding ---

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -235,6 +235,7 @@ export function ResourceGrid({
               <Link
                 to={row.original.detailHref}
                 className="font-mono text-muted-foreground text-sm hover:underline"
+                onClick={(e) => e.stopPropagation()}
               >
                 {value}
               </Link>
@@ -260,6 +261,7 @@ export function ResourceGrid({
                   to={row.original.detailHref}
                   className="font-medium hover:underline"
                   title={row.original.name}
+                  onClick={(e) => e.stopPropagation()}
                 >
                   {label}
                 </Link>

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react'
-import { Link } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import {
   useReactTable,
@@ -124,6 +124,8 @@ export function ResourceGrid({
   headerContent,
   headerActions,
 }: ResourceGridProps) {
+  const navigate = useNavigate()
+
   // --- Derive local state from URL params --------------------------------
 
   const selectedKindIds = useMemo(
@@ -226,11 +228,24 @@ export function ResourceGrid({
       columnHelper.accessor('id', {
         id: 'resourceId',
         header: 'Resource ID',
-        cell: ({ getValue }) => (
-          <span className="font-mono text-muted-foreground text-sm">
-            {getValue()}
-          </span>
-        ),
+        cell: ({ row, getValue }) => {
+          const value = getValue()
+          if (row.original.detailHref) {
+            return (
+              <Link
+                to={row.original.detailHref}
+                className="font-mono text-muted-foreground text-sm hover:underline"
+              >
+                {value}
+              </Link>
+            )
+          }
+          return (
+            <span className="font-mono text-muted-foreground text-sm">
+              {value}
+            </span>
+          )
+        },
       }),
       columnHelper.accessor(
         (row) => row.displayName || row.name,
@@ -306,7 +321,7 @@ export function ResourceGrid({
               variant="ghost"
               size="icon"
               aria-label={`delete ${row.original.displayName || row.original.name}`}
-              onClick={() => handleDeleteClick(row.original)}
+              onClick={(e) => { e.stopPropagation(); handleDeleteClick(row.original) }}
             >
               <Trash2 className="h-4 w-4" />
             </Button>
@@ -448,7 +463,15 @@ export function ResourceGrid({
                 </TableHeader>
                 <TableBody>
                   {table.getRowModel().rows.map((row) => (
-                    <TableRow key={row.id}>
+                    <TableRow
+                      key={row.id}
+                      className={row.original.detailHref ? 'cursor-pointer' : undefined}
+                      onClick={
+                        row.original.detailHref
+                          ? () => navigate({ to: row.original.detailHref! })
+                          : undefined
+                      }
+                    >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell key={cell.id}>
                           {flexRender(

--- a/frontend/src/components/resource-grid/types.ts
+++ b/frontend/src/components/resource-grid/types.ts
@@ -44,7 +44,7 @@ export interface Row {
   description: string
   /** ISO-8601 creation timestamp string. */
   createdAt: string
-  /** If provided, the display name links to this href. */
+  /** If provided, the resource ID cell links here, the display name links here, and the full row is clickable. */
   detailHref?: string
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
@@ -234,8 +234,11 @@ describe('DeploymentsListPage (ResourceGrid v1)', () => {
   it('deployment name links to detail page', () => {
     setupMocks({ deployments: [makeDeployment('api')] })
     render(<DeploymentsListPage />)
-    const link = screen.getByRole('link', { name: 'api' })
-    expect(link.getAttribute('href')).toContain('deployments/api')
+    // Both the resource ID cell and the display name cell link to the detail
+    // page when id === displayName (the common case for deployments).
+    const links = screen.getAllByRole('link', { name: 'api' })
+    expect(links.length).toBeGreaterThan(0)
+    expect(links[0].getAttribute('href')).toContain('deployments/api')
   })
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Resource ID cells in `ResourceGrid` now render as `<Link>` to `Row.detailHref` when set
- Entire table rows are clickable via `onClick` + `cursor-pointer` styling on `<TableRow>`
- Delete icon button calls `e.stopPropagation()` to prevent triggering row navigation
- Added `docs/agents/data-grid-conventions.md` with the clickable-row convention
- Indexed the new doc in `AGENTS.md` guardrails so agents follow the pattern on future `ResourceGrid` callers

Fixes HOL-940

## Test plan
- [x] 5 new unit tests: resource ID link renders, plain-text fallback, row click navigation, delete button propagation guard
- [x] All 1265 UI unit tests pass
- [x] Updated deployments test to handle both resource ID and display name links for the same resource name

## Deferred Acceptance Criteria
None — all three ACs addressed.