### PR TITLE
chore(docs): final sweep, remove stale docs, summarize on parent issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@ Agent-facing frontend docs:
   `returnTo`, selected-entity sync, ConnectRPC transport, and build/test
   commands.
 - [TanStack Query Conventions](docs/agents/tanstack-query-conventions.md) —
-  placeholder for Phase 4 query-key and invalidation conventions.
+  query-key factories, transport/hook split, stale time defaults, enabled
+  guards, mutation invalidation matrix, and prefetch policy.
 - [Data Grid Architecture](docs/agents/data-grid-architecture.md) —
   source of record for `ResourceGrid` architecture conventions.
 - [Data Grid Conventions](docs/agents/data-grid-conventions.md) — quick

--- a/docs/agents/frontend-architecture.md
+++ b/docs/agents/frontend-architecture.md
@@ -137,7 +137,8 @@ unit tests unless the test strategy explicitly calls for E2E coverage.
 - [docs/agents/frontend-audit-2026-04.md](frontend-audit-2026-04.md) - current
   inventory and target conventions from Phase 1.
 - [docs/agents/tanstack-query-conventions.md](tanstack-query-conventions.md) -
-  Phase 4 placeholder for query-key and invalidation rules.
+  query-key factories, stale time defaults, mutation invalidation matrix, and
+  prefetch policy (HOL-946).
 - [docs/ui/resource-routing.md](../ui/resource-routing.md) - authoritative URL
   and `returnTo` behavior.
 - [docs/ui/selected-entity-state.md](../ui/selected-entity-state.md) -

--- a/docs/agents/frontend-audit-2026-04.md
+++ b/docs/agents/frontend-audit-2026-04.md
@@ -74,7 +74,7 @@ the same auth/parameter guard but compose multiple queries with
 
 `frontend/src/components/resource-grid/` contains:
 
-- `ResourceGrid.tsx` - shared TanStack Table wrapper, currently 590 lines.
+- `ResourceGrid.tsx` - shared TanStack Table wrapper, 470 lines after the HOL-947 split.
 - `types.ts` - `Row`, `Kind`, `LineageDirection`, and `ResourceGridSearch`.
 - `url-state.ts` - `parseGridSearch`, `serialiseGridSearch`,
   `parseKindIds`, and `serialiseKindIds`.
@@ -152,9 +152,9 @@ direct component test and callers only need page-level rendering coverage.
 - Query keys are still a convention, not a shared contract. Some modules expose
   well-named factories, while others use ad-hoc inline keys such as direct
   `['templates', 'policy-state', namespace]` invalidation from callers.
-- `ResourceGrid.tsx` is already large enough that unrelated behavior can
-  collide in one file. Loading, empty, error, toolbar, columns, row navigation,
-  and delete confirmation are all implemented together.
+- `ResourceGrid.tsx` was split in HOL-947: loading, empty, error, toolbar,
+  columns, row navigation, and delete confirmation now live in separate modules
+  (`Toolbar.tsx`, `KindFilter.tsx`, `useDeleteConfirm.ts`).
 - There is no documented virtualization decision rule. Current tables render
   straightforward in-memory rows, which is fine for current data sizes but
   leaves future high-cardinality resource lists without a trigger for when to
@@ -198,7 +198,7 @@ direct component test and callers only need page-level rendering coverage.
 
 ## Out-of-scope follow-ups
 
-- Split `ResourceGrid.tsx` into smaller internal pieces after conventions land.
+- Split `ResourceGrid.tsx` into smaller internal pieces after conventions land. **Done in HOL-947**: `Toolbar.tsx`, `KindFilter.tsx`, `useDeleteConfirm.ts` extracted.
 - Decide and document the virtualization or pagination threshold for resource
   lists.
 - Normalize TemplatePolicyBinding path spelling across organization and folder


### PR DESCRIPTION
## Summary

- Removes stale "placeholder for Phase 4" language from `AGENTS.md` and `docs/agents/frontend-architecture.md` — `tanstack-query-conventions.md` is now a complete doc, not a placeholder
- Updates `docs/agents/frontend-audit-2026-04.md` to reflect that `ResourceGrid.tsx` was split in HOL-947 (590 lines → 470 lines; `Toolbar.tsx`, `KindFilter.tsx`, `useDeleteConfirm.ts` extracted)
- Marks the "split ResourceGrid" out-of-scope follow-up as done

All three files are now mutually consistent. No document makes claims that contradict the current codebase or other docs.

Fixes HOL-950

## Test plan

- [x] `make test-ui` — 1262 tests across 96 files, all pass
- [x] No conflicting claims remain between `AGENTS.md`, `docs/agents/frontend-architecture.md`, `docs/agents/tanstack-query-conventions.md`, and `docs/agents/data-grid-architecture.md`
- [x] All cross-links in modified files resolve to existing files