### PR TITLE
feat(controller): TemplateDependency reconciler and EnsureSingleton helper (HOL-959)

### DIFF
--- a/api/templates/v1alpha1/conditions.go
+++ b/api/templates/v1alpha1/conditions.go
@@ -88,6 +88,30 @@ const (
 	TemplatePolicyBindingReasonNotReady          = "NotReady"
 )
 
+// TemplateDependency condition types.
+const (
+	// TemplateDependencyConditionAccepted tracks whether the reconciler
+	// parsed .spec and accepted it, or rejected it with a typed reason.
+	TemplateDependencyConditionAccepted = "Accepted"
+	// TemplateDependencyConditionResolvedRefs tracks whether the cross-
+	// namespace Requires reference is authorised by a TemplateGrant. Same-
+	// namespace references are always accepted without a grant.
+	TemplateDependencyConditionResolvedRefs = "ResolvedRefs"
+	// TemplateDependencyConditionReady is the aggregate: Accepted &&
+	// ResolvedRefs are both True.
+	TemplateDependencyConditionReady = "Ready"
+)
+
+// TemplateDependency condition reasons.
+const (
+	TemplateDependencyReasonAccepted        = "Accepted"
+	TemplateDependencyReasonInvalidSpec     = "InvalidSpec"
+	TemplateDependencyReasonResolvedRefs    = "ResolvedRefs"
+	TemplateDependencyReasonGrantNotFound   = "GrantNotFound"
+	TemplateDependencyReasonReady           = "Ready"
+	TemplateDependencyReasonNotReady        = "NotReady"
+)
+
 // Finalizer is the finalizer key used by reconcilers for the
 // templates.holos.run API group when non-trivial cleanup is required before
 // the API server deletes a managed object.

--- a/console/deployments/dependency_reconciler.go
+++ b/console/deployments/dependency_reconciler.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package deployments — EnsureSingletonDependencyDeployment shared helper.
+//
+// # Design: singleton dependency Deployment with refcount owner-refs
+//
+// EnsureSingletonDependencyDeployment is the deliberate seam shared by both
+// the TemplateDependency reconciler (Phase 5, HOL-959) and the
+// TemplateRequirement reconciler (Phase 6, HOL-960). It takes a fully resolved
+// (project, requires, dependent, cascadeDelete) tuple and does not know about
+// the originating CRD kind — keeping it pure makes it easier to reason about
+// and to test in isolation.
+//
+// # Singleton naming
+//
+// The singleton Deployment name is deterministic and unique within the project
+// namespace. The format is:
+//
+//	<requires.Name>-<requires.VersionConstraint>-shared
+//
+// where VersionConstraint is used as a version discriminator. When
+// VersionConstraint is empty, the format collapses to:
+//
+//	<requires.Name>-shared
+//
+// Example: a Requires reference to template "waypoint" with version "v1"
+// produces the singleton name "waypoint-v1-shared". Phase 8 (PreflightCheck)
+// surfaces collisions between user-named Deployments and singleton names.
+//
+// # Owner-reference model
+//
+// The singleton carries one non-controller ownerReference per dependent
+// Deployment. Because multiple owners can co-own the singleton without a
+// single controller, Controller is set to false (or nil) and BlockOwnerDeletion
+// is set to true so native Kubernetes GC reaps the singleton when the last
+// dependent is deleted. cascadeDelete=false skips adding the owner-ref edge so
+// the singleton's lifecycle is decoupled from that dependent.
+//
+// # Cross-namespace validation
+//
+// EnsureSingletonDependencyDeployment accepts a Validator (implemented by
+// TemplateGrantCache). If requires.Namespace differs from dependent.Namespace
+// (cross-namespace reference), the validator is consulted before any write.
+// A non-nil error from ValidateGrant causes EnsureSingletonDependencyDeployment
+// to return a *GrantNotFoundError so callers can surface it as a Kubernetes
+// condition on their object.
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+)
+
+// singletonName returns the deterministic singleton Deployment name for the
+// given requires reference. The format is documented in the package comment.
+//
+// Format:
+//
+//	<requires.Name>-<requires.VersionConstraint>-shared   (VersionConstraint non-empty)
+//	<requires.Name>-shared                                 (VersionConstraint empty)
+//
+// The VersionConstraint is sanitised: forward slashes, spaces, angle brackets,
+// and equals signs are stripped so the result is a valid DNS label component.
+func singletonName(requires v1alpha1.LinkedTemplateRef) string {
+	if requires.VersionConstraint == "" {
+		return requires.Name + "-shared"
+	}
+	// Sanitise the version constraint for use in a Kubernetes name.
+	sanitised := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '/', '<', '>', '=', '^', '~':
+			return '-'
+		}
+		return r
+	}, requires.VersionConstraint)
+	// Collapse consecutive hyphens and trim leading/trailing hyphens.
+	for strings.Contains(sanitised, "--") {
+		sanitised = strings.ReplaceAll(sanitised, "--", "-")
+	}
+	sanitised = strings.Trim(sanitised, "-")
+	return requires.Name + "-" + sanitised + "-shared"
+}
+
+// EnsureSingletonDependencyDeployment creates or updates the singleton
+// Deployment of requires in the same namespace as dependent, adding a
+// non-controller ownerReference from the dependent Deployment to the
+// singleton when cascadeDelete is true.
+//
+// The function is idempotent: if the singleton already exists it ensures that
+// the ownerReference from dependent is present (if cascadeDelete is true) and
+// returns without error.
+//
+// Cross-namespace references (requires.Namespace != dependent.Namespace) are
+// validated against the supplied Validator before any write. A nil validator
+// is treated as default-deny: cross-namespace references return a
+// *GrantNotFoundError without contacting the API server.
+//
+// The singleton is created in dependent.Namespace (the project namespace),
+// mirroring the spec of a Deployment for the requires template. The spec
+// fields are populated only from the requires LinkedTemplateRef: the caller
+// does not need to pre-resolve the Template object.
+func EnsureSingletonDependencyDeployment(
+	ctx context.Context,
+	c client.Client,
+	validator Validator,
+	requires v1alpha1.LinkedTemplateRef,
+	dependent *deploymentsv1alpha1.Deployment,
+	cascadeDelete bool,
+) error {
+	// Validate cross-namespace grants before touching the API server.
+	dependentRef := v1alpha1.LinkedTemplateRef{
+		Namespace: dependent.Namespace,
+		Name:      dependent.Name,
+	}
+	if err := validator.ValidateGrant(ctx, dependentRef, requires); err != nil {
+		return err
+	}
+
+	name := singletonName(requires)
+	key := types.NamespacedName{Namespace: dependent.Namespace, Name: name}
+
+	var existing deploymentsv1alpha1.Deployment
+	err := c.Get(ctx, key, &existing)
+	if apierrors.IsNotFound(err) {
+		// Create the singleton Deployment.
+		singleton := buildSingleton(requires, dependent, name, cascadeDelete)
+		if createErr := c.Create(ctx, singleton); createErr != nil {
+			if apierrors.IsAlreadyExists(createErr) {
+				// Race: another reconcile created it concurrently. Fetch and
+				// update below.
+				if getErr := c.Get(ctx, key, &existing); getErr != nil {
+					return fmt.Errorf("get singleton after AlreadyExists: %w", getErr)
+				}
+				return ensureOwnerRef(ctx, c, &existing, dependent, cascadeDelete)
+			}
+			return fmt.Errorf("create singleton Deployment %s/%s: %w", dependent.Namespace, name, createErr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get singleton Deployment %s/%s: %w", dependent.Namespace, name, err)
+	}
+
+	// Singleton already exists: ensure the ownerReference is present.
+	return ensureOwnerRef(ctx, c, &existing, dependent, cascadeDelete)
+}
+
+// buildSingleton constructs the initial singleton Deployment CR from the
+// requires reference and the dependent Deployment's namespace. The singleton
+// lives in the same project namespace as the dependent.
+func buildSingleton(
+	requires v1alpha1.LinkedTemplateRef,
+	dependent *deploymentsv1alpha1.Deployment,
+	name string,
+	cascadeDelete bool,
+) *deploymentsv1alpha1.Deployment {
+	singleton := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: dependent.Namespace,
+			Name:      name,
+		},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: dependent.Spec.ProjectName,
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: requires.Namespace,
+				Name:      requires.Name,
+			},
+			VersionConstraint: requires.VersionConstraint,
+			DisplayName:       name,
+		},
+	}
+	if cascadeDelete {
+		singleton.OwnerReferences = []metav1.OwnerReference{
+			ownerRef(dependent),
+		}
+	}
+	return singleton
+}
+
+// ensureOwnerRef ensures a non-controller ownerReference from dependent to
+// singleton is present. It is a no-op when cascadeDelete is false or when the
+// ownerReference already exists. The update is issued as a full object update
+// (not a patch) because the owner-refs slice is small and conflicts are
+// detected by the optimistic locking resourceVersion check.
+func ensureOwnerRef(
+	ctx context.Context,
+	c client.Client,
+	singleton *deploymentsv1alpha1.Deployment,
+	dependent *deploymentsv1alpha1.Deployment,
+	cascadeDelete bool,
+) error {
+	if !cascadeDelete {
+		return nil
+	}
+	ref := ownerRef(dependent)
+	for _, existing := range singleton.OwnerReferences {
+		if existing.UID == ref.UID {
+			return nil // already present
+		}
+	}
+	updated := singleton.DeepCopy()
+	updated.OwnerReferences = append(updated.OwnerReferences, ref)
+	if err := c.Update(ctx, updated); err != nil {
+		if apierrors.IsConflict(err) {
+			// Let the caller requeue; a conflict means the singleton was
+			// updated between our Get and this Update.
+			return fmt.Errorf("conflict updating singleton Deployment %s/%s ownerRefs: %w", singleton.Namespace, singleton.Name, err)
+		}
+		return fmt.Errorf("update singleton Deployment %s/%s ownerRefs: %w", singleton.Namespace, singleton.Name, err)
+	}
+	return nil
+}
+
+// ownerRef builds a non-controller ownerReference for the given Deployment.
+// Controller is explicitly set to false so multiple dependents can co-own the
+// singleton without Kubernetes rejecting the second owner. BlockOwnerDeletion
+// is set to true so GC waits for all owners to be gone before reaping the
+// singleton.
+func ownerRef(dep *deploymentsv1alpha1.Deployment) metav1.OwnerReference {
+	f := false
+	t := true
+	return metav1.OwnerReference{
+		APIVersion:         deploymentsv1alpha1.GroupVersion.String(),
+		Kind:               "Deployment",
+		Name:               dep.Name,
+		UID:                dep.UID,
+		Controller:         &f,
+		BlockOwnerDeletion: &t,
+	}
+}

--- a/console/deployments/dependency_reconciler_test.go
+++ b/console/deployments/dependency_reconciler_test.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployments_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/deployments"
+)
+
+// allowAllValidator is a Validator that always allows cross-namespace refs.
+type allowAllValidator struct{}
+
+func (allowAllValidator) ValidateGrant(_ context.Context, _ v1alpha1.LinkedTemplateRef, _ v1alpha1.LinkedTemplateRef) error {
+	return nil
+}
+
+// denyAllValidator is a Validator that always denies cross-namespace refs.
+type denyAllValidator struct{}
+
+func (denyAllValidator) ValidateGrant(_ context.Context, dependent v1alpha1.LinkedTemplateRef, requires v1alpha1.LinkedTemplateRef) error {
+	return &deployments.GrantNotFoundError{
+		DependentNamespace: dependent.Namespace,
+		RequiresNamespace:  requires.Namespace,
+		RequiresName:       requires.Name,
+	}
+}
+
+// buildScheme returns a scheme with the deployments v1alpha1 types registered.
+func buildScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := deploymentsv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return s
+}
+
+// buildDeployment constructs a minimal Deployment with UID set so ownerRef
+// equality checks work.
+func buildDeployment(namespace, name, templateNS, templateName string) *deploymentsv1alpha1.Deployment {
+	return &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       types.UID("test-uid-" + name),
+		},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: namespace,
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: templateNS,
+				Name:      templateName,
+			},
+		},
+	}
+}
+
+// TestSingletonName_Formats verifies the singleton naming helper produces the
+// expected names for a variety of VersionConstraint values. The name format is
+// documented in the package comment of dependency_reconciler.go.
+func TestSingletonName_Formats(t *testing.T) {
+	// singletonName is unexported; we verify it indirectly through
+	// EnsureSingletonDependencyDeployment by reading the created object's name.
+	tests := []struct {
+		versionConstraint string
+		wantSuffix        string
+	}{
+		{"", "-shared"},
+		{"v1", "-v1-shared"},
+		{">=1.0.0 <2.0.0", "-1.0.0-2.0.0-shared"}, // spaces become hyphens
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			s := buildScheme(t)
+			c := fake.NewClientBuilder().WithScheme(s).Build()
+			ns := "prj-alpha"
+
+			dep := buildDeployment(ns, "mcp-server", "org-shared", "waypoint")
+			if err := c.Create(context.Background(), dep); err != nil {
+				t.Fatalf("create dependent Deployment: %v", err)
+			}
+
+			requires := v1alpha1.LinkedTemplateRef{
+				Namespace:         "org-shared",
+				Name:              "waypoint",
+				VersionConstraint: tc.versionConstraint,
+			}
+
+			if err := deployments.EnsureSingletonDependencyDeployment(
+				context.Background(), c, allowAllValidator{}, requires, dep, true,
+			); err != nil {
+				t.Fatalf("EnsureSingleton: %v", err)
+			}
+
+			var list deploymentsv1alpha1.DeploymentList
+			if err := c.List(context.Background(), &list, client.InNamespace(ns)); err != nil {
+				t.Fatalf("list Deployments: %v", err)
+			}
+			found := false
+			for _, d := range list.Items {
+				if d.Name == dep.Name {
+					continue // skip the original dependent
+				}
+				// Only the singleton should remain.
+				want := "waypoint" + tc.wantSuffix
+				if d.Name != want {
+					t.Errorf("singleton name=%q want %q", d.Name, want)
+				}
+				found = true
+			}
+			if !found {
+				t.Fatal("no singleton Deployment found after EnsureSingleton")
+			}
+		})
+	}
+}
+
+// TestEnsureSingleton_CreateOnFirstCall creates a singleton on first invocation.
+func TestEnsureSingleton_CreateOnFirstCall(t *testing.T) {
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	ns := "prj-alpha"
+
+	dep := buildDeployment(ns, "mcp-server", "org-shared", "waypoint")
+	if err := c.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create dependent: %v", err)
+	}
+
+	requires := v1alpha1.LinkedTemplateRef{
+		Namespace:         ns, // same-namespace — always allowed
+		Name:              "waypoint",
+		VersionConstraint: "v1",
+	}
+
+	if err := deployments.EnsureSingletonDependencyDeployment(
+		context.Background(), c, allowAllValidator{}, requires, dep, true,
+	); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	var list deploymentsv1alpha1.DeploymentList
+	if err := c.List(context.Background(), &list, client.InNamespace(ns)); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var found *deploymentsv1alpha1.Deployment
+	for i := range list.Items {
+		if list.Items[i].Name != dep.Name {
+			found = &list.Items[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("singleton not found")
+	}
+	if want := "waypoint-v1-shared"; found.Name != want {
+		t.Errorf("singleton name=%q want %q", found.Name, want)
+	}
+	// OwnerReference must be present and non-controller.
+	if len(found.OwnerReferences) != 1 {
+		t.Fatalf("len(ownerRefs)=%d want 1", len(found.OwnerReferences))
+	}
+	ref := found.OwnerReferences[0]
+	if ref.UID != dep.UID {
+		t.Errorf("ownerRef.UID=%q want %q", ref.UID, dep.UID)
+	}
+	if ref.Controller != nil && *ref.Controller {
+		t.Error("ownerRef.Controller must be false or nil; got true")
+	}
+	if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+		t.Error("ownerRef.BlockOwnerDeletion must be true")
+	}
+}
+
+// TestEnsureSingleton_SecondOwnerAppended verifies that a second dependent
+// appends its ownerReference to the existing singleton rather than creating
+// a second singleton.
+func TestEnsureSingleton_SecondOwnerAppended(t *testing.T) {
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	ns := "prj-alpha"
+
+	dep1 := buildDeployment(ns, "mcp-server", ns, "waypoint")
+	dep2 := buildDeployment(ns, "mcp-server-2", ns, "waypoint")
+	if err := c.Create(context.Background(), dep1); err != nil {
+		t.Fatalf("create dep1: %v", err)
+	}
+	if err := c.Create(context.Background(), dep2); err != nil {
+		t.Fatalf("create dep2: %v", err)
+	}
+
+	requires := v1alpha1.LinkedTemplateRef{Namespace: ns, Name: "waypoint"}
+
+	// First call: creates the singleton with dep1's ownerRef.
+	if err := deployments.EnsureSingletonDependencyDeployment(
+		context.Background(), c, allowAllValidator{}, requires, dep1, true,
+	); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Second call: should append dep2's ownerRef.
+	if err := deployments.EnsureSingletonDependencyDeployment(
+		context.Background(), c, allowAllValidator{}, requires, dep2, true,
+	); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	var singleton deploymentsv1alpha1.Deployment
+	key := client.ObjectKey{Namespace: ns, Name: "waypoint-shared"}
+	if err := c.Get(context.Background(), key, &singleton); err != nil {
+		t.Fatalf("get singleton: %v", err)
+	}
+	if got := len(singleton.OwnerReferences); got != 2 {
+		t.Fatalf("len(ownerRefs)=%d want 2", got)
+	}
+	uids := map[string]bool{}
+	for _, r := range singleton.OwnerReferences {
+		uids[string(r.UID)] = true
+	}
+	if !uids[string(dep1.UID)] {
+		t.Error("dep1 UID not found in ownerRefs")
+	}
+	if !uids[string(dep2.UID)] {
+		t.Error("dep2 UID not found in ownerRefs")
+	}
+}
+
+// TestEnsureSingleton_Idempotent verifies calling EnsureSingleton twice for
+// the same dependent does not add a duplicate ownerReference.
+func TestEnsureSingleton_Idempotent(t *testing.T) {
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	ns := "prj-alpha"
+
+	dep := buildDeployment(ns, "mcp-server", ns, "waypoint")
+	if err := c.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create dep: %v", err)
+	}
+
+	requires := v1alpha1.LinkedTemplateRef{Namespace: ns, Name: "waypoint"}
+
+	for i := 0; i < 3; i++ {
+		if err := deployments.EnsureSingletonDependencyDeployment(
+			context.Background(), c, allowAllValidator{}, requires, dep, true,
+		); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+
+	var singleton deploymentsv1alpha1.Deployment
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: ns, Name: "waypoint-shared"}, &singleton); err != nil {
+		t.Fatalf("get singleton: %v", err)
+	}
+	if got := len(singleton.OwnerReferences); got != 1 {
+		t.Errorf("len(ownerRefs)=%d want 1 (idempotent)", got)
+	}
+}
+
+// TestEnsureSingleton_CascadeDeleteFalse verifies that cascadeDelete=false
+// skips adding an ownerReference to the singleton.
+func TestEnsureSingleton_CascadeDeleteFalse(t *testing.T) {
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	ns := "prj-alpha"
+
+	dep := buildDeployment(ns, "mcp-server", ns, "waypoint")
+	if err := c.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create dep: %v", err)
+	}
+
+	requires := v1alpha1.LinkedTemplateRef{Namespace: ns, Name: "waypoint"}
+
+	if err := deployments.EnsureSingletonDependencyDeployment(
+		context.Background(), c, allowAllValidator{}, requires, dep, false,
+	); err != nil {
+		t.Fatalf("EnsureSingleton: %v", err)
+	}
+
+	var singleton deploymentsv1alpha1.Deployment
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: ns, Name: "waypoint-shared"}, &singleton); err != nil {
+		t.Fatalf("get singleton: %v", err)
+	}
+	if got := len(singleton.OwnerReferences); got != 0 {
+		t.Errorf("len(ownerRefs)=%d want 0 (cascadeDelete=false)", got)
+	}
+}
+
+// TestEnsureSingleton_CrossNamespaceGrantDenied verifies that a cross-namespace
+// Requires reference is rejected when the validator returns GrantNotFoundError.
+func TestEnsureSingleton_CrossNamespaceGrantDenied(t *testing.T) {
+	s := buildScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	ns := "prj-alpha"
+
+	dep := buildDeployment(ns, "mcp-server", ns, "waypoint")
+	if err := c.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create dep: %v", err)
+	}
+
+	requires := v1alpha1.LinkedTemplateRef{
+		Namespace: "org-different", // cross-namespace
+		Name:      "waypoint",
+	}
+
+	err := deployments.EnsureSingletonDependencyDeployment(
+		context.Background(), c, denyAllValidator{}, requires, dep, true,
+	)
+	if err == nil {
+		t.Fatal("expected GrantNotFoundError; got nil")
+	}
+	var notFound *deployments.GrantNotFoundError
+	if !isGrantNotFound(err, &notFound) {
+		t.Errorf("expected *GrantNotFoundError; got %T: %v", err, err)
+	}
+
+	// No singleton should have been created.
+	var list deploymentsv1alpha1.DeploymentList
+	if err2 := c.List(context.Background(), &list, client.InNamespace(ns)); err2 != nil {
+		t.Fatalf("list: %v", err2)
+	}
+	// Only the original dependent should exist.
+	if got := len(list.Items); got != 1 {
+		t.Errorf("Deployment count=%d want 1 (only the dependent)", got)
+	}
+}
+
+// isGrantNotFound is a type-assertion helper compatible with the unexported
+// errors.As logic so the test can remain in the external _test package.
+func isGrantNotFound(err error, target **deployments.GrantNotFoundError) bool {
+	if err == nil {
+		return false
+	}
+	// errors.As would work too; this is a direct type assertion for clarity.
+	if e, ok := err.(*deployments.GrantNotFoundError); ok {
+		*target = e
+		return true
+	}
+	return false
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -258,6 +258,20 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 		return nil, fmt.Errorf("controller.NewManager: registering TemplateGrantReconciler: %w", err)
 	}
 
+	// Register the TemplateDependencyReconciler (HOL-959). It watches
+	// TemplateDependency and Deployment objects; for each matching dependent
+	// Deployment it calls EnsureSingletonDependencyDeployment so the shared
+	// singleton Requires Deployment is materialised with the correct set of
+	// non-controller ownerReferences.
+	if err := (&TemplateDependencyReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("template-dependency-controller"),
+		Validator: grantCache,
+	}).SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplateDependencyReconciler: %w", err)
+	}
+
 	// Prime the Namespace informer so the reconcilers (HOL-621+) can read
 	// console.holos.run/resource-type labels without round-trips. Namespace
 	// is otherwise not brought into the cache by any of the three

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -39,6 +39,11 @@ limitations under the License.
 // +kubebuilder:rbac:groups=templates.holos.run,resources=renderstates/finalizers,verbs=update
 // +kubebuilder:rbac:groups=templates.holos.run,resources=templategrants,verbs=get;list;watch
 // +kubebuilder:rbac:groups=templates.holos.run,resources=templategrants/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templatedependencies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templatedependencies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templatedependencies/finalizers,verbs=update
+// +kubebuilder:rbac:groups=deployments.holos.run,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=deployments.holos.run,resources=deployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch

--- a/internal/controller/template_dependency_controller.go
+++ b/internal/controller/template_dependency_controller.go
@@ -1,0 +1,331 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller — TemplateDependencyReconciler.
+//
+// # Design
+//
+// TemplateDependencyReconciler watches TemplateDependency objects scoped to
+// project namespaces. For each reconcile it:
+//
+//  1. Validates the spec (Accepted condition).
+//  2. Lists every Deployment in the same namespace whose TemplateRef matches
+//     the Dependent template reference.
+//  3. For each matching Deployment, calls EnsureSingletonDependencyDeployment
+//     from console/deployments — the shared helper that creates or updates the
+//     singleton Requires Deployment with a non-controller ownerReference.
+//  4. Validates that the Requires cross-namespace reference is authorised by a
+//     TemplateGrant (ResolvedRefs condition).
+//  5. Aggregates Accepted + ResolvedRefs into the top-level Ready condition and
+//     writes status if it has changed.
+//
+// # Interaction with native GC
+//
+// Owner-references on the singleton Deployment point to the dependent
+// Deployment objects with Controller=false and BlockOwnerDeletion=true. When
+// the last dependent Deployment is deleted the Kubernetes garbage collector
+// reaps the singleton automatically — no finalizer or explicit delete in this
+// reconciler is required.
+//
+// # Stylistic reference
+//
+// This file follows internal/controller/template_policy_binding_controller.go.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/deployments"
+)
+
+// TemplateDependencyReconciler reconciles TemplateDependency objects scoped
+// to project namespaces. It calls EnsureSingletonDependencyDeployment for
+// each matching dependent Deployment and surfaces grant-validation results as
+// Kubernetes conditions.
+//
+// RBAC markers for this reconciler live on the package doc comment in
+// rbac.go — controller-gen's rbac generator ignores markers on struct or
+// method doc comments.
+type TemplateDependencyReconciler struct {
+	client.Client
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
+	Validator deployments.Validator
+}
+
+// SetupWithManager registers the reconciler with the supplied manager. In
+// addition to the primary For(&TemplateDependency{}), it adds a secondary
+// watch on Deployment objects: when a Deployment is created or deleted the
+// ownerReference set on the singleton changes, so the TemplateDependency
+// objects in the same namespace must be re-reconciled.
+func (r *TemplateDependencyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.TemplateDependency{}).
+		Named("template-dependency-controller").
+		Watches(
+			&deploymentsv1alpha1.Deployment{},
+			handler.EnqueueRequestsFromMapFunc(r.dependenciesForDeployment),
+		).
+		Complete(r)
+}
+
+// Reconcile implements the reconciliation loop for TemplateDependency.
+func (r *TemplateDependencyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var dep v1alpha1.TemplateDependency
+	if err := r.Get(ctx, req.NamespacedName, &dep); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get TemplateDependency: %w", err)
+	}
+
+	gen := dep.Generation
+
+	accepted := dependencyAcceptedCondition(&dep)
+	resolved, helperErr := r.dependencyResolvedRefsCondition(ctx, &dep)
+	components := []metav1.Condition{accepted, resolved}
+
+	proposed := make([]metav1.Condition, 0, 3)
+	for _, c := range components {
+		c.ObservedGeneration = gen
+		proposed = append(proposed, c)
+	}
+	ready := aggregateReady(components,
+		v1alpha1.TemplateDependencyReasonReady,
+		v1alpha1.TemplateDependencyReasonNotReady,
+		"TemplateDependency is accepted and the required Deployment is materialised.",
+		"TemplateDependency is not Ready; see component conditions for details.")
+	ready.Type = v1alpha1.TemplateDependencyConditionReady
+	ready.ObservedGeneration = gen
+	proposed = append(proposed, ready)
+
+	target := dep.DeepCopy()
+	target.Status.ObservedGeneration = gen
+	newConds := append([]metav1.Condition(nil), dep.Status.Conditions...)
+	for _, pc := range proposed {
+		mergeCondition(&newConds, gen, pc)
+	}
+	target.Status.Conditions = newConds
+
+	if dep.Status.ObservedGeneration == gen &&
+		conditionsEqualIgnoringTransitionTime(dep.Status.Conditions, target.Status.Conditions) {
+		logger.V(1).Info("TemplateDependency status unchanged; skipping update", "generation", gen)
+		// If the helper encountered a transient error (conflict, API server
+		// hiccup), requeue even though status did not change.
+		if helperErr != nil {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.Status().Update(ctx, target); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("update TemplateDependency status: %w", err)
+	}
+	if ready.Status == metav1.ConditionTrue {
+		r.Recorder.Eventf(target, "Normal", v1alpha1.TemplateDependencyReasonReady, "TemplateDependency is Ready")
+	} else {
+		r.Recorder.Eventf(target, "Warning", ready.Reason, "%s", ready.Message)
+	}
+
+	if helperErr != nil {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// dependencyAcceptedCondition validates the TemplateDependency spec fields
+// the reconciler can check without API server calls: non-empty namespace/name
+// on both Dependent and Requires references.
+func dependencyAcceptedCondition(dep *v1alpha1.TemplateDependency) metav1.Condition {
+	if dep.Spec.Dependent.Namespace == "" || dep.Spec.Dependent.Name == "" {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateDependencyConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateDependencyReasonInvalidSpec,
+			Message: "spec.dependent must set both namespace and name",
+		}
+	}
+	if dep.Spec.Requires.Namespace == "" || dep.Spec.Requires.Name == "" {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateDependencyConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateDependencyReasonInvalidSpec,
+			Message: "spec.requires must set both namespace and name",
+		}
+	}
+	return metav1.Condition{
+		Type:    v1alpha1.TemplateDependencyConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.TemplateDependencyReasonAccepted,
+		Message: "spec passed reconciler validation",
+	}
+}
+
+// dependencyResolvedRefsCondition lists matching dependent Deployments,
+// calls EnsureSingletonDependencyDeployment for each, and returns the
+// ResolvedRefs condition. The second return value carries the first
+// transient error encountered (conflict, API server error); callers requeue
+// when it is non-nil regardless of whether the condition changed.
+func (r *TemplateDependencyReconciler) dependencyResolvedRefsCondition(ctx context.Context, dep *v1alpha1.TemplateDependency) (metav1.Condition, error) {
+	// Short-circuit: if Accepted=False the spec is broken; we cannot
+	// safely do any reconcile work.
+	if dep.Spec.Dependent.Namespace == "" || dep.Spec.Dependent.Name == "" ||
+		dep.Spec.Requires.Namespace == "" || dep.Spec.Requires.Name == "" {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateDependencyConditionResolvedRefs,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateDependencyReasonInvalidSpec,
+			Message: "spec is invalid; see Accepted condition",
+		}, nil
+	}
+
+	// Validate cross-namespace grant before listing Deployments.
+	dependentRef := v1alpha1.LinkedTemplateRef{
+		Namespace: dep.Namespace,
+		Name:      dep.Spec.Dependent.Name,
+	}
+	if err := r.Validator.ValidateGrant(ctx, dependentRef, dep.Spec.Requires); err != nil {
+		var notFound *deployments.GrantNotFoundError
+		if errors.As(err, &notFound) {
+			return metav1.Condition{
+				Type:    v1alpha1.TemplateDependencyConditionResolvedRefs,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1alpha1.TemplateDependencyReasonGrantNotFound,
+				Message: err.Error(),
+			}, nil
+		}
+		return metav1.Condition{}, fmt.Errorf("validating grant: %w", err)
+	}
+
+	// List Deployments in the TemplateDependency's namespace whose
+	// TemplateRef matches the Dependent reference.
+	var depList deploymentsv1alpha1.DeploymentList
+	if err := r.List(ctx, &depList, client.InNamespace(dep.Namespace)); err != nil {
+		return metav1.Condition{}, fmt.Errorf("list Deployments: %w", err)
+	}
+
+	cascadeDelete := true
+	if dep.Spec.CascadeDelete != nil {
+		cascadeDelete = *dep.Spec.CascadeDelete
+	}
+
+	var firstTransient error
+	matched := 0
+	for i := range depList.Items {
+		d := &depList.Items[i]
+		if d.Spec.TemplateRef.Namespace != dep.Spec.Dependent.Namespace ||
+			d.Spec.TemplateRef.Name != dep.Spec.Dependent.Name {
+			continue
+		}
+		matched++
+		if err := deployments.EnsureSingletonDependencyDeployment(ctx, r.Client, r.Validator, dep.Spec.Requires, d, cascadeDelete); err != nil {
+			var notFound *deployments.GrantNotFoundError
+			if errors.As(err, &notFound) {
+				// Grant was revoked between the check above and the call
+				// here (race). Surface as ResolvedRefs=False.
+				return metav1.Condition{
+					Type:    v1alpha1.TemplateDependencyConditionResolvedRefs,
+					Status:  metav1.ConditionFalse,
+					Reason:  v1alpha1.TemplateDependencyReasonGrantNotFound,
+					Message: err.Error(),
+				}, nil
+			}
+			// Transient error (conflict, etc.). Record and keep going so
+			// all matched Deployments are attempted; we'll requeue at the
+			// end.
+			if firstTransient == nil {
+				firstTransient = err
+			}
+		}
+	}
+
+	if firstTransient != nil {
+		// Return a degraded ResolvedRefs condition so the status reflects
+		// the partial state rather than silently claiming Ready=True.
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateDependencyConditionResolvedRefs,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateDependencyReasonNotReady,
+			Message: fmt.Sprintf("transient error ensuring singleton: %v", firstTransient),
+		}, firstTransient
+	}
+
+	if matched == 0 {
+		// No matching Deployments yet — the dependency is registered but
+		// no dependent has been deployed. This is Ready=True from the
+		// dependency's perspective; the singleton will be materialised on
+		// first Deployment creation.
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateDependencyConditionResolvedRefs,
+			Status:  metav1.ConditionTrue,
+			Reason:  v1alpha1.TemplateDependencyReasonResolvedRefs,
+			Message: "no matching Deployments found; singleton will be created on first Deployment",
+		}, nil
+	}
+
+	return metav1.Condition{
+		Type:    v1alpha1.TemplateDependencyConditionResolvedRefs,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.TemplateDependencyReasonResolvedRefs,
+		Message: fmt.Sprintf("singleton Deployment ensured for %d dependent Deployment(s)", matched),
+	}, nil
+}
+
+// dependenciesForDeployment returns the reconcile requests for every
+// TemplateDependency in the same namespace as the Deployment whose Dependent
+// reference matches the Deployment's TemplateRef. Called by the Watches
+// handler set up in SetupWithManager so that creating or deleting a Deployment
+// re-enqueues the affected TemplateDependency objects.
+func (r *TemplateDependencyReconciler) dependenciesForDeployment(ctx context.Context, obj client.Object) []reconcile.Request {
+	d, ok := obj.(*deploymentsv1alpha1.Deployment)
+	if !ok {
+		return nil
+	}
+	var list v1alpha1.TemplateDependencyList
+	if err := r.List(ctx, &list, client.InNamespace(d.Namespace)); err != nil {
+		return nil
+	}
+	var out []reconcile.Request
+	for _, dep := range list.Items {
+		if dep.Spec.Dependent.Namespace != d.Spec.TemplateRef.Namespace ||
+			dep.Spec.Dependent.Name != d.Spec.TemplateRef.Name {
+			continue
+		}
+		out = append(out, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&dep),
+		})
+	}
+	return out
+}

--- a/internal/controller/template_dependency_controller_test.go
+++ b/internal/controller/template_dependency_controller_test.go
@@ -20,20 +20,20 @@ package controller_test
 //
 // Test coverage:
 //
-//  1. Accepted=False surfaces for an invalid spec (missing namespace).
+//  1. Accepted=True + Ready=True for a valid spec with no matching Deployments.
 //  2. ResolvedRefs=False + GrantNotFound when a cross-namespace requires ref
 //     is not authorised by a TemplateGrant.
 //  3. The mcp-server / mcp-server-2 / waypoint smoke scenario:
-//     a. Create TemplateDependency (waypoint requires).
-//     b. Create dep1=mcp-server, dep2=mcp-server-2 — both with TemplateRef
-//        pointing at the "waypoint" template.
-//     c. Assert the singleton "waypoint-shared" Deployment is created with two
-//        non-controller ownerReferences (one per dependent).
-//     d. Delete dep1 — assert singleton still exists (dep2 still owns it).
-//     e. Delete dep2 — assert singleton is eventually reaped by GC.
+//     a. Create TemplateDependency: mcp-server-tmpl Deployments require waypoint-tmpl.
+//     b. Create dep1=mcp-server (TemplateRef=mcp-server-tmpl) → singleton
+//        "waypoint-tmpl-shared" is created with dep1's ownerReference.
+//     c. Create dep2=mcp-server-2 → reconciler appends dep2's ownerReference.
+//     d. Verify both ownerRefs are non-controller (Controller=false/nil) and
+//        BlockOwnerDeletion=true — the GC preconditions.
 //
-// Note: native GC in envtest behaves the same as in a real cluster; the test
-// polls with a generous timeout to let the garbage collector run.
+// Note: envtest boots kube-apiserver + etcd but NOT kube-controller-manager,
+// so the garbage collector is absent. Tests assert ownerRef preconditions
+// rather than waiting for GC to fire.
 
 import (
 	"context"
@@ -76,25 +76,6 @@ func waitForTemplateDependencyCondition(
 		time.Sleep(100 * time.Millisecond)
 	}
 	t.Fatalf("condition %q on TemplateDependency %s never reached %s", condType, key, wantStatus)
-}
-
-// waitForDeploymentGone polls until the Deployment at key is 404 or the
-// deadline expires. Used to assert native GC has reaped the singleton.
-func waitForDeploymentGone(t *testing.T, c client.Client, key client.ObjectKey) {
-	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
-		var d deploymentsv1alpha1.Deployment
-		err := c.Get(context.Background(), key, &d)
-		if apierrors.IsNotFound(err) {
-			return
-		}
-		if err != nil {
-			t.Fatalf("get Deployment %s: %v", key, err)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("Deployment %s still exists after deadline; native GC did not reap it", key)
 }
 
 // waitForDeploymentExists polls until the Deployment at key exists or the

--- a/internal/controller/template_dependency_controller_test.go
+++ b/internal/controller/template_dependency_controller_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+// HOL-959 envtest: TemplateDependency reconciler smoke scenarios.
+//
+// Test coverage:
+//
+//  1. Accepted=False surfaces for an invalid spec (missing namespace).
+//  2. ResolvedRefs=False + GrantNotFound when a cross-namespace requires ref
+//     is not authorised by a TemplateGrant.
+//  3. The mcp-server / mcp-server-2 / waypoint smoke scenario:
+//     a. Create TemplateDependency (waypoint requires).
+//     b. Create dep1=mcp-server, dep2=mcp-server-2 — both with TemplateRef
+//        pointing at the "waypoint" template.
+//     c. Assert the singleton "waypoint-shared" Deployment is created with two
+//        non-controller ownerReferences (one per dependent).
+//     d. Delete dep1 — assert singleton still exists (dep2 still owns it).
+//     e. Delete dep2 — assert singleton is eventually reaped by GC.
+//
+// Note: native GC in envtest behaves the same as in a real cluster; the test
+// polls with a generous timeout to let the garbage collector run.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+)
+
+// waitForTemplateDependencyCondition polls until the named condition on the
+// TemplateDependency reaches wantStatus, or the deadline expires.
+func waitForTemplateDependencyCondition(
+	t *testing.T,
+	c client.Client,
+	key client.ObjectKey,
+	condType string,
+	wantStatus metav1.ConditionStatus,
+) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var obj v1alpha1.TemplateDependency
+	for time.Now().Before(deadline) {
+		if err := c.Get(context.Background(), key, &obj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				t.Fatalf("get TemplateDependency %s: %v", key, err)
+			}
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == condType && cond.Status == wantStatus {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("condition %q on TemplateDependency %s never reached %s", condType, key, wantStatus)
+}
+
+// waitForDeploymentGone polls until the Deployment at key is 404 or the
+// deadline expires. Used to assert native GC has reaped the singleton.
+func waitForDeploymentGone(t *testing.T, c client.Client, key client.ObjectKey) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var d deploymentsv1alpha1.Deployment
+		err := c.Get(context.Background(), key, &d)
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("get Deployment %s: %v", key, err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("Deployment %s still exists after deadline; native GC did not reap it", key)
+}
+
+// waitForDeploymentExists polls until the Deployment at key exists or the
+// deadline expires.
+func waitForDeploymentExists(t *testing.T, c client.Client, key client.ObjectKey) *deploymentsv1alpha1.Deployment {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		var d deploymentsv1alpha1.Deployment
+		if err := c.Get(context.Background(), key, &d); err == nil {
+			return &d
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("Deployment %s did not appear within deadline", key)
+	return nil
+}
+
+// TestTemplateDependency_ValidSpecSurfacesAcceptedTrue asserts that a
+// TemplateDependency with a valid spec gets Accepted=True and Ready=True
+// (no matching Deployments yet → no work to do, still Ready).
+func TestTemplateDependency_ValidSpecSurfacesAcceptedTrue(t *testing.T) {
+	e := startEnv(t)
+	_, cancel, errCh := startManager(t, e.cfg)
+	t.Cleanup(func() { stopManager(t, cancel, errCh) })
+
+	ns := "prj-tdep-valid-spec"
+	mustCreateNamespace(t, e.client, ns, "project")
+
+	td := &v1alpha1.TemplateDependency{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "valid"},
+		Spec: v1alpha1.TemplateDependencySpec{
+			Dependent: v1alpha1.LinkedTemplateRef{Namespace: ns, Name: "mcp-server-tmpl"},
+			Requires:  v1alpha1.LinkedTemplateRef{Namespace: ns, Name: "waypoint-tmpl"},
+		},
+	}
+	if err := e.client.Create(context.Background(), td); err != nil {
+		t.Fatalf("create TemplateDependency: %v", err)
+	}
+	key := client.ObjectKeyFromObject(td)
+	waitForTemplateDependencyCondition(t, e.client, key, v1alpha1.TemplateDependencyConditionAccepted, metav1.ConditionTrue)
+	waitForTemplateDependencyCondition(t, e.client, key, v1alpha1.TemplateDependencyConditionReady, metav1.ConditionTrue)
+
+	var got v1alpha1.TemplateDependency
+	if err := e.client.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if got.Status.ObservedGeneration != got.Generation {
+		t.Errorf("observedGeneration=%d want %d", got.Status.ObservedGeneration, got.Generation)
+	}
+}
+
+// TestTemplateDependency_CrossNamespaceGrantNotFound asserts that a
+// cross-namespace Requires reference without an authorising TemplateGrant
+// surfaces ResolvedRefs=False with GrantNotFound reason.
+func TestTemplateDependency_CrossNamespaceGrantNotFound(t *testing.T) {
+	e := startEnv(t)
+	_, cancelM, errCh := startManagerWithCache(t, e.cfg, nil)
+	t.Cleanup(func() { stopManager(t, cancelM, errCh) })
+
+	prjNS := "prj-tdep-grant-missing"
+	orgNS := "org-tdep-grant-missing"
+	mustCreateNamespace(t, e.client, prjNS, "project")
+	mustCreateNamespace(t, e.client, orgNS, "organization")
+
+	// Cross-namespace requires ref: prj -> org namespace. No TemplateGrant.
+	td := &v1alpha1.TemplateDependency{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjNS, Name: "cross-ns"},
+		Spec: v1alpha1.TemplateDependencySpec{
+			Dependent: v1alpha1.LinkedTemplateRef{Namespace: prjNS, Name: "mcp-server"},
+			Requires:  v1alpha1.LinkedTemplateRef{Namespace: orgNS, Name: "waypoint"},
+		},
+	}
+	if err := e.client.Create(context.Background(), td); err != nil {
+		t.Fatalf("create TemplateDependency: %v", err)
+	}
+	key := client.ObjectKeyFromObject(td)
+
+	// Grant cache starts empty → cross-namespace ref should be denied.
+	waitForTemplateDependencyCondition(t, e.client, key, v1alpha1.TemplateDependencyConditionResolvedRefs, metav1.ConditionFalse)
+
+	var got v1alpha1.TemplateDependency
+	if err := e.client.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	for _, c := range got.Status.Conditions {
+		if c.Type == v1alpha1.TemplateDependencyConditionResolvedRefs {
+			if c.Reason != v1alpha1.TemplateDependencyReasonGrantNotFound {
+				t.Errorf("ResolvedRefs reason=%q want %q", c.Reason, v1alpha1.TemplateDependencyReasonGrantNotFound)
+			}
+		}
+	}
+}
+
+// TestTemplateDependency_SmokeScenario_WaypointOwnerRefs is the headline
+// HOL-959 envtest exercising the mcp-server / mcp-server-2 / waypoint scenario.
+//
+// The TemplateDependency declares: any Deployment rendered from "mcp-server-tmpl"
+// requires a singleton Deployment of "waypoint-tmpl" (same namespace). The test
+// verifies:
+//
+//  1. With no matching Deployments: Ready=True (nothing to materialise yet).
+//  2. dep1=mcp-server (TemplateRef=mcp-server-tmpl) created → singleton
+//     "waypoint-tmpl-shared" is created with dep1's ownerReference.
+//  3. dep2=mcp-server-2 (TemplateRef=mcp-server-tmpl) created → reconciler
+//     appends dep2's ownerReference to the existing singleton.
+//  4. Both ownerRefs are non-controller (Controller=false/nil) so native GC
+//     in a production cluster would reap the singleton when both dependents are
+//     deleted. Envtest does not run the GC controller, so we assert only the
+//     ownerRef preconditions rather than waiting for GC to fire.
+func TestTemplateDependency_SmokeScenario_WaypointOwnerRefs(t *testing.T) {
+	e := startEnv(t)
+	_, cancel, errCh := startManager(t, e.cfg)
+	t.Cleanup(func() { stopManager(t, cancel, errCh) })
+
+	prjNS := "prj-tdep-smoke"
+	mustCreateNamespace(t, e.client, prjNS, "project")
+
+	// TemplateDependency: Deployments rendered from "mcp-server-tmpl"
+	// require a singleton "waypoint-tmpl" Deployment (same namespace).
+	td := &v1alpha1.TemplateDependency{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjNS, Name: "waypoint-dep"},
+		Spec: v1alpha1.TemplateDependencySpec{
+			Dependent: v1alpha1.LinkedTemplateRef{
+				Namespace: prjNS,
+				Name:      "mcp-server-tmpl", // template that mcp-server* Deployments use
+			},
+			Requires: v1alpha1.LinkedTemplateRef{
+				Namespace: prjNS,
+				Name:      "waypoint-tmpl", // the singleton to materialise
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), td); err != nil {
+		t.Fatalf("create TemplateDependency: %v", err)
+	}
+	tdKey := client.ObjectKeyFromObject(td)
+
+	// Stage 1: no matching Deployments yet → Ready=True.
+	waitForTemplateDependencyCondition(t, e.client, tdKey, v1alpha1.TemplateDependencyConditionReady, metav1.ConditionTrue)
+
+	// Stage 2: create dep1 — its TemplateRef points at mcp-server-tmpl.
+	dep1 := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjNS, Name: "mcp-server"},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: prjNS,
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: prjNS,
+				Name:      "mcp-server-tmpl",
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), dep1); err != nil {
+		t.Fatalf("create dep1: %v", err)
+	}
+
+	// Singleton "waypoint-tmpl-shared" should be created.
+	singletonKey := client.ObjectKey{Namespace: prjNS, Name: "waypoint-tmpl-shared"}
+	singleton := waitForDeploymentExists(t, e.client, singletonKey)
+	t.Logf("singleton created after dep1: %s/%s ownerRefs=%d", singleton.Namespace, singleton.Name, len(singleton.OwnerReferences))
+
+	// Stage 3: create dep2 — reconciler should append its ownerReference.
+	dep2 := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjNS, Name: "mcp-server-2"},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: prjNS,
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: prjNS,
+				Name:      "mcp-server-tmpl",
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), dep2); err != nil {
+		t.Fatalf("create dep2: %v", err)
+	}
+
+	// Poll until both ownerReferences are present.
+	deadline := time.Now().Add(15 * time.Second)
+	var finalSingleton deploymentsv1alpha1.Deployment
+	for time.Now().Before(deadline) {
+		if err := e.client.Get(context.Background(), singletonKey, &finalSingleton); err != nil {
+			t.Fatalf("get singleton: %v", err)
+		}
+		if len(finalSingleton.OwnerReferences) == 2 {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if got := len(finalSingleton.OwnerReferences); got != 2 {
+		t.Fatalf("singleton ownerRefs=%d want 2 (one per dependent)", got)
+	}
+
+	// Verify ownerRef properties: non-controller, block-owner-deletion.
+	for _, ref := range finalSingleton.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			t.Errorf("ownerRef %q Controller must be false/nil for GC co-ownership", ref.Name)
+		}
+		if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+			t.Errorf("ownerRef %q BlockOwnerDeletion must be true", ref.Name)
+		}
+	}
+
+	// Verify both expected UIDs are present.
+	uids := map[string]bool{}
+	for _, ref := range finalSingleton.OwnerReferences {
+		uids[string(ref.UID)] = true
+	}
+	if !uids[string(dep1.UID)] {
+		t.Errorf("dep1 UID %q not found in singleton ownerRefs %+v", dep1.UID, finalSingleton.OwnerReferences)
+	}
+	if !uids[string(dep2.UID)] {
+		t.Errorf("dep2 UID %q not found in singleton ownerRefs %+v", dep2.UID, finalSingleton.OwnerReferences)
+	}
+
+	t.Logf("smoke scenario passed: singleton has ownerRefs for both dep1 and dep2; "+
+		"native GC would reap singleton in a production cluster when both are deleted. "+
+		"(Envtest does not run kube-controller-manager GC, so GC is not asserted here.)")
+}


### PR DESCRIPTION
## Summary

- Add `TemplateDependencyCondition*` / `TemplateDependencyReason*` constants to the v1alpha1 conditions package
- Introduce `EnsureSingletonDependencyDeployment` in `console/deployments/dependency_reconciler.go` — the shared seam for Phase 5 and Phase 6 reconcilers; deterministic singleton naming, non-controller ownerRefs, cross-namespace grant validation
- Add `TemplateDependencyReconciler` in `internal/controller/template_dependency_controller.go` — watches TemplateDependency + Deployment objects, materialises singleton for each matching dependent, surfaces Accepted/ResolvedRefs/Ready conditions
- Register the reconciler in `manager.go` and add RBAC markers in `rbac.go`
- 6 unit tests (fake client) + 3 envtest tests covering the mcp-server/mcp-server-2/waypoint smoke scenario

Fixes HOL-959

## Test plan

- [x] `go test ./console/deployments/... -run "TestEnsureSingleton|TestSingletonName"` — 6 unit tests pass
- [x] `go test ./internal/controller/... -run "TestTemplateDependency"` — 3 envtest tests pass
- [x] `make test-go` — all packages pass (pre-existing `TestScripts` failure in `console/` package is unrelated — network/TLS integration test that requires a running server)

## Notes on envtest and GC

Envtest boots kube-apiserver + etcd but does NOT run the kube-controller-manager, so the garbage collector is absent. The smoke test (`TestTemplateDependency_SmokeScenario_WaypointOwnerRefs`) verifies the ownerReference preconditions (Controller=false, BlockOwnerDeletion=true, both UID present) rather than waiting for GC to reap the singleton. In a real cluster, native GC would reap the singleton when both dependent Deployments are deleted.