### PR TITLE
refactor(frontend): codify TanStack Query conventions

### DIFF
--- a/docs/agents/tanstack-query-conventions.md
+++ b/docs/agents/tanstack-query-conventions.md
@@ -1,0 +1,188 @@
+# TanStack Query Conventions
+
+Source issue: HOL-946. This document codifies the frontend query patterns
+identified in the HOL-943 audit and makes `frontend/src/queries/secrets.ts` the
+reference implementation.
+
+## Query Key Factories
+
+All hand-written TanStack Query keys live in
+`frontend/src/queries/keys.ts`. Use `keys.<resource>.<scope>(...)` for every
+`queryKey` and invalidation call. Do not add ad-hoc query-key array literals in
+query modules, routes, or components.
+
+Key factories return readonly tuples with the resource first, then the scope or
+operation, then identifiers:
+
+```ts
+keys.secrets.list(project)
+keys.secrets.get(project, name)
+keys.templates.policyState(namespace, name)
+```
+
+Use explicit prefix factories for broad invalidation. For example,
+`keys.folders.listScope(organization)` invalidates every folder-list variant
+under an organization, while `keys.folders.list(organization, parentType,
+parentName)` targets one concrete list.
+
+ConnectRPC queries created by `@connectrpc/connect-query` keep the library's
+cache shape. Mutations that affect those library-owned reads invalidate
+`keys.connect.all()`.
+
+## Transport And Hook Split
+
+Query hooks own transport and client creation:
+
+```ts
+const { isAuthenticated } = useAuth()
+const transport = useTransport()
+const client = useMemo(() => createClient(Service, transport), [transport])
+```
+
+Keep RPC request construction inside the hook's `queryFn` or `mutationFn`.
+Routes and components should call hooks instead of creating clients directly.
+The exception is a cross-namespace action that cannot bind a namespace at hook
+creation time; when that is needed, the caller must use `keys.ts` for direct
+invalidation.
+
+Preserve public hook names when refactoring internals.
+
+## Stale Time And GC Time Defaults
+
+Use TanStack Query defaults unless a resource has a clear stability contract.
+The current default means normal resource data becomes stale immediately and is
+eligible for the app-level garbage-collection default.
+
+Allowed overrides:
+
+- Static server-binary data may use `staleTime: Infinity`, as
+  `useListTemplateExamples()` does.
+- Polling or live-status reads may set `refetchInterval` from caller options.
+- Do not set `gcTime` in resource hooks unless an issue explicitly documents
+  the memory and UX tradeoff.
+
+## Enabled Guards
+
+Every read hook gates on authentication and all required identifiers:
+
+```ts
+enabled: isAuthenticated && !!project && !!name
+```
+
+For caller-controlled optional reads, combine the caller flag with the standard
+guard:
+
+```ts
+enabled: isAuthenticated && !!namespace && !!name && callerEnabled
+```
+
+Creation pages may read selected-entity store fallbacks, but query hooks should
+still treat empty route/search-derived identifiers as disabled.
+
+## Mutation Invalidation Matrix
+
+Use the smallest scope that refreshes every visible stale surface. Invalidate
+lists before details for predictable list-page refreshes.
+
+| Mutation | Invalidation scope |
+|---|---|
+| `createSecret(project)` | `keys.secrets.list(project)`, `keys.secrets.get(project, name)` |
+| `updateSecret(project)` | `keys.secrets.list(project)`, `keys.secrets.get(project, name)` |
+| `updateSecretSharing(project)` | `keys.secrets.list(project)`, `keys.secrets.get(project, name)` |
+| `deleteSecret(project)` | `keys.secrets.list(project)`, `keys.secrets.get(project, name)` |
+| Create resource | Affected list key |
+| Update resource | Affected list key and affected detail key |
+| Delete resource | Affected list key; detail key when the deleted item has a detail cache |
+| Sharing/default-sharing update | Affected list key and affected detail key when metadata appears in both |
+| Render-affecting template/deployment update | The resource list, resource detail, and affected policy-state key |
+
+`useGetSecretMetadata()` deliberately derives metadata from
+`keys.secrets.list(project)` because there is no dedicated metadata RPC.
+Invalidating the secret list therefore refreshes secret detail metadata panes.
+
+## Optimistic Updates
+
+Do not use optimistic updates by default. They are allowed only when the
+mutation payload is sufficient to update all affected cache entries without
+inventing server-owned fields.
+
+When a future hook uses optimism, it must:
+
+- cancel affected queries before writing optimistic cache state;
+- snapshot every affected cache entry;
+- roll back every snapshot in `onError`;
+- invalidate the documented mutation scope in `onSettled`;
+- avoid optimistic writes for secret material or any sensitive value.
+
+Secrets currently use invalidation-only mutation handlers.
+
+## Prefetch Policy
+
+Do not prefetch automatically from list rows. The current resource lists are
+metadata-heavy and details can be permission-sensitive, so prefetch must be an
+explicit issue-level decision.
+
+Allowed prefetch cases:
+
+- a route transition where the destination is already certain;
+- static reference data used by a soon-to-open editor;
+- a measured latency problem with documented query scope and cancellation.
+
+Prefetches must use `keys.ts` factories and the same auth/identifier guards as
+the owning read hook.
+
+## Dependent Queries
+
+Express dependencies through enabled guards and stable fallback arrays. Fan-out
+hooks should wait for structural parents, then map those results into child
+queries with `useQueries`.
+
+Use module-level empty sentinels for pending parent lists so dependency arrays
+stay referentially stable:
+
+```ts
+const EMPTY_PROJECTS: readonly Project[] = []
+const projects = useMemo(() => projectsQuery.data ?? EMPTY_PROJECTS, [
+  projectsQuery.data,
+])
+```
+
+Aggregate fan-out results with `aggregateFanOut` so partial data can remain
+visible when one branch fails.
+
+## KPD And Placeholder Rules For Grid Lists
+
+ResourceGrid-backed list reads should keep previous data across route/search
+parameter changes when showing stale rows is less disruptive than blanking the
+table. Use:
+
+```ts
+placeholderData: keepPreviousData
+```
+
+Apply this to list-style hooks such as `useListSecrets()` and fan-out list
+queries. Do not apply keep-previous-data to secret-value detail reads, editor
+payloads, or any read where stale data could be mistaken for the selected
+resource's sensitive content.
+
+## URL-Driven Filter And Sort Coordination
+
+ResourceGrid URL state is parsed and serialized by
+`frontend/src/components/resource-grid/url-state.ts`. Query hooks should accept
+already-normalized route/search params and put every server-side filter
+dimension into the query key.
+
+Client-only grid search, kind filters, and sort state stay in the route search
+params and should not be duplicated in query keys unless the server request
+uses them.
+
+## Mutation Success Handlers
+
+Mutation `onSuccess` handlers are responsible for cache invalidation only.
+Toast copy and navigation belong to the route or component that initiated the
+mutation, because that layer knows whether the user is staying in an editor,
+returning to a list, or following a `returnTo` search param.
+
+When a mutation needs both navigation and invalidation, await the mutation from
+the caller, let the hook invalidate the documented scope, then navigate or show
+toast from the caller after the mutation resolves.

