### PR TITLE
docs(agents): codify frontend stack constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,55 @@ All testing guidance lives in this repo. Read the entries below in order the fir
 
 **Make targets**: `make test-go` (Go tests), `make test-ui` (Vitest unit tests), `make test-e2e` (Playwright, needs `make certs` and a k3d cluster), `make test` (all three). Run `make generate` before committing if proto or generated code is affected.
 
+## Frontend stack and constraints
+
+The frontend under `frontend/` is a Vite single-page React app. Treat these as
+the locked stack dependencies for new UI work:
+
+| Layer | Dependency |
+|---|---|
+| Build/dev server | `vite@7.3.1`, `@vitejs/plugin-react@5.1.4` |
+| UI runtime | `react@19.2.4`, `react-dom@19.2.4` |
+| Routing | `@tanstack/react-router@1.163.3`, `@tanstack/router-plugin@1.163.3` |
+| Server state | `@tanstack/react-query@5.90.21` |
+| Tables | `@tanstack/react-table@8.21.3` |
+| RPC transport | `@connectrpc/connect@2.1.1`, `@connectrpc/connect-web@2.1.1`, `@connectrpc/connect-query@2.2.0` |
+| Styling | `tailwindcss@4.2.1`, `@tailwindcss/vite@4.2.1` |
+| UI primitives | `shadcn@3.8.5`, `radix-ui@1.4.3`, `lucide-react@0.575.0` |
+
+Do not introduce Next.js or a parallel framework. New frontend code must fit
+the existing Vite + React + TanStack Router model unless an accepted architecture
+issue explicitly changes this stack.
+
+Agent-facing frontend docs:
+
+- [Frontend Architecture](docs/agents/frontend-architecture.md) — routing,
+  `returnTo`, selected-entity sync, ConnectRPC transport, and build/test
+  commands.
+- [TanStack Query Conventions](docs/agents/tanstack-query-conventions.md) —
+  placeholder for Phase 4 query-key and invalidation conventions.
+- [Data Grid Architecture](docs/agents/data-grid-architecture.md) —
+  placeholder for Phase 5 `ResourceGrid` architecture conventions.
+- [Data Grid Conventions](docs/agents/data-grid-conventions.md) — current
+  clickable resource ID and fully-clickable row rule.
+- [Frontend Audit Baseline](docs/agents/frontend-audit-2026-04.md) — Phase 1
+  inventory and target conventions.
+
+### Security: secrets in the UI
+
+Never display raw secret values by default. Secret list pages and grid columns
+must be metadata-only: name, scope, type, sharing/usage summaries, timestamps,
+and other non-sensitive descriptors. Any reveal of secret material requires an
+explicit user action in a detail/editor flow, and the default view after
+navigation or refresh must return to a non-revealed state.
+
+Do not place secret material in CR specs or status. Template CRs carry metadata
+and `v1.Secret` refs only, and `secrets.holos.run/v1alpha1` CRs are control
+objects, not vaults. The Holos invariant forbids plaintext credentials, hash
+bytes, salt bytes, pepper bytes, API key prefixes, last-4 digits, and any other
+entropy-revealing truncation in CR fields; see
+[No-sensitive-values invariant](#no-sensitive-values-invariant-must-read-before-editing-any-cr-field).
+
 ## MVP UI — ResourceGrid v1 and sidebar nav (HOL-854 + HOL-911)
 
 The HOL-854 plan shipped seven phases (HOL-855 – HOL-861) that replace the old

--- a/docs/agents/frontend-architecture.md
+++ b/docs/agents/frontend-architecture.md
@@ -1,0 +1,143 @@
+# Frontend Architecture
+
+> **Agent quick-read** (~5 min). Navigation hub for frontend stack decisions.
+> Source of record: HOL-944. For detailed UX behavior, defer to the linked
+> `docs/ui/` contracts.
+
+## Stack Boundary
+
+The application in `frontend/` is a Vite + React single-page app using
+TanStack Router, TanStack Query, TanStack Table, Tailwind v4, shadcn/Radix
+primitives, lucide icons, and ConnectRPC.
+
+Do not introduce Next.js, Remix, server components, or another parallel
+frontend framework. Keep new work inside the existing Vite app, generated
+TanStack route tree, query modules, and shared UI primitives.
+
+## Routing Model
+
+Routes are file-based TanStack Router routes under `frontend/src/routes/`.
+`@tanstack/router-plugin/vite` generates `frontend/src/routeTree.gen.ts`; do
+not edit the generated file by hand.
+
+The active authenticated app lives under the pathless `_authenticated` layout
+segment. User-visible URLs omit `_authenticated`.
+
+Use the resource URL convention from
+[docs/ui/resource-routing.md](../ui/resource-routing.md):
+
+| Purpose | URL pattern | Examples |
+|---|---|---|
+| Create a resource | `/singular/new` | `/organization/new`, `/folder/new`, `/project/new` |
+| Operate on an existing resource | `/plurals/$name/...` | `/organizations/$orgName/settings`, `/projects/$projectName/secrets` |
+
+Use full plural nouns for scoped route prefixes: `organizations`, `projects`,
+and `folders`. Do not reintroduce `/orgs/...`.
+
+## `returnTo` Pattern
+
+Creation flows pass the caller's current location in a `returnTo` search param
+and resolve it after a successful create:
+
+- Build it with `buildReturnTo({ pathname, search })` from
+  `frontend/src/lib/return-to.ts`.
+- Consume it with `resolveReturnTo(search.returnTo, fallbackPath)`.
+- Keep it same-origin and in-app; `resolveReturnTo` owns the validation rules.
+
+The authoritative behavior and examples live in
+[docs/ui/resource-routing.md](../ui/resource-routing.md#the-returnto-search-param-convention).
+
+## Selected-Entity Sync
+
+`useOrg()` and `useProject()` are the canonical selected-entity stores. URL
+params are authoritative when present, and layouts sync URL params into stores
+in one direction only: URL -> store.
+
+Reference layouts:
+
+| Route layout | Store sync |
+|---|---|
+| `frontend/src/routes/_authenticated/organizations/$orgName.tsx` | `$orgName` -> `useOrg().setSelectedOrg` |
+| `frontend/src/routes/_authenticated/projects/$projectName.tsx` | `$projectName` -> `useProject().setSelectedProject` |
+
+Pages read active context in this order:
+
+1. Route params (`$orgName`, `$projectName`).
+2. Search params (`orgName`, `projectName`).
+3. Store fallback (`useOrg()`, `useProject()`).
+
+Creation pages may read store fallback for ergonomics, but must not write to
+the selected-entity stores. The authoritative contract is
+[docs/ui/selected-entity-state.md](../ui/selected-entity-state.md).
+
+## ConnectRPC Transport
+
+The root route wires ConnectRPC and TanStack Query providers:
+
+- `frontend/src/routes/__root.tsx` wraps the app in `TransportProvider` and
+  `QueryClientProvider`.
+- `frontend/src/lib/transport.ts` creates the ConnectRPC web transport and
+  auth interceptor.
+- `frontend/src/lib/query-client.ts` owns shared TanStack Query defaults.
+
+Query hooks live in `frontend/src/queries/`. The common read-hook shape is:
+
+```ts
+const { isAuthenticated } = useAuth()
+const transport = useTransport()
+const client = useMemo(() => createClient(Service, transport), [transport])
+
+return useQuery({
+  queryKey,
+  queryFn,
+  enabled: isAuthenticated && !!requiredParam,
+})
+```
+
+Tests at route boundaries should mock query modules with `vi.mock('@/queries/*')`
+rather than mocking ConnectRPC clients directly. See
+[docs/agents/testing-patterns.md](testing-patterns.md) for the worked testing
+patterns.
+
+## Tables and Data Grids
+
+New flat resource list pages should use `ResourceGrid` when the page is a named
+resource table with search/filter state, create actions, optional delete
+actions, and detail navigation.
+
+Every `ResourceGrid` row with a detail page must set `detailHref` so both the
+resource ID cell and the whole row navigate to the detail page. Row action
+buttons must stop event propagation before opening menus or dialogs.
+
+Current conventions live in
+[docs/agents/data-grid-conventions.md](data-grid-conventions.md). Phase 5 will
+fill in [docs/agents/data-grid-architecture.md](data-grid-architecture.md).
+
+## Build and Test Commands
+
+Run commands from the repo root unless noted:
+
+| Task | Command |
+|---|---|
+| Install frontend dependencies | `cd frontend && npm install` |
+| Start Vite dev server | `make dev` |
+| Build generated frontend assets | `make generate` |
+| Run UI unit tests | `make test-ui` |
+| Run frontend lint directly | `cd frontend && npm run lint` |
+| Run repo lint target | `make lint` |
+| Run Playwright E2E | `make test-e2e` |
+
+`make test-ui` runs `cd frontend && npm test -- --run`. E2E tests require
+local certificates and, for Kubernetes CRUD specs, a real k3d cluster; prefer
+unit tests unless the test strategy explicitly calls for E2E coverage.
+
+## Related Docs
+
+- [docs/agents/frontend-audit-2026-04.md](frontend-audit-2026-04.md) - current
+  inventory and target conventions from Phase 1.
+- [docs/agents/tanstack-query-conventions.md](tanstack-query-conventions.md) -
+  Phase 4 placeholder for query-key and invalidation rules.
+- [docs/ui/resource-routing.md](../ui/resource-routing.md) - authoritative URL
+  and `returnTo` behavior.
+- [docs/ui/selected-entity-state.md](../ui/selected-entity-state.md) -
+  authoritative selected-entity store behavior.


### PR DESCRIPTION
## Summary
- Add a frontend stack and constraints section to `AGENTS.md`, including the explicit no-Next.js rule and locked stack versions.
- Document UI secret-handling guardrails in `AGENTS.md`.
- Add `docs/agents/frontend-architecture.md` as the agent-facing frontend routing, state, ConnectRPC, grid, and test-command hub.

## Verification
- `make test-ui` ✅
- `make generate` ✅
- `make vet` ✅
- `make check-imports` ✅

Additional local checks:
- `make lint` reaches non-CI `golangci-lint run` and fails on pre-existing Go lint issues in unchanged files.
- `make test-go` fails locally with existing race/envtest metrics-port issues; latest `main` CI is green and PR CI runs in the same clean environment.

Closes HOL-944.
