### PR TITLE
test(frontend): add coverage for query hooks, grid behavior, and route-state

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -178,10 +178,13 @@ Test files in `src/components/` and `src/lib/` can use any name.
 | `src/queries/-organizations.test.ts` | Organization query hooks: get, update, sharing, default sharing, delete |
 | `src/queries/-projects.test.ts` | useListProjects and useCreateProject hooks |
 | `src/queries/-templatePolicies.test.ts` | `aggregateFanOut` helper: idle/disabled queries, pending while fetching, org-only and org+folder concatenation, partial-failure tolerance, non-Error wrapping, empty input |
+| `src/queries/secrets.test.ts` | Secret query hooks: list key shape, mutation invalidation (create/delete/update/sharing), keep-previous-data across project changes |
+| `src/queries/-deployments.test.ts` | Deployment query hooks: list key shape, mutation invalidation (create/delete/update + policyState), keep-previous-data across project changes |
+| `src/queries/-templates.test.ts` | Template query hooks: list key shape, mutation invalidation (create/delete/update + policyStateScope), keep-previous-data across namespace changes |
 | `src/routes/_authenticated/organization/-new.test.tsx` | Create organization page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error |
 | `src/routes/_authenticated/folder/-new.test.tsx` | Create folder page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error, orgName guard |
 | `src/routes/_authenticated/project/-new.test.tsx` | Create project page: heading, full-page (not dialog), fields, slug auto-derivation, validation, submit, returnTo, error, orgName/folderName guards |
-| `src/components/resource-grid/-resource-grid.test.tsx` | ResourceGrid v1: column headers, kind filter, global search, empty/loading/error states, delete-confirm dialog |
+| `src/components/resource-grid/-resource-grid.test.tsx` | ResourceGrid v1: column headers, kind filter, global search, empty/loading/error states, delete-confirm dialog, onSearchChange wiring (kind checkbox and search input) |
 | `src/components/ui/-confirm-delete-dialog.test.tsx` | ConfirmDeleteDialog: open/close, confirm, error, isDeleting state |
 | `src/components/-app-sidebar.tree.test.tsx` | Sidebar integration (real primitives): enabled entries render Link, disabled entries render tooltip-wrapped button |
 | `src/components/templates/-templates-help-pane.test.tsx` | TemplatesHelpPane: renders help content sections |

--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -424,4 +424,54 @@ describe('ResourceGrid', () => {
       screen.getByText(/no resources match the current filters/i),
     ).toBeInTheDocument()
   })
+
+  // --- onSearchChange wiring — kind filter checkbox and search input ---
+
+  it('calls onSearchChange with the new kind when kind checkbox is clicked', () => {
+    const onSearchChange = vi.fn()
+    renderGrid({
+      kinds: [SECRET_KIND, DEPLOYMENT_KIND],
+      rows: [
+        makeRow({ kind: 'secret' }),
+        makeRow({ kind: 'deployment', id: 'dep-1', name: 'my-dep', displayName: 'My Deployment', description: '' }),
+      ],
+      onSearchChange,
+    })
+
+    fireEvent.click(screen.getByLabelText('Filter Deployment'))
+
+    expect(onSearchChange).toHaveBeenCalled()
+    // The updater function should produce a search with kind set
+    const updater = onSearchChange.mock.calls[0][0] as (prev: Record<string, unknown>) => Record<string, unknown>
+    const result = updater({})
+    expect(result['kind']).toBe('deployment')
+  })
+
+  it('calls onSearchChange with updated search string when search input changes', () => {
+    const onSearchChange = vi.fn()
+    renderGrid({ onSearchChange })
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: 'my query' },
+    })
+
+    expect(onSearchChange).toHaveBeenCalled()
+    const updater = onSearchChange.mock.calls[0][0] as (prev: Record<string, unknown>) => Record<string, unknown>
+    const result = updater({})
+    expect(result['search']).toBe('my query')
+  })
+
+  it('calls onSearchChange with search undefined when search input is cleared', () => {
+    const onSearchChange = vi.fn()
+    renderGrid({ onSearchChange, search: { search: 'existing' } })
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: '' },
+    })
+
+    expect(onSearchChange).toHaveBeenCalled()
+    const updater = onSearchChange.mock.calls[0][0] as (prev: Record<string, unknown>) => Record<string, unknown>
+    const result = updater({ search: 'existing' })
+    expect(result['search']).toBeUndefined()
+  })
 })

--- a/frontend/src/queries/-deployments.test.ts
+++ b/frontend/src/queries/-deployments.test.ts
@@ -1,0 +1,236 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { keys } from '@/queries/keys'
+import {
+  useListDeployments,
+  useCreateDeployment,
+  useDeleteDeployment,
+  useUpdateDeployment,
+} from '@/queries/deployments'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useAuth } from '@/lib/auth'
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function deployment(name: string) {
+  return {
+    name,
+    project: 'demo-project',
+    displayName: name,
+    description: '',
+    image: 'ghcr.io/org/app',
+    tag: 'v1.0.0',
+    template: 'web-app',
+    phase: 0,
+    message: '',
+    createdAt: '',
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+// ---------------------------------------------------------------------------
+// Query key shape
+// ---------------------------------------------------------------------------
+
+describe('deployment query keys', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      listDeployments: vi.fn().mockResolvedValue({ deployments: [deployment('api')] }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('uses the canonical list key factory', async () => {
+    const { result } = renderHook(() => useListDeployments('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const matches = queryClient.getQueryCache().findAll({
+      queryKey: keys.deployments.list('demo-project'),
+    })
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.queryKey).toEqual(keys.deployments.list('demo-project'))
+  })
+
+  it('is disabled when project is empty', () => {
+    const { result } = renderHook(() => useListDeployments(''), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.listDeployments).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mutation invalidation
+// ---------------------------------------------------------------------------
+
+describe('deployment mutation invalidation', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      createDeployment: vi.fn().mockResolvedValue({}),
+      deleteDeployment: vi.fn().mockResolvedValue({}),
+      updateDeployment: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+  })
+
+  it('invalidates deployment list after create', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useCreateDeployment('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'api',
+        image: 'ghcr.io/org/app',
+        tag: 'v1.0.0',
+        template: 'web-app',
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.list('demo-project'),
+    })
+  })
+
+  it('invalidates list only after delete', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useDeleteDeployment('demo-project'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'api' })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.list('demo-project'),
+    })
+  })
+
+  it('invalidates list, detail, and policyState after update', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(
+      () => useUpdateDeployment('demo-project', 'api'),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ tag: 'v2.0.0' })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.list('demo-project'),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.get('demo-project', 'api'),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.policyState('demo-project', 'api'),
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Keep-previous-data across project param changes
+// ---------------------------------------------------------------------------
+
+describe('deployment list keep-previous-data', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      listDeployments: vi.fn(),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('keeps previous list data while the next project list is loading', async () => {
+    const alpha = deferred<{ deployments: ReturnType<typeof deployment>[] }>()
+    const beta = deferred<{ deployments: ReturnType<typeof deployment>[] }>()
+    mockClient.listDeployments.mockImplementation(({ project }: { project: string }) => {
+      if (project === 'alpha') return alpha.promise
+      if (project === 'beta') return beta.promise
+      throw new Error(`unexpected project ${project}`)
+    })
+
+    const { result, rerender } = renderHook(
+      ({ project }) => useListDeployments(project),
+      {
+        initialProps: { project: 'alpha' },
+        wrapper: makeWrapper(queryClient),
+      },
+    )
+
+    await act(async () => {
+      alpha.resolve({ deployments: [deployment('alpha-dep')] })
+      await alpha.promise
+    })
+    await waitFor(() => expect(result.current.data?.[0]?.name).toBe('alpha-dep'))
+
+    rerender({ project: 'beta' })
+
+    await waitFor(() =>
+      expect(mockClient.listDeployments).toHaveBeenCalledWith({ project: 'beta' }),
+    )
+    expect(result.current.data?.[0]?.name).toBe('alpha-dep')
+    expect(result.current.isPlaceholderData).toBe(true)
+
+    await act(async () => {
+      beta.resolve({ deployments: [deployment('beta-dep')] })
+      await beta.promise
+    })
+    await waitFor(() => expect(result.current.data?.[0]?.name).toBe('beta-dep'))
+    expect(result.current.isPlaceholderData).toBe(false)
+  })
+})

--- a/frontend/src/queries/-templates.test.ts
+++ b/frontend/src/queries/-templates.test.ts
@@ -53,6 +53,14 @@ function template(name: string, namespace = 'project-demo') {
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 // ---------------------------------------------------------------------------
 // Query key shape
 // ---------------------------------------------------------------------------
@@ -195,14 +203,11 @@ describe('template list keep-previous-data', () => {
   })
 
   it('keeps previous list data while the next namespace list is loading', async () => {
-    let resolveAlpha!: (value: { templates: ReturnType<typeof template>[] }) => void
-    let resolveBeta!: (value: { templates: ReturnType<typeof template>[] }) => void
-    const alphaPromise = new Promise<{ templates: ReturnType<typeof template>[] }>((res) => { resolveAlpha = res })
-    const betaPromise = new Promise<{ templates: ReturnType<typeof template>[] }>((res) => { resolveBeta = res })
-
+    const alpha = deferred<{ templates: ReturnType<typeof template>[] }>()
+    const beta = deferred<{ templates: ReturnType<typeof template>[] }>()
     mockClient.listTemplates.mockImplementation(({ namespace }: { namespace: string }) => {
-      if (namespace === 'project-alpha') return alphaPromise
-      if (namespace === 'project-beta') return betaPromise
+      if (namespace === 'project-alpha') return alpha.promise
+      if (namespace === 'project-beta') return beta.promise
       throw new Error(`unexpected namespace ${namespace}`)
     })
 
@@ -215,8 +220,8 @@ describe('template list keep-previous-data', () => {
     )
 
     await act(async () => {
-      resolveAlpha({ templates: [template('alpha-tpl', 'project-alpha')] })
-      await alphaPromise
+      alpha.resolve({ templates: [template('alpha-tpl', 'project-alpha')] })
+      await alpha.promise
     })
     await waitFor(() => expect(result.current.data?.[0]?.name).toBe('alpha-tpl'))
 
@@ -229,8 +234,8 @@ describe('template list keep-previous-data', () => {
     expect(result.current.isPlaceholderData).toBe(true)
 
     await act(async () => {
-      resolveBeta({ templates: [template('beta-tpl', 'project-beta')] })
-      await betaPromise
+      beta.resolve({ templates: [template('beta-tpl', 'project-beta')] })
+      await beta.promise
     })
     await waitFor(() => expect(result.current.data?.[0]?.name).toBe('beta-tpl'))
     expect(result.current.isPlaceholderData).toBe(false)

--- a/frontend/src/queries/-templates.test.ts
+++ b/frontend/src/queries/-templates.test.ts
@@ -1,0 +1,238 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { keys } from '@/queries/keys'
+import {
+  useListTemplates,
+  useCreateTemplate,
+  useDeleteTemplate,
+  useUpdateTemplate,
+} from '@/queries/templates'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+// useAllTemplatesForOrg depends on folder and project list hooks; mock them so
+// tests that import the templates module do not need them.
+vi.mock('@/queries/folders', () => ({
+  useListFolders: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+}))
+
+vi.mock('@/queries/projects', () => ({
+  useListProjectsByParent: vi.fn().mockReturnValue({ data: [], isPending: false, error: null }),
+}))
+
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useAuth } from '@/lib/auth'
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function template(name: string, namespace = 'project-demo') {
+  return {
+    name,
+    namespace,
+    displayName: name,
+    description: '',
+    cueTemplate: '',
+    enabled: false,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query key shape
+// ---------------------------------------------------------------------------
+
+describe('template query keys', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      listTemplates: vi.fn().mockResolvedValue({ templates: [template('my-template')] }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('uses the canonical list key factory', async () => {
+    const { result } = renderHook(() => useListTemplates('project-demo'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const matches = queryClient.getQueryCache().findAll({
+      queryKey: keys.templates.list('project-demo'),
+    })
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.queryKey).toEqual(keys.templates.list('project-demo'))
+  })
+
+  it('is disabled when namespace is empty', () => {
+    const { result } = renderHook(() => useListTemplates(''), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.listTemplates).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mutation invalidation
+// ---------------------------------------------------------------------------
+
+describe('template mutation invalidation', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      createTemplate: vi.fn().mockResolvedValue({}),
+      deleteTemplate: vi.fn().mockResolvedValue({}),
+      updateTemplate: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+  })
+
+  it('invalidates template list after create', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useCreateTemplate('project-demo'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'my-template',
+        displayName: 'My Template',
+        description: 'desc',
+        cueTemplate: 'platform: #PlatformInput',
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templates.list('project-demo'),
+    })
+  })
+
+  it('invalidates template list after delete', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() => useDeleteTemplate('project-demo'), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'my-template' })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templates.list('project-demo'),
+    })
+  })
+
+  it('invalidates list, detail, and policyStateScope after update', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(
+      () => useUpdateTemplate('project-demo', 'my-template'),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ displayName: 'Updated', cueTemplate: 'platform: #PlatformInput' })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templates.list('project-demo'),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templates.get('project-demo', 'my-template'),
+    })
+    // HOL-559: policyState scope invalidated so drift badge refreshes
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templates.policyStateScope('project-demo'),
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Keep-previous-data across namespace param changes
+// ---------------------------------------------------------------------------
+
+describe('template list keep-previous-data', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      listTemplates: vi.fn(),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('keeps previous list data while the next namespace list is loading', async () => {
+    let resolveAlpha!: (value: { templates: ReturnType<typeof template>[] }) => void
+    let resolveBeta!: (value: { templates: ReturnType<typeof template>[] }) => void
+    const alphaPromise = new Promise<{ templates: ReturnType<typeof template>[] }>((res) => { resolveAlpha = res })
+    const betaPromise = new Promise<{ templates: ReturnType<typeof template>[] }>((res) => { resolveBeta = res })
+
+    mockClient.listTemplates.mockImplementation(({ namespace }: { namespace: string }) => {
+      if (namespace === 'project-alpha') return alphaPromise
+      if (namespace === 'project-beta') return betaPromise
+      throw new Error(`unexpected namespace ${namespace}`)
+    })
+
+    const { result, rerender } = renderHook(
+      ({ namespace }) => useListTemplates(namespace),
+      {
+        initialProps: { namespace: 'project-alpha' },
+        wrapper: makeWrapper(queryClient),
+      },
+    )
+
+    await act(async () => {
+      resolveAlpha({ templates: [template('alpha-tpl', 'project-alpha')] })
+      await alphaPromise
+    })
+    await waitFor(() => expect(result.current.data?.[0]?.name).toBe('alpha-tpl'))
+
+    rerender({ namespace: 'project-beta' })
+
+    await waitFor(() =>
+      expect(mockClient.listTemplates).toHaveBeenCalledWith({ namespace: 'project-beta' }),
+    )
+    expect(result.current.data?.[0]?.name).toBe('alpha-tpl')
+    expect(result.current.isPlaceholderData).toBe(true)
+
+    await act(async () => {
+      resolveBeta({ templates: [template('beta-tpl', 'project-beta')] })
+      await betaPromise
+    })
+    await waitFor(() => expect(result.current.data?.[0]?.name).toBe('beta-tpl'))
+    expect(result.current.isPlaceholderData).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `-deployments.test.ts`: covers `useListDeployments` canonical list key shape, `useCreateDeployment`/`useDeleteDeployment`/`useUpdateDeployment` mutation invalidation (including policyState per HOL-559), and KPD keep-previous-data across project param changes.
- Add `-templates.test.ts`: same pattern for templates — list key shape, mutation invalidation (policyStateScope per HOL-559), and KPD across namespace param changes.
- Extend `-resource-grid.test.tsx`: three new `onSearchChange`-wiring tests asserting kind-filter checkbox and search-input changes invoke the updater with the correct URL-state shape.
- Update `docs/testing.md`: register all three new test files in the existing table.

Fixes HOL-949

## Test plan

- [x] `make test-ui` passes (96 test files, 1262 tests — up from 94 files / 1247 tests)
- [x] All new tests run deterministically (verified by running each file individually)
- [x] No snapshot tests introduced — all assertions are behavior-focused
- [x] No new E2E coverage added