--- a/frontend/src/queries/-organizations.test.ts
+++ b/frontend/src/queries/-organizations.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/lib/auth', () => ({
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import { useAuth } from '@/lib/auth'
+import { keys } from '@/queries/keys'
 import {
   useGetOrganization,
   useUpdateOrganization,
@@ -127,7 +128,7 @@ describe('useUpdateOrganization', () => {
       await result.current.mutateAsync({ name: 'my-org' })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })
 
@@ -170,7 +171,7 @@ describe('useUpdateOrganizationSharing', () => {
       await result.current.mutateAsync({ name: 'my-org', userGrants: [], roleGrants: [] })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })
 
@@ -217,7 +218,7 @@ describe('useUpdateOrganizationDefaultSharing', () => {
       await result.current.mutateAsync({ name: 'my-org', defaultUserGrants: [], defaultRoleGrants: [] })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })
 
@@ -258,6 +259,6 @@ describe('useDeleteOrganization', () => {
       await result.current.mutateAsync({ name: 'my-org' })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })

--- a/frontend/src/queries/-projects.test.ts
+++ b/frontend/src/queries/-projects.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/lib/auth', () => ({
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import { useAuth } from '@/lib/auth'
+import { keys } from '@/queries/keys'
 import {
   useGetProject,
   useUpdateProject,
@@ -128,7 +129,7 @@ describe('useUpdateProject', () => {
       await result.current.mutateAsync({ name: 'my-project' })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })
 
@@ -171,7 +172,7 @@ describe('useUpdateProjectSharing', () => {
       await result.current.mutateAsync({ name: 'my-project', userGrants: [], roleGrants: [] })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })
 
@@ -214,7 +215,7 @@ describe('useUpdateProjectDefaultSharing', () => {
       await result.current.mutateAsync({ name: 'my-project', defaultUserGrants: [], defaultRoleGrants: [] })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })
 
@@ -255,6 +256,6 @@ describe('useDeleteProject', () => {
       await result.current.mutateAsync({ name: 'my-project' })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['connect-query'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: keys.connect.all() })
   })
 })

--- a/frontend/src/queries/deployments.ts
+++ b/frontend/src/queries/deployments.ts
@@ -5,21 +5,14 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { DeploymentService } from '@/gen/holos/console/v1/deployments_pb.js'
 import type { EnvVar } from '@/gen/holos/console/v1/deployments_pb.js'
 import { useAuth } from '@/lib/auth'
-
-function deploymentListKey(project: string) {
-  return ['deployments', 'list', project] as const
-}
-
-function deploymentGetKey(project: string, name: string) {
-  return ['deployments', 'get', project, name] as const
-}
+import { keys } from '@/queries/keys'
 
 export function useListDeployments(project: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: deploymentListKey(project),
+    queryKey: keys.deployments.list(project),
     queryFn: async () => {
       const response = await client.listDeployments({ project })
       return response.deployments
@@ -33,7 +26,7 @@ export function useGetDeployment(project: string, name: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: deploymentGetKey(project, name),
+    queryKey: keys.deployments.get(project, name),
     queryFn: async () => {
       const response = await client.getDeployment({ project, name })
       return response.deployment
@@ -50,7 +43,7 @@ export function useCreateDeployment(project: string) {
     mutationFn: (params: { name: string; image: string; tag: string; template: string; displayName?: string; description?: string; port?: number; command?: string[]; args?: string[]; env?: EnvVar[] }) =>
       client.createDeployment({ project, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: deploymentListKey(project) })
+      queryClient.invalidateQueries({ queryKey: keys.deployments.list(project) })
     },
   })
 }
@@ -63,14 +56,14 @@ export function useUpdateDeployment(project: string, name: string) {
     mutationFn: (params: { image?: string; tag?: string; displayName?: string; description?: string; port?: number; command?: string[]; args?: string[]; env?: EnvVar[] }) =>
       client.updateDeployment({ project, name, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: deploymentListKey(project) })
-      queryClient.invalidateQueries({ queryKey: deploymentGetKey(project, name) })
+      queryClient.invalidateQueries({ queryKey: keys.deployments.list(project) })
+      queryClient.invalidateQueries({ queryKey: keys.deployments.get(project, name) })
       // HOL-559: a successful UpdateDeployment re-renders against the
       // current TemplatePolicy chain and records a fresh applied render
       // set on the backend. Invalidate the policy-state query so the
       // UI's drift badge + diff refresh from the authoritative state
       // rather than continuing to show the stale "drifted" snapshot.
-      queryClient.invalidateQueries({ queryKey: deploymentPolicyStateKey(project, name) })
+      queryClient.invalidateQueries({ queryKey: keys.deployments.policyState(project, name) })
     },
   })
 }
@@ -83,17 +76,9 @@ export function useDeleteDeployment(project: string) {
     mutationFn: (params: { name: string }) =>
       client.deleteDeployment({ project, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: deploymentListKey(project) })
+      queryClient.invalidateQueries({ queryKey: keys.deployments.list(project) })
     },
   })
-}
-
-function deploymentStatusKey(project: string, name: string) {
-  return ['deployments', 'status', project, name] as const
-}
-
-function deploymentStatusSummaryKey(project: string, name: string) {
-  return ['deployments', 'status-summary', project, name] as const
 }
 
 export function useGetDeploymentStatusSummary(
@@ -105,7 +90,7 @@ export function useGetDeploymentStatusSummary(
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: deploymentStatusSummaryKey(project, name),
+    queryKey: keys.deployments.statusSummary(project, name),
     queryFn: async () => {
       const response = await client.getDeploymentStatusSummary({ project, name })
       return response.summary
@@ -115,16 +100,12 @@ export function useGetDeploymentStatusSummary(
   })
 }
 
-function deploymentLogsKey(project: string, name: string, container?: string, tailLines?: number, previous?: boolean) {
-  return ['deployments', 'logs', project, name, container, tailLines, previous] as const
-}
-
 export function useGetDeploymentStatus(project: string, name: string, options?: { refetchInterval?: number }) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: deploymentStatusKey(project, name),
+    queryKey: keys.deployments.status(project, name),
     queryFn: async () => {
       const response = await client.getDeploymentStatus({ project, name })
       return response.status
@@ -143,7 +124,7 @@ export function useGetDeploymentLogs(
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: deploymentLogsKey(project, name, options?.container, options?.tailLines, options?.previous),
+    queryKey: keys.deployments.logs(project, name, options?.container, options?.tailLines, options?.previous),
     queryFn: async () => {
       const response = await client.getDeploymentLogs({
         project,
@@ -158,16 +139,12 @@ export function useGetDeploymentLogs(
   })
 }
 
-function deploymentRenderPreviewKey(project: string, name: string) {
-  return ['deployments', 'render-preview', project, name] as const
-}
-
 export function useGetDeploymentRenderPreview(project: string, name: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: deploymentRenderPreviewKey(project, name),
+    queryKey: keys.deployments.renderPreview(project, name),
     queryFn: async () => {
       const response = await client.getDeploymentRenderPreview({ project, name })
       return response
@@ -182,16 +159,12 @@ export function useGetDeploymentRenderPreview(project: string, name: string) {
 // comment for the storage-isolation guarantee. This hook is the sole read
 // path used by the drift UI; never infer drift from other deployment
 // fields.
-function deploymentPolicyStateKey(project: string, name: string) {
-  return ['deployments', 'policy-state', project, name] as const
-}
-
 export function useGetDeploymentPolicyState(project: string, name: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: deploymentPolicyStateKey(project, name),
+    queryKey: keys.deployments.policyState(project, name),
     queryFn: async () => {
       const response = await client.getDeploymentPolicyState({ project, name })
       return response.state
@@ -200,20 +173,12 @@ export function useGetDeploymentPolicyState(project: string, name: string) {
   })
 }
 
-function namespaceSecretsKey(project: string) {
-  return ['deployments', 'namespace-secrets', project] as const
-}
-
-function namespaceConfigMapsKey(project: string) {
-  return ['deployments', 'namespace-configmaps', project] as const
-}
-
 export function useListNamespaceSecrets(project: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: namespaceSecretsKey(project),
+    queryKey: keys.deployments.namespaceSecrets(project),
     queryFn: async () => {
       const response = await client.listNamespaceSecrets({ project })
       return response.secrets
@@ -227,7 +192,7 @@ export function useListNamespaceConfigMaps(project: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(DeploymentService, transport), [transport])
   return useQuery({
-    queryKey: namespaceConfigMapsKey(project),
+    queryKey: keys.deployments.namespaceConfigMaps(project),
     queryFn: async () => {
       const response = await client.listNamespaceConfigMaps({ project })
       return response.configMaps

--- a/frontend/src/queries/folders.ts
+++ b/frontend/src/queries/folders.ts
@@ -5,21 +5,14 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { FolderService } from '@/gen/holos/console/v1/folders_pb.js'
 import type { ParentType } from '@/gen/holos/console/v1/folders_pb.js'
 import { useAuth } from '@/lib/auth'
-
-function folderListKey(organization: string, parentType?: number, parentName?: string) {
-  return ['folders', 'list', organization, parentType, parentName] as const
-}
-
-function folderGetKey(name: string, organization?: string) {
-  return ['folders', 'get', organization ?? '', name] as const
-}
+import { keys } from '@/queries/keys'
 
 export function useListFolders(organization: string, parentType?: ParentType, parentName?: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(FolderService, transport), [transport])
   return useQuery({
-    queryKey: folderListKey(organization, parentType, parentName),
+    queryKey: keys.folders.list(organization, parentType, parentName),
     queryFn: async () => {
       const response = await client.listFolders({ organization, parentType, parentName })
       return response.folders
@@ -33,7 +26,7 @@ export function useGetFolder(name: string, organization?: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(FolderService, transport), [transport])
   return useQuery({
-    queryKey: folderGetKey(name, organization),
+    queryKey: keys.folders.get(name, organization),
     queryFn: async () => {
       const response = await client.getFolder({ organization: organization ?? '', name })
       return response.folder
@@ -47,7 +40,7 @@ export function useGetFolderRaw(name: string, organization?: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(FolderService, transport), [transport])
   return useQuery({
-    queryKey: ['folders', 'raw', organization ?? '', name] as const,
+    queryKey: keys.folders.raw(organization, name),
     queryFn: async () => {
       const response = await client.getFolderRaw({ organization: organization ?? '', name })
       return response.raw
@@ -72,7 +65,7 @@ export function useCreateFolder(organization: string) {
     }) =>
       client.createFolder({ organization, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['folders', 'list', organization] })
+      queryClient.invalidateQueries({ queryKey: keys.folders.listScope(organization) })
     },
   })
 }
@@ -85,8 +78,8 @@ export function useUpdateFolder(organization: string, name: string) {
     mutationFn: (params: { displayName?: string; description?: string; parentType?: ParentType; parentName?: string }) =>
       client.updateFolder({ organization, name, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
-      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
+      queryClient.invalidateQueries({ queryKey: keys.folders.list(organization) })
+      queryClient.invalidateQueries({ queryKey: keys.folders.getScope() })
     },
   })
 }
@@ -101,8 +94,8 @@ export function useUpdateFolderSharing(organization: string, name: string) {
       roleGrants: { principal: string; role: number }[]
     }) => client.updateFolderSharing({ name, organization, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
-      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
+      queryClient.invalidateQueries({ queryKey: keys.folders.list(organization) })
+      queryClient.invalidateQueries({ queryKey: keys.folders.getScope() })
     },
   })
 }
@@ -117,8 +110,8 @@ export function useUpdateFolderDefaultSharing(organization: string, name: string
       defaultRoleGrants: { principal: string; role: number }[]
     }) => client.updateFolderDefaultSharing({ name, organization, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
-      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
+      queryClient.invalidateQueries({ queryKey: keys.folders.list(organization) })
+      queryClient.invalidateQueries({ queryKey: keys.folders.getScope() })
     },
   })
 }
@@ -131,8 +124,8 @@ export function useDeleteFolder(organization: string) {
     mutationFn: (params: { name: string }) =>
       client.deleteFolder({ organization, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: folderListKey(organization) })
-      queryClient.invalidateQueries({ queryKey: ['folders', 'get'] })
+      queryClient.invalidateQueries({ queryKey: keys.folders.list(organization) })
+      queryClient.invalidateQueries({ queryKey: keys.folders.getScope() })
     },
   })
 }

--- a/frontend/src/queries/keys.ts
+++ b/frontend/src/queries/keys.ts
@@ -1,0 +1,109 @@
+export const keys = {
+  connect: {
+    all: () => ['connect-query'] as const,
+    getOrganization: (name: string) =>
+      ['connect-query', 'getOrganization', name] as const,
+    getOrganizationRaw: (name: string) =>
+      ['connect-query', 'getOrganizationRaw', name] as const,
+    getProject: (name: string) => ['connect-query', 'getProject', name] as const,
+  },
+  deployments: {
+    list: (project: string) => ['deployments', 'list', project] as const,
+    get: (project: string, name: string) =>
+      ['deployments', 'get', project, name] as const,
+    status: (project: string, name: string) =>
+      ['deployments', 'status', project, name] as const,
+    statusSummary: (project: string, name: string) =>
+      ['deployments', 'status-summary', project, name] as const,
+    logs: (
+      project: string,
+      name: string,
+      container?: string,
+      tailLines?: number,
+      previous?: boolean,
+    ) =>
+      ['deployments', 'logs', project, name, container, tailLines, previous] as const,
+    renderPreview: (project: string, name: string) =>
+      ['deployments', 'render-preview', project, name] as const,
+    policyState: (project: string, name: string) =>
+      ['deployments', 'policy-state', project, name] as const,
+    namespaceSecrets: (project: string) =>
+      ['deployments', 'namespace-secrets', project] as const,
+    namespaceConfigMaps: (project: string) =>
+      ['deployments', 'namespace-configmaps', project] as const,
+  },
+  folders: {
+    list: (organization: string, parentType?: number, parentName?: string) =>
+      ['folders', 'list', organization, parentType, parentName] as const,
+    listScope: (organization: string) => ['folders', 'list', organization] as const,
+    get: (name: string, organization?: string) =>
+      ['folders', 'get', organization ?? '', name] as const,
+    getScope: () => ['folders', 'get'] as const,
+    raw: (organization: string | undefined, name: string) =>
+      ['folders', 'raw', organization ?? '', name] as const,
+  },
+  organizations: {
+    get: (name: string) => keys.connect.getOrganization(name),
+    raw: (name: string) => keys.connect.getOrganizationRaw(name),
+  },
+  projectSettings: {
+    get: (project: string) => ['project-settings', 'get', project] as const,
+    raw: (project: string) => ['project-settings', 'raw', project] as const,
+  },
+  projects: {
+    listByParent: (
+      organization: string,
+      parentType?: number,
+      parentName?: string,
+    ) => ['projects', 'listByParent', organization, parentType, parentName] as const,
+    get: (name: string) => keys.connect.getProject(name),
+  },
+  releases: {
+    list: (namespace: string, templateName: string) =>
+      ['releases', 'list', namespace, templateName] as const,
+    get: (namespace: string, templateName: string, version: string) =>
+      ['releases', 'get', namespace, templateName, version] as const,
+  },
+  secrets: {
+    list: (project: string) => ['secrets', 'list', project] as const,
+    get: (project: string, name: string) =>
+      ['secrets', 'get', project, name] as const,
+    fanout: (project: string) => ['secrets', 'list', project, 'fanout'] as const,
+  },
+  templatePolicies: {
+    list: (namespace: string) => ['templatePolicies', 'list', namespace] as const,
+    get: (namespace: string, name: string) =>
+      ['templatePolicies', 'get', namespace, name] as const,
+    linkable: (namespace: string) =>
+      ['templatePolicies', 'linkable', namespace] as const,
+  },
+  templatePolicyBindings: {
+    list: (namespace: string) =>
+      ['templatePolicyBindings', 'list', namespace] as const,
+    get: (namespace: string, name: string) =>
+      ['templatePolicyBindings', 'get', namespace, name] as const,
+  },
+  templates: {
+    list: (namespace: string) => ['templates', 'list', namespace] as const,
+    get: (namespace: string, name: string) =>
+      ['templates', 'get', namespace, name] as const,
+    linkable: (namespace: string, includeSelfScope: boolean) =>
+      ['templates', 'linkable', namespace, includeSelfScope] as const,
+    examples: () => ['templates', 'examples'] as const,
+    search: (
+      namespace: string,
+      name: string,
+      displayNameContains: string,
+      organization: string,
+    ) =>
+      ['templates', 'search', namespace, name, displayNameContains, organization] as const,
+    defaults: (namespace: string, name: string) =>
+      ['templates', 'defaults', namespace, name] as const,
+    policyState: (namespace: string, name: string) =>
+      ['templates', 'policy-state', namespace, name] as const,
+    policyStateScope: (namespace: string) =>
+      ['templates', 'policy-state', namespace] as const,
+    render: (namespace: string, cueTemplate: string, cueInput: string) =>
+      ['templates', 'render', namespace, cueTemplate, cueInput] as const,
+  },
+} as const

--- a/frontend/src/queries/organizations.ts
+++ b/frontend/src/queries/organizations.ts
@@ -6,6 +6,7 @@ import {
   OrganizationService,
 } from '@/gen/holos/console/v1/organizations_pb.js'
 import { useAuth } from '@/lib/auth'
+import { keys } from '@/queries/keys'
 
 export function useListOrganizations() {
   const { isAuthenticated } = useAuth()
@@ -21,7 +22,7 @@ export function useGetOrganization(name: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(OrganizationService, transport), [transport])
   return useTanstackQuery({
-    queryKey: ['connect-query', 'getOrganization', name],
+    queryKey: keys.organizations.get(name),
     queryFn: async () => {
       const response = await client.getOrganization({ name })
       return response.organization
@@ -35,7 +36,7 @@ export function useGetOrganizationRaw(name: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(OrganizationService, transport), [transport])
   return useTanstackQuery({
-    queryKey: ['connect-query', 'getOrganizationRaw', name],
+    queryKey: keys.organizations.raw(name),
     queryFn: async () => {
       const response = await client.getOrganizationRaw({ name })
       return response.raw
@@ -52,7 +53,7 @@ export function useCreateOrganization() {
     mutationFn: (params: { name: string; displayName?: string; description?: string; populateDefaults?: boolean }) =>
       client.createOrganization(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -70,7 +71,7 @@ export function useUpdateOrganization() {
       gatewayNamespace?: string
     }) => client.updateOrganization(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -86,7 +87,7 @@ export function useUpdateOrganizationSharing() {
       roleGrants: { principal: string; role: number }[]
     }) => client.updateOrganizationSharing(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -102,7 +103,7 @@ export function useUpdateOrganizationDefaultSharing() {
       defaultRoleGrants: { principal: string; role: number }[]
     }) => client.updateOrganizationDefaultSharing(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -114,7 +115,7 @@ export function useDeleteOrganization() {
   return useMutation({
     mutationFn: (params: { name: string }) => client.deleteOrganization(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }

--- a/frontend/src/queries/project-settings.ts
+++ b/frontend/src/queries/project-settings.ts
@@ -4,17 +4,14 @@ import { useTransport } from '@connectrpc/connect-query'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ProjectSettingsService } from '@/gen/holos/console/v1/project_settings_pb.js'
 import { useAuth } from '@/lib/auth'
-
-function projectSettingsKey(project: string) {
-  return ['project-settings', 'get', project] as const
-}
+import { keys } from '@/queries/keys'
 
 export function useGetProjectSettings(project: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(ProjectSettingsService, transport), [transport])
   return useQuery({
-    queryKey: projectSettingsKey(project),
+    queryKey: keys.projectSettings.get(project),
     queryFn: async () => {
       const response = await client.getProjectSettings({ project })
       return response.settings
@@ -28,7 +25,7 @@ export function useGetProjectSettingsRaw(project: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(ProjectSettingsService, transport), [transport])
   return useQuery({
-    queryKey: ['project-settings', 'raw', project] as const,
+    queryKey: keys.projectSettings.raw(project),
     queryFn: async () => {
       const response = await client.getProjectSettingsRaw({ project })
       return response.raw
@@ -48,7 +45,7 @@ export function useUpdateProjectSettings(project: string) {
         settings: { project, ...params },
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: projectSettingsKey(project) })
+      queryClient.invalidateQueries({ queryKey: keys.projectSettings.get(project) })
     },
   })
 }

--- a/frontend/src/queries/projects.ts
+++ b/frontend/src/queries/projects.ts
@@ -9,6 +9,7 @@ import {
 } from '@/gen/holos/console/v1/projects_pb.js'
 import type { ParentType } from '@/gen/holos/console/v1/folders_pb.js'
 import { useAuth } from '@/lib/auth'
+import { keys } from '@/queries/keys'
 
 export function useListProjects(organization: string) {
   const { isAuthenticated } = useAuth()
@@ -24,7 +25,7 @@ export function useListProjectsByParent(organization: string, parentType?: Paren
   const transport = useTransport()
   const client = useMemo(() => createClient(ProjectService, transport), [transport])
   return useTanstackQuery({
-    queryKey: ['projects', 'listByParent', organization, parentType, parentName] as const,
+    queryKey: keys.projects.listByParent(organization, parentType, parentName),
     queryFn: async () => {
       const response = await client.listProjects({ organization, parentType, parentName })
       return response.projects
@@ -38,7 +39,7 @@ export function useGetProject(name: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(ProjectService, transport), [transport])
   return useTanstackQuery({
-    queryKey: ['connect-query', 'getProject', name],
+    queryKey: keys.projects.get(name),
     queryFn: async () => {
       const response = await client.getProject({ name })
       return response.project
@@ -55,7 +56,7 @@ export function useCreateProject() {
     mutationFn: (params: { name: string; displayName?: string; description?: string; organization: string; parentType?: number; parentName?: string }) =>
       client.createProject(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -68,7 +69,7 @@ export function useUpdateProject() {
     mutationFn: (params: { name: string; displayName?: string; description?: string; parentType?: ParentType; parentName?: string }) =>
       client.updateProject(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -84,7 +85,7 @@ export function useUpdateProjectSharing() {
       roleGrants: { principal: string; role: number }[]
     }) => client.updateProjectSharing(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -100,7 +101,7 @@ export function useUpdateProjectDefaultSharing() {
       defaultRoleGrants: { principal: string; role: number }[]
     }) => client.updateProjectDefaultSharing(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }
@@ -112,7 +113,7 @@ export function useDeleteProject() {
   return useMutation({
     mutationFn: (params: { name: string }) => client.deleteProject(params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['connect-query'] })
+      queryClient.invalidateQueries({ queryKey: keys.connect.all() })
     },
   })
 }

--- a/frontend/src/queries/secrets.test.ts
+++ b/frontend/src/queries/secrets.test.ts
@@ -1,0 +1,229 @@
+import { create } from '@bufbuild/protobuf'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import {
+  SecretMetadataSchema,
+  type SecretMetadata,
+} from '@/gen/holos/console/v1/secrets_pb.js'
+import { keys } from '@/queries/keys'
+import {
+  useCreateSecret,
+  useDeleteSecret,
+  useListSecrets,
+  useUpdateSecret,
+  useUpdateSecretSharing,
+} from '@/queries/secrets'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useAuth } from '@/lib/auth'
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function secret(name: string): SecretMetadata {
+  return create(SecretMetadataSchema, {
+    name,
+    accessible: true,
+    userGrants: [],
+    roleGrants: [],
+  })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function expectSecretInvalidation(invalidateSpy: unknown, project: string, name: string) {
+  expect(invalidateSpy).toHaveBeenCalledWith({
+    queryKey: keys.secrets.list(project),
+  })
+  expect(invalidateSpy).toHaveBeenCalledWith({
+    queryKey: keys.secrets.get(project, name),
+  })
+}
+
+describe('secret query keys', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      listSecrets: vi.fn().mockResolvedValue({ secrets: [secret('api-key')] }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('uses the canonical list key factory', async () => {
+    const { result } = renderHook(() => useListSecrets('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const matches = queryClient.getQueryCache().findAll({
+      queryKey: keys.secrets.list('demo-project'),
+    })
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.queryKey).toEqual(keys.secrets.list('demo-project'))
+  })
+})
+
+describe('secret mutation invalidation', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      createSecret: vi.fn().mockResolvedValue({}),
+      deleteSecret: vi.fn().mockResolvedValue({}),
+      updateSecret: vi.fn().mockResolvedValue({}),
+      updateSharing: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+  })
+
+  it('invalidates list and detail keys after create', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useCreateSecret('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'api-key',
+        data: {},
+        userGrants: [],
+        roleGrants: [],
+      })
+    })
+
+    expectSecretInvalidation(invalidateSpy, 'demo-project', 'api-key')
+  })
+
+  it('invalidates list and detail keys after delete', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useDeleteSecret('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync('api-key')
+    })
+
+    expectSecretInvalidation(invalidateSpy, 'demo-project', 'api-key')
+  })
+
+  it('invalidates list and detail keys after value update', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useUpdateSecret('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'api-key', data: {} })
+    })
+
+    expectSecretInvalidation(invalidateSpy, 'demo-project', 'api-key')
+  })
+
+  it('invalidates list and detail keys after sharing update', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useUpdateSecretSharing('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'api-key',
+        userGrants: [],
+        roleGrants: [],
+      })
+    })
+
+    expectSecretInvalidation(invalidateSpy, 'demo-project', 'api-key')
+  })
+})
+
+describe('secret list keep-previous-data', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      listSecrets: vi.fn(),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('keeps previous list data while the next project list is loading', async () => {
+    const alpha = deferred<{ secrets: SecretMetadata[] }>()
+    const beta = deferred<{ secrets: SecretMetadata[] }>()
+    mockClient.listSecrets.mockImplementation(({ project }: { project: string }) => {
+      if (project === 'alpha') return alpha.promise
+      if (project === 'beta') return beta.promise
+      throw new Error(`unexpected project ${project}`)
+    })
+
+    const { result, rerender } = renderHook(
+      ({ project }) => useListSecrets(project),
+      {
+        initialProps: { project: 'alpha' },
+        wrapper: makeWrapper(queryClient),
+      },
+    )
+
+    await act(async () => {
+      alpha.resolve({ secrets: [secret('alpha-secret')] })
+      await alpha.promise
+    })
+    await waitFor(() => expect(result.current.data?.[0]?.name).toBe('alpha-secret'))
+
+    rerender({ project: 'beta' })
+
+    await waitFor(() =>
+      expect(mockClient.listSecrets).toHaveBeenCalledWith({ project: 'beta' }),
+    )
+    expect(result.current.data?.[0]?.name).toBe('alpha-secret')
+    expect(result.current.isPlaceholderData).toBe(true)
+
+    await act(async () => {
+      beta.resolve({ secrets: [secret('beta-secret')] })
+      await beta.promise
+    })
+    await waitFor(() => expect(result.current.data?.[0]?.name).toBe('beta-secret'))
+    expect(result.current.isPlaceholderData).toBe(false)
+  })
+})

--- a/frontend/src/queries/secrets.ts
+++ b/frontend/src/queries/secrets.ts
@@ -1,14 +1,26 @@
 import { useMemo } from 'react'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query'
 import { SecretsService } from '@/gen/holos/console/v1/secrets_pb.js'
 import type { SecretMetadata } from '@/gen/holos/console/v1/secrets_pb.js'
 import { useAuth } from '@/lib/auth'
 import { aggregateFanOut, type FanOutAggregate, type FanOutQueryState } from '@/queries/templatePolicies'
+import { keys } from '@/queries/keys'
 
-function listSecretsKey(project: string) {
-  return ['secrets', 'list', project] as const
+function invalidateSecretListAndDetail(
+  queryClient: QueryClient,
+  project: string,
+  name: string,
+) {
+  queryClient.invalidateQueries({ queryKey: keys.secrets.list(project) })
+  queryClient.invalidateQueries({ queryKey: keys.secrets.get(project, name) })
 }
 
 export function useListSecrets(project: string) {
@@ -16,12 +28,13 @@ export function useListSecrets(project: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
   return useQuery({
-    queryKey: listSecretsKey(project),
+    queryKey: keys.secrets.list(project),
     queryFn: async () => {
       const response = await client.listSecrets({ project })
       return response.secrets
     },
     enabled: isAuthenticated && !!project,
+    placeholderData: keepPreviousData,
   })
 }
 
@@ -30,7 +43,7 @@ export function useGetSecret(project: string, name: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
   return useQuery({
-    queryKey: ['secrets', 'get', project, name],
+    queryKey: keys.secrets.get(project, name),
     queryFn: async () => {
       const response = await client.getSecret({ name, project })
       return response.data as Record<string, Uint8Array>
@@ -48,7 +61,7 @@ export function useGetSecretMetadata(project: string, name: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
   return useQuery({
-    queryKey: listSecretsKey(project),
+    queryKey: keys.secrets.list(project),
     queryFn: async () => {
       const response = await client.listSecrets({ project })
       return response.secrets
@@ -71,8 +84,8 @@ export function useCreateSecret(project: string) {
       description?: string
       url?: string
     }) => client.createSecret({ ...params, project }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: listSecretsKey(project) })
+    onSuccess: (_data, variables) => {
+      invalidateSecretListAndDetail(queryClient, project, variables.name)
     },
   })
 }
@@ -83,8 +96,8 @@ export function useDeleteSecret(project: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (name: string) => client.deleteSecret({ name, project }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: listSecretsKey(project) })
+    onSuccess: (_data, name) => {
+      invalidateSecretListAndDetail(queryClient, project, name)
     },
   })
 }
@@ -92,6 +105,7 @@ export function useDeleteSecret(project: string) {
 export function useUpdateSecret(project: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (params: {
       name: string
@@ -99,6 +113,9 @@ export function useUpdateSecret(project: string) {
       description?: string
       url?: string
     }) => client.updateSecret({ ...params, project }),
+    onSuccess: (_data, variables) => {
+      invalidateSecretListAndDetail(queryClient, project, variables.name)
+    },
   })
 }
 
@@ -112,8 +129,8 @@ export function useUpdateSecretSharing(project: string) {
       userGrants: { principal: string; role: number }[]
       roleGrants: { principal: string; role: number }[]
     }) => client.updateSharing({ ...params, project }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: listSecretsKey(project) })
+    onSuccess: (_data, variables) => {
+      invalidateSecretListAndDetail(queryClient, project, variables.name)
     },
   })
 }
@@ -138,12 +155,13 @@ export function useAllSecretsForProject(
   const client = useMemo(() => createClient(SecretsService, transport), [transport])
 
   const projectSecretsQuery = useQuery({
-    queryKey: [...listSecretsKey(projectName), 'fanout'] as const,
+    queryKey: keys.secrets.fanout(projectName),
     queryFn: async (): Promise<SecretRow[]> => {
       const response = await client.listSecrets({ project: projectName })
       return response.secrets.map((s) => ({ secret: s, scope: projectName }))
     },
     enabled: isAuthenticated && !!projectName,
+    placeholderData: keepPreviousData,
   })
 
   const projectAsQuery: FanOutQueryState<SecretRow[]> = {
@@ -155,4 +173,3 @@ export function useAllSecretsForProject(
 
   return aggregateFanOut<SecretRow>([projectAsQuery])
 }
-

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -22,27 +22,13 @@ import { useAuth } from '@/lib/auth'
 import { useListFolders } from '@/queries/folders'
 import type { Folder } from '@/gen/holos/console/v1/folders_pb.js'
 import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
+import { keys } from '@/queries/keys'
 
 // Re-export generated types/enums used by UI consumers. HOL-600 removed
 // TemplatePolicyTarget from the proto — render-target selection now
 // lives on TemplatePolicyBinding.
 export type { TemplatePolicy, TemplatePolicyRule, LinkableTemplatePolicy }
 export { TemplatePolicyKind }
-
-/** Query key helper for the template policies list at a given namespace. */
-function templatePolicyListKey(namespace: string) {
-  return ['templatePolicies', 'list', namespace] as const
-}
-
-/** Query key helper for a single template policy. */
-function templatePolicyGetKey(namespace: string, name: string) {
-  return ['templatePolicies', 'get', namespace, name] as const
-}
-
-/** Query key helper for the linkable template policies list at a given namespace. */
-function linkableTemplatePolicyListKey(namespace: string) {
-  return ['templatePolicies', 'linkable', namespace] as const
-}
 
 // useListTemplatePolicies fetches all policies visible within a namespace.
 // Mirrors the shape of useListTemplates in queries/templates.ts.
@@ -54,7 +40,7 @@ export function useListTemplatePolicies(namespace: string) {
     [transport],
   )
   return useQuery({
-    queryKey: templatePolicyListKey(namespace),
+    queryKey: keys.templatePolicies.list(namespace),
     queryFn: async () => {
       const response = await client.listTemplatePolicies({ namespace })
       return response.policies
@@ -79,7 +65,7 @@ export function useListLinkableTemplatePolicies(namespace: string) {
     [transport],
   )
   return useQuery({
-    queryKey: linkableTemplatePolicyListKey(namespace),
+    queryKey: keys.templatePolicies.linkable(namespace),
     queryFn: async () => {
       const response = await client.listLinkableTemplatePolicies({
         namespace,
@@ -178,7 +164,7 @@ export function useAllTemplatePoliciesForOrg(
 
   const folderQueries = useQueries({
     queries: folders.map((folder) => ({
-      queryKey: templatePolicyListKey(namespaceForFolder(folder.name)),
+      queryKey: keys.templatePolicies.list(namespaceForFolder(folder.name)),
       queryFn: async (): Promise<TemplatePolicy[]> => {
         const response = await client.listTemplatePolicies({
           namespace: namespaceForFolder(folder.name),
@@ -190,7 +176,7 @@ export function useAllTemplatePoliciesForOrg(
   })
 
   const orgQuery = useQuery({
-    queryKey: templatePolicyListKey(orgNamespace),
+    queryKey: keys.templatePolicies.list(orgNamespace),
     queryFn: async () => {
       const response = await client.listTemplatePolicies({
         namespace: orgNamespace,
@@ -240,7 +226,7 @@ export function useGetTemplatePolicy(namespace: string, name: string) {
     [transport],
   )
   return useQuery({
-    queryKey: templatePolicyGetKey(namespace, name),
+    queryKey: keys.templatePolicies.get(namespace, name),
     queryFn: async () => {
       const response = await client.getTemplatePolicy({ namespace, name })
       return response.policy
@@ -276,7 +262,7 @@ export function useCreateTemplatePolicy(namespace: string) {
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: templatePolicyListKey(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicies.list(namespace) })
     },
   })
 }
@@ -307,8 +293,8 @@ export function useUpdateTemplatePolicy(namespace: string, name: string) {
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: templatePolicyListKey(namespace) })
-      queryClient.invalidateQueries({ queryKey: templatePolicyGetKey(namespace, name) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicies.list(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicies.get(namespace, name) })
     },
   })
 }
@@ -325,7 +311,7 @@ export function useDeleteTemplatePolicy(namespace: string) {
     mutationFn: (params: { name: string }) =>
       client.deleteTemplatePolicy({ namespace, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: templatePolicyListKey(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicies.list(namespace) })
     },
   })
 }

--- a/frontend/src/queries/templatePolicyBindings.ts
+++ b/frontend/src/queries/templatePolicyBindings.ts
@@ -22,6 +22,7 @@ import { useAuth } from '@/lib/auth'
 import { useListFolders } from '@/queries/folders'
 import type { Folder } from '@/gen/holos/console/v1/folders_pb.js'
 import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
+import { keys } from '@/queries/keys'
 import {
   aggregateFanOut,
   type FanOutAggregate,
@@ -31,16 +32,6 @@ import {
 // Re-export generated types/enums used by UI consumers.
 export type { TemplatePolicyBinding, TemplatePolicyBindingTargetRef, LinkedTemplatePolicyRef }
 export { TemplatePolicyBindingTargetKind }
-
-/** Query key helper for the template policy bindings list at a given namespace. */
-function bindingListKey(namespace: string) {
-  return ['templatePolicyBindings', 'list', namespace] as const
-}
-
-/** Query key helper for a single template policy binding. */
-function bindingGetKey(namespace: string, name: string) {
-  return ['templatePolicyBindings', 'get', namespace, name] as const
-}
 
 // useListTemplatePolicyBindings fetches all bindings visible within a namespace.
 // Mirrors the shape of useListTemplatePolicies in queries/templatePolicies.ts.
@@ -52,7 +43,7 @@ export function useListTemplatePolicyBindings(namespace: string) {
     [transport],
   )
   return useQuery({
-    queryKey: bindingListKey(namespace),
+    queryKey: keys.templatePolicyBindings.list(namespace),
     queryFn: async () => {
       const response = await client.listTemplatePolicyBindings({ namespace })
       return response.bindings
@@ -93,7 +84,7 @@ export function useAllTemplatePolicyBindingsForOrg(
 
   const folderQueries = useQueries({
     queries: folders.map((folder) => ({
-      queryKey: bindingListKey(namespaceForFolder(folder.name)),
+      queryKey: keys.templatePolicyBindings.list(namespaceForFolder(folder.name)),
       queryFn: async (): Promise<TemplatePolicyBinding[]> => {
         const response = await client.listTemplatePolicyBindings({
           namespace: namespaceForFolder(folder.name),
@@ -105,7 +96,7 @@ export function useAllTemplatePolicyBindingsForOrg(
   })
 
   const orgQuery = useQuery({
-    queryKey: bindingListKey(orgNamespace),
+    queryKey: keys.templatePolicyBindings.list(orgNamespace),
     queryFn: async () => {
       const response = await client.listTemplatePolicyBindings({
         namespace: orgNamespace,
@@ -151,7 +142,7 @@ export function useGetTemplatePolicyBinding(namespace: string, name: string) {
     [transport],
   )
   return useQuery({
-    queryKey: bindingGetKey(namespace, name),
+    queryKey: keys.templatePolicyBindings.get(namespace, name),
     queryFn: async () => {
       const response = await client.getTemplatePolicyBinding({ namespace, name })
       return response.binding
@@ -189,7 +180,7 @@ export function useCreateTemplatePolicyBinding(namespace: string) {
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: bindingListKey(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicyBindings.list(namespace) })
     },
   })
 }
@@ -225,8 +216,8 @@ export function useUpdateTemplatePolicyBinding(
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: bindingListKey(namespace) })
-      queryClient.invalidateQueries({ queryKey: bindingGetKey(namespace, name) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicyBindings.list(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicyBindings.get(namespace, name) })
     },
   })
 }
@@ -243,7 +234,7 @@ export function useDeleteTemplatePolicyBinding(namespace: string) {
     mutationFn: (params: { name: string }) =>
       client.deleteTemplatePolicyBinding({ namespace, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: bindingListKey(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templatePolicyBindings.list(namespace) })
     },
   })
 }

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -34,6 +34,7 @@ import {
   type FanOutAggregate,
   type FanOutQueryState,
 } from '@/queries/templatePolicies'
+import { keys } from '@/queries/keys'
 
 // Re-export generated types used by consumers.
 export type {
@@ -60,22 +61,6 @@ export function parseLinkableKey(key: string): { namespace: string; name: string
   return { namespace: key.slice(0, slash), name: key.slice(slash + 1) }
 }
 
-function templateListKey(namespace: string) {
-  return ['templates', 'list', namespace] as const
-}
-
-function templateGetKey(namespace: string, name: string) {
-  return ['templates', 'get', namespace, name] as const
-}
-
-function linkableTemplatesKey(namespace: string, includeSelfScope: boolean) {
-  return ['templates', 'linkable', namespace, includeSelfScope] as const
-}
-
-function templateExamplesKey() {
-  return ['templates', 'examples'] as const
-}
-
 // useListTemplateExamples fetches the built-in CUE example templates embedded
 // in the server binary (HOL-797). The template example picker UI calls this
 // hook to offer drop-in starting points when creating a new template — the
@@ -89,7 +74,7 @@ export function useListTemplateExamples() {
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: templateExamplesKey(),
+    queryKey: keys.templates.examples(),
     queryFn: async () => {
       const response = await client.listTemplateExamples({})
       return response.examples
@@ -104,7 +89,7 @@ export function useListTemplates(namespace: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: templateListKey(namespace),
+    queryKey: keys.templates.list(namespace),
     queryFn: async () => {
       const response = await client.listTemplates({ namespace })
       return response.templates
@@ -151,7 +136,7 @@ export function useAllTemplatesForOrg(orgName: string): FanOutAggregate<Template
 
   const folderQueries = useQueries({
     queries: folders.map((folder) => ({
-      queryKey: templateListKey(namespaceForFolder(folder.name)),
+      queryKey: keys.templates.list(namespaceForFolder(folder.name)),
       queryFn: async (): Promise<Template[]> => {
         const response = await client.listTemplates({
           namespace: namespaceForFolder(folder.name),
@@ -164,7 +149,7 @@ export function useAllTemplatesForOrg(orgName: string): FanOutAggregate<Template
 
   const projectQueries = useQueries({
     queries: projects.map((project) => ({
-      queryKey: templateListKey(namespaceForProject(project.name)),
+      queryKey: keys.templates.list(namespaceForProject(project.name)),
       queryFn: async (): Promise<Template[]> => {
         const response = await client.listTemplates({
           namespace: namespaceForProject(project.name),
@@ -176,7 +161,7 @@ export function useAllTemplatesForOrg(orgName: string): FanOutAggregate<Template
   })
 
   const orgQuery = useQuery({
-    queryKey: templateListKey(orgNamespace),
+    queryKey: keys.templates.list(orgNamespace),
     queryFn: async () => {
       const response = await client.listTemplates({ namespace: orgNamespace })
       return response.templates
@@ -225,15 +210,6 @@ export function useAllTemplatesForOrg(orgName: string): FanOutAggregate<Template
   ])
 }
 
-function searchTemplatesKey(
-  namespace: string,
-  name: string,
-  displayNameContains: string,
-  organization: string,
-) {
-  return ['templates', 'search', namespace, name, displayNameContains, organization] as const
-}
-
 // useSearchTemplates returns templates matching the given filters across every
 // namespace scope the caller can see. Introduced in HOL-607 for the unified
 // Templates index at /organizations/$orgName/templates. Pass `organization` to restrict
@@ -255,7 +231,7 @@ export function useSearchTemplates(params: {
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: searchTemplatesKey(namespace, name, displayNameContains, organization),
+    queryKey: keys.templates.search(namespace, name, displayNameContains, organization),
     queryFn: async () => {
       const response = await client.searchTemplates({
         namespace,
@@ -267,10 +243,6 @@ export function useSearchTemplates(params: {
     },
     enabled: isAuthenticated && organization !== '',
   })
-}
-
-function templateDefaultsKey(namespace: string, name: string) {
-  return ['templates', 'defaults', namespace, name] as const
 }
 
 // useGetTemplateDefaults fetches the TemplateDefaults payload for a given
@@ -290,7 +262,7 @@ export function useGetTemplateDefaults(
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   const callerEnabled = options?.enabled ?? true
   return useQuery({
-    queryKey: templateDefaultsKey(namespace, name),
+    queryKey: keys.templates.defaults(namespace, name),
     queryFn: async () => {
       const response = await client.getTemplateDefaults({ namespace, name })
       return response.defaults
@@ -304,7 +276,7 @@ export function useGetTemplate(namespace: string, name: string) {
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: templateGetKey(namespace, name),
+    queryKey: keys.templates.get(namespace, name),
     queryFn: async () => {
       const response = await client.getTemplate({ namespace, name })
       return response.template
@@ -338,7 +310,7 @@ export function useCreateTemplate(namespace: string) {
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: templateListKey(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templates.list(namespace) })
     },
   })
 }
@@ -367,15 +339,15 @@ export function useUpdateTemplate(namespace: string, name: string) {
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: templateListKey(namespace) })
-      queryClient.invalidateQueries({ queryKey: templateGetKey(namespace, name) })
+      queryClient.invalidateQueries({ queryKey: keys.templates.list(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templates.get(namespace, name) })
       // HOL-559: a successful UpdateTemplate re-renders against the
       // current TemplatePolicy chain and records a fresh applied render
       // set on the backend. Invalidate all policy-state queries for this
       // namespace so the list-row drift badge and the detail PolicySection
       // both refresh from the authoritative state rather than showing
       // the stale "drifted" snapshot after reconcile.
-      queryClient.invalidateQueries({ queryKey: ['templates', 'policy-state', namespace] })
+      queryClient.invalidateQueries({ queryKey: keys.templates.policyStateScope(namespace) })
     },
   })
 }
@@ -388,7 +360,7 @@ export function useDeleteTemplate(namespace: string) {
     mutationFn: (params: { name: string }) =>
       client.deleteTemplate({ namespace, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: templateListKey(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templates.list(namespace) })
     },
   })
 }
@@ -401,7 +373,7 @@ export function useCloneTemplate(namespace: string) {
     mutationFn: (params: { sourceName: string; name: string; displayName: string }) =>
       client.cloneTemplate({ namespace, ...params }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: templateListKey(namespace) })
+      queryClient.invalidateQueries({ queryKey: keys.templates.list(namespace) })
     },
   })
 }
@@ -422,7 +394,7 @@ export function useListLinkableTemplates(
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: linkableTemplatesKey(namespace, includeSelfScope),
+    queryKey: keys.templates.linkable(namespace, includeSelfScope),
     queryFn: async () => {
       const response = await client.listLinkableTemplates({ namespace, includeSelfScope })
       return response.templates
@@ -433,20 +405,12 @@ export function useListLinkableTemplates(
 
 // --- Release hooks ---
 
-function releaseListKey(namespace: string, templateName: string) {
-  return ['releases', 'list', namespace, templateName] as const
-}
-
-function releaseGetKey(namespace: string, templateName: string, version: string) {
-  return ['releases', 'get', namespace, templateName, version] as const
-}
-
 export function useListReleases(namespace: string, templateName: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: releaseListKey(namespace, templateName),
+    queryKey: keys.releases.list(namespace, templateName),
     queryFn: async () => {
       const response = await client.listReleases({ namespace, templateName })
       return response.releases
@@ -460,7 +424,7 @@ export function useGetRelease(namespace: string, templateName: string, version: 
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: releaseGetKey(namespace, templateName, version),
+    queryKey: keys.releases.get(namespace, templateName, version),
     queryFn: async () => {
       const response = await client.getRelease({ namespace, templateName, version })
       return response.release
@@ -495,7 +459,7 @@ export function useCreateRelease(namespace: string, templateName: string) {
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: releaseListKey(namespace, templateName) })
+      queryClient.invalidateQueries({ queryKey: keys.releases.list(namespace, templateName) })
     },
   })
 }
@@ -511,16 +475,12 @@ export function useCreateRelease(namespace: string, templateName: string) {
 // validates that the namespace corresponds to a project scope and rejects
 // non-project scopes with InvalidArgument; the UI should therefore only
 // invoke this hook on project-scope editor pages. See the callsite.
-function projectTemplatePolicyStateKey(namespace: string, name: string) {
-  return ['templates', 'policy-state', namespace, name] as const
-}
-
 export function useGetProjectTemplatePolicyState(namespace: string, name: string) {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: projectTemplatePolicyStateKey(namespace, name),
+    queryKey: keys.templates.policyState(namespace, name),
     queryFn: async () => {
       const response = await client.getProjectTemplatePolicyState({ namespace, name })
       return response.state
@@ -542,7 +502,7 @@ export function useRenderTemplate(
   const transport = useTransport()
   const client = useMemo(() => createClient(TemplateService, transport), [transport])
   return useQuery({
-    queryKey: ['templates', 'render', namespace, cueTemplate, cueInput] as const,
+    queryKey: keys.templates.render(namespace, cueTemplate, cueInput),
     queryFn: async () => {
       const response = await client.renderTemplate({
         namespace,

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -32,6 +32,7 @@ import { Button } from '@/components/ui/button'
 import { TemplatesHelpPane } from '@/components/templates/TemplatesHelpPane'
 import { useGetProject } from '@/queries/projects'
 import { useGetOrganization } from '@/queries/organizations'
+import { keys } from '@/queries/keys'
 import { useAllTemplatesForOrg } from '@/queries/templates'
 import { useAllTemplatePoliciesForOrg } from '@/queries/templatePolicies'
 import { useAllTemplatePolicyBindingsForOrg } from '@/queries/templatePolicyBindings'
@@ -273,7 +274,7 @@ export function ProjectTemplatesIndexPage({
           const client = createClient(TemplateService, transport)
           await client.deleteTemplate({ namespace, name })
           await queryClient.invalidateQueries({
-            queryKey: ['templates', 'list', namespace],
+            queryKey: keys.templates.list(namespace),
           })
           break
         }
@@ -281,7 +282,7 @@ export function ProjectTemplatesIndexPage({
           const client = createClient(TemplatePolicyService, transport)
           await client.deleteTemplatePolicy({ namespace, name })
           await queryClient.invalidateQueries({
-            queryKey: ['templatePolicies', 'list', namespace],
+            queryKey: keys.templatePolicies.list(namespace),
           })
           break
         }
@@ -289,7 +290,7 @@ export function ProjectTemplatesIndexPage({
           const client = createClient(TemplatePolicyBindingService, transport)
           await client.deleteTemplatePolicyBinding({ namespace, name })
           await queryClient.invalidateQueries({
-            queryKey: ['templatePolicyBindings', 'list', namespace],
+            queryKey: keys.templatePolicyBindings.list(namespace),
           })
           break
         }


### PR DESCRIPTION
## Summary
- add docs/agents/tanstack-query-conventions.md as the canonical TanStack Query convention reference
- add frontend/src/queries/keys.ts and route hand-written query keys/invalidation through it
- refactor secrets queries with documented list/detail invalidation and keep-previous-data list behavior
- add secrets query tests for key shape, mutation invalidation, and KPD across project changes

## Verification
- cd frontend && npm test -- --run
- cd frontend && npm run build
- cd frontend && npm run lint (attempted; fails on pre-existing unrelated lint debt outside this PR's changed files)