### PR TITLE
feat(frontend): apply ResourceGrid + TanStack Query conventions to five resource views

### DIFF
--- a/frontend/src/queries/deployments.ts
+++ b/frontend/src/queries/deployments.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { DeploymentService } from '@/gen/holos/console/v1/deployments_pb.js'
 import type { EnvVar } from '@/gen/holos/console/v1/deployments_pb.js'
 import { useAuth } from '@/lib/auth'
@@ -18,6 +18,7 @@ export function useListDeployments(project: string) {
       return response.deployments
     },
     enabled: isAuthenticated && !!project,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import {
+  keepPreviousData,
   useQuery,
   useQueries,
   useMutation,
@@ -46,6 +47,7 @@ export function useListTemplatePolicies(namespace: string) {
       return response.policies
     },
     enabled: isAuthenticated && !!namespace,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/src/queries/templatePolicyBindings.ts
+++ b/frontend/src/queries/templatePolicyBindings.ts
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import {
+  keepPreviousData,
   useQuery,
   useQueries,
   useMutation,
@@ -49,6 +50,7 @@ export function useListTemplatePolicyBindings(namespace: string) {
       return response.bindings
     },
     enabled: isAuthenticated && !!namespace,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import {
+  keepPreviousData,
   useQuery,
   useQueries,
   useMutation,
@@ -95,6 +96,7 @@ export function useListTemplates(namespace: string) {
       return response.templates
     },
     enabled: isAuthenticated && !!namespace,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-index.test.tsx
@@ -1,7 +1,20 @@
-import { render, screen, fireEvent, within } from '@testing-library/react'
+/**
+ * Tests for OrgTemplateBindingsIndexPage (HOL-948) — ResourceGrid v1 migration.
+ *
+ * Mocks @/queries/templatePolicyBindings and @/queries/organizations.
+ * Exercises: grid render, extra Scope + Policy + Targets columns, row navigation,
+ * loading/error states, empty state, create-button visibility.
+ */
+
+import { render, screen } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+
+// ---------------------------------------------------------------------------
+// Router mock — Route.useParams / useSearch / useNavigate / fullPath
+// ---------------------------------------------------------------------------
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -9,6 +22,8 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     ...actual,
     createFileRoute: () => () => ({
       useParams: () => ({ orgName: 'test-org' }),
+      useSearch: () => ({}),
+      fullPath: '/organizations/test-org/template-bindings/',
     }),
     Link: ({
       children,
@@ -27,13 +42,18 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
         })
       }
       return (
-        <a href={href} data-params={JSON.stringify(params)} {...props}>
+        <a href={href} {...props}>
           {children}
         </a>
       )
     },
+    useNavigate: () => vi.fn(),
   }
 })
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
 
 vi.mock('@/queries/templatePolicyBindings', async () => {
   const actual = await vi.importActual<
@@ -42,6 +62,7 @@ vi.mock('@/queries/templatePolicyBindings', async () => {
   return {
     ...actual,
     useListTemplatePolicyBindings: vi.fn(),
+    useDeleteTemplatePolicyBinding: vi.fn(),
   }
 })
 
@@ -49,21 +70,25 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-// Namespace prefixes default to 'holos-' / 'org-' / 'fld-' / 'prj-' when
-// __CONSOLE_CONFIG__ is not injected (see console-config.ts), which matches
-// the fixtures below — no mock needed.
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { useListTemplatePolicyBindings, useDeleteTemplatePolicyBinding } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { OrgTemplateBindingsIndexPage } from './index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function makeBinding(
   name: string,
   options: {
     namespace?: string
     description?: string
-    creatorEmail?: string
     targets?: number
     policyName?: string
   } = {},
@@ -73,7 +98,8 @@ function makeBinding(
     displayName: name,
     namespace: options.namespace ?? 'holos-org-test-org',
     description: options.description ?? '',
-    creatorEmail: options.creatorEmail ?? '',
+    creatorEmail: '',
+    createdAt: undefined,
     policyRef: options.policyName
       ? { namespace: 'holos-org-test-org', name: options.policyName }
       : undefined,
@@ -88,11 +114,12 @@ function makeBinding(
 function setup(
   userRole: Role = Role.OWNER,
   bindings: ReturnType<typeof makeBinding>[] = [],
+  isPending = false,
   error: Error | null = null,
 ) {
   ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
-    data: bindings,
-    isPending: false,
+    data: isPending ? undefined : bindings,
+    isPending,
     error,
   })
   ;(useGetOrganization as Mock).mockReturnValue({
@@ -100,136 +127,88 @@ function setup(
     isPending: false,
     error: null,
   })
+  ;(useDeleteTemplatePolicyBinding as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  })
 }
 
-describe('OrgTemplateBindingsIndexPage', () => {
+describe('OrgTemplateBindingsIndexPage (ResourceGrid v1)', () => {
   beforeEach(() => vi.clearAllMocks())
+
+  it('renders loading skeleton while fetching', () => {
+    setup(Role.OWNER, [], true)
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
+  })
 
   it('renders empty state when no bindings exist', () => {
     setup(Role.OWNER, [])
     render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-    expect(
-      screen.getByText(/no template bindings yet/i),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
   })
 
-  it('renders the grid with org-scoped name links, scope badges, and target counts', () => {
-    setup(Role.OWNER, [
-      makeBinding('org-bind', {
-        targets: 3,
-        policyName: 'require-http',
-      }),
-    ])
+  it('renders binding rows in the grid', () => {
+    setup(Role.OWNER, [makeBinding('org-bind', { targets: 3, policyName: 'require-http' })])
     render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
+    expect(screen.getByText('org-bind')).toBeInTheDocument()
+  })
 
-    // Name cell renders as a link to the new template-bindings route.
-    const orgLink = screen.getByRole('link', { name: 'org-bind' })
-    expect(orgLink.getAttribute('href')).toBe(
-      '/organizations/test-org/template-bindings/org-bind',
-    )
-
-    // Scope and targets columns.
+  it('renders a Scope extra column with badge', () => {
+    setup(Role.OWNER, [makeBinding('org-bind')])
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
+    expect(screen.getByRole('columnheader', { name: /^scope$/i })).toBeInTheDocument()
     expect(screen.getByText(/^Organization: test-org$/)).toBeInTheDocument()
-    expect(screen.getByText(/3 targets/)).toBeInTheDocument()
+  })
+
+  it('renders a Policy extra column with policy name', () => {
+    setup(Role.OWNER, [makeBinding('org-bind', { policyName: 'require-http' })])
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
+    expect(screen.getByRole('columnheader', { name: /^policy$/i })).toBeInTheDocument()
     expect(screen.getByText('require-http')).toBeInTheDocument()
   })
 
-  it('renders plain text (no link) for non-org-scoped rows', () => {
-    setup(Role.OWNER, [
-      makeBinding('fld-bind', {
-        namespace: 'holos-fld-team-alpha',
-        targets: 1,
-        policyName: 'exclude-http',
-      }),
-    ])
+  it('renders a Targets extra column with count badge', () => {
+    setup(Role.OWNER, [makeBinding('org-bind', { targets: 3 })])
     render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-
-    // Folder-scoped binding should NOT produce a link (this page is org-only).
-    expect(screen.queryByRole('link', { name: 'fld-bind' })).not.toBeInTheDocument()
-    expect(screen.getByText('fld-bind')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^targets$/i })).toBeInTheDocument()
+    expect(screen.getByText(/3 targets/)).toBeInTheDocument()
   })
 
-  it('filters rows by the global search input', () => {
-    setup(Role.OWNER, [
-      makeBinding('alpha', { policyName: 'p1' }),
-      makeBinding('beta', { policyName: 'p2' }),
-    ])
+  it('renders org-scoped rows with detailHref links', () => {
+    setup(Role.OWNER, [makeBinding('org-bind')])
     render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-
-    const input = screen.getByLabelText('Search template bindings')
-    fireEvent.change(input, { target: { value: 'alph' } })
-
-    expect(screen.getByRole('link', { name: 'alpha' })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'beta' })).not.toBeInTheDocument()
+    // ResourceGrid renders a Link for the display name when detailHref is set.
+    const links = screen.getAllByRole('link', { name: 'org-bind' })
+    expect(links.length).toBeGreaterThan(0)
+    expect(links[0].getAttribute('href')).toContain('template-bindings/org-bind')
   })
 
-  it('does not render a scope filter select in the toolbar', () => {
-    setup(Role.OWNER, [makeBinding('org-bind', { policyName: 'p1' })])
+  it('shows Create Binding button for OWNER', () => {
+    setup(Role.OWNER, [])
     render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-    expect(
-      screen.queryByRole('combobox', { name: /filter by scope/i }),
-    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /new template binding/i })).toBeInTheDocument()
   })
 
-  it('lists bindings returned from the org namespace RPC call', () => {
+  it('shows Create Binding button for EDITOR', () => {
+    setup(Role.EDITOR, [])
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /new template binding/i })).toBeInTheDocument()
+  })
+
+  it('hides Create Binding button for VIEWER', () => {
+    setup(Role.VIEWER, [])
+    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
+    expect(screen.queryByRole('button', { name: /new template binding/i })).not.toBeInTheDocument()
+  })
+
+  it('lists multiple bindings returned from the org namespace RPC call', () => {
     setup(Role.OWNER, [
       makeBinding('bind-a', { policyName: 'policy-a' }),
       makeBinding('bind-b', { policyName: 'policy-b' }),
     ])
     render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-    expect(screen.getByRole('link', { name: 'bind-a' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'bind-b' })).toBeInTheDocument()
-  })
-
-  it('shows Create Binding for OWNER and EDITOR', () => {
-    setup(Role.OWNER, [])
-    const { unmount } = render(
-      <OrgTemplateBindingsIndexPage orgName="test-org" />,
-    )
-    expect(
-      screen.getByRole('link', { name: /create binding/i }),
-    ).toBeInTheDocument()
-    unmount()
-
-    setup(Role.EDITOR, [])
-    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-    expect(
-      screen.getByRole('link', { name: /create binding/i }),
-    ).toBeInTheDocument()
-  })
-
-  it('hides Create Binding for VIEWER', () => {
-    setup(Role.VIEWER, [])
-    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-    expect(
-      screen.queryByRole('link', { name: /create binding/i }),
-    ).not.toBeInTheDocument()
-  })
-
-  it('surfaces an error when the list query fails with no partial data', () => {
-    ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
-      data: [],
-      isPending: false,
-      error: new Error('backend unreachable'),
-    })
-    ;(useGetOrganization as Mock).mockReturnValue({
-      data: { name: 'test-org', userRole: Role.OWNER },
-      isPending: false,
-      error: null,
-    })
-    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-    expect(screen.getByText('backend unreachable')).toBeInTheDocument()
-  })
-
-  it('shows a partial-error banner when the query errors but some rows loaded', () => {
-    setup(
-      Role.OWNER,
-      [makeBinding('org-bind', { policyName: 'p1' })],
-      new Error('fetch failed'),
-    )
-    render(<OrgTemplateBindingsIndexPage orgName="test-org" />)
-    const banner = screen.getByTestId('bindings-partial-error')
-    expect(within(banner).getByText('fetch failed')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'org-bind' })).toBeInTheDocument()
+    expect(screen.getByText('bind-a')).toBeInTheDocument()
+    expect(screen.getByText('bind-b')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/index.tsx
@@ -1,40 +1,49 @@
-import { useMemo, useState } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
-import {
-  useReactTable,
-  getCoreRowModel,
-  getFilteredRowModel,
-  flexRender,
-  createColumnHelper,
-} from '@tanstack/react-table'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Skeleton } from '@/components/ui/skeleton'
+/**
+ * Organization-scoped TemplatePolicyBinding index — migrated to ResourceGrid v1 (HOL-948).
+ *
+ * Shows org-scoped bindings only. The RPC is called with the org namespace directly
+ * so only org-scoped bindings are returned. Folder-scoped binding browsing lives on
+ * the folder detail pages.
+ *
+ * Extra columns:
+ *   - Scope    — badge showing org or folder scope
+ *   - Policy   — name of the bound TemplatePolicy
+ *   - Targets  — count of target refs
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Badge } from '@/components/ui/badge'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import {
+  useListTemplatePolicyBindings,
+  useDeleteTemplatePolicyBinding,
+} from '@/queries/templatePolicyBindings'
 import type { TemplatePolicyBinding } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import {
   scopeDisplayLabel,
-  scopeLabelFromNamespace,
   scopeNameFromNamespace,
   namespaceForOrg,
 } from '@/lib/scope-labels'
+import {
+  resolveTemplateRowHref,
+  parentLabelFromNamespace,
+} from '@/lib/template-row-link'
+import type { ColumnDef } from '@tanstack/react-table'
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-bindings/',
 )({
+  validateSearch: parseGridSearch,
   component: OrgTemplateBindingsIndexRoute,
 })
 
@@ -43,7 +52,94 @@ function OrgTemplateBindingsIndexRoute() {
   return <OrgTemplateBindingsIndexPage orgName={orgName} />
 }
 
-const columnHelper = createColumnHelper<TemplatePolicyBinding>()
+// ---------------------------------------------------------------------------
+// Extra columns — Scope badge, Policy reference, and target count
+// ---------------------------------------------------------------------------
+
+function useBindingExtraColumns(
+  bindingsByKey: Map<string, TemplatePolicyBinding>,
+): ColumnDef<Row>[] {
+  return useMemo(
+    () => [
+      {
+        id: 'scope',
+        header: 'Scope',
+        accessorFn: (row: Row) => {
+          const label = scopeDisplayLabel(row.namespace)
+          const name = scopeNameFromNamespace(row.namespace)
+          if (!label) return ''
+          return name ? `${label}: ${name}` : label
+        },
+        cell: ({ row }: { row: { original: Row } }) => {
+          const label = scopeDisplayLabel(row.original.namespace)
+          const name = scopeNameFromNamespace(row.original.namespace)
+          if (!label) {
+            return (
+              <Badge variant="outline" className="text-xs">
+                unknown
+              </Badge>
+            )
+          }
+          return (
+            <Badge variant="outline" className="text-xs">
+              {label}
+              {name ? `: ${name}` : ''}
+            </Badge>
+          )
+        },
+      },
+      {
+        id: 'policy',
+        header: 'Policy',
+        accessorFn: (row: Row) => {
+          const b = bindingsByKey.get(`${row.namespace}/${row.name}`)
+          return b?.policyRef?.name ?? ''
+        },
+        cell: ({ row }: { row: { original: Row } }) => {
+          const b = bindingsByKey.get(`${row.original.namespace}/${row.original.name}`)
+          const policyName = b?.policyRef?.name
+          if (!policyName) {
+            return <span className="text-muted-foreground">—</span>
+          }
+          return (
+            <span className="font-mono text-sm text-blue-500">{policyName}</span>
+          )
+        },
+      },
+      {
+        id: 'targets',
+        header: 'Targets',
+        accessorFn: (row: Row) => {
+          const b = bindingsByKey.get(`${row.namespace}/${row.name}`)
+          return b?.targetRefs?.length ?? 0
+        },
+        cell: ({ row }: { row: { original: Row } }) => {
+          const b = bindingsByKey.get(`${row.original.namespace}/${row.original.name}`)
+          const n = b?.targetRefs?.length ?? 0
+          return (
+            <Badge variant="outline" className="text-xs">
+              {n} target{n === 1 ? '' : 's'}
+            </Badge>
+          )
+        },
+      },
+    ],
+    [bindingsByKey],
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function timestampToISOString(ts: { seconds: bigint } | undefined): string {
+  if (!ts) return ''
+  return new Date(Number(ts.seconds) * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
 
 export function OrgTemplateBindingsIndexPage({
   orgName: propOrgName,
@@ -57,261 +153,86 @@ export function OrgTemplateBindingsIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
-  // This page is org-scoped only. The RPC is called with the org namespace
-  // directly so only org-scoped bindings are returned. Folder-scoped bindings
-  // are excluded — the folder-scoped index remains at
-  // /folders/$folderName/template-policy-bindings.
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+
   const orgNamespace = namespaceForOrg(orgName)
-  const { data: bindings, isPending, error } =
-    useListTemplatePolicyBindings(orgNamespace)
+  const { data: bindings = [], isPending, error } = useListTemplatePolicyBindings(orgNamespace)
   const { data: org } = useGetOrganization(orgName)
+  const deleteMutation = useDeleteTemplatePolicyBinding(orgNamespace)
 
   const userRole = org?.userRole ?? Role.VIEWER
-  // PERMISSION_TEMPLATE_POLICIES_WRITE cascades to editors too (bindings reuse
-  // the policy permission family — see HOL-595).
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
-  const [globalFilter, setGlobalFilter] = useState('')
-
-  const rows = useMemo(() => {
-    return bindings ?? []
+  // Build a lookup map for extra columns to access the original binding object.
+  const bindingsByKey = useMemo(() => {
+    const map = new Map<string, TemplatePolicyBinding>()
+    for (const b of bindings) {
+      if (b) map.set(`${b.namespace}/${b.name}`, b)
+    }
+    return map
   }, [bindings])
 
-  const columns = useMemo(
+  // Map TemplatePolicyBinding → ResourceGrid Row
+  const rows: Row[] = useMemo(
+    () =>
+      bindings.map((b) => ({
+        kind: 'TemplatePolicyBinding',
+        name: b.name,
+        namespace: b.namespace,
+        id: `${b.namespace}/${b.name}`,
+        parentId: b.namespace,
+        parentLabel: parentLabelFromNamespace(b.namespace),
+        displayName: b.displayName || b.name,
+        description: b.description ?? '',
+        createdAt: timestampToISOString(b.createdAt),
+        detailHref: resolveTemplateRowHref('TemplatePolicyBinding', b.namespace, b.name),
+      })),
+    [bindings],
+  )
+
+  const kinds = useMemo(
     () => [
-      columnHelper.accessor((row) => row.displayName || row.name, {
-        id: 'name',
-        header: 'Name',
-        cell: ({ row }) => {
-          const b = row.original
-          const label = b.displayName || b.name
-          const scope = scopeLabelFromNamespace(b.namespace)
-          // This page shows org-scoped bindings only (namespaceForOrg). Any
-          // row from a folder namespace would indicate stale cache / proto
-          // drift — render as plain text to avoid a broken link.
-          if (scope === 'org') {
-            return (
-              <Link
-                to="/organizations/$orgName/template-bindings/$bindingName"
-                params={{ orgName, bindingName: b.name }}
-                title={b.name}
-                className="hover:underline font-medium"
-              >
-                {label}
-              </Link>
-            )
-          }
-          return (
-            <span className="font-medium" title={b.name}>
-              {label}
-            </span>
-          )
-        },
-      }),
-      columnHelper.accessor((row) => scopeCellText(row.namespace), {
-        id: 'scope',
-        header: 'Scope',
-        cell: ({ row }) => <ScopeBadge namespace={row.original.namespace} />,
-      }),
-      columnHelper.accessor((row) => row.policyRef?.name ?? '', {
-        id: 'policy',
-        header: 'Policy',
-        cell: ({ row }) => {
-          const p = row.original.policyRef
-          if (!p?.name) {
-            return <span className="text-muted-foreground">—</span>
-          }
-          return (
-            <span className="font-mono text-sm text-blue-500">{p.name}</span>
-          )
-        },
-      }),
-      columnHelper.accessor((row) => row.targetRefs.length, {
-        id: 'targets',
-        header: 'Targets',
-        cell: ({ getValue }) => {
-          const n = getValue() as number
-          return (
-            <Badge variant="outline" className="text-xs">
-              {n} target{n === 1 ? '' : 's'}
-            </Badge>
-          )
-        },
-      }),
-      columnHelper.accessor('description', {
-        header: 'Description',
-        cell: ({ getValue }) => {
-          const d = getValue()
-          if (!d) return <span className="text-muted-foreground">—</span>
-          return (
-            <span className="text-sm text-muted-foreground truncate">{d}</span>
-          )
-        },
-      }),
+      {
+        id: 'TemplatePolicyBinding',
+        label: 'Template Binding',
+        newHref: `/organizations/${orgName}/template-bindings/new`,
+        canCreate: canWrite,
+      },
     ],
-    [orgName],
+    [orgName, canWrite],
   )
 
-  const table = useReactTable({
-    data: rows,
-    columns,
-    state: { globalFilter },
-    onGlobalFilterChange: setGlobalFilter,
-    globalFilterFn: 'includesString',
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-  })
+  const extraColumns = useBindingExtraColumns(bindingsByKey)
 
-  if (isPending) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>Template Bindings</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-2" data-testid="bindings-loading">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  if (error && (bindings ?? []).length === 0) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <Alert variant="destructive">
-            <AlertDescription>{error.message}</AlertDescription>
-          </Alert>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  return (
-    <Card>
-      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-        <div>
-          <p className="text-sm text-muted-foreground">
-            {orgName} / Template Bindings
-          </p>
-          <CardTitle className="mt-1">Template Bindings</CardTitle>
-        </div>
-        {canWrite && (
-          <Link
-            to="/organizations/$orgName/template-bindings/new"
-            params={{ orgName }}
-          >
-            <Button size="sm">Create Binding</Button>
-          </Link>
-        )}
-      </CardHeader>
-      <CardContent>
-        {error && (
-          <Alert
-            variant="destructive"
-            className="mb-4"
-            data-testid="bindings-partial-error"
-          >
-            <AlertDescription>{error.message}</AlertDescription>
-          </Alert>
-        )}
-        {(bindings ?? []).length === 0 ? (
-          <div className="rounded-md border border-dashed border-border p-6 text-center">
-            <p className="text-sm font-medium">
-              No template bindings yet.
-            </p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Bindings attach a single TemplatePolicy to project templates and
-              deployments via target refs. Bindings live only at folder or
-              organization scope.
-            </p>
-          </div>
-        ) : (
-          <>
-            <div className="mb-3 flex flex-col sm:flex-row gap-2 sm:items-center">
-              <Input
-                placeholder="Search bindings…"
-                value={globalFilter}
-                onChange={(e) => setGlobalFilter(e.target.value)}
-                className="max-w-sm"
-                aria-label="Search template bindings"
-              />
-            </div>
-            {rows.length === 0 ? (
-              <div className="rounded-md border border-dashed border-border p-6 text-center">
-                <p className="text-sm text-muted-foreground">
-                  No bindings match the current search.
-                </p>
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => (
-                        <TableHead key={header.id}>
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                        </TableHead>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableHeader>
-                <TableBody>
-                  {table.getRowModel().rows.map((row) => (
-                    <TableRow key={row.id}>
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                          )}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-          </>
-        )}
-      </CardContent>
-    </Card>
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
   )
-}
 
-// scopeCellText supplies the string the global search filter matches against
-// when the user types a scope label. Having an accessor that returns text
-// (rather than a ReactNode cell) lets `includesString` search this column.
-function scopeCellText(namespace: string): string {
-  const label = scopeDisplayLabel(namespace)
-  const name = scopeNameFromNamespace(namespace)
-  if (!label) return ''
-  return name ? `${label}: ${name}` : label
-}
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
 
-function ScopeBadge({ namespace }: { namespace: string }) {
-  const label = scopeDisplayLabel(namespace)
-  const name = scopeNameFromNamespace(namespace)
-  if (!label) {
-    return (
-      <Badge variant="outline" className="text-xs">
-        unknown
-      </Badge>
-    )
-  }
   return (
-    <Badge variant="outline" className="text-xs">
-      {label}
-      {name ? `: ${name}` : ''}
-    </Badge>
+    <ResourceGrid
+      title={`${orgName} / Template Bindings`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+      extraColumns={extraColumns}
+    />
   )
 }

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-index.test.tsx
@@ -1,7 +1,21 @@
-import { render, screen, fireEvent, within } from '@testing-library/react'
+/**
+ * Tests for OrgTemplatePoliciesIndexPage (HOL-948) — ResourceGrid v1 migration.
+ *
+ * Mocks @/queries/templatePolicies and @/queries/organizations.
+ * Exercises: grid render, extra Scope + Rules columns, row navigation,
+ * loading/error states, empty state, create-button visibility.
+ */
+
+import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { namespaceForOrg, namespaceForFolder } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Router mock — Route.useParams / useSearch / useNavigate / fullPath
+// ---------------------------------------------------------------------------
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -9,34 +23,39 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     ...actual,
     createFileRoute: () => () => ({
       useParams: () => ({ orgName: 'test-org' }),
+      useSearch: () => ({}),
+      fullPath: '/organizations/test-org/template-policies/',
     }),
     Link: ({
       children,
       to,
       params,
-      title,
       className,
     }: {
       children: React.ReactNode
-      to: string
+      to?: string
       params?: Record<string, string>
-      title?: string
       className?: string
     }) => {
-      let href = to
+      let href = to ?? '#'
       if (params) {
         for (const [k, v] of Object.entries(params)) {
           href = href.replace(`$${k}`, v)
         }
       }
       return (
-        <a href={href} title={title} className={className}>
+        <a href={href} className={className}>
           {children}
         </a>
       )
     },
+    useNavigate: () => vi.fn(),
   }
 })
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
 
 vi.mock('@/queries/templatePolicies', async () => {
   const actual = await vi.importActual<typeof import('@/queries/templatePolicies')>(
@@ -45,6 +64,7 @@ vi.mock('@/queries/templatePolicies', async () => {
   return {
     ...actual,
     useListTemplatePolicies: vi.fn(),
+    useDeleteTemplatePolicy: vi.fn(),
   }
 })
 
@@ -52,13 +72,19 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-import {
-  useListTemplatePolicies,
-} from '@/queries/templatePolicies'
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { useListTemplatePolicies, useDeleteTemplatePolicy } from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { namespaceForOrg, namespaceForFolder } from '@/lib/scope-labels'
 import { OrgTemplatePoliciesIndexPage } from './index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 type PolicyFixture = {
   name: string
@@ -67,12 +93,14 @@ type PolicyFixture = {
   description?: string
   creatorEmail?: string
   rules: unknown[]
+  createdAt?: undefined
 }
 
 function makePolicy(
   name: string,
   namespace: string,
   displayName = name,
+  rules: unknown[] = [],
 ): PolicyFixture {
   return {
     name,
@@ -80,7 +108,8 @@ function makePolicy(
     displayName,
     description: '',
     creatorEmail: '',
-    rules: [],
+    rules,
+    createdAt: undefined,
   }
 }
 
@@ -99,67 +128,46 @@ function setup(
     isPending: false,
     error: null,
   })
+  ;(useDeleteTemplatePolicy as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  })
 }
 
 const ORG_NS = namespaceForOrg('test-org')
 const FOLDER_NS = namespaceForFolder('team-alpha')
 
-describe('OrgTemplatePoliciesIndexPage', () => {
+describe('OrgTemplatePoliciesIndexPage (ResourceGrid v1)', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('renders skeleton while loading', () => {
+  it('renders loading skeleton while fetching', () => {
     setup([], Role.OWNER, { isPending: true })
-    const { container } = render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(container.querySelector('[data-testid="policies-loading"]')).toBeInTheDocument()
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
   })
 
-  it('renders error alert when the fan-out fails with no data', () => {
+  it('renders error state when the query fails with no data', () => {
     setup([], Role.OWNER, { error: new Error('bad gateway') })
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(screen.getByText('bad gateway')).toBeInTheDocument()
-    // full-page error — table should not be rendered
-    expect(screen.queryByRole('table')).toBeNull()
-  })
-
-  it('renders rows with inline warning banner when partial data and error coexist', () => {
-    ;(useListTemplatePolicies as Mock).mockReturnValue({
-      data: [makePolicy('p-org', namespaceForOrg('test-org'), 'Org Policy')],
-      isPending: false,
-      error: new Error('folders unavailable'),
-    })
-    ;(useGetOrganization as Mock).mockReturnValue({
-      data: { name: 'test-org', userRole: Role.OWNER },
-      isPending: false,
-      error: null,
-    })
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    // rows must be visible
-    expect(screen.getByText('Org Policy')).toBeInTheDocument()
-    expect(screen.getByRole('table')).toBeInTheDocument()
-    // inline warning banner must be present
-    expect(screen.getByTestId('policies-partial-error')).toBeInTheDocument()
-    expect(screen.getByText('folders unavailable')).toBeInTheDocument()
   })
 
   it('renders empty state when no policies exist', () => {
     setup([])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.getByText(/no template policies yet/i)).toBeInTheDocument()
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
   })
 
-  it('renders org-scoped policies only', () => {
+  it('renders org-scoped policy rows in the grid', () => {
     setup([makePolicy('p-org', ORG_NS, 'Org Policy')])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(screen.getByText('Org Policy')).toBeInTheDocument()
-    expect(screen.getAllByText(ORG_NS).length).toBeGreaterThan(0)
-    expect(screen.getByText('p-org')).toBeInTheDocument()
   })
 
-  it('renders folder-scoped policies only', () => {
+  it('renders folder-scoped policy rows in the grid', () => {
     setup([makePolicy('p-folder', FOLDER_NS, 'Folder Policy')])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
     expect(screen.getByText('Folder Policy')).toBeInTheDocument()
-    expect(screen.getAllByText(FOLDER_NS).length).toBeGreaterThan(0)
   })
 
   it('renders org and folder policies combined in one grid', () => {
@@ -172,118 +180,7 @@ describe('OrgTemplatePoliciesIndexPage', () => {
     expect(screen.getByText('Folder Policy')).toBeInTheDocument()
   })
 
-  it('routes org-scoped rows to the org detail page', () => {
-    setup([makePolicy('p-org', ORG_NS, 'Org Policy')])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    const link = screen.getByRole('link', { name: 'Org Policy' })
-    expect(link).toHaveAttribute(
-      'href',
-      '/organizations/test-org/template-policies/p-org',
-    )
-  })
-
-  it('routes folder-scoped rows to the folder detail page', () => {
-    setup([makePolicy('p-folder', FOLDER_NS, 'Folder Policy')])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    const link = screen.getByRole('link', { name: 'Folder Policy' })
-    expect(link).toHaveAttribute(
-      'href',
-      '/folders/team-alpha/template-policies/p-folder',
-    )
-  })
-
-  it('falls back to the name when displayName is empty', () => {
-    setup([makePolicy('p-nodn', ORG_NS, '')])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    const link = screen.getByRole('link', { name: 'p-nodn' })
-    expect(link).toBeInTheDocument()
-  })
-
-  it('renders a plain span (not a link) for unknown or project-scoped namespaces', () => {
-    // Safety net for stale caches or proto drift: HOL-590 guarantees policies
-    // live only at org or folder scope, but if the server ever surfaces a
-    // project-scoped row we must not forge a link to a 404 page.
-    setup([
-      makePolicy('p-proj', 'holos-prj-billing', 'Project Policy'),
-      makePolicy('p-bad', 'some-other-ns', 'Bad Scope Policy'),
-    ])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.queryByRole('link', { name: 'Project Policy' })).toBeNull()
-    expect(screen.queryByRole('link', { name: 'Bad Scope Policy' })).toBeNull()
-    expect(screen.getByText('Project Policy')).toBeInTheDocument()
-    expect(screen.getByText('Bad Scope Policy')).toBeInTheDocument()
-  })
-
-  it('filters by display name', () => {
-    setup([
-      makePolicy('p-alpha', ORG_NS, 'Alpha Policy'),
-      makePolicy('p-beta', ORG_NS, 'Beta Policy'),
-    ])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    const search = screen.getByRole('textbox', { name: /search template policies/i })
-    fireEvent.change(search, { target: { value: 'alpha' } })
-    expect(screen.getByText('Alpha Policy')).toBeInTheDocument()
-    expect(screen.queryByText('Beta Policy')).not.toBeInTheDocument()
-  })
-
-  it('filters by namespace', () => {
-    setup([
-      makePolicy('p-org', ORG_NS, 'Org Policy'),
-      makePolicy('p-folder', FOLDER_NS, 'Folder Policy'),
-    ])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    const search = screen.getByRole('textbox', { name: /search template policies/i })
-    fireEvent.change(search, { target: { value: 'fld-team-alpha' } })
-    expect(screen.getByText('Folder Policy')).toBeInTheDocument()
-    expect(screen.queryByText('Org Policy')).not.toBeInTheDocument()
-  })
-
-  it('filters by policy name', () => {
-    setup([
-      makePolicy('reference-grant', ORG_NS, 'ReferenceGrant'),
-      makePolicy('tls-required', ORG_NS, 'Require TLS'),
-    ])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    const search = screen.getByRole('textbox', { name: /search template policies/i })
-    fireEvent.change(search, { target: { value: 'reference' } })
-    expect(screen.getByText('ReferenceGrant')).toBeInTheDocument()
-    expect(screen.queryByText('Require TLS')).not.toBeInTheDocument()
-  })
-
-  it('shows Create Policy for OWNER', () => {
-    setup([])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.getByRole('link', { name: /create policy/i })).toBeInTheDocument()
-  })
-
-  it('shows Create Policy for EDITOR', () => {
-    setup([], Role.EDITOR)
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.getByRole('link', { name: /create policy/i })).toBeInTheDocument()
-  })
-
-  it('hides Create Policy for VIEWER', () => {
-    setup([], Role.VIEWER)
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.queryByRole('link', { name: /create policy/i })).not.toBeInTheDocument()
-  })
-
-  it('renders each policy row with a distinct Display Name cell', () => {
-    setup([
-      makePolicy('p-org', ORG_NS, 'Org Policy'),
-      makePolicy('p-folder', FOLDER_NS, 'Folder Policy'),
-    ])
-    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    const table = screen.getByRole('table')
-    const rows = within(table).getAllByRole('row')
-    // 1 header + 2 body rows
-    expect(rows.length).toBe(3)
-  })
-
-  // HOL-793: the Scope column renders a human-readable label per row so users
-  // can tell org-vs-folder rows apart at a glance. Previously scope was only
-  // visible from the name-cell link target.
-  it('renders a Scope column with a badge per row', () => {
+  it('renders a Scope extra column with badges', () => {
     setup([
       makePolicy('p-org', ORG_NS, 'Org Policy'),
       makePolicy('p-folder', FOLDER_NS, 'Folder Policy'),
@@ -294,25 +191,44 @@ describe('OrgTemplatePoliciesIndexPage', () => {
     expect(screen.getByText('Folder: team-alpha')).toBeInTheDocument()
   })
 
-  // HOL-917: the "All scopes / Organization / Folder" Select was removed. The
-  // page is now org-scoped only — no scope filter in the toolbar.
-  it('does not render a scope filter select in the toolbar', () => {
+  it('renders a Rules extra column', () => {
     setup([makePolicy('p-org', ORG_NS, 'Org Policy')])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(
-      screen.queryByRole('combobox', { name: /filter by scope/i }),
-    ).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^rules$/i })).toBeInTheDocument()
   })
 
-  // HOL-917: prove that org-namespace policies appear in the listing (the page
-  // now calls useListTemplatePolicies(orgNamespace) directly).
-  it('lists policies returned from the org namespace RPC call', () => {
-    setup([
-      makePolicy('allow-tls', ORG_NS, 'Allow TLS'),
-      makePolicy('deny-http', ORG_NS, 'Deny HTTP'),
-    ])
+  it('org-scoped row links to the org detail page via detailHref', () => {
+    setup([makePolicy('p-org', ORG_NS, 'Org Policy')])
     render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
-    expect(screen.getByText('Allow TLS')).toBeInTheDocument()
-    expect(screen.getByText('Deny HTTP')).toBeInTheDocument()
+    // ResourceGrid renders a Link for the display name when detailHref is set.
+    const links = screen.getAllByRole('link', { name: 'Org Policy' })
+    expect(links.length).toBeGreaterThan(0)
+    expect(links[0].getAttribute('href')).toContain('template-policies/p-org')
+  })
+
+  it('falls back to the name when displayName is empty', () => {
+    setup([makePolicy('p-nodn', ORG_NS, '')])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    // The display name cell falls back to the name field.
+    const links = screen.getAllByRole('link', { name: 'p-nodn' })
+    expect(links.length).toBeGreaterThan(0)
+  })
+
+  it('shows Create Policy button for OWNER', () => {
+    setup([])
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /new template policy/i })).toBeInTheDocument()
+  })
+
+  it('shows Create Policy button for EDITOR', () => {
+    setup([], Role.EDITOR)
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /new template policy/i })).toBeInTheDocument()
+  })
+
+  it('hides Create Policy button for VIEWER', () => {
+    setup([], Role.VIEWER)
+    render(<OrgTemplatePoliciesIndexPage orgName="test-org" />)
+    expect(screen.queryByRole('button', { name: /new template policy/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/index.tsx
@@ -1,40 +1,49 @@
-import { useMemo, useState } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
-import {
-  useReactTable,
-  getCoreRowModel,
-  getFilteredRowModel,
-  flexRender,
-  createColumnHelper,
-} from '@tanstack/react-table'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Skeleton } from '@/components/ui/skeleton'
+/**
+ * Organization-scoped TemplatePolicy index — migrated to ResourceGrid v1 (HOL-948).
+ *
+ * Shows org-scoped policies only. The RPC is called with the org namespace directly
+ * so only org-scoped policies are returned (HOL-917). Folder-scoped policy browsing
+ * lives on the folder detail pages.
+ *
+ * Extra columns:
+ *   - Scope  — badge showing org or folder scope
+ *   - Rules  — REQUIRE / EXCLUDE rule counts
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Badge } from '@/components/ui/badge'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { useListTemplatePolicies } from '@/queries/templatePolicies'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import {
+  useListTemplatePolicies,
+  useDeleteTemplatePolicy,
+  countRulesByKind,
+} from '@/queries/templatePolicies'
 import type { TemplatePolicy } from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
 import {
   scopeDisplayLabel,
-  scopeLabelFromNamespace,
   scopeNameFromNamespace,
   namespaceForOrg,
 } from '@/lib/scope-labels'
+import {
+  resolveTemplateRowHref,
+  parentLabelFromNamespace,
+} from '@/lib/template-row-link'
+import type { ColumnDef } from '@tanstack/react-table'
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-policies/',
 )({
+  validateSearch: parseGridSearch,
   component: OrgTemplatePoliciesIndexRoute,
 })
 
@@ -43,7 +52,89 @@ function OrgTemplatePoliciesIndexRoute() {
   return <OrgTemplatePoliciesIndexPage orgName={orgName} />
 }
 
-const columnHelper = createColumnHelper<TemplatePolicy>()
+// ---------------------------------------------------------------------------
+// Extra columns — Scope badge and rule counts
+// ---------------------------------------------------------------------------
+
+function usePolicyExtraColumns(
+  policiesByName: Map<string, TemplatePolicy>,
+): ColumnDef<Row>[] {
+  return useMemo(
+    () => [
+      {
+        id: 'scope',
+        header: 'Scope',
+        accessorFn: (row: Row) => {
+          const label = scopeDisplayLabel(row.namespace)
+          const name = scopeNameFromNamespace(row.namespace)
+          if (!label) return ''
+          return name ? `${label}: ${name}` : label
+        },
+        cell: ({ row }: { row: { original: Row } }) => {
+          const label = scopeDisplayLabel(row.original.namespace)
+          const name = scopeNameFromNamespace(row.original.namespace)
+          if (!label) {
+            return (
+              <Badge variant="outline" className="text-xs">
+                unknown
+              </Badge>
+            )
+          }
+          return (
+            <Badge variant="outline" className="text-xs">
+              {label}
+              {name ? `: ${name}` : ''}
+            </Badge>
+          )
+        },
+      },
+      {
+        id: 'rules',
+        header: 'Rules',
+        accessorFn: (row: Row) => {
+          const p = policiesByName.get(`${row.namespace}/${row.name}`)
+          const counts = countRulesByKind(p)
+          return `${counts.require}R ${counts.exclude}E`
+        },
+        cell: ({ row }: { row: { original: Row } }) => {
+          const p = policiesByName.get(`${row.original.namespace}/${row.original.name}`)
+          const counts = countRulesByKind(p)
+          return (
+            <div className="flex items-center gap-1">
+              {counts.require > 0 && (
+                <Badge variant="outline" className="text-xs font-mono">
+                  {counts.require} REQUIRE
+                </Badge>
+              )}
+              {counts.exclude > 0 && (
+                <Badge variant="destructive" className="text-xs font-mono">
+                  {counts.exclude} EXCLUDE
+                </Badge>
+              )}
+              {counts.require === 0 && counts.exclude === 0 && (
+                <span className="text-muted-foreground text-xs">—</span>
+              )}
+            </div>
+          )
+        },
+      },
+    ],
+    [policiesByName],
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function timestampToISOString(ts: { seconds: bigint } | undefined): string {
+  if (!ts) return ''
+  return new Date(Number(ts.seconds) * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
 
 export function OrgTemplatePoliciesIndexPage({
   orgName: propOrgName,
@@ -57,245 +148,86 @@ export function OrgTemplatePoliciesIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
-  // HOL-917: this page is now org-scoped only. The RPC is called with the org
-  // namespace directly so only org-scoped policies are returned. The previous
-  // fan-out across org+folder namespaces and the "All scopes" Select filter
-  // have been removed.
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+
   const orgNamespace = namespaceForOrg(orgName)
-  const { data: policies, isPending, error } = useListTemplatePolicies(orgNamespace)
+  const { data: policies = [], isPending, error } = useListTemplatePolicies(orgNamespace)
   const { data: org } = useGetOrganization(orgName)
+  const deleteMutation = useDeleteTemplatePolicy(orgNamespace)
 
   const userRole = org?.userRole ?? Role.VIEWER
-  // PERMISSION_TEMPLATE_POLICIES_WRITE cascades to editors too.
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
-  const [globalFilter, setGlobalFilter] = useState('')
-
-  const rows = useMemo(() => {
-    return policies ?? []
+  // Build a lookup map for extra columns to access the original policy object.
+  const policiesByName = useMemo(() => {
+    const map = new Map<string, TemplatePolicy>()
+    for (const p of policies) {
+      if (p) map.set(`${p.namespace}/${p.name}`, p)
+    }
+    return map
   }, [policies])
 
-  const columns = useMemo(
+  // Map TemplatePolicy → ResourceGrid Row
+  const rows: Row[] = useMemo(
+    () =>
+      policies.map((p) => ({
+        kind: 'TemplatePolicy',
+        name: p.name,
+        namespace: p.namespace,
+        id: `${p.namespace}/${p.name}`,
+        parentId: p.namespace,
+        parentLabel: parentLabelFromNamespace(p.namespace),
+        displayName: p.displayName || p.name,
+        description: p.description ?? '',
+        createdAt: timestampToISOString(p.createdAt),
+        detailHref: resolveTemplateRowHref('TemplatePolicy', p.namespace, p.name),
+      })),
+    [policies],
+  )
+
+  const kinds = useMemo(
     () => [
-      columnHelper.accessor((row) => row.displayName || row.name, {
-        id: 'displayName',
-        header: 'Display Name',
-        cell: ({ row }) => {
-          const p = row.original
-          const label = p.displayName || p.name
-          const scope = scopeLabelFromNamespace(p.namespace)
-          // HOL-590 guarantees policies live only at org or folder scope.
-          // If the server ever surfaces a project-scoped or unprefixed
-          // namespace (stale cache, proto drift) we render a plain cell
-          // rather than forging a link to a page that will 404.
-          if (scope === 'folder') {
-            const folderName = scopeNameFromNamespace(p.namespace)
-            if (folderName) {
-              return (
-                <Link
-                  to="/folders/$folderName/template-policies/$policyName"
-                  params={{ folderName, policyName: p.name }}
-                  title={p.name}
-                  className="hover:underline font-medium"
-                >
-                  {label}
-                </Link>
-              )
-            }
-          } else if (scope === 'org') {
-            return (
-              <Link
-                to="/organizations/$orgName/template-policies/$policyName"
-                params={{ orgName, policyName: p.name }}
-                title={p.name}
-                className="hover:underline font-medium"
-              >
-                {label}
-              </Link>
-            )
-          }
-          return (
-            <span className="font-medium" title={p.name}>
-              {label}
-            </span>
-          )
-        },
-      }),
-      columnHelper.accessor((row) => scopeCellText(row.namespace), {
-        id: 'scope',
-        header: 'Scope',
-        cell: ({ row }) => <ScopeBadge namespace={row.original.namespace} />,
-      }),
-      columnHelper.accessor('namespace', {
-        header: 'Namespace',
-        cell: ({ getValue }) => (
-          <span className="text-muted-foreground font-mono text-sm">
-            {getValue()}
-          </span>
-        ),
-      }),
-      columnHelper.accessor('name', {
-        header: 'Name',
-        cell: ({ getValue }) => (
-          <span className="text-muted-foreground font-mono text-sm">
-            {getValue()}
-          </span>
-        ),
-      }),
+      {
+        id: 'TemplatePolicy',
+        label: 'Template Policy',
+        newHref: `/organizations/${orgName}/template-policies/new`,
+        canCreate: canWrite,
+      },
     ],
-    [orgName],
+    [orgName, canWrite],
   )
 
-  const table = useReactTable({
-    data: rows,
-    columns,
-    state: { globalFilter },
-    onGlobalFilterChange: setGlobalFilter,
-    globalFilterFn: 'includesString',
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-  })
+  const extraColumns = usePolicyExtraColumns(policiesByName)
 
-  if (isPending) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>Template Policies</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-2" data-testid="policies-loading">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  if (error && (policies ?? []).length === 0) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <Alert variant="destructive">
-            <AlertDescription>{error.message}</AlertDescription>
-          </Alert>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  return (
-    <Card>
-      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-        <div>
-          <p className="text-sm text-muted-foreground">
-            {orgName} / Template Policies
-          </p>
-          <CardTitle className="mt-1">Template Policies</CardTitle>
-        </div>
-        {canWrite && (
-          <Link to="/organizations/$orgName/template-policies/new" params={{ orgName }}>
-            <Button size="sm">Create Policy</Button>
-          </Link>
-        )}
-      </CardHeader>
-      <CardContent>
-        {error && (
-          <Alert variant="destructive" className="mb-4" data-testid="policies-partial-error">
-            <AlertDescription>{error.message}</AlertDescription>
-          </Alert>
-        )}
-        {(policies ?? []).length === 0 ? (
-          <div className="rounded-md border border-dashed border-border p-6 text-center">
-            <p className="text-sm font-medium">No template policies yet.</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Policies attach templates to projects through REQUIRE or EXCLUDE
-              rules. Rules apply to both project templates and deployments.
-              Policies live only at folder or organization scope.
-            </p>
-          </div>
-        ) : (
-          <>
-            <div className="mb-3 flex flex-col sm:flex-row gap-2 sm:items-center">
-              <Input
-                placeholder="Search policies…"
-                value={globalFilter}
-                onChange={(e) => setGlobalFilter(e.target.value)}
-                className="max-w-sm"
-                aria-label="Search template policies"
-              />
-            </div>
-            {rows.length === 0 && (
-              <div className="mb-3 rounded-md border border-dashed border-border p-4 text-center">
-                <p className="text-sm text-muted-foreground">
-                  No policies match the current search.
-                </p>
-              </div>
-            )}
-            <Table>
-              <TableHeader>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <TableRow key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <TableHead key={header.id}>
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext(),
-                            )}
-                      </TableHead>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableHeader>
-              <TableBody>
-                {table.getRowModel().rows.map((row) => (
-                  <TableRow key={row.id}>
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </>
-        )}
-      </CardContent>
-    </Card>
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
   )
-}
 
-// scopeCellText supplies the string the global search filter matches against
-// when the user types a scope label. An accessor that returns text (rather
-// than a ReactNode cell) lets `includesString` search this column.
-function scopeCellText(namespace: string): string {
-  const label = scopeDisplayLabel(namespace)
-  const name = scopeNameFromNamespace(namespace)
-  if (!label) return ''
-  return name ? `${label}: ${name}` : label
-}
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
 
-function ScopeBadge({ namespace }: { namespace: string }) {
-  const label = scopeDisplayLabel(namespace)
-  const name = scopeNameFromNamespace(namespace)
-  if (!label) {
-    return (
-      <Badge variant="outline" className="text-xs">
-        unknown
-      </Badge>
-    )
-  }
   return (
-    <Badge variant="outline" className="text-xs">
-      {label}
-      {name ? `: ${name}` : ''}
-    </Badge>
+    <ResourceGrid
+      title={`${orgName} / Template Policies`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+      extraColumns={extraColumns}
+    />
   )
 }


### PR DESCRIPTION
## Summary

- Migrates `TemplatePolicies` and `TemplatePolicyBindings` org-scoped index pages from raw TanStack Table to `ResourceGrid` v1 — consistent grid shell, loading/error/empty states, URL-backed search, and row navigation via `detailHref`
- Adds `placeholderData: keepPreviousData` to `useListDeployments`, `useListTemplates`, `useListTemplatePolicies`, and `useListTemplatePolicyBindings` so KPD is applied uniformly across all five resource views
- TemplatePolicy grid surfaces Scope badge and REQUIRE/EXCLUDE rule counts as `extraColumns`
- TemplatePolicyBinding grid surfaces Scope badge, bound Policy name, and target count as `extraColumns`
- Row delete wired via existing `useDeleteTemplatePolicy` / `useDeleteTemplatePolicyBinding` hooks
- All five views now set `detailHref` so the Resource ID cell, Display Name cell, and full row are clickable links per data-grid-conventions.md
- Updated route-level tests to match the ResourceGrid v1 mock pattern (router mock provides `useSearch`, `fullPath`, `useNavigate`)

Fixes HOL-948

## Test plan

- [x] `make test-ui` passes (1247 tests)
- [x] TemplatePolicies index: loading, error, empty, row render, Scope/Rules columns, create button visibility
- [x] TemplateBindings index: loading, empty, row render, Scope/Policy/Targets columns, create button visibility
- [x] Existing secrets, deployments, and templates route tests unaffected

## Deferred Acceptance Criteria

- [ ] `make test-e2e` — requires a running k3d cluster, not exercised in this PR