### PR TITLE
feat(admission): add ValidatingAdmissionPolicy for TemplateGrant, TemplateDependency, TemplateRequirement

### DIFF
--- a/api/templates/v1alpha1/crd_test.go
+++ b/api/templates/v1alpha1/crd_test.go
@@ -490,6 +490,208 @@ func TestCRDRoundTrip_TemplateRequirement(t *testing.T) {
 	deleteAndWait(t, ctx, s.client, obj)
 }
 
+// TestAdmission_TemplateGrant_AllNamespacesAllowed exercises the
+// templategrant-namespace-allowed policy. TemplateGrant is a cross-namespace
+// visibility grant that may live in organization, folder, or project namespaces,
+// so the policy is a no-op (always allows). We assert that creation succeeds in
+// all three namespace types.
+func TestAdmission_TemplateGrant_AllNamespacesAllowed(t *testing.T) {
+	s := setupEnvTest(t)
+	ctx := context.Background()
+
+	envtesthelpers.WaitForAdmissionPolicy(t, ctx, s.client, "templategrant-namespace-allowed")
+
+	tests := []struct {
+		name          string
+		nsName        string
+		nsResourceTyp string
+	}{
+		{
+			name:          "grant-in-project-accepted",
+			nsName:        "holos-prj-admission-grant-project",
+			nsResourceTyp: "project",
+		},
+		{
+			name:          "grant-in-folder-accepted",
+			nsName:        "holos-fld-admission-grant-folder",
+			nsResourceTyp: "folder",
+		},
+		{
+			name:          "grant-in-org-accepted",
+			nsName:        "holos-org-admission-grant-org",
+			nsResourceTyp: "organization",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			createNamespace(t, ctx, s.client, tc.nsName, tc.nsResourceTyp)
+			obj := &v1alpha1.TemplateGrant{
+				ObjectMeta: metav1.ObjectMeta{Name: "allow-alpha", Namespace: tc.nsName},
+				Spec: v1alpha1.TemplateGrantSpec{
+					From: []v1alpha1.TemplateGrantFromRef{
+						{Namespace: "holos-prj-alpha"},
+					},
+				},
+			}
+			if err := s.client.Create(ctx, obj); err != nil {
+				t.Fatalf("expected templategrant-namespace-allowed to accept in %q namespace, got %v", tc.nsResourceTyp, err)
+			}
+		})
+	}
+}
+
+// TestAdmission_TemplateDependency_ProjectOnly exercises the
+// templatedependency-project-only policy. TemplateDependency wires two
+// Templates together within a project namespace, so it must be rejected in
+// folder and organization namespaces and accepted in project namespaces.
+func TestAdmission_TemplateDependency_ProjectOnly(t *testing.T) {
+	s := setupEnvTest(t)
+	ctx := context.Background()
+
+	envtesthelpers.WaitForAdmissionPolicy(t, ctx, s.client, "templatedependency-project-only")
+
+	tests := []struct {
+		name          string
+		nsName        string
+		nsResourceTyp string
+		wantRejected  bool
+	}{
+		{
+			name:          "dependency-in-project-accepted",
+			nsName:        "holos-prj-admission-dep-project",
+			nsResourceTyp: "project",
+			wantRejected:  false,
+		},
+		{
+			name:          "dependency-in-folder-rejected",
+			nsName:        "holos-fld-admission-dep-folder",
+			nsResourceTyp: "folder",
+			wantRejected:  true,
+		},
+		{
+			name:          "dependency-in-org-rejected",
+			nsName:        "holos-org-admission-dep-org",
+			nsResourceTyp: "organization",
+			wantRejected:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			createNamespace(t, ctx, s.client, tc.nsName, tc.nsResourceTyp)
+			obj := &v1alpha1.TemplateDependency{
+				ObjectMeta: metav1.ObjectMeta{Name: "web-needs-db", Namespace: tc.nsName},
+				Spec: v1alpha1.TemplateDependencySpec{
+					Dependent: v1alpha1.LinkedTemplateRef{
+						Namespace: tc.nsName,
+						Name:      "web",
+					},
+					Requires: v1alpha1.LinkedTemplateRef{
+						Namespace: tc.nsName,
+						Name:      "db",
+					},
+				},
+			}
+			err := s.client.Create(ctx, obj)
+			if tc.wantRejected {
+				if err == nil {
+					t.Fatalf("expected admission rejection for %q namespace, got nil", tc.nsResourceTyp)
+				}
+				if !apierrors.IsInvalid(err) && !apierrors.IsForbidden(err) {
+					t.Fatalf("expected Invalid/Forbidden admission error, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), "project") &&
+					!strings.Contains(err.Error(), "Forbidden") &&
+					!strings.Contains(err.Error(), "denied") {
+					t.Fatalf("expected CEL-originated rejection message, got %q", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected admission to accept in %q namespace, got %v", tc.nsResourceTyp, err)
+			}
+		})
+	}
+}
+
+// TestAdmission_TemplateRequirement_FolderOrOrgOnly exercises the
+// templaterequirement-folder-or-org-only policy. TemplateRequirement is
+// admin-scoped (like TemplatePolicy) and must only live in folder or
+// organization namespaces, never in project namespaces.
+func TestAdmission_TemplateRequirement_FolderOrOrgOnly(t *testing.T) {
+	s := setupEnvTest(t)
+	ctx := context.Background()
+
+	envtesthelpers.WaitForAdmissionPolicy(t, ctx, s.client, "templaterequirement-folder-or-org-only")
+
+	tests := []struct {
+		name          string
+		nsName        string
+		nsResourceTyp string
+		wantRejected  bool
+	}{
+		{
+			name:          "requirement-in-project-rejected",
+			nsName:        "holos-prj-admission-req-project",
+			nsResourceTyp: "project",
+			wantRejected:  true,
+		},
+		{
+			name:          "requirement-in-folder-accepted",
+			nsName:        "holos-fld-admission-req-folder",
+			nsResourceTyp: "folder",
+			wantRejected:  false,
+		},
+		{
+			name:          "requirement-in-org-accepted",
+			nsName:        "holos-org-admission-req-org",
+			nsResourceTyp: "organization",
+			wantRejected:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			createNamespace(t, ctx, s.client, tc.nsName, tc.nsResourceTyp)
+			obj := &v1alpha1.TemplateRequirement{
+				ObjectMeta: metav1.ObjectMeta{Name: "require-istio", Namespace: tc.nsName},
+				Spec: v1alpha1.TemplateRequirementSpec{
+					Requires: v1alpha1.LinkedTemplateRef{
+						Namespace: "holos-org-acme",
+						Name:      "istio-base",
+					},
+					TargetRefs: []v1alpha1.TemplateRequirementTargetRef{
+						{
+							Kind:        v1alpha1.TemplatePolicyBindingTargetKindDeployment,
+							Name:        "web",
+							ProjectName: "alpha",
+						},
+					},
+				},
+			}
+			err := s.client.Create(ctx, obj)
+			if tc.wantRejected {
+				if err == nil {
+					t.Fatalf("expected admission rejection for project namespace, got nil")
+				}
+				if !apierrors.IsInvalid(err) && !apierrors.IsForbidden(err) {
+					t.Fatalf("expected Invalid/Forbidden admission error, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), "project namespace") &&
+					!strings.Contains(err.Error(), "Forbidden") &&
+					!strings.Contains(err.Error(), "denied") {
+					t.Fatalf("expected CEL-originated rejection message, got %q", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected admission to accept in %q namespace, got %v", tc.nsResourceTyp, err)
+			}
+		})
+	}
+}
+
 // TestAdmissionPolicy_TemplatePolicy_ProjectNamespace_Rejected and
 // TestAdmissionPolicy_TemplatePolicyBinding_ProjectNamespace_Rejected exercise
 // the CEL ValidatingAdmissionPolicy shipped in config/holos-console/admission. Table-driven

--- a/config/holos-console/admission/kustomization.yaml
+++ b/config/holos-console/admission/kustomization.yaml
@@ -5,5 +5,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - renderstate-folder-or-org-only.yaml
+- templatedependency-project-only.yaml
+- templategrant-namespace-allowed.yaml
 - templatepolicy-folder-or-org-only.yaml
 - templatepolicybinding-folder-or-org-only.yaml
+- templaterequirement-folder-or-org-only.yaml

--- a/config/holos-console/admission/templatedependency-project-only.yaml
+++ b/config/holos-console/admission/templatedependency-project-only.yaml
@@ -1,0 +1,56 @@
+# TemplateDependency records an intra-project wiring — it wires two Templates
+# together within a single project namespace. It MUST only be stored in a
+# namespace labeled `console.holos.run/resource-type: project`. Storing it in
+# a folder or organization namespace would conflate a project-scoped resource
+# with admin-scoped resources and break the dependency graph resolver.
+# (HOL-954).
+#
+# Namespace classification. The resolver.Resolver package labels every
+# console-managed namespace with `console.holos.run/resource-type`, whose
+# values are `organization`, `folder`, or `project`. This CEL policy reads
+# exactly that label and rejects admission when the label value is NOT
+# `project`. Namespaces without the label (for example, cluster-default or
+# manually-created namespaces) are not classified and therefore accepted here;
+# operators who want to bootstrap a TemplateDependency outside a classified
+# namespace may do so — the resolver will skip unclassified namespaces.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: templatedependency-project-only
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["templates.holos.run"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["templatedependencies"]
+  validations:
+  - expression: >-
+      !has(namespaceObject.metadata.labels)
+      || !("console.holos.run/resource-type" in namespaceObject.metadata.labels)
+      || namespaceObject.metadata.labels["console.holos.run/resource-type"] == "project"
+    messageExpression: >-
+      "TemplateDependency must be stored in a project namespace; namespace " +
+      namespaceObject.metadata.name + " has resource-type " +
+      (has(namespaceObject.metadata.labels) &&
+       "console.holos.run/resource-type" in namespaceObject.metadata.labels
+       ? namespaceObject.metadata.labels["console.holos.run/resource-type"]
+       : "<unset>") +
+      " (see HOL-954)."
+    reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: templatedependency-project-only
+spec:
+  policyName: templatedependency-project-only
+  validationActions:
+  - Deny
+  matchResources:
+    resourceRules:
+    - apiGroups: ["templates.holos.run"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["templatedependencies"]

--- a/config/holos-console/admission/templategrant-namespace-allowed.yaml
+++ b/config/holos-console/admission/templategrant-namespace-allowed.yaml
@@ -1,0 +1,40 @@
+# TemplateGrant governs cross-namespace Template visibility. It may be created
+# in any namespace that already hosts Templates — that includes organization,
+# folder, and project namespaces — so no namespace restriction is applied.
+# This file exists as a symmetry placeholder alongside the other admission
+# YAMLs for the deployment-dependencies CRDs (HOL-954). A real CEL expression
+# can be added here later without changing the file structure.
+#
+# The policy uses an expression that always evaluates to true so it never
+# blocks admission. `failurePolicy: Fail` is still set so a misconfigured
+# admission webhook does not silently permit unexpected requests.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: templategrant-namespace-allowed
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["templates.holos.run"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["templategrants"]
+  validations:
+  - expression: "true"
+    reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: templategrant-namespace-allowed
+spec:
+  policyName: templategrant-namespace-allowed
+  validationActions:
+  - Deny
+  matchResources:
+    resourceRules:
+    - apiGroups: ["templates.holos.run"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["templategrants"]

--- a/config/holos-console/admission/templaterequirement-folder-or-org-only.yaml
+++ b/config/holos-console/admission/templaterequirement-folder-or-org-only.yaml
@@ -1,0 +1,46 @@
+# TemplateRequirement mirrors the TemplatePolicy isolation invariant: a
+# requirement that declares which Templates must be present for a given
+# deployment is admin-scoped and lives only in an organization or folder
+# namespace (HOL-954). This policy enforces that contract at API-server
+# admission time so the handler-side guard can be removed later without
+# reopening the hole.
+#
+# See config/holos-console/admission/templatepolicy-folder-or-org-only.yaml for the full
+# rationale on namespace classification and the
+# `console.holos.run/resource-type` label.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: templaterequirement-folder-or-org-only
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["templates.holos.run"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["templaterequirements"]
+  validations:
+  - expression: >-
+      !has(namespaceObject.metadata.labels)
+      || !("console.holos.run/resource-type" in namespaceObject.metadata.labels)
+      || namespaceObject.metadata.labels["console.holos.run/resource-type"] != "project"
+    messageExpression: >-
+      "TemplateRequirement cannot be stored in project namespace " + namespaceObject.metadata.name +
+      "; use the owning folder or organization namespace (see HOL-954)."
+    reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: templaterequirement-folder-or-org-only
+spec:
+  policyName: templaterequirement-folder-or-org-only
+  validationActions:
+  - Deny
+  matchResources:
+    resourceRules:
+    - apiGroups: ["templates.holos.run"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["templaterequirements"]


### PR DESCRIPTION
## Summary

- Adds `config/holos-console/admission/templategrant-namespace-allowed.yaml` — always-allow no-op placeholder; TemplateGrant may live in org/folder/project namespaces
- Adds `config/holos-console/admission/templatedependency-project-only.yaml` — enforces project-only namespace constraint for TemplateDependency via CEL
- Adds `config/holos-console/admission/templaterequirement-folder-or-org-only.yaml` — mirrors `templatepolicybinding-folder-or-org-only.yaml` but targets `templaterequirements`
- Updates `config/holos-console/admission/kustomization.yaml` to include all three new files
- Adds three table-driven admission test functions to `api/templates/v1alpha1/crd_test.go` covering positive/negative paths for each policy

Fixes HOL-956

## Test plan

- [x] `TestAdmission_TemplateGrant_AllNamespacesAllowed` — verifies TemplateGrant accepted in project, folder, org namespaces
- [x] `TestAdmission_TemplateDependency_ProjectOnly` — verifies TemplateDependency accepted in project, rejected in folder/org
- [x] `TestAdmission_TemplateRequirement_FolderOrOrgOnly` — verifies TemplateRequirement accepted in folder/org, rejected in project
- [x] Existing `TestAdmission_FolderOrOrgOnly` (TemplatePolicy + TemplatePolicyBinding) — no regressions
- [x] `make test-go` passes all packages