### PR TITLE
feat(deployments): dual-write Deployment CRD via server-side apply

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -593,6 +593,18 @@ func (s *Server) Serve(ctx context.Context) error {
 			// across every kind apply.go writes.
 			deploymentsK8s = deploymentsK8s.WithDynamicClient(dynamicClient)
 		}
+		// HOL-957: wire the CRWriter so every Deployment create/update/delete
+		// is dual-written to the deployments.holos.run/v1alpha1 CRD via SSA
+		// alongside the existing ConfigMap proto-store. The CRWriter is only
+		// active when the embedded controller-runtime manager is available —
+		// the manager provides the cache-backed client.Client the CRWriter
+		// uses and ensures the Deployment CRD's informer is registered before
+		// /readyz goes green.
+		if s.controllerMgr != nil {
+			deploymentsK8s = deploymentsK8s.WithCRWriter(
+				deployments.NewCRWriter(s.controllerMgr.GetClient(), nsResolver),
+			)
+		}
 		projectFolderResolver := projects.NewProjectFolderResolver(projectsK8s, nsWalker)
 		ancestorTemplateResolver := templates.NewAncestorTemplateResolver(templatesK8s, nsWalker, policyResolverSeam)
 		// Deployment status informer cache: one shared watch scoped to

--- a/console/deployments/cr_writer.go
+++ b/console/deployments/cr_writer.go
@@ -1,0 +1,195 @@
+// Package deployments — CR dual-write layer.
+//
+// # Design: server-side apply with a unique field manager
+//
+// CRWriter mirrors every ConfigMap proto-store write to the
+// deployments.holos.run/v1alpha1.Deployment CRD using server-side apply
+// (SSA) with field manager "holos-console-deployment-writer".
+//
+// SSA is the right tool here because the dependency reconcilers introduced in
+// Phases 5–6 (HOL-959, HOL-960) will write non-controller ownerReference
+// entries onto the Deployment CR. A regular Update/Patch call would overwrite
+// the metadata.ownerReferences field and destroy those entries; SSA with a
+// distinct field manager lets each actor own only its own fields — the
+// reconciler owns ownerReferences, the dual-writer owns spec.* — so the two
+// paths compose without conflict.
+//
+// Lazy creation: if a Deployment already exists in the proto-store but its CR
+// is absent, the next Create or Update call via this writer issues an SSA
+// apply which creates the CR in-place (Apply is idempotent and create-or-update
+// by definition). No migration step is required (ADR Decision 12).
+//
+// Delete propagation: DeleteCR deletes the CR via the typed client.Delete call.
+// This is intentionally a hard delete rather than an SSA no-op: when the
+// operator removes a deployment from the proto-store the corresponding CR
+// should be garbage-collected immediately.
+package deployments
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+)
+
+const (
+	// crFieldManager is the SSA field manager identity for the dual-writer.
+	// It must be stable across calls so SSA can track owned fields across
+	// subsequent apply cycles without conflict errors.
+	crFieldManager = "holos-console-deployment-writer"
+)
+
+// CRWriter writes Deployment CRs alongside the existing ConfigMap proto-store.
+// A nil CRWriter is valid; all methods become no-ops so local/dev wiring
+// without a controller-runtime client remains unchanged.
+type CRWriter struct {
+	client   ctrlclient.Client
+	resolver *resolver.Resolver
+}
+
+// NewCRWriter constructs a CRWriter. Both client and resolver are required;
+// callers that cannot supply a controller-runtime client should leave the
+// CRWriter field on K8sClient nil instead of calling this function.
+func NewCRWriter(cl ctrlclient.Client, r *resolver.Resolver) *CRWriter {
+	return &CRWriter{client: cl, resolver: r}
+}
+
+// applyDeploymentCR builds the desired Deployment CR state and applies it via
+// SSA. The SSA field manager is crFieldManager; Force=true so this writer
+// always wins on its own fields (spec.*) without conflicting with other field
+// managers (e.g. dependency reconcilers owning ownerReferences).
+//
+// "Apply" is create-or-update: the call creates the CR when it does not exist
+// yet (lazy creation path) and updates it when it does (update path).
+//
+// ownerReferences are intentionally absent from the SSA payload — SSA merges
+// the desired state for each field manager in isolation, so omitting
+// ownerReferences means the reconciler-written entries are never touched by
+// this writer.
+func (w *CRWriter) applyDeploymentCR(
+	ctx context.Context,
+	project, name, image, tag, templateName, displayName, description string,
+	command, args []string,
+	port int32,
+) error {
+	if w == nil {
+		return nil
+	}
+	ns := w.resolver.ProjectNamespace(project)
+	slog.DebugContext(ctx, "applying deployment CR via SSA",
+		slog.String("project", project),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+
+	// Build the SSA payload as a partially-typed object. We set only the
+	// fields owned by this field manager (spec.*) so SSA does not touch
+	// ownerReferences, status, or any other field owned by another actor.
+	desired := &deploymentsv1alpha1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: deploymentsv1alpha1.GroupVersion.String(),
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeDeployment,
+			},
+		},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName:  project,
+			DisplayName:  displayName,
+			Description:  description,
+			Image:        image,
+			Tag:          tag,
+			Command:      command,
+			Args:         args,
+			Port:         port,
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: ns,
+				Name:      templateName,
+			},
+		},
+	}
+
+	// Encode as JSON for the SSA patch. Using raw JSON patch rather than
+	// ctrlclient.Apply (the Apply helper in controller-runtime v0.14+ uses
+	// the same underlying server-side apply path but works directly with
+	// typed objects). We use the dynamic patch approach to stay consistent
+	// with how other SSA patches are done in the codebase (projectapply,
+	// deployments/apply.go).
+	data, err := json.Marshal(desired)
+	if err != nil {
+		return fmt.Errorf("marshaling deployment CR for SSA: %w", err)
+	}
+
+	force := true
+	return w.client.Patch(ctx, desired, ctrlclient.RawPatch(types.ApplyPatchType, data), &ctrlclient.PatchOptions{
+		FieldManager: crFieldManager,
+		Force:        &force,
+	})
+}
+
+// ApplyOnCreate writes the Deployment CR after a successful proto-store create.
+// Parameters mirror K8sClient.CreateDeployment.
+func (w *CRWriter) ApplyOnCreate(
+	ctx context.Context,
+	project, name, image, tag, templateName, displayName, description string,
+	command, args []string,
+	env []v1alpha2.EnvVar,
+	port int32,
+) error {
+	if w == nil {
+		return nil
+	}
+	return w.applyDeploymentCR(ctx, project, name, image, tag, templateName, displayName, description, command, args, port)
+}
+
+// ApplyOnUpdate writes the Deployment CR after a successful proto-store update.
+// Callers pass the post-update ConfigMap values so the CR stays in sync with
+// the proto-store.
+func (w *CRWriter) ApplyOnUpdate(
+	ctx context.Context,
+	project, name, image, tag, templateName, displayName, description string,
+	command, args []string,
+	port int32,
+) error {
+	if w == nil {
+		return nil
+	}
+	return w.applyDeploymentCR(ctx, project, name, image, tag, templateName, displayName, description, command, args, port)
+}
+
+// DeleteCR removes the Deployment CR when the proto-store record is deleted.
+// A NotFound error is silenced — delete is idempotent (per the lazy-creation
+// guarantee the CR may never have been written for old records). All other
+// errors are returned to the caller.
+func (w *CRWriter) DeleteCR(ctx context.Context, project, name string) error {
+	if w == nil {
+		return nil
+	}
+	ns := w.resolver.ProjectNamespace(project)
+	slog.DebugContext(ctx, "deleting deployment CR",
+		slog.String("project", project),
+		slog.String("namespace", ns),
+		slog.String("name", name),
+	)
+	obj := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+	}
+	err := w.client.Delete(ctx, obj)
+	if ctrlclient.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("deleting deployment CR: %w", err)
+	}
+	return nil
+}

--- a/console/deployments/cr_writer.go
+++ b/console/deployments/cr_writer.go
@@ -141,12 +141,15 @@ func (w *CRWriter) applyDeploymentCR(
 }
 
 // ApplyOnCreate writes the Deployment CR after a successful proto-store create.
-// Parameters mirror K8sClient.CreateDeployment.
+// Parameters mirror K8sClient.CreateDeployment. The env parameter is accepted
+// for API symmetry with CreateDeployment but is intentionally not written to
+// the CR: DeploymentSpec carries no Env field (env vars are proto-side only,
+// stored in the ConfigMap and surfaced via the ConnectRPC surface).
 func (w *CRWriter) ApplyOnCreate(
 	ctx context.Context,
 	project, name, image, tag, templateName, displayName, description string,
 	command, args []string,
-	env []v1alpha2.EnvVar,
+	_ []v1alpha2.EnvVar, // env — proto-store only; not reflected in DeploymentSpec
 	port int32,
 ) error {
 	if w == nil {

--- a/console/deployments/cr_writer_test.go
+++ b/console/deployments/cr_writer_test.go
@@ -1,0 +1,337 @@
+// cr_writer_test.go exercises the CR ↔ proto-store consistency requirement
+// introduced in HOL-957. Tests use the shared envtest helper from
+// console/crdmgr/testing so the Deployment CRD is installed against a real
+// kube-apiserver.
+//
+// Coverage:
+//  1. Create via proto-store → CR appears with matching spec fields.
+//  2. Update via proto-store → CR spec reflects updated values.
+//  3. Delete via proto-store → CR is removed.
+//  4. ownerReferences written onto the CR by an external actor survive an
+//     UpdateDeployment call (SSA field-manager isolation).
+//  5. Lazy creation: ApplyOnUpdate creates the CR when the CR is absent (the
+//     ConfigMap already exists but the CR was never written).
+package deployments
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
+	"github.com/holos-run/holos-console/console/resolver"
+)
+
+// TestMain hooks the shared envtest shutdown into this package's test run.
+// Without it, the apiserver subprocess launched by the first StartManager call
+// leaks until the OS kills it.
+func TestMain(m *testing.M) {
+	os.Exit(crdmgrtesting.RunTestsWithSharedEnv(m))
+}
+
+// testDeploymentScheme returns a runtime.Scheme with core and
+// deployments.holos.run/v1alpha1 types registered — enough for the
+// controller-runtime client to CRUD Deployment CRs.
+func testDeploymentScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("register clientgo scheme: %v", err)
+	}
+	if err := deploymentsv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("register deployments scheme: %v", err)
+	}
+	return s
+}
+
+// newEnvtestCRWriter builds a CRWriter backed by the shared envtest bootstrap.
+// Returns the crdmgrtesting.Env (for direct client access) and the CRWriter.
+func newEnvtestCRWriter(t *testing.T) (*crdmgrtesting.Env, *CRWriter) {
+	t.Helper()
+	env := crdmgrtesting.StartManager(t, crdmgrtesting.Options{
+		Scheme: testDeploymentScheme(t),
+		InformerObjects: []ctrlclient.Object{
+			&deploymentsv1alpha1.Deployment{},
+		},
+	})
+	if env == nil {
+		t.SkipNow()
+	}
+	r := &resolver.Resolver{ProjectPrefix: "prj-"}
+	return env, NewCRWriter(env.Client, r)
+}
+
+// ensureProjectNamespace creates the project namespace in the envtest
+// apiserver when it does not already exist. Deployment CRs are namespaced
+// (the resolver maps a project name to a "prj-<project>" namespace), so the
+// namespace must exist before any CR write.
+func ensureProjectNamespace(t *testing.T, c ctrlclient.Client, project string) {
+	t.Helper()
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "prj-" + project},
+	}
+	if err := c.Create(context.Background(), ns); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create namespace prj-%s: %v", project, err)
+	}
+}
+
+// eventuallyGetCR polls the direct client until the named Deployment CR
+// appears or the deadline expires. Necessary because the SSA patch applied by
+// CRWriter goes through the apiserver; the cache-backed read might lag by one
+// watch event.
+func eventuallyGetCR(t *testing.T, c ctrlclient.Client, ns, name string) *deploymentsv1alpha1.Deployment {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	key := types.NamespacedName{Namespace: ns, Name: name}
+	for {
+		var dep deploymentsv1alpha1.Deployment
+		if err := c.Get(context.Background(), key, &dep); err == nil {
+			return &dep
+		} else if !apierrors.IsNotFound(err) {
+			t.Fatalf("unexpected error fetching CR %s/%s: %v", ns, name, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("CR %s/%s did not appear within deadline", ns, name)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// eventuallyAbsentCR polls the direct client until the named Deployment CR
+// is gone or the deadline expires.
+func eventuallyAbsentCR(t *testing.T, c ctrlclient.Client, ns, name string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	key := types.NamespacedName{Namespace: ns, Name: name}
+	for {
+		var dep deploymentsv1alpha1.Deployment
+		err := c.Get(context.Background(), key, &dep)
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("unexpected error checking absence of CR %s/%s: %v", ns, name, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("CR %s/%s was not deleted within deadline", ns, name)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestCRWriter_ApplyOnCreate_CreatesMatchingCR verifies that after
+// ApplyOnCreate the Deployment CR exists with spec fields matching the
+// proto-store inputs.
+func TestCRWriter_ApplyOnCreate_CreatesMatchingCR(t *testing.T) {
+	env, w := newEnvtestCRWriter(t)
+	project := "cr-create"
+	ensureProjectNamespace(t, env.Direct, project)
+
+	if err := w.ApplyOnCreate(
+		context.Background(),
+		project, "web-app",
+		"nginx", "latest",
+		"default-template",
+		"Web App", "A web application",
+		nil, nil, nil,
+		8080,
+	); err != nil {
+		t.Fatalf("ApplyOnCreate: %v", err)
+	}
+
+	cr := eventuallyGetCR(t, env.Direct, "prj-"+project, "web-app")
+
+	if cr.Spec.ProjectName != project {
+		t.Errorf("spec.projectName=%q want %q", cr.Spec.ProjectName, project)
+	}
+	if cr.Spec.Image != "nginx" {
+		t.Errorf("spec.image=%q want %q", cr.Spec.Image, "nginx")
+	}
+	if cr.Spec.Tag != "latest" {
+		t.Errorf("spec.tag=%q want %q", cr.Spec.Tag, "latest")
+	}
+	if cr.Spec.DisplayName != "Web App" {
+		t.Errorf("spec.displayName=%q want %q", cr.Spec.DisplayName, "Web App")
+	}
+	if cr.Spec.Port != 8080 {
+		t.Errorf("spec.port=%d want 8080", cr.Spec.Port)
+	}
+}
+
+// TestCRWriter_ApplyOnUpdate_UpdatesCR verifies that after ApplyOnUpdate the
+// Deployment CR spec reflects the new values.
+func TestCRWriter_ApplyOnUpdate_UpdatesCR(t *testing.T) {
+	env, w := newEnvtestCRWriter(t)
+	project := "cr-update"
+	ensureProjectNamespace(t, env.Direct, project)
+
+	// Seed with initial values.
+	if err := w.ApplyOnCreate(context.Background(), project, "api-svc", "my-image", "v1", "tmpl", "", "", nil, nil, nil, 9000); err != nil {
+		t.Fatalf("ApplyOnCreate (seed): %v", err)
+	}
+	eventuallyGetCR(t, env.Direct, "prj-"+project, "api-svc")
+
+	// Update with new image and tag.
+	if err := w.ApplyOnUpdate(context.Background(), project, "api-svc", "my-image", "v2", "tmpl", "", "", nil, nil, 9000); err != nil {
+		t.Fatalf("ApplyOnUpdate: %v", err)
+	}
+
+	// Poll until the CR reflects the new tag.
+	deadline := time.Now().Add(10 * time.Second)
+	key := types.NamespacedName{Namespace: "prj-" + project, Name: "api-svc"}
+	for {
+		var cr deploymentsv1alpha1.Deployment
+		if err := env.Direct.Get(context.Background(), key, &cr); err != nil {
+			t.Fatalf("re-get CR after update: %v", err)
+		}
+		if cr.Spec.Tag == "v2" {
+			return // pass
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("CR spec.tag did not update to %q within deadline; got %q", "v2", cr.Spec.Tag)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestCRWriter_DeleteCR_RemovesCR verifies that after DeleteCR the Deployment
+// CR is gone from the apiserver.
+func TestCRWriter_DeleteCR_RemovesCR(t *testing.T) {
+	env, w := newEnvtestCRWriter(t)
+	project := "cr-delete"
+	ensureProjectNamespace(t, env.Direct, project)
+
+	// Seed a CR.
+	if err := w.ApplyOnCreate(context.Background(), project, "svc-to-delete", "img", "v1", "tmpl", "", "", nil, nil, nil, 0); err != nil {
+		t.Fatalf("ApplyOnCreate (seed): %v", err)
+	}
+	eventuallyGetCR(t, env.Direct, "prj-"+project, "svc-to-delete")
+
+	// Delete it.
+	if err := w.DeleteCR(context.Background(), project, "svc-to-delete"); err != nil {
+		t.Fatalf("DeleteCR: %v", err)
+	}
+	eventuallyAbsentCR(t, env.Direct, "prj-"+project, "svc-to-delete")
+}
+
+// TestCRWriter_DeleteCR_NotFoundIsIdempotent verifies that calling DeleteCR
+// when the CR does not exist returns no error. This covers the lazy-creation
+// invariant: old proto-store records that were never dual-written must
+// not block deletion.
+func TestCRWriter_DeleteCR_NotFoundIsIdempotent(t *testing.T) {
+	env, w := newEnvtestCRWriter(t)
+	project := "cr-delete-notfound"
+	ensureProjectNamespace(t, env.Direct, project)
+
+	// DeleteCR on a non-existent CR should not return an error.
+	if err := w.DeleteCR(context.Background(), project, "does-not-exist"); err != nil {
+		t.Fatalf("DeleteCR on absent CR returned error: %v", err)
+	}
+}
+
+// TestCRWriter_OwnerRefsPreservedAcrossUpdate verifies that ownerReferences
+// written onto the Deployment CR by an external actor (simulating a
+// dependency reconciler from Phase 5–6) are not removed by a subsequent
+// ApplyOnUpdate call.
+//
+// SSA field-manager isolation is the mechanism: the CRWriter owns spec.* via
+// the "holos-console-deployment-writer" field manager; ownerReferences are
+// owned by the reconciler's field manager. A Force=true SSA apply for one
+// manager cannot clear fields managed by another.
+func TestCRWriter_OwnerRefsPreservedAcrossUpdate(t *testing.T) {
+	env, w := newEnvtestCRWriter(t)
+	project := "cr-ownerref"
+	ensureProjectNamespace(t, env.Direct, project)
+
+	// Step 1: create the CR via the writer.
+	if err := w.ApplyOnCreate(context.Background(), project, "svc", "img", "v1", "tmpl", "", "", nil, nil, nil, 0); err != nil {
+		t.Fatalf("ApplyOnCreate: %v", err)
+	}
+	cr := eventuallyGetCR(t, env.Direct, "prj-"+project, "svc")
+
+	// Step 2: an external actor (dependency reconciler) adds an ownerReference
+	// via a direct Patch to simulate Phase 5–6 behavior. We use the same SSA
+	// patch mechanism with a different field manager so the ownership is
+	// correctly attributed.
+	ownerUID := types.UID("fake-owner-uid-1")
+	// Use MergeFrom patch to add an ownerReference without clobbering the spec.
+	// In a real reconciler this would be an SSA patch; for the test a strategic
+	// merge patch on metadata is simpler and equivalent for ownerRef mutation.
+	patchedCR := cr.DeepCopy()
+	patchedCR.OwnerReferences = append(patchedCR.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       "parent-cm",
+		UID:        ownerUID,
+	})
+	if err := env.Direct.Update(context.Background(), patchedCR); err != nil {
+		t.Fatalf("adding ownerReference: %v", err)
+	}
+
+	// Step 3: apply an update through the CRWriter (simulates a
+	// deployments-service update).
+	if err := w.ApplyOnUpdate(context.Background(), project, "svc", "img", "v2", "tmpl", "", "", nil, nil, 0); err != nil {
+		t.Fatalf("ApplyOnUpdate: %v", err)
+	}
+
+	// Step 4: assert the ownerReference survived the update.
+	deadline := time.Now().Add(10 * time.Second)
+	key := types.NamespacedName{Namespace: "prj-" + project, Name: "svc"}
+	for {
+		var got deploymentsv1alpha1.Deployment
+		if err := env.Direct.Get(context.Background(), key, &got); err != nil {
+			t.Fatalf("re-get after update: %v", err)
+		}
+		if got.Spec.Tag != "v2" {
+			// Update has not landed yet; keep polling.
+			if time.Now().After(deadline) {
+				t.Fatalf("CR spec.tag did not update to v2 within deadline")
+			}
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		// Update landed — now check ownerReferences.
+		found := false
+		for _, ref := range got.OwnerReferences {
+			if ref.UID == ownerUID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("ownerReference (uid=%s) was removed by ApplyOnUpdate; ownerRefs=%+v", ownerUID, got.OwnerReferences)
+		}
+		return // pass
+	}
+}
+
+// TestCRWriter_LazyCreate_ApplyOnUpdateCreatesAbsentCR verifies that calling
+// ApplyOnUpdate when the CR does not yet exist creates it (lazy creation per
+// ADR Decision 12). This is the migration path: a Deployment already in the
+// proto-store that was created before the dual-write was wired gets its CR
+// lazily on the next update.
+func TestCRWriter_LazyCreate_ApplyOnUpdateCreatesAbsentCR(t *testing.T) {
+	env, w := newEnvtestCRWriter(t)
+	project := "cr-lazy"
+	ensureProjectNamespace(t, env.Direct, project)
+
+	// No prior Create call — simulate an existing proto-store record.
+	if err := w.ApplyOnUpdate(context.Background(), project, "legacy-svc", "img", "v1", "tmpl", "Legacy", "Desc", nil, nil, 0); err != nil {
+		t.Fatalf("ApplyOnUpdate (lazy create): %v", err)
+	}
+
+	cr := eventuallyGetCR(t, env.Direct, "prj-"+project, "legacy-svc")
+	if cr.Spec.Image != "img" {
+		t.Errorf("lazy-created CR spec.image=%q want %q", cr.Spec.Image, "img")
+	}
+}

--- a/console/deployments/k8s.go
+++ b/console/deployments/k8s.go
@@ -50,6 +50,11 @@ type K8sClient struct {
 	// working.
 	dynamic  dynamic.Interface
 	Resolver *resolver.Resolver
+	// crWriter, when non-nil, mirrors every Create/Update/Delete call to the
+	// deployments.holos.run/v1alpha1.Deployment CRD via server-side apply.
+	// A nil crWriter disables dual-write so local/dev wiring without a
+	// controller-runtime client remains unchanged.
+	crWriter *CRWriter
 }
 
 // NewK8sClient creates a client for deployment operations.
@@ -64,6 +69,15 @@ func NewK8sClient(client kubernetes.Interface, r *resolver.Resolver) *K8sClient 
 // every test that builds a K8sClient.
 func (k *K8sClient) WithDynamicClient(d dynamic.Interface) *K8sClient {
 	k.dynamic = d
+	return k
+}
+
+// WithCRWriter configures the K8sClient to dual-write every create, update,
+// and delete to the deployments.holos.run/v1alpha1 Deployment CRD via SSA
+// in addition to the existing ConfigMap proto-store (HOL-957). A nil writer
+// is safe — all CRWriter methods are nil-receiver no-ops.
+func (k *K8sClient) WithCRWriter(w *CRWriter) *K8sClient {
+	k.crWriter = w
 	return k
 }
 
@@ -149,7 +163,23 @@ func (k *K8sClient) CreateDeployment(ctx context.Context, project, name, image, 
 	if port > 0 {
 		cm.Data[PortKey] = strconv.Itoa(int(port))
 	}
-	return k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+	created, err := k.client.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	// Dual-write: mirror the new Deployment to the CRD store. A nil crWriter
+	// (local/dev wiring without a controller-runtime client) is a no-op.
+	if crErr := k.crWriter.ApplyOnCreate(ctx, project, name, image, tag, tmpl, displayName, description, command, args, env, port); crErr != nil {
+		slog.WarnContext(ctx, "deployment CR dual-write failed after proto-store create",
+			slog.String("project", project),
+			slog.String("namespace", ns),
+			slog.String("name", name),
+			slog.Any("error", crErr),
+		)
+		// Do not surface the error to the caller: the ConfigMap write already
+		// succeeded. The CR will be lazily re-created on the next update.
+	}
+	return created, nil
 }
 
 // UpdateDeployment updates an existing deployment ConfigMap.
@@ -204,7 +234,75 @@ func (k *K8sClient) UpdateDeployment(ctx context.Context, project, name string, 
 			delete(cm.Data, PortKey)
 		}
 	}
-	return k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+	updated, err := k.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	// Dual-write: mirror the updated Deployment to the CRD store. Extract
+	// the canonical post-update values from the updated ConfigMap so the CR
+	// always reflects what the proto-store actually recorded.
+	if k.crWriter != nil {
+		updatedImage := updated.Data[ImageKey]
+		updatedTag := updated.Data[TagKey]
+		updatedTemplate := updated.Data[TemplateKey]
+		updatedDisplayName := updated.Annotations[v1alpha2.AnnotationDisplayName]
+		updatedDescription := updated.Annotations[v1alpha2.AnnotationDescription]
+		updatedCommand := commandFromConfigMapData(updated.Data)
+		updatedArgs := argsFromConfigMapData(updated.Data)
+		updatedPort := portFromConfigMapData(updated.Data)
+		if crErr := k.crWriter.ApplyOnUpdate(ctx, project, name, updatedImage, updatedTag, updatedTemplate, updatedDisplayName, updatedDescription, updatedCommand, updatedArgs, updatedPort); crErr != nil {
+			slog.WarnContext(ctx, "deployment CR dual-write failed after proto-store update",
+				slog.String("project", project),
+				slog.String("namespace", ns),
+				slog.String("name", name),
+				slog.Any("error", crErr),
+			)
+			// Do not surface the error: the ConfigMap update succeeded.
+		}
+	}
+	return updated, nil
+}
+
+// commandFromConfigMapData returns the decoded command slice from cm data,
+// or nil when the key is absent or the JSON is malformed.
+func commandFromConfigMapData(data map[string]string) []string {
+	raw, ok := data[CommandKey]
+	if !ok || raw == "" {
+		return nil
+	}
+	var v []string
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return nil
+	}
+	return v
+}
+
+// argsFromConfigMapData returns the decoded args slice from cm data, or nil
+// when the key is absent or the JSON is malformed.
+func argsFromConfigMapData(data map[string]string) []string {
+	raw, ok := data[ArgsKey]
+	if !ok || raw == "" {
+		return nil
+	}
+	var v []string
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return nil
+	}
+	return v
+}
+
+// portFromConfigMapData returns the port from cm data, or 0 when the key is
+// absent or not parseable as an integer.
+func portFromConfigMapData(data map[string]string) int32 {
+	raw, ok := data[PortKey]
+	if !ok || raw == "" {
+		return 0
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	return int32(v)
 }
 
 // ListDeploymentResources returns every resource currently owned by the given
@@ -378,7 +476,7 @@ func (k *K8sClient) SetOutputURLAnnotation(ctx context.Context, project, name, u
 	return nil
 }
 
-// DeleteDeployment deletes a deployment ConfigMap.
+// DeleteDeployment deletes a deployment ConfigMap and the corresponding CR.
 func (k *K8sClient) DeleteDeployment(ctx context.Context, project, name string) error {
 	ns := k.Resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "deleting deployment from kubernetes",
@@ -386,7 +484,20 @@ func (k *K8sClient) DeleteDeployment(ctx context.Context, project, name string) 
 		slog.String("namespace", ns),
 		slog.String("name", name),
 	)
-	return k.client.CoreV1().ConfigMaps(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	if err := k.client.CoreV1().ConfigMaps(ns).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	// Dual-write: delete the Deployment CR. NotFound is silenced (idempotent).
+	if crErr := k.crWriter.DeleteCR(ctx, project, name); crErr != nil {
+		slog.WarnContext(ctx, "deployment CR delete failed after proto-store delete",
+			slog.String("project", project),
+			slog.String("namespace", ns),
+			slog.String("name", name),
+			slog.Any("error", crErr),
+		)
+		// Do not surface the error: the ConfigMap delete succeeded.
+	}
+	return nil
 }
 
 // NamespaceResourceItem holds a resource name and its sorted data keys.

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
 	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 )
 
@@ -61,6 +62,11 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
 	// Our custom types.
 	utilruntime.Must(v1alpha1.AddToScheme(Scheme))
+	// Deployment CRD (deployments.holos.run/v1alpha1) — registered so the
+	// controller-runtime cache-backed client can read/write Deployment CRs
+	// and the CRWriter can issue SSA patches through the manager's client
+	// (HOL-957).
+	utilruntime.Must(deploymentsv1alpha1.AddToScheme(Scheme))
 }
 
 // Options holds the knobs the console needs to construct a controller-runtime
@@ -260,6 +266,16 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 	// absent CRD / RBAC gap surfaces at Start rather than on first request.
 	if _, err := mgr.GetCache().GetInformer(context.Background(), &v1alpha1.TemplateRelease{}); err != nil {
 		return nil, fmt.Errorf("controller.NewManager: priming templaterelease informer: %w", err)
+	}
+
+	// Prime the Deployment informer (HOL-957). The CRWriter issues SSA
+	// patches through the manager's cache-backed client; without this eager
+	// registration a missing Deployment CRD or RBAC gap would surface as a
+	// silent cache-miss on first write rather than a startup failure. Register
+	// it eagerly so an absent CRD is caught at Start before the pod reports
+	// /readyz green.
+	if _, err := mgr.GetCache().GetInformer(context.Background(), &deploymentsv1alpha1.Deployment{}); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: priming deployment informer: %w", err)
 	}
 
 	return m, nil


### PR DESCRIPTION
## Summary

- Introduces `CRWriter` in `console/deployments/cr_writer.go` that mirrors every Deployment create/update/delete to the `deployments.holos.run/v1alpha1` CRD using server-side apply with field manager `holos-console-deployment-writer`
- Lazy creation on `ApplyOnUpdate` covers pre-existing proto-store records with no migration step (ADR Decision 12)
- SSA field-manager isolation ensures dependency reconcilers' `ownerReferences` (Phases 5-6) are never clobbered by dual-write updates
- `K8sClient.WithCRWriter()` fluent wiring; `crWriter` errors are warn-logged but non-fatal (ConfigMap write already succeeded)
- `internal/controller/manager.go` registers `deploymentsv1alpha1` in the scheme and primes the Deployment informer eagerly
- `console.go` wires `NewCRWriter` when the controller-runtime manager is available
- Six envtest tests in `cr_writer_test.go`: create, update, delete, idempotent delete, owner-ref preservation across update, lazy creation

Fixes HOL-957

## Test plan

- [x] `go test ./console/deployments/` — all tests pass including 6 new CRWriter envtest tests
- [x] `go test ./internal/controller/` — all controller suite tests pass
- [x] `make test-go` passes (pre-existing `TestScripts/grpc_reflection` and `TestScripts/version` failures are unrelated to this PR and were present before this change)
- [x] `go vet ./console/deployments/ ./internal/controller/` — clean