### PR TITLE
feat(controller): TemplateGrant cross-namespace validator with informer cache

### DIFF
--- a/console/deployments/grant_validator.go
+++ b/console/deployments/grant_validator.go
@@ -96,8 +96,8 @@ type Validator interface {
 // accidentally allow cross-namespace references.
 type TemplateGrantCache struct {
 	mu         sync.RWMutex
-	grants     []v1alpha1.TemplateGrant      // snapshot of all TemplateGrants
-	namespaces map[string]corev1.Namespace   // snapshot of Namespaces keyed by name
+	grants     []v1alpha1.TemplateGrant    // snapshot of all TemplateGrants
+	namespaces map[string]corev1.Namespace // snapshot of Namespaces keyed by name
 }
 
 // NewTemplateGrantCache returns an initialised TemplateGrantCache. Callers

--- a/console/deployments/grant_validator.go
+++ b/console/deployments/grant_validator.go
@@ -1,0 +1,252 @@
+// Package deployments — TemplateGrant cross-namespace LinkedTemplateRef validator.
+//
+// # Design: ReferenceGrant-style cross-namespace authorization
+//
+// ValidateGrant is the single public surface that any cross-namespace
+// LinkedTemplateRef resolution calls into. It mirrors the Gateway API
+// ReferenceGrant semantics: a TemplateGrant must live in the *source* template's
+// namespace (the "to" side) and must list the *dependent*'s namespace in its
+// From entries (the "from" side) before a cross-namespace reference is allowed.
+//
+// # Backing store
+//
+// The validator is backed by TemplateGrantCache, a concurrency-safe in-memory
+// snapshot of every TemplateGrant and every Namespace (for label-selector
+// evaluation). The cache is populated and kept current by the
+// TemplateGrantController defined in internal/controller/template_grant_controller.go.
+// The controller calls SetGrants and SetNamespaces on every informer event;
+// the validator reads those snapshots under a read lock.
+//
+// # Hard-revoke semantics (ADR 035, Decision 10)
+//
+// When a TemplateGrant is deleted the cache is updated immediately and
+// ValidateGrant rejects new materialisation attempts through the deleted grant.
+// Existing materialised dependency Deployments are NOT removed — callers must
+// clean up orphans manually. This file documents that invariant in the function
+// header below.
+//
+// # Three From shapes
+//
+// ValidateGrant evaluates three forms of TemplateGrantFromRef.Namespace:
+//
+//  1. Literal namespace — exact match against the dependent's namespace.
+//  2. "*" wildcard (HOL-767) — permits any dependent namespace.
+//  3. NamespaceSelector — the NamespaceSelector field is evaluated against
+//     the labels of the dependent's namespace (read from the Namespace cache).
+//     If the dependent's Namespace is absent from the cache the selector match
+//     is treated as a miss (not an error) so a missing namespace cannot be
+//     used to bypass a pending label check.
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+)
+
+// GrantNotFoundError is returned by ValidateGrant when no matching TemplateGrant
+// permits the cross-namespace reference. Callers that want to distinguish a
+// missing-grant rejection from other errors can use errors.As:
+//
+//	var notFound *GrantNotFoundError
+//	if errors.As(err, &notFound) { ... }
+type GrantNotFoundError struct {
+	DependentNamespace string
+	RequiresNamespace  string
+	RequiresName       string
+}
+
+func (e *GrantNotFoundError) Error() string {
+	return fmt.Sprintf(
+		"no TemplateGrant in namespace %q permits namespace %q to reference template %q",
+		e.RequiresNamespace, e.DependentNamespace, e.RequiresName,
+	)
+}
+
+// Validator is the interface consumed by Phase 5 and Phase 6 reconcilers
+// (TemplateDependency and TemplateRequirement). It is intentionally minimal:
+// a single method that returns nil when the cross-namespace reference is
+// permitted and a *GrantNotFoundError when it is not.
+type Validator interface {
+	// ValidateGrant checks whether the cross-namespace LinkedTemplateRef
+	// described by `requires` is authorised from `dependent`'s namespace.
+	//
+	// Hard-revoke contract: on TemplateGrant deletion the validator
+	// immediately rejects new materialisation attempts; existing materialised
+	// dependency Deployments are preserved (no cascade). Callers must manage
+	// orphan cleanup independently.
+	//
+	// Returns nil on same-namespace references (no grant required).
+	ValidateGrant(ctx context.Context, dependent v1alpha1.LinkedTemplateRef, requires v1alpha1.LinkedTemplateRef) error
+}
+
+// TemplateGrantCache is a concurrency-safe in-memory snapshot of TemplateGrant
+// and Namespace objects used by ValidateGrant. The TemplateGrantController
+// (internal/controller/template_grant_controller.go) calls SetGrants and
+// SetNamespaces on every informer event to keep the snapshots current.
+//
+// A nil *TemplateGrantCache is valid: ValidateGrant returns a GrantNotFoundError
+// (safe default-deny) so callers that cannot supply a populated cache do not
+// accidentally allow cross-namespace references.
+type TemplateGrantCache struct {
+	mu         sync.RWMutex
+	grants     []v1alpha1.TemplateGrant      // snapshot of all TemplateGrants
+	namespaces map[string]corev1.Namespace   // snapshot of Namespaces keyed by name
+}
+
+// NewTemplateGrantCache returns an initialised TemplateGrantCache. Callers
+// should call SetGrants and SetNamespaces at least once before querying.
+func NewTemplateGrantCache() *TemplateGrantCache {
+	return &TemplateGrantCache{
+		namespaces: make(map[string]corev1.Namespace),
+	}
+}
+
+// SetGrants replaces the full TemplateGrant snapshot. Called by the controller
+// on every TemplateGrant create / update / delete event.
+func (c *TemplateGrantCache) SetGrants(grants []v1alpha1.TemplateGrant) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.grants = grants
+}
+
+// SetNamespaces replaces the full Namespace snapshot. Called by the controller
+// on every Namespace create / update / delete event.
+func (c *TemplateGrantCache) SetNamespaces(nsList []corev1.Namespace) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	m := make(map[string]corev1.Namespace, len(nsList))
+	for _, ns := range nsList {
+		m[ns.Name] = ns
+	}
+	c.namespaces = m
+}
+
+// ValidateGrant implements Validator. Same-namespace references are always
+// allowed without consulting the cache. Cross-namespace references require a
+// matching TemplateGrant in the source template's namespace.
+//
+// Hard-revoke: the function reads the live in-memory cache snapshot; once the
+// controller removes a deleted grant from the cache this function starts
+// rejecting new cross-namespace references immediately. Existing materialised
+// dependency Deployments are not touched — callers own orphan cleanup.
+func (c *TemplateGrantCache) ValidateGrant(ctx context.Context, dependent v1alpha1.LinkedTemplateRef, requires v1alpha1.LinkedTemplateRef) error {
+	// Same-namespace references never require a TemplateGrant.
+	if dependent.Namespace == requires.Namespace {
+		return nil
+	}
+
+	// nil cache → safe default-deny.
+	if c == nil {
+		return &GrantNotFoundError{
+			DependentNamespace: dependent.Namespace,
+			RequiresNamespace:  requires.Namespace,
+			RequiresName:       requires.Name,
+		}
+	}
+
+	c.mu.RLock()
+	grants := c.grants
+	namespaces := c.namespaces
+	c.mu.RUnlock()
+
+	// Retrieve the dependent namespace's labels for NamespaceSelector evaluation.
+	var dependentNsLabels labels.Set
+	if ns, ok := namespaces[dependent.Namespace]; ok {
+		dependentNsLabels = labels.Set(ns.Labels)
+	}
+
+	for _, grant := range grants {
+		// The grant must live in the source template's namespace.
+		if grant.Namespace != requires.Namespace {
+			continue
+		}
+
+		// If the grant restricts which templates are reachable via `to`,
+		// check that the requires ref is covered. An empty `to` list means
+		// all templates in the namespace are reachable.
+		if !grantCoversTo(grant, requires) {
+			continue
+		}
+
+		// Evaluate each from entry.
+		for _, from := range grant.Spec.From {
+			if fromPermitsDependentNamespace(from, dependent.Namespace, dependentNsLabels) {
+				return nil
+			}
+		}
+	}
+
+	return &GrantNotFoundError{
+		DependentNamespace: dependent.Namespace,
+		RequiresNamespace:  requires.Namespace,
+		RequiresName:       requires.Name,
+	}
+}
+
+// grantCoversTo reports whether the grant's To list covers the requires ref.
+// An empty To list means all templates in the grant's namespace are reachable.
+func grantCoversTo(grant v1alpha1.TemplateGrant, requires v1alpha1.LinkedTemplateRef) bool {
+	if len(grant.Spec.To) == 0 {
+		return true
+	}
+	for _, ref := range grant.Spec.To {
+		if ref.Namespace == requires.Namespace && ref.Name == requires.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// fromPermitsDependentNamespace reports whether a single TemplateGrantFromRef
+// permits the given dependent namespace. It handles the three from shapes:
+//
+//  1. Literal "*" wildcard without NamespaceSelector — permits any namespace.
+//  2. Literal "*" wildcard with NamespaceSelector — permits any namespace
+//     whose labels match the selector (the wildcard scopes the candidate set
+//     to all namespaces; the selector then filters that set).
+//  3. Exact namespace match without NamespaceSelector — permits exactly the
+//     named namespace.
+//  4. Exact namespace match with NamespaceSelector — the named namespace must
+//     additionally satisfy the selector.
+//
+// If dependentNsLabels is nil (the namespace is absent from the cache) any
+// selector match is treated as a miss so a missing namespace cannot bypass a
+// pending label check.
+func fromPermitsDependentNamespace(from v1alpha1.TemplateGrantFromRef, dependentNs string, dependentNsLabels labels.Set) bool {
+	// Determine whether the dependent namespace is within scope of the
+	// From.Namespace field.
+	namespaceInScope := false
+	if from.Namespace == "*" {
+		namespaceInScope = true
+	} else if from.Namespace == dependentNs {
+		namespaceInScope = true
+	}
+
+	if !namespaceInScope {
+		return false
+	}
+
+	// Namespace is in scope. If no selector is set, the match is unconditional.
+	if from.NamespaceSelector == nil {
+		return true
+	}
+
+	// A NamespaceSelector is set: the dependent namespace must also satisfy it.
+	if dependentNsLabels == nil {
+		// Namespace not in cache — treat as miss.
+		return false
+	}
+	selector, err := metav1.LabelSelectorAsSelector(from.NamespaceSelector)
+	if err != nil {
+		// Malformed selector — treat as miss rather than panic.
+		return false
+	}
+	return selector.Matches(dependentNsLabels)
+}

--- a/console/deployments/grant_validator_test.go
+++ b/console/deployments/grant_validator_test.go
@@ -1,0 +1,295 @@
+package deployments_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/deployments"
+)
+
+// makeCache returns a TemplateGrantCache pre-loaded with the provided grants
+// and namespaces.
+func makeCache(grants []v1alpha1.TemplateGrant, namespaces []corev1.Namespace) *deployments.TemplateGrantCache {
+	c := deployments.NewTemplateGrantCache()
+	c.SetGrants(grants)
+	c.SetNamespaces(namespaces)
+	return c
+}
+
+// makeNS returns a Namespace with the given name and labels.
+func makeNS(name string, lbls map[string]string) corev1.Namespace {
+	return corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: lbls,
+		},
+	}
+}
+
+// makeGrant returns a TemplateGrant in the given namespace with a single From
+// entry.
+func makeGrant(ns, name string, from []v1alpha1.TemplateGrantFromRef, to []v1alpha1.LinkedTemplateRef) v1alpha1.TemplateGrant {
+	return v1alpha1.TemplateGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Spec: v1alpha1.TemplateGrantSpec{
+			From: from,
+			To:   to,
+		},
+	}
+}
+
+// ref returns a LinkedTemplateRef for the given namespace and name.
+func ref(ns, name string) v1alpha1.LinkedTemplateRef {
+	return v1alpha1.LinkedTemplateRef{Namespace: ns, Name: name}
+}
+
+// TestGrantValidator_SameNamespace asserts that same-namespace references are
+// always allowed without consulting the cache.
+func TestGrantValidator_SameNamespace(t *testing.T) {
+	// Even a nil cache must allow same-namespace references.
+	var c *deployments.TemplateGrantCache
+	dependent := ref("org-acme", "my-deployment")
+	requires := ref("org-acme", "some-template")
+	if err := c.ValidateGrant(context.Background(), dependent, requires); err != nil {
+		t.Fatalf("same-namespace reference should always be allowed; got %v", err)
+	}
+}
+
+// TestGrantValidator_LiteralMatch asserts that a TemplateGrant with a literal
+// From.Namespace permits the named dependent namespace.
+func TestGrantValidator_LiteralMatch(t *testing.T) {
+	grant := makeGrant("org-acme", "grant-1",
+		[]v1alpha1.TemplateGrantFromRef{{Namespace: "prj-alpha"}},
+		nil, // all templates reachable
+	)
+	c := makeCache([]v1alpha1.TemplateGrant{grant}, nil)
+
+	dependent := ref("prj-alpha", "dep")
+	requires := ref("org-acme", "base-template")
+
+	if err := c.ValidateGrant(context.Background(), dependent, requires); err != nil {
+		t.Fatalf("literal match should be allowed; got %v", err)
+	}
+}
+
+// TestGrantValidator_WildcardMatch asserts that a TemplateGrant with
+// From.Namespace == "*" permits any dependent namespace (HOL-767).
+func TestGrantValidator_WildcardMatch(t *testing.T) {
+	grant := makeGrant("org-acme", "grant-wildcard",
+		[]v1alpha1.TemplateGrantFromRef{{Namespace: "*"}},
+		nil,
+	)
+	c := makeCache([]v1alpha1.TemplateGrant{grant}, nil)
+
+	for _, depNS := range []string{"prj-alpha", "prj-beta", "fld-shared", "some-random-ns"} {
+		dependent := ref(depNS, "dep")
+		requires := ref("org-acme", "base-template")
+		if err := c.ValidateGrant(context.Background(), dependent, requires); err != nil {
+			t.Fatalf("wildcard should permit namespace %q; got %v", depNS, err)
+		}
+	}
+}
+
+// TestGrantValidator_LabelSelectorMatch asserts that a TemplateGrant with a
+// NamespaceSelector permits dependent namespaces whose labels match the selector.
+func TestGrantValidator_LabelSelectorMatch(t *testing.T) {
+	grant := makeGrant("org-acme", "grant-selector",
+		[]v1alpha1.TemplateGrantFromRef{
+			{
+				Namespace: "*",
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"console.holos.run/resource-type": "project",
+					},
+				},
+			},
+		},
+		nil,
+	)
+	ns := makeNS("prj-alpha", map[string]string{
+		"console.holos.run/resource-type": "project",
+	})
+	c := makeCache([]v1alpha1.TemplateGrant{grant}, []corev1.Namespace{ns})
+
+	dependent := ref("prj-alpha", "dep")
+	requires := ref("org-acme", "base-template")
+
+	if err := c.ValidateGrant(context.Background(), dependent, requires); err != nil {
+		t.Fatalf("label selector match should be allowed; got %v", err)
+	}
+}
+
+// TestGrantValidator_LabelSelectorMismatch asserts that a TemplateGrant with a
+// NamespaceSelector rejects a namespace whose labels do not match.
+func TestGrantValidator_LabelSelectorMismatch(t *testing.T) {
+	grant := makeGrant("org-acme", "grant-selector",
+		[]v1alpha1.TemplateGrantFromRef{
+			{
+				Namespace: "*",
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"console.holos.run/resource-type": "project",
+					},
+				},
+			},
+		},
+		nil,
+	)
+	// Folder namespace — label does not match the selector.
+	ns := makeNS("fld-alpha", map[string]string{
+		"console.holos.run/resource-type": "folder",
+	})
+	c := makeCache([]v1alpha1.TemplateGrant{grant}, []corev1.Namespace{ns})
+
+	dependent := ref("fld-alpha", "dep")
+	requires := ref("org-acme", "base-template")
+
+	err := c.ValidateGrant(context.Background(), dependent, requires)
+	if err == nil {
+		t.Fatal("label selector mismatch should be rejected; got nil error")
+	}
+	var notFound *deployments.GrantNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected *GrantNotFoundError; got %T: %v", err, err)
+	}
+}
+
+// TestGrantValidator_MissingGrant asserts that a cross-namespace reference with
+// no matching TemplateGrant is rejected with *GrantNotFoundError.
+func TestGrantValidator_MissingGrant(t *testing.T) {
+	c := makeCache(nil, nil) // empty cache
+
+	dependent := ref("prj-alpha", "dep")
+	requires := ref("org-acme", "base-template")
+
+	err := c.ValidateGrant(context.Background(), dependent, requires)
+	if err == nil {
+		t.Fatal("missing grant should be rejected; got nil error")
+	}
+	var notFound *deployments.GrantNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected *GrantNotFoundError; got %T: %v", err, err)
+	}
+	if notFound.DependentNamespace != "prj-alpha" {
+		t.Errorf("DependentNamespace=%q want %q", notFound.DependentNamespace, "prj-alpha")
+	}
+	if notFound.RequiresNamespace != "org-acme" {
+		t.Errorf("RequiresNamespace=%q want %q", notFound.RequiresNamespace, "org-acme")
+	}
+	if notFound.RequiresName != "base-template" {
+		t.Errorf("RequiresName=%q want %q", notFound.RequiresName, "base-template")
+	}
+}
+
+// TestGrantValidator_DeletedGrantRejectedForNewMaterialisations verifies that
+// once a grant is removed from the cache (simulating a delete event processed
+// by the controller), new cross-namespace references through it are rejected.
+func TestGrantValidator_DeletedGrantRejectedForNewMaterialisations(t *testing.T) {
+	grant := makeGrant("org-acme", "grant-1",
+		[]v1alpha1.TemplateGrantFromRef{{Namespace: "prj-alpha"}},
+		nil,
+	)
+	c := makeCache([]v1alpha1.TemplateGrant{grant}, nil)
+
+	dependent := ref("prj-alpha", "dep")
+	requires := ref("org-acme", "base-template")
+
+	// Before delete: allowed.
+	if err := c.ValidateGrant(context.Background(), dependent, requires); err != nil {
+		t.Fatalf("pre-delete: expected allowed; got %v", err)
+	}
+
+	// Simulate TemplateGrant deletion by replacing the grants list with an
+	// empty snapshot (what the controller does on delete event).
+	c.SetGrants(nil)
+
+	// After delete: new materialisation through the deleted grant is rejected.
+	err := c.ValidateGrant(context.Background(), dependent, requires)
+	if err == nil {
+		t.Fatal("post-delete: new materialisation should be rejected; got nil error")
+	}
+	var notFound *deployments.GrantNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected *GrantNotFoundError; got %T: %v", err, err)
+	}
+}
+
+// TestGrantValidator_DeletedGrantPreservesExistingMaterialisations documents
+// the hard-revoke contract: the validator does not cascade deletes. "Existing
+// materialised dependency Deployments are preserved" means ValidateGrant does
+// not touch or enumerate existing Deployments — this test asserts that the
+// validator's only job is to allow/deny new cross-namespace references and does
+// not have any side effects on existing Deployments. The contract is enforced
+// at the documentation level here; the controller and the reconciler that calls
+// ValidateGrant are responsible for not cascading.
+func TestGrantValidator_DeletedGrantPreservesExistingMaterialisations(t *testing.T) {
+	// This test is a documentation/coverage test. It verifies that
+	// ValidateGrant's reject path returns only an error and has no other
+	// observable side effect. Callers observe the error and decide not to
+	// create a new Deployment; they do NOT delete existing ones.
+	c := makeCache(nil, nil)
+
+	dependent := ref("prj-alpha", "dep")
+	requires := ref("org-acme", "base-template")
+
+	err := c.ValidateGrant(context.Background(), dependent, requires)
+	if err == nil {
+		t.Fatal("expected rejection; got nil")
+	}
+	// The only observable output is the error — no Deployments were touched.
+	var notFound *deployments.GrantNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected *GrantNotFoundError; got %T", err)
+	}
+}
+
+// TestGrantValidator_ToListNarrowsScope verifies that a grant with a non-empty
+// `to` list only permits references to the listed templates.
+func TestGrantValidator_ToListNarrowsScope(t *testing.T) {
+	grant := makeGrant("org-acme", "grant-narrow",
+		[]v1alpha1.TemplateGrantFromRef{{Namespace: "prj-alpha"}},
+		[]v1alpha1.LinkedTemplateRef{
+			{Namespace: "org-acme", Name: "allowed-template"},
+		},
+	)
+	c := makeCache([]v1alpha1.TemplateGrant{grant}, nil)
+
+	dependent := ref("prj-alpha", "dep")
+
+	// Allowed template.
+	allowed := ref("org-acme", "allowed-template")
+	if err := c.ValidateGrant(context.Background(), dependent, allowed); err != nil {
+		t.Fatalf("to-list: allowed template should be permitted; got %v", err)
+	}
+
+	// Not-listed template — should be rejected.
+	denied := ref("org-acme", "other-template")
+	if err := c.ValidateGrant(context.Background(), dependent, denied); err == nil {
+		t.Fatal("to-list: non-listed template should be rejected; got nil error")
+	}
+}
+
+// TestGrantValidator_NilCacheDefaultDeny asserts that a nil *TemplateGrantCache
+// safely default-denies cross-namespace references.
+func TestGrantValidator_NilCacheDefaultDeny(t *testing.T) {
+	var c *deployments.TemplateGrantCache
+	dependent := ref("prj-alpha", "dep")
+	requires := ref("org-acme", "base-template")
+
+	err := c.ValidateGrant(context.Background(), dependent, requires)
+	if err == nil {
+		t.Fatal("nil cache: cross-namespace reference should be denied; got nil error")
+	}
+	var notFound *deployments.GrantNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected *GrantNotFoundError; got %T", err)
+	}
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -48,6 +48,7 @@ import (
 
 	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
 	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/deployments"
 )
 
 // Scheme is the controller-runtime scheme shared by the embedded manager and
@@ -114,6 +115,13 @@ type Options struct {
 	OrganizationPrefix string
 	FolderPrefix       string
 	ProjectPrefix      string
+
+	// GrantCache is the TemplateGrantCache the TemplateGrantReconciler
+	// keeps current. When nil, NewManager allocates a fresh cache so
+	// callers that only need the cache-backed client can omit it.
+	// The console wires its GrantCache here so ValidateGrant reads from
+	// the same snapshot the reconciler maintains.
+	GrantCache *deployments.TemplateGrantCache
 }
 
 // Manager wraps a sigs.k8s.io/controller-runtime manager.Manager plus a
@@ -134,6 +142,7 @@ type Manager struct {
 	ready            atomic.Bool
 	cacheSyncTimeout time.Duration
 	logger           *slog.Logger
+	grantCache       *deployments.TemplateGrantCache
 }
 
 // NewManager constructs a Manager from the provided rest config, scheme, and
@@ -234,6 +243,21 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 		return nil, fmt.Errorf("controller.NewManager: registering TemplatePolicyBindingReconciler: %w", err)
 	}
 
+	// Register the TemplateGrantReconciler (HOL-958). It watches
+	// TemplateGrant and Namespace objects and keeps the GrantCache current
+	// so ValidateGrant calls never need to round-trip to the API server.
+	grantCache := opts.GrantCache
+	if grantCache == nil {
+		grantCache = deployments.NewTemplateGrantCache()
+	}
+	if err := (&TemplateGrantReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Cache:  grantCache,
+	}).SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplateGrantReconciler: %w", err)
+	}
+
 	// Prime the Namespace informer so the reconcilers (HOL-621+) can read
 	// console.holos.run/resource-type labels without round-trips. Namespace
 	// is otherwise not brought into the cache by any of the three
@@ -278,6 +302,10 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 		return nil, fmt.Errorf("controller.NewManager: priming deployment informer: %w", err)
 	}
 
+	// Store the grant cache on the Manager so console.go can retrieve it
+	// and pass it to the validator path.
+	m.grantCache = grantCache
+
 	return m, nil
 }
 
@@ -286,6 +314,14 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 // rewires every storage client to consume this method.
 func (m *Manager) GetClient() client.Client {
 	return m.mgr.GetClient()
+}
+
+// GetGrantCache returns the TemplateGrantCache that the TemplateGrantReconciler
+// keeps current. Callers that need to perform TemplateGrant validation (e.g.,
+// the Phase 5 and Phase 6 reconcilers) should read from this cache rather than
+// issuing direct API server reads.
+func (m *Manager) GetGrantCache() *deployments.TemplateGrantCache {
+	return m.grantCache
 }
 
 // GetManager returns the underlying controller-runtime manager.Manager for

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -37,6 +37,8 @@ limitations under the License.
 // +kubebuilder:rbac:groups=templates.holos.run,resources=renderstates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=templates.holos.run,resources=renderstates/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=templates.holos.run,resources=renderstates/finalizers,verbs=update
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templategrants,verbs=get;list;watch
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templategrants/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch

--- a/internal/controller/template_grant_controller.go
+++ b/internal/controller/template_grant_controller.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller — TemplateGrantController.
+//
+// # Design: informer-backed cache for TemplateGrant validation
+//
+// TemplateGrantController watches every TemplateGrant and every Namespace in
+// the cluster. On each reconcile it rebuilds the full list snapshots and
+// pushes them to the TemplateGrantCache defined in
+// console/deployments/grant_validator.go. The cache then serves ValidateGrant
+// reads under a read lock without any further API server calls.
+//
+// # Hard-revoke semantics (ADR 035, Decision 10)
+//
+// When a TemplateGrant is deleted, the reconcile triggered by the delete event
+// re-lists all surviving grants and overwrites the cache. From that point on,
+// ValidateGrant immediately rejects new cross-namespace materialisation
+// attempts. Existing materialised dependency Deployments are preserved — the
+// controller does not cascade deletes. Project Owners must clean up orphans
+// manually; the deleted grant blocks only new materialisations.
+//
+// # Namespace informer
+//
+// The Namespace watch is required for NamespaceSelector evaluation: the cache
+// must hold namespace labels so the validator can call
+// metav1.LabelSelectorAsSelector without a live API round-trip.
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/deployments"
+)
+
+// TemplateGrantReconciler watches TemplateGrant and Namespace objects and
+// keeps the supplied TemplateGrantCache current. On each reconcile it
+// re-lists all grants and namespaces and calls SetGrants / SetNamespaces so
+// the cache is always consistent with the API server's current state.
+//
+// RBAC markers for this reconciler live on the package doc comment in
+// rbac.go — controller-gen's rbac generator ignores markers on struct or
+// method doc comments.
+type TemplateGrantReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Cache  *deployments.TemplateGrantCache
+}
+
+// SetupWithManager registers the reconciler with the supplied manager.
+// In addition to the primary For(&TemplateGrant{}) watch it adds a secondary
+// Namespace watch: Namespace label changes affect NamespaceSelector evaluation
+// inside the cache, so any namespace event must re-sync the cache snapshot.
+func (r *TemplateGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.TemplateGrant{}).
+		Named("template-grant-controller").
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.grantsForNamespace),
+		).
+		Complete(r)
+}
+
+// Reconcile re-syncs the TemplateGrantCache whenever a TemplateGrant or
+// Namespace event fires. The reconcile key is the TemplateGrant that triggered
+// the event; we ignore it and do a full list-sync so the cache is always a
+// consistent snapshot of all grants and namespaces.
+func (r *TemplateGrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Re-list all TemplateGrants.
+	var grantList v1alpha1.TemplateGrantList
+	if err := r.List(ctx, &grantList); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("list TemplateGrants: %w", err)
+	}
+
+	// Re-list all Namespaces.
+	var nsList corev1.NamespaceList
+	if err := r.List(ctx, &nsList); err != nil {
+		return ctrl.Result{}, fmt.Errorf("list Namespaces: %w", err)
+	}
+
+	r.Cache.SetGrants(grantList.Items)
+	r.Cache.SetNamespaces(nsList.Items)
+
+	logger.V(1).Info("template grant cache refreshed",
+		"grants", len(grantList.Items),
+		"namespaces", len(nsList.Items),
+	)
+	return ctrl.Result{}, nil
+}
+
+// grantsForNamespace is the watch-handler mapper for Namespace events. It
+// returns a reconcile.Request for every TemplateGrant in the cluster so the
+// full cache sync runs on any namespace label change.
+func (r *TemplateGrantReconciler) grantsForNamespace(ctx context.Context, obj client.Object) []reconcile.Request {
+	var list v1alpha1.TemplateGrantList
+	if err := r.List(ctx, &list); err != nil {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	for _, g := range list.Items {
+		out = append(out, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&g),
+		})
+	}
+	// If there are no grants, still run one synthetic reconcile via a
+	// well-known sentinel so the namespace snapshot stays current even
+	// when no grants exist. We use an empty NamespacedName; Reconcile
+	// re-lists unconditionally so the key value is irrelevant.
+	if len(out) == 0 {
+		out = append(out, reconcile.Request{})
+	}
+	return out
+}

--- a/internal/controller/template_grant_controller.go
+++ b/internal/controller/template_grant_controller.go
@@ -45,7 +45,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,9 +95,6 @@ func (r *TemplateGrantReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Re-list all TemplateGrants.
 	var grantList v1alpha1.TemplateGrantList
 	if err := r.List(ctx, &grantList); err != nil {
-		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
 		return ctrl.Result{}, fmt.Errorf("list TemplateGrants: %w", err)
 	}
 

--- a/internal/controller/template_grant_controller_test.go
+++ b/internal/controller/template_grant_controller_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	controllerpkg "github.com/holos-run/holos-console/internal/controller"
+	"github.com/holos-run/holos-console/console/deployments"
+)
+
+// grantRef is a shorthand LinkedTemplateRef constructor for tests.
+func grantRef(ns, name string) v1alpha1.LinkedTemplateRef {
+	return v1alpha1.LinkedTemplateRef{Namespace: ns, Name: name}
+}
+
+// startManagerWithCache constructs and starts a Manager with the provided
+// TemplateGrantCache wired into Options.GrantCache. This allows tests to
+// observe the same cache the TemplateGrantReconciler updates.
+func startManagerWithCache(t *testing.T, cfg *rest.Config, cache *deployments.TemplateGrantCache) (*controllerpkg.Manager, context.CancelFunc, <-chan error) {
+	t.Helper()
+
+	m, err := controllerpkg.NewManager(cfg, nil, controllerpkg.Options{
+		CacheSyncTimeout:             30 * time.Second,
+		SkipControllerNameValidation: true,
+		GrantCache:                   cache,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- m.Start(ctx)
+	}()
+
+	deadline := time.Now().Add(30 * time.Second)
+	for !m.Ready() {
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatalf("manager did not become ready within deadline")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return m, cancel, errCh
+}
+
+// waitForGrantAllowed polls c.ValidateGrant until it returns nil (allowed) or
+// the deadline expires.
+func waitForGrantAllowed(t *testing.T, c *deployments.TemplateGrantCache, dependent, requires v1alpha1.LinkedTemplateRef) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := c.ValidateGrant(context.Background(), dependent, requires); err == nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("ValidateGrant(%q→%q/%q) never became allowed within deadline",
+		dependent.Namespace, requires.Namespace, requires.Name)
+}
+
+// waitForGrantDenied polls c.ValidateGrant until it returns a *GrantNotFoundError
+// or the deadline expires.
+func waitForGrantDenied(t *testing.T, c *deployments.TemplateGrantCache, dependent, requires v1alpha1.LinkedTemplateRef) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		err := c.ValidateGrant(context.Background(), dependent, requires)
+		var notFound *deployments.GrantNotFoundError
+		if errors.As(err, &notFound) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("ValidateGrant(%q→%q/%q) never became denied within deadline",
+		dependent.Namespace, requires.Namespace, requires.Name)
+}
+
+// TestTemplateGrantController_CreateResolveDeleteCycle is the headline envtest
+// for HOL-958. It exercises the full grant create → resolve → delete →
+// re-resolve cycle against a live kube-apiserver:
+//
+//  1. No grant exists → cross-namespace reference is denied.
+//  2. Create TemplateGrant → controller reconciles → reference is allowed.
+//  3. Delete TemplateGrant → controller reconciles → reference is denied again
+//     (hard-revoke: new materialisations blocked).
+func TestTemplateGrantController_CreateResolveDeleteCycle(t *testing.T) {
+	e := startEnv(t)
+
+	// Allocate a fresh GrantCache and wire it into the manager via Options.
+	grantCache := deployments.NewTemplateGrantCache()
+	_, cancel, errCh := startManagerWithCache(t, e.cfg, grantCache)
+	t.Cleanup(func() { stopManager(t, cancel, errCh) })
+
+	// Create the namespaces the grant and references will use.
+	orgNS := "org-grant-cycle"
+	prjNS := "prj-grant-cycle"
+	mustCreateNamespace(t, e.client, orgNS, "organization")
+	mustCreateNamespace(t, e.client, prjNS, "project")
+
+	dependent := grantRef(prjNS, "my-deployment")
+	requires := grantRef(orgNS, "base-template")
+
+	// --- Stage 1: no grant → denied ----------------------------------------
+	if err := grantCache.ValidateGrant(context.Background(), dependent, requires); err == nil {
+		t.Fatal("stage 1: expected cross-namespace reference to be denied before grant creation; got nil")
+	}
+
+	// --- Stage 2: create grant → allowed ------------------------------------
+	grant := &v1alpha1.TemplateGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: orgNS,
+			Name:      "allow-prj",
+		},
+		Spec: v1alpha1.TemplateGrantSpec{
+			From: []v1alpha1.TemplateGrantFromRef{
+				{Namespace: prjNS},
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), grant); err != nil {
+		t.Fatalf("stage 2: create TemplateGrant: %v", err)
+	}
+
+	waitForGrantAllowed(t, grantCache, dependent, requires)
+
+	// --- Stage 3: delete grant → denied again (hard-revoke) -----------------
+	if err := e.client.Delete(context.Background(), grant); err != nil {
+		t.Fatalf("stage 3: delete TemplateGrant: %v", err)
+	}
+
+	waitForGrantDenied(t, grantCache, dependent, requires)
+}


### PR DESCRIPTION
## Summary

- Adds `console/deployments/grant_validator.go`: `TemplateGrantCache` (concurrency-safe in-memory snapshot) implementing the `Validator` interface with `ValidateGrant(ctx, dependent, requires)` returning `*GrantNotFoundError` on missing grant
- Adds `internal/controller/template_grant_controller.go`: `TemplateGrantReconciler` watches `TemplateGrant` + `Namespace` objects and keeps the cache current via `SetGrants`/`SetNamespaces`
- Wires `TemplateGrantReconciler` into `controller.NewManager` via `Options.GrantCache`; exposes `Manager.GetGrantCache()` for Phase 5/6 reconcilers
- Adds RBAC markers for `templategrants` get/list/watch + `templategrants/status` patch
- 10 unit tests cover literal match, wildcard, label-selector match/mismatch, missing grant, deleted-grant hard-revoke, to-list scoping, nil-cache default-deny
- Envtest exercises full create → resolve → delete → re-resolve cycle (hard-revoke path)

Fixes HOL-958

## Test plan

- [ ] `make test-go` passes (only pre-existing `TestScripts` failure in `console` package, unrelated to this PR)
- [ ] `TestGrantValidator_*` unit tests: 10/10 pass
- [ ] `TestTemplateGrantController_CreateResolveDeleteCycle` envtest: grant create → allowed, grant delete → denied
- [ ] `internal/controller` and `console/deployments` packages both show `ok` in test output