### PR TITLE
feat(controller,policyresolver): TemplateRequirement reconciler with ancestor-walk extension

### DIFF
--- a/api/templates/v1alpha1/conditions.go
+++ b/api/templates/v1alpha1/conditions.go
@@ -112,6 +112,30 @@ const (
 	TemplateDependencyReasonNotReady        = "NotReady"
 )
 
+// TemplateRequirement condition types.
+const (
+	// TemplateRequirementConditionAccepted tracks whether the reconciler parsed
+	// .spec and accepted it, or rejected it with a typed reason.
+	TemplateRequirementConditionAccepted = "Accepted"
+	// TemplateRequirementConditionResolvedRefs tracks whether the cross-
+	// namespace Requires reference is authorised by a TemplateGrant. Same-
+	// namespace references are always accepted without a grant.
+	TemplateRequirementConditionResolvedRefs = "ResolvedRefs"
+	// TemplateRequirementConditionReady is the aggregate: Accepted &&
+	// ResolvedRefs are both True.
+	TemplateRequirementConditionReady = "Ready"
+)
+
+// TemplateRequirement condition reasons.
+const (
+	TemplateRequirementReasonAccepted        = "Accepted"
+	TemplateRequirementReasonInvalidSpec     = "InvalidSpec"
+	TemplateRequirementReasonResolvedRefs    = "ResolvedRefs"
+	TemplateRequirementReasonGrantNotFound   = "GrantNotFound"
+	TemplateRequirementReasonReady           = "Ready"
+	TemplateRequirementReasonNotReady        = "NotReady"
+)
+
 // Finalizer is the finalizer key used by reconcilers for the
 // templates.holos.run API group when non-trivial cleanup is required before
 // the API server deletes a managed object.

--- a/console/policyresolver/ancestor_requirements.go
+++ b/console/policyresolver/ancestor_requirements.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package policyresolver — AncestorRequirementLister.
+//
+// This file mirrors ancestor_bindings.go for TemplateRequirement objects.
+// The upward ancestor walk, the skip-project-namespaces rule (HOL-554), and
+// the fail-open / per-namespace-error contracts are identical. The only
+// difference is the CRD kind being collected.
+package policyresolver
+
+import (
+	"context"
+	"log/slog"
+
+	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/resolver"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// RequirementListerInNamespace reports the TemplateRequirement CRD objects
+// stored in a specific Kubernetes namespace. The AncestorRequirementLister
+// uses this to fetch requirements from each folder or organization namespace
+// in the ancestor chain without importing an external package that would
+// create an import cycle.
+//
+// Implementations MUST only read from folder and organization namespaces.
+// The ancestor walker guarantees it never passes a project namespace to this
+// method because the ancestor walk skips project-kind namespaces before
+// calling the lister, but implementations should still treat a project
+// namespace as a programming error and return an empty list.
+type RequirementListerInNamespace interface {
+	ListRequirementsInNamespace(ctx context.Context, ns string) ([]*templatesv1alpha1.TemplateRequirement, error)
+}
+
+// ResolvedRequirement is the decoded form of a TemplateRequirement CRD
+// bundled with the owning namespace and the parsed target_refs so the
+// TemplateRequirementReconciler can evaluate which Deployments each
+// requirement covers.
+type ResolvedRequirement struct {
+	// Name is the requirement's DNS-label slug (metadata.name).
+	Name string
+	// Namespace is the folder or organization namespace that owns the
+	// TemplateRequirement CRD.
+	Namespace string
+	// Requires is the LinkedTemplateRef that must be materialised as a
+	// singleton Deployment for each matched target.
+	Requires templatesv1alpha1.LinkedTemplateRef
+	// TargetRefs enumerates the render targets that this requirement
+	// applies to. The caller uses bindingAppliesTo / nameMatches (from
+	// folder_resolver.go) for matching.
+	TargetRefs []templatesv1alpha1.TemplateRequirementTargetRef
+	// CascadeDelete mirrors spec.cascadeDelete. Defaults to true when nil.
+	CascadeDelete *bool
+}
+
+// AncestorRequirementLister walks the ancestor chain of a starting namespace
+// and collects every TemplateRequirement CRD stored in the folder and
+// organization namespaces on that chain. Project namespaces are skipped to
+// mirror the HOL-554 storage-isolation guardrail — a TemplateRequirement in a
+// project namespace would allow project owners to bypass platform mandates.
+//
+// This helper is used by the TemplateRequirementReconciler (HOL-960) to
+// evaluate which TemplateRequirements apply to a given Deployment.
+type AncestorRequirementLister struct {
+	requirementLister RequirementListerInNamespace
+	walker            WalkerInterface
+	resolver          *resolver.Resolver
+}
+
+// NewAncestorRequirementLister returns a lister wired with the given
+// dependencies. Any nil dependency yields a lister whose ListRequirements
+// method returns an empty slice without error (fail-open behavior).
+func NewAncestorRequirementLister(
+	requirementLister RequirementListerInNamespace,
+	walker WalkerInterface,
+	r *resolver.Resolver,
+) *AncestorRequirementLister {
+	return &AncestorRequirementLister{
+		requirementLister: requirementLister,
+		walker:            walker,
+		resolver:          r,
+	}
+}
+
+// ListRequirements returns every TemplateRequirement declared in a folder or
+// organization namespace on the ancestor chain starting from startNs. The
+// returned requirements preserve the walker's order (closest ancestor first)
+// within each namespace and the lister's order within each namespace.
+//
+// A misconfigured lister (any nil dependency) returns (nil, nil) — the
+// fail-open contract mirrors AncestorBindingLister so a bootstrap
+// misconfiguration degrades to "no requirements" rather than "errors on
+// every call".
+//
+// A walker failure returns (nil, err) so callers can decide how to surface
+// the failure (same behavior as AncestorBindingLister).
+//
+// Individual per-namespace lister errors do not abort traversal; they are
+// logged and the namespace is skipped. A single corrupted
+// TemplateRequirement must not prevent legitimate requirements in peer
+// namespaces from being honored.
+func (a *AncestorRequirementLister) ListRequirements(ctx context.Context, startNs string) ([]*ResolvedRequirement, error) {
+	if a == nil || a.requirementLister == nil || a.walker == nil || a.resolver == nil {
+		slog.WarnContext(ctx, "ancestor requirement lister is misconfigured; returning no requirements",
+			slog.String("startNs", startNs),
+			slog.Bool("requirementListerNil", a == nil || a.requirementLister == nil),
+			slog.Bool("walkerNil", a == nil || a.walker == nil),
+			slog.Bool("resolverNil", a == nil || a.resolver == nil),
+		)
+		return nil, nil
+	}
+
+	ancestors, err := a.walker.WalkAncestors(ctx, startNs)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*ResolvedRequirement
+	for _, ns := range ancestors {
+		if ns == nil {
+			continue
+		}
+		kind, _, kErr := a.resolver.ResourceTypeFromNamespace(ns.Name)
+		if kErr != nil {
+			continue
+		}
+		// Skip project namespaces — the HOL-554 storage-isolation guardrail
+		// ensures only folder and organization namespaces host authoritative
+		// TemplateRequirement objects. This is the same skip applied in
+		// ancestor_bindings.go:138.
+		if kind == v1alpha2.ResourceTypeProject {
+			continue
+		}
+		items, listErr := a.requirementLister.ListRequirementsInNamespace(ctx, ns.Name)
+		if listErr != nil {
+			slog.WarnContext(ctx, "failed to list template requirements in ancestor namespace",
+				slog.String("namespace", ns.Name),
+				slog.Any("error", listErr),
+			)
+			continue
+		}
+		for _, req := range items {
+			if req == nil {
+				continue
+			}
+			out = append(out, &ResolvedRequirement{
+				Name:          req.Name,
+				Namespace:     ns.Name,
+				Requires:      req.Spec.Requires,
+				TargetRefs:    req.Spec.TargetRefs,
+				CascadeDelete: req.Spec.CascadeDelete,
+			})
+		}
+	}
+	return out, nil
+}
+
+// RequirementTargetRefToResolved converts a TemplateRequirementTargetRef
+// slice into the ResolvedBinding shape expected by bindingAppliesTo and
+// nameMatches so the controller can reuse those functions without duplicating
+// the matching logic.
+//
+// The TemplateRequirementTargetRef and TemplatePolicyBindingTargetRef share
+// the same Kind enum, Name, and ProjectName fields, so a thin adapter is all
+// that is needed. Exported so the TemplateRequirementReconciler can call it
+// without importing an internal helper.
+func RequirementTargetRefToResolved(ns, name string, refs []templatesv1alpha1.TemplateRequirementTargetRef) *ResolvedBinding {
+	protoRefs := make([]*consolev1.TemplatePolicyBindingTargetRef, 0, len(refs))
+	for i := range refs {
+		r := &refs[i]
+		protoRefs = append(protoRefs, &consolev1.TemplatePolicyBindingTargetRef{
+			Kind:        targetKindCRDToProto(r.Kind),
+			Name:        r.Name,
+			ProjectName: r.ProjectName,
+		})
+	}
+	return &ResolvedBinding{
+		Name:       name,
+		Namespace:  ns,
+		TargetRefs: protoRefs,
+	}
+}
+
+// BindingAppliesToDeployment is an exported wrapper around bindingAppliesTo
+// for the DEPLOYMENT target kind. It lets the TemplateRequirementReconciler
+// (which lives in internal/controller) reuse the same matching logic as the
+// folderResolver without re-implementing the wildcard semantics.
+func BindingAppliesToDeployment(b *ResolvedBinding, project, deploymentName string) bool {
+	return bindingAppliesTo(b, project, TargetKindDeployment, deploymentName)
+}

--- a/console/policyresolver/ancestor_requirements_test.go
+++ b/console/policyresolver/ancestor_requirements_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policyresolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/resolver"
+)
+
+// requirementListerFromMap adapts an in-memory map to
+// RequirementListerInNamespace. Mirrors bindingListerFromMap.
+type requirementListerFromMap struct {
+	items map[string][]templatesv1alpha1.TemplateRequirement
+}
+
+func (r *requirementListerFromMap) ListRequirementsInNamespace(_ context.Context, ns string) ([]*templatesv1alpha1.TemplateRequirement, error) {
+	src := r.items[ns]
+	if len(src) == 0 {
+		return nil, nil
+	}
+	out := make([]*templatesv1alpha1.TemplateRequirement, 0, len(src))
+	for i := range src {
+		out = append(out, &src[i])
+	}
+	return out, nil
+}
+
+// errorRequirementLister returns a hardcoded error for a given namespace and
+// forwards all other namespaces to inner. Mirrors errorBindingLister.
+type errorRequirementLister struct {
+	inner   RequirementListerInNamespace
+	failFor string
+	err     error
+}
+
+func (e *errorRequirementLister) ListRequirementsInNamespace(ctx context.Context, ns string) ([]*templatesv1alpha1.TemplateRequirement, error) {
+	if ns == e.failFor {
+		return nil, e.err
+	}
+	return e.inner.ListRequirementsInNamespace(ctx, ns)
+}
+
+// requirementCRD builds a minimal TemplateRequirement CRD for testing.
+func requirementCRD(
+	ns, name string,
+	requires templatesv1alpha1.LinkedTemplateRef,
+	targetRefs []templatesv1alpha1.TemplateRequirementTargetRef,
+	cascadeDelete *bool,
+) templatesv1alpha1.TemplateRequirement {
+	return templatesv1alpha1.TemplateRequirement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: templatesv1alpha1.TemplateRequirementSpec{
+			Requires:      requires,
+			TargetRefs:    targetRefs,
+			CascadeDelete: cascadeDelete,
+		},
+	}
+}
+
+// deploymentRequirementTargetRef returns a DEPLOYMENT-kind target ref for
+// use in TemplateRequirement specs.
+func deploymentRequirementTargetRef(project, name string) templatesv1alpha1.TemplateRequirementTargetRef {
+	return templatesv1alpha1.TemplateRequirementTargetRef{
+		Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+		Name:        name,
+		ProjectName: project,
+	}
+}
+
+// wildcardRequirementTargetRef returns a DEPLOYMENT-kind target ref with
+// the projectName: "*" wildcard.
+func wildcardRequirementTargetRef() templatesv1alpha1.TemplateRequirementTargetRef {
+	return templatesv1alpha1.TemplateRequirementTargetRef{
+		Kind:        templatesv1alpha1.TemplatePolicyBindingTargetKindDeployment,
+		Name:        WildcardAny,
+		ProjectName: WildcardAny,
+	}
+}
+
+// TestAncestorRequirementLister_SkipsProjectNamespaces is the HOL-554
+// storage-isolation guardrail for requirements: even if a (forbidden)
+// TemplateRequirement CR is seeded in a project namespace, the lister must
+// not pick it up.
+func TestAncestorRequirementLister_SkipsProjectNamespaces(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	boolTrue := true
+	requiresRef := templatesv1alpha1.LinkedTemplateRef{Namespace: ns["org"], Name: "waypoint"}
+
+	reqs := map[string][]templatesv1alpha1.TemplateRequirement{
+		// Forbidden: requirement in a project namespace.
+		ns["projectLilies"]: {
+			requirementCRD(ns["projectLilies"], "pwned", requiresRef,
+				[]templatesv1alpha1.TemplateRequirementTargetRef{wildcardRequirementTargetRef()},
+				&boolTrue),
+		},
+		// Legitimate: requirement in the org namespace.
+		ns["org"]: {
+			requirementCRD(ns["org"], "legit", requiresRef,
+				[]templatesv1alpha1.TemplateRequirementTargetRef{wildcardRequirementTargetRef()},
+				&boolTrue),
+		},
+	}
+
+	lister := NewAncestorRequirementLister(
+		&requirementListerFromMap{items: reqs},
+		walker,
+		r,
+	)
+
+	got, err := lister.ListRequirements(context.Background(), ns["projectLilies"])
+	if err != nil {
+		t.Fatalf("ListRequirements: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 requirement (the org-namespace one); got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "legit" {
+		t.Errorf("expected the legit org-namespace requirement; got %q", got[0].Name)
+	}
+	if got[0].Namespace != ns["org"] {
+		t.Errorf("expected namespace %q; got %q", ns["org"], got[0].Namespace)
+	}
+}
+
+// TestAncestorRequirementLister_PerNamespaceErrorIsLogged: a lister error for
+// one namespace should not break traversal. Peer-namespace requirements still
+// flow through. Mirrors TestAncestorBindingLister_PerNamespaceErrorIsLogged.
+func TestAncestorRequirementLister_PerNamespaceErrorIsLogged(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	boolTrue := true
+	requiresRef := templatesv1alpha1.LinkedTemplateRef{Namespace: ns["org"], Name: "waypoint"}
+
+	inner := &requirementListerFromMap{items: map[string][]templatesv1alpha1.TemplateRequirement{
+		ns["org"]: {
+			requirementCRD(ns["org"], "org-req", requiresRef,
+				[]templatesv1alpha1.TemplateRequirementTargetRef{wildcardRequirementTargetRef()},
+				&boolTrue),
+		},
+	}}
+	wrapped := &errorRequirementLister{inner: inner, failFor: ns["folderEng"], err: errors.New("boom")}
+
+	lister := NewAncestorRequirementLister(wrapped, walker, r)
+
+	got, err := lister.ListRequirements(context.Background(), ns["projectLilies"])
+	if err != nil {
+		t.Fatalf("ListRequirements: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "org-req" {
+		t.Errorf("expected org-req to survive folder-namespace error; got %+v", got)
+	}
+}
+
+// TestAncestorRequirementLister_Misconfigured returns nil without error on
+// any nil dependency — the fail-open contract mirrors AncestorBindingLister.
+func TestAncestorRequirementLister_Misconfigured(t *testing.T) {
+	l := NewAncestorRequirementLister(nil, nil, nil)
+	got, err := l.ListRequirements(context.Background(), "holos-prj-x")
+	if err != nil {
+		t.Fatalf("expected nil error on misconfigured lister; got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result on misconfigured lister; got %v", got)
+	}
+}
+
+// TestAncestorRequirementLister_WildcardCoversMultipleProjects verifies that
+// a single TemplateRequirement with projectName: "*" appears in the output
+// for projects under the same ancestor — the resolver simply returns the
+// requirement and lets the controller evaluate matching at reconcile time.
+// This is the core property required by the HOL-960 AC: "projectName: '*'
+// covers every project under the ancestor."
+func TestAncestorRequirementLister_WildcardCoversMultipleProjects(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	boolTrue := true
+	requiresRef := templatesv1alpha1.LinkedTemplateRef{Namespace: ns["org"], Name: "cert-manager"}
+
+	orgReq := requirementCRD(ns["org"], "cert-manager-req", requiresRef,
+		[]templatesv1alpha1.TemplateRequirementTargetRef{wildcardRequirementTargetRef()},
+		&boolTrue)
+
+	lister := NewAncestorRequirementLister(
+		&requirementListerFromMap{items: map[string][]templatesv1alpha1.TemplateRequirement{
+			ns["org"]: {orgReq},
+		}},
+		walker,
+		r,
+	)
+
+	// Both projectLilies (under folderEng) and projectOrchids (direct child
+	// of org) should see the wildcard requirement.
+	for _, startNs := range []string{ns["projectLilies"], ns["projectOrchids"]} {
+		t.Run(startNs, func(t *testing.T) {
+			got, err := lister.ListRequirements(context.Background(), startNs)
+			if err != nil {
+				t.Fatalf("ListRequirements(%s): %v", startNs, err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("expected 1 requirement; got %d: %+v", len(got), got)
+			}
+			if got[0].Name != "cert-manager-req" {
+				t.Errorf("expected cert-manager-req; got %q", got[0].Name)
+			}
+			if len(got[0].TargetRefs) != 1 {
+				t.Fatalf("expected 1 targetRef; got %d", len(got[0].TargetRefs))
+			}
+			if got[0].TargetRefs[0].ProjectName != WildcardAny {
+				t.Errorf("expected wildcard projectName; got %q", got[0].TargetRefs[0].ProjectName)
+			}
+		})
+	}
+}
+
+// TestRequirementTargetRefAdapter verifies that requirementTargetRefToResolved
+// converts a TemplateRequirementTargetRef slice into the ResolvedBinding shape
+// that bindingAppliesTo expects, preserving Kind, Name, and ProjectName.
+func TestRequirementTargetRefAdapter(t *testing.T) {
+	boolTrue := true
+	refs := []templatesv1alpha1.TemplateRequirementTargetRef{
+		wildcardRequirementTargetRef(),
+		deploymentRequirementTargetRef("alpha", "api-server"),
+	}
+
+	rb := RequirementTargetRefToResolved("holos-org-acme", "test-req", refs)
+	if rb == nil {
+		t.Fatal("expected non-nil ResolvedBinding")
+	}
+	if len(rb.TargetRefs) != 2 {
+		t.Fatalf("expected 2 TargetRefs; got %d", len(rb.TargetRefs))
+	}
+
+	// Wildcard ref should match a non-empty deployment target.
+	binding := RequirementTargetRefToResolved("holos-org-acme", "wildcard-req", refs[:1])
+	if !BindingAppliesToDeployment(binding, "beta", "web") {
+		t.Error("wildcard ref should apply to any project/deployment")
+	}
+	if BindingAppliesToDeployment(binding, "", "web") {
+		t.Error("wildcard ref must NOT apply when project is empty (HOL-554 guard)")
+	}
+
+	// Exact ref should only match the named project and deployment.
+	exact := RequirementTargetRefToResolved("holos-org-acme", "exact-req", refs[1:])
+	if !BindingAppliesToDeployment(exact, "alpha", "api-server") {
+		t.Error("exact ref should apply to the named target")
+	}
+	if BindingAppliesToDeployment(exact, "alpha", "other") {
+		t.Error("exact ref should NOT apply to a different deployment name")
+	}
+	// Suppress the boolTrue warning
+	_ = boolTrue
+}

--- a/docs/adrs/035-deployment-dependencies.md
+++ b/docs/adrs/035-deployment-dependencies.md
@@ -1,0 +1,165 @@
+<!--
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# ADR 035: Deployment Dependencies via TemplateGrant, TemplateDependency, TemplateRequirement (HOL-954)
+
+- Status: Accepted
+- Date: 2026-04-25
+- Binary: `holos-console` (multiple packages)
+- Follows: [ADR 034 — Namespace TemplatePolicyBinding for new Projects](034-namespace-template-policy-binding-for-new-projects.md)
+
+## Context
+
+Platform owners need to express that certain templates depend on other
+templates being deployed alongside them (e.g., every `mcp-server` deployment
+requires a shared `waypoint` sidecar). Project-scope declarations
+(`TemplateDependency`) let Service Owners declare this within a single project.
+Org- or folder-scope mandates (`TemplateRequirement`) let Platform Owners
+declare this for all projects under an ancestor without any per-project
+configuration.
+
+Cross-namespace template references also require an authorization mechanism
+(`TemplateGrant`) to prevent project owners from referencing templates they
+do not own.
+
+## Decisions
+
+### Decision 1 — Three new CRDs
+
+Three tightly scoped CRDs are introduced:
+
+| CRD | Scope | Purpose |
+|-----|-------|---------|
+| `TemplateGrant` | org or folder namespace | Authorizes cross-namespace template references from listed project namespaces |
+| `TemplateDependency` | project namespace | Declares that Deployments from template A require a singleton of template B |
+| `TemplateRequirement` | org or folder namespace | Mandates that all Deployments matching `targetRefs[]` require a singleton of template B |
+
+### Decision 2 — Singleton Deployment with refcount owner-refs
+
+The first Deployment that triggers a dependency edge creates a singleton
+Deployment in the same project namespace. Subsequent Deployments that match
+the same edge add a non-controller `ownerReference` (Controller=false,
+BlockOwnerDeletion=true). Native Kubernetes GC reaps the singleton when the
+last owner is deleted.
+
+### Decision 3 — Singleton naming
+
+The singleton Deployment name is deterministic:
+
+```
+<requires.Name>-<sanitized-versionConstraint>-shared
+```
+
+When `VersionConstraint` is empty: `<requires.Name>-shared`.
+
+This ensures idempotent applies and allows Phase 8 (PreflightCheck) to detect
+name collisions before apply.
+
+### Decision 4 — cascadeDelete controls owner-ref edge
+
+`cascadeDelete: true` (default) adds the non-controller ownerReference.
+`cascadeDelete: false` creates the singleton but skips the ownerReference,
+decoupling the singleton's lifecycle from the dependent.
+
+### Decision 5 — TemplateGrant: ReferenceGrant-style authorization
+
+A `TemplateGrant` in namespace `N` grants listed project namespaces access to
+templates in `N`. Same-namespace references are always allowed without a grant.
+Supports literal namespace, `"*"` wildcard, and `namespaceSelector`.
+
+### Decision 6 — Hard-revoke on grant deletion
+
+When a TemplateGrant is deleted, the TemplateGrantController immediately
+removes it from the cache. New cross-namespace materializations are rejected
+from that point. Existing materialised singletons are NOT removed — callers
+must manage orphan cleanup manually.
+
+### Decision 7 — HOL-554 storage-isolation for TemplateRequirement
+
+`TemplateRequirement` objects stored in project namespaces are ignored by the
+ancestor walker (mirrors the existing storage-isolation rule for
+`TemplatePolicyBinding`). The CEL ValidatingAdmissionPolicy enforces this at
+admission time; the ancestor walker enforces it as belt-and-suspenders.
+
+### Decision 8 — TemplateRequirement targeting
+
+`TemplateRequirement.targetRefs[]` uses the same Kind/Name/ProjectName shape
+as `TemplatePolicyBindingTargetRef`. The wildcard `"*"` semantics from ADR 029
+apply: `projectName: "*"` matches all projects reachable via the ancestor walk;
+`name: "*"` matches all Deployments of that kind within the matched projects.
+
+### Decision 9 — Render order (Open Question 2, resolved)
+
+`TemplatePolicy.Require` runs at render time (unchanged). `TemplateRequirement`
+materialises sibling Deployments **after** the dependent's render succeeds.
+
+The ordering is enforced by the controller: it watches Deployment objects and
+only calls `EnsureSingletonDependencyDeployment` for Deployments that already
+exist as CRs (i.e., whose render has produced a Deployment CR). This avoids
+races where the sibling singleton references rendered output that does not yet
+exist.
+
+### Decision 10 — TemplateRequirement overlap policy (Open Question 1, resolved)
+
+When two `TemplateRequirement` objects in the same ancestor chain match the
+same Deployment:
+
+- **Different `requires` templates**: each requirement is processed
+  independently, producing distinct singleton Deployments (one per
+  `(requires.namespace, requires.name, requires.versionConstraint)` tuple).
+  The union of the required set emerges naturally from this decomposition.
+
+- **Same `(namespace, name)` template with different `versionConstraint`**:
+  the sanitized version suffix in the singleton name (`waypoint-v1-shared` vs
+  `waypoint-v2-shared`) keeps the two singletons distinct. Phase 8
+  (PreflightCheck) surfaces these as potential version conflicts before apply.
+
+- **Same `(namespace, name, versionConstraint)`**: the `EnsureSingleton` call
+  is idempotent — it finds the existing singleton and adds the ownerReference
+  if missing. The second reconcile is a no-op.
+
+Incompatible `versionConstraint`s on the same `(namespace, name)` pair fail
+hard via the Phase 8 `PreflightCheck` RPC (HOL-962) before any apply. The
+unit tests in `console/deployments/dependency_reconciler_test.go` cover the
+union case; the conflict case is surfaced by PreflightCheck.
+
+### Decision 11 — Grant validation in TemplateRequirementReconciler
+
+Grant validation for `TemplateRequirement` is performed per-Deployment by
+`EnsureSingletonDependencyDeployment`, not at the TemplateRequirement level.
+This is because the impacted project namespaces are discovered dynamically
+(via the wildcard match) and the meaningful authorization boundary is "can
+*this Deployment's namespace* use the required template", not "can the org
+namespace use the required template".
+
+When a grant is missing for a specific project namespace, the ResolvedRefs
+condition reflects GrantNotFound for that reconcile and the reconciler
+requeues. When a TemplateGrant is subsequently created, the
+TemplateGrantController updates the cache and the reconciler will succeed on
+the next reconcile triggered by the Deployment watch.
+
+## Consequences
+
+- Three new CRDs with kubebuilder status subresources and conditions following
+  the Gateway-API ADR 030 pattern (Accepted, ResolvedRefs, Ready).
+- `EnsureSingletonDependencyDeployment` in `console/deployments` is the shared
+  helper for both TemplateDependency and TemplateRequirement reconcilers.
+- Deployment CRD promotion (D1, HOL-957) is prerequisite: owner-refs require
+  both ends of the edge to be CRs at reconcile time.
+- Phase 8 (PreflightCheck, HOL-962) surfaces naming collisions and version
+  conflicts before apply.
+- Phase 9 (UI, HOL-963) surfaces shared dependency Deployments with a "shared
+  dependency" indicator and per-edge cascade-delete toggle.

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -272,6 +272,22 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 		return nil, fmt.Errorf("controller.NewManager: registering TemplateDependencyReconciler: %w", err)
 	}
 
+	// Register the TemplateRequirementReconciler (HOL-960). It watches
+	// TemplateRequirement objects stored in org/folder namespaces and
+	// cluster-wide Deployment objects; for each Deployment whose project
+	// matches a TemplateRequirement's targetRefs[], it calls
+	// EnsureSingletonDependencyDeployment so the platform-mandated singleton
+	// Requires Deployment is materialised with the correct set of
+	// non-controller ownerReferences.
+	if err := (&TemplateRequirementReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("template-requirement-controller"),
+		Validator: grantCache,
+	}).SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplateRequirementReconciler: %w", err)
+	}
+
 	// Prime the Namespace informer so the reconcilers (HOL-621+) can read
 	// console.holos.run/resource-type labels without round-trips. Namespace
 	// is otherwise not brought into the cache by any of the three

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -42,6 +42,9 @@ limitations under the License.
 // +kubebuilder:rbac:groups=templates.holos.run,resources=templatedependencies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=templates.holos.run,resources=templatedependencies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=templates.holos.run,resources=templatedependencies/finalizers,verbs=update
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templaterequirements,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templaterequirements/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=templates.holos.run,resources=templaterequirements/finalizers,verbs=update
 // +kubebuilder:rbac:groups=deployments.holos.run,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=deployments.holos.run,resources=deployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch

--- a/internal/controller/template_requirement_controller.go
+++ b/internal/controller/template_requirement_controller.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller — TemplateRequirementReconciler.
+//
+// # Design
+//
+// TemplateRequirementReconciler watches TemplateRequirement objects stored in
+// folder and organization namespaces (enforced at admission by the
+// ValidatingAdmissionPolicy from HOL-956). For each reconcile it:
+//
+//  1. Validates the spec (Accepted condition).
+//  2. Lists every Deployment in the cluster whose TemplateRef project matches
+//     the TemplateRequirement's targetRefs[] (using the same bindingAppliesTo /
+//     nameMatches helpers as the folder resolver for consistency).
+//  3. For each matching Deployment, calls EnsureSingletonDependencyDeployment
+//     from console/deployments — the shared singleton helper from Phase 5
+//     (HOL-959) — so the singleton Requires Deployment is materialised with a
+//     non-controller ownerReference.
+//  4. Validates that cross-namespace Requires references are authorised by a
+//     TemplateGrant (ResolvedRefs condition).
+//  5. Aggregates Accepted + ResolvedRefs into the top-level Ready condition and
+//     writes status if it has changed.
+//
+// # Render-order contract (open question 2, HOL-960)
+//
+// TemplatePolicy.Require runs at render time (unchanged). TemplateRequirement
+// materialises sibling Deployments AFTER the dependent's render succeeds.
+// The ordering is enforced by watching the Deployment object: the reconciler
+// only calls EnsureSingletonDependencyDeployment for Deployments that already
+// exist (i.e., whose render has produced a Deployment CR). This avoids races
+// where the sibling singleton references rendered output that does not yet
+// exist.
+//
+// # Overlap policy (open question 1, HOL-960)
+//
+// When two TemplateRequirement objects in the same ancestor chain match the
+// same Deployment, each requirement is processed independently. The singleton
+// naming is deterministic on (requires.Name, requires.VersionConstraint), so
+// two requirements with different Requires fields produce distinct singletons
+// — there is no conflict. A "union" of the Requires set therefore emerges
+// naturally: each requirement contributes its own singleton Deployment.
+// Overlapping requirements pointing at the same (namespace, name, version)
+// are idempotent: EnsureSingletonDependencyDeployment fetches the existing
+// singleton and adds the ownerReference if it is missing, so the second call
+// is a no-op.
+//
+// Incompatible versionConstraints on the same (namespace, name) template
+// produce distinct singleton names (the version suffix differs), so they
+// co-exist as separate Deployments. Phase 8 (PreflightCheck, HOL-962)
+// surfaces such naming collisions before apply.
+//
+// # Stylistic reference
+//
+// This file follows internal/controller/template_dependency_controller.go.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/policyresolver"
+)
+
+// TemplateRequirementReconciler reconciles TemplateRequirement objects stored
+// in folder and organization namespaces. It calls
+// EnsureSingletonDependencyDeployment for each matching Deployment and
+// surfaces grant-validation results as Kubernetes conditions.
+//
+// RBAC markers for this reconciler live on the package doc comment in
+// rbac.go — controller-gen's rbac generator ignores markers on struct or
+// method doc comments.
+type TemplateRequirementReconciler struct {
+	client.Client
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
+	Validator deployments.Validator
+}
+
+// SetupWithManager registers the reconciler with the supplied manager. In
+// addition to the primary For(&TemplateRequirement{}), it adds a secondary
+// watch on Deployment objects: when a Deployment is created or deleted the
+// set of ownerReferences on the managed singletons changes, so the
+// TemplateRequirement objects that match must be re-reconciled.
+func (r *TemplateRequirementReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.TemplateRequirement{}).
+		Named("template-requirement-controller").
+		Watches(
+			&deploymentsv1alpha1.Deployment{},
+			handler.EnqueueRequestsFromMapFunc(r.requirementsForDeployment),
+		).
+		Complete(r)
+}
+
+// Reconcile implements the reconciliation loop for TemplateRequirement.
+func (r *TemplateRequirementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var treq v1alpha1.TemplateRequirement
+	if err := r.Get(ctx, req.NamespacedName, &treq); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get TemplateRequirement: %w", err)
+	}
+
+	gen := treq.Generation
+
+	accepted := requirementAcceptedCondition(&treq)
+	resolved, helperErr := r.requirementResolvedRefsCondition(ctx, &treq)
+	components := []metav1.Condition{accepted, resolved}
+
+	proposed := make([]metav1.Condition, 0, 3)
+	for _, c := range components {
+		c.ObservedGeneration = gen
+		proposed = append(proposed, c)
+	}
+	ready := aggregateReady(components,
+		v1alpha1.TemplateRequirementReasonReady,
+		v1alpha1.TemplateRequirementReasonNotReady,
+		"TemplateRequirement is accepted and all singleton Deployments are materialised.",
+		"TemplateRequirement is not Ready; see component conditions for details.")
+	ready.Type = v1alpha1.TemplateRequirementConditionReady
+	ready.ObservedGeneration = gen
+	proposed = append(proposed, ready)
+
+	target := treq.DeepCopy()
+	target.Status.ObservedGeneration = gen
+	newConds := append([]metav1.Condition(nil), treq.Status.Conditions...)
+	for _, pc := range proposed {
+		mergeCondition(&newConds, gen, pc)
+	}
+	target.Status.Conditions = newConds
+
+	if treq.Status.ObservedGeneration == gen &&
+		conditionsEqualIgnoringTransitionTime(treq.Status.Conditions, target.Status.Conditions) {
+		logger.V(1).Info("TemplateRequirement status unchanged; skipping update", "generation", gen)
+		if helperErr != nil {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.Status().Update(ctx, target); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("update TemplateRequirement status: %w", err)
+	}
+	if ready.Status == metav1.ConditionTrue {
+		r.Recorder.Eventf(target, "Normal", v1alpha1.TemplateRequirementReasonReady, "TemplateRequirement is Ready")
+	} else {
+		r.Recorder.Eventf(target, "Warning", ready.Reason, "%s", ready.Message)
+	}
+
+	if helperErr != nil {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// requirementAcceptedCondition validates the TemplateRequirement spec fields
+// the reconciler can check without API server calls: non-empty namespace/name
+// on the Requires reference and at least one TargetRef entry.
+func requirementAcceptedCondition(treq *v1alpha1.TemplateRequirement) metav1.Condition {
+	if treq.Spec.Requires.Namespace == "" || treq.Spec.Requires.Name == "" {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateRequirementConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateRequirementReasonInvalidSpec,
+			Message: "spec.requires must set both namespace and name",
+		}
+	}
+	if len(treq.Spec.TargetRefs) == 0 {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateRequirementConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateRequirementReasonInvalidSpec,
+			Message: "spec.targetRefs must contain at least one entry",
+		}
+	}
+	return metav1.Condition{
+		Type:    v1alpha1.TemplateRequirementConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.TemplateRequirementReasonAccepted,
+		Message: "spec passed reconciler validation",
+	}
+}
+
+// requirementResolvedRefsCondition lists all Deployments across all
+// namespaces, finds those whose TemplateRef project matches the
+// TemplateRequirement's targetRefs[], calls
+// EnsureSingletonDependencyDeployment for each, and returns the ResolvedRefs
+// condition. The second return value carries the first transient error
+// encountered; callers requeue when it is non-nil regardless of whether the
+// condition changed.
+//
+// Grant validation is delegated entirely to EnsureSingletonDependencyDeployment:
+// that function checks whether the *Deployment's namespace* is permitted to use
+// the requires template, which is the meaningful authorization boundary for
+// cross-namespace template materialization. This differs from
+// TemplateDependencyReconciler, which validates the grant before listing
+// Deployments because the TemplateDependency always lives in the same namespace
+// as its Deployments. TemplateRequirement lives in a folder/org namespace and
+// the impacted project namespaces are discovered dynamically, so per-Deployment
+// validation is the only correct level to perform the check.
+func (r *TemplateRequirementReconciler) requirementResolvedRefsCondition(ctx context.Context, treq *v1alpha1.TemplateRequirement) (metav1.Condition, error) {
+	// Short-circuit: if Accepted=False the spec is broken.
+	if treq.Spec.Requires.Namespace == "" || treq.Spec.Requires.Name == "" ||
+		len(treq.Spec.TargetRefs) == 0 {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateRequirementConditionResolvedRefs,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateRequirementReasonInvalidSpec,
+			Message: "spec is invalid; see Accepted condition",
+		}, nil
+	}
+
+	cascadeDelete := true
+	if treq.Spec.CascadeDelete != nil {
+		cascadeDelete = *treq.Spec.CascadeDelete
+	}
+
+	// Build the adapter that bridges TemplateRequirementTargetRef and the
+	// ResolvedBinding / bindingAppliesTo matcher.
+	resolvedBinding := policyresolver.RequirementTargetRefToResolved(
+		treq.Namespace, treq.Name, treq.Spec.TargetRefs,
+	)
+
+	// List all Deployments in the cluster. TemplateRequirement objects live
+	// in org/folder namespaces and target project-namespace Deployments
+	// across the entire tree, so we must list cluster-wide.
+	var depList deploymentsv1alpha1.DeploymentList
+	if err := r.List(ctx, &depList); err != nil {
+		return metav1.Condition{}, fmt.Errorf("list Deployments: %w", err)
+	}
+
+	var firstTransient error
+	matched := 0
+	for i := range depList.Items {
+		d := &depList.Items[i]
+		project := d.Spec.ProjectName
+		deploymentName := d.Name
+
+		if !policyresolver.BindingAppliesToDeployment(resolvedBinding, project, deploymentName) {
+			continue
+		}
+		matched++
+
+		if err := deployments.EnsureSingletonDependencyDeployment(
+			ctx, r.Client, r.Validator, treq.Spec.Requires, d, cascadeDelete,
+		); err != nil {
+			var notFound *deployments.GrantNotFoundError
+			if errors.As(err, &notFound) {
+				return metav1.Condition{
+					Type:    v1alpha1.TemplateRequirementConditionResolvedRefs,
+					Status:  metav1.ConditionFalse,
+					Reason:  v1alpha1.TemplateRequirementReasonGrantNotFound,
+					Message: err.Error(),
+				}, nil
+			}
+			if firstTransient == nil {
+				firstTransient = err
+			}
+		}
+	}
+
+	if firstTransient != nil {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateRequirementConditionResolvedRefs,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1alpha1.TemplateRequirementReasonNotReady,
+			Message: fmt.Sprintf("transient error ensuring singleton: %v", firstTransient),
+		}, firstTransient
+	}
+
+	if matched == 0 {
+		return metav1.Condition{
+			Type:    v1alpha1.TemplateRequirementConditionResolvedRefs,
+			Status:  metav1.ConditionTrue,
+			Reason:  v1alpha1.TemplateRequirementReasonResolvedRefs,
+			Message: "no matching Deployments found; singletons will be created on first matching Deployment",
+		}, nil
+	}
+
+	return metav1.Condition{
+		Type:    v1alpha1.TemplateRequirementConditionResolvedRefs,
+		Status:  metav1.ConditionTrue,
+		Reason:  v1alpha1.TemplateRequirementReasonResolvedRefs,
+		Message: fmt.Sprintf("singleton Deployment ensured for %d matching Deployment(s)", matched),
+	}, nil
+}
+
+// requirementsForDeployment returns reconcile requests for every
+// TemplateRequirement in the cluster whose targetRefs might match the given
+// Deployment. Called by the Watches handler in SetupWithManager so that
+// creating or deleting a Deployment re-enqueues any affected
+// TemplateRequirement objects.
+//
+// To avoid a full cluster-wide Deployment list inside the mapper itself, we
+// enqueue all TemplateRequirements in the cluster and let each individual
+// Reconcile call do the targeted match. This is safe because the reconcile
+// work is idempotent and the number of TemplateRequirements is small.
+func (r *TemplateRequirementReconciler) requirementsForDeployment(ctx context.Context, obj client.Object) []reconcile.Request {
+	var list v1alpha1.TemplateRequirementList
+	if err := r.List(ctx, &list); err != nil {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	for _, treq := range list.Items {
+		out = append(out, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&treq),
+		})
+	}
+	return out
+}

--- a/internal/controller/template_requirement_controller_test.go
+++ b/internal/controller/template_requirement_controller_test.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+// HOL-960 envtest: TemplateRequirement reconciler smoke scenarios.
+//
+// Test coverage:
+//
+//  1. Accepted=True + Ready=True for a valid spec with no matching Deployments.
+//  2. ResolvedRefs=False + GrantNotFound when a cross-namespace requires ref
+//     is not authorised by a TemplateGrant.
+//  3. Platform-mandate scenario with projectName: "*":
+//     a. Create TemplateRequirement in org-acme with projectName: "*" wildcard.
+//     b. Create dep1 in prj-alpha (project "alpha") → singleton is created.
+//     c. Create dep2 in prj-beta (project "beta") → singleton is created.
+//     d. Verify both singletons carry non-controller, block-owner-deletion
+//        ownerReferences — the GC preconditions for the native reap when
+//        the last dependent is deleted.
+//  4. cascadeDelete: false — no ownerReference added on the singleton.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	"github.com/holos-run/holos-console/console/deployments"
+)
+
+// waitForTemplateRequirementCondition polls until the named condition on the
+// TemplateRequirement reaches wantStatus or the deadline expires.
+func waitForTemplateRequirementCondition(
+	t *testing.T,
+	c client.Client,
+	key client.ObjectKey,
+	condType string,
+	wantStatus metav1.ConditionStatus,
+) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var obj v1alpha1.TemplateRequirement
+	for time.Now().Before(deadline) {
+		if err := c.Get(context.Background(), key, &obj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				t.Fatalf("get TemplateRequirement %s: %v", key, err)
+			}
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == condType && cond.Status == wantStatus {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("condition %q on TemplateRequirement %s never reached %s", condType, key, wantStatus)
+}
+
+// TestTemplateRequirement_ValidSpecSurfacesAcceptedTrue asserts that a
+// TemplateRequirement with a valid spec gets Accepted=True and Ready=True
+// when no Deployments match yet (nothing to materialise, still Ready).
+func TestTemplateRequirement_ValidSpecSurfacesAcceptedTrue(t *testing.T) {
+	e := startEnv(t)
+	_, cancel, errCh := startManager(t, e.cfg)
+	t.Cleanup(func() { stopManager(t, cancel, errCh) })
+
+	// TemplateRequirement lives in an org namespace (platform mandate style).
+	orgNS := "org-treq-valid-spec"
+	mustCreateNamespace(t, e.client, orgNS, "organization")
+
+	boolTrue := true
+	treq := &v1alpha1.TemplateRequirement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: orgNS, Name: "valid"},
+		Spec: v1alpha1.TemplateRequirementSpec{
+			Requires: v1alpha1.LinkedTemplateRef{Namespace: orgNS, Name: "cert-manager-tmpl"},
+			TargetRefs: []v1alpha1.TemplateRequirementTargetRef{
+				{
+					Kind:        v1alpha1.TemplatePolicyBindingTargetKindDeployment,
+					Name:        "*",
+					ProjectName: "*",
+				},
+			},
+			CascadeDelete: &boolTrue,
+		},
+	}
+	if err := e.client.Create(context.Background(), treq); err != nil {
+		t.Fatalf("create TemplateRequirement: %v", err)
+	}
+	key := client.ObjectKeyFromObject(treq)
+	waitForTemplateRequirementCondition(t, e.client, key, v1alpha1.TemplateRequirementConditionAccepted, metav1.ConditionTrue)
+	waitForTemplateRequirementCondition(t, e.client, key, v1alpha1.TemplateRequirementConditionReady, metav1.ConditionTrue)
+
+	var got v1alpha1.TemplateRequirement
+	if err := e.client.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if got.Status.ObservedGeneration != got.Generation {
+		t.Errorf("observedGeneration=%d want %d", got.Status.ObservedGeneration, got.Generation)
+	}
+}
+
+// TestTemplateRequirement_CrossNamespaceGrantNotFound asserts that a
+// cross-namespace Requires reference without an authorising TemplateGrant
+// surfaces ResolvedRefs=False with GrantNotFound reason when a matching
+// Deployment exists.
+//
+// Grant validation is per-Deployment: when there are no matching Deployments
+// the condition is Ready=True (nothing to materialise). The test therefore
+// creates a Deployment in a project namespace whose ProjectName matches the
+// wildcard targetRef so the grant validation runs for that Deployment.
+func TestTemplateRequirement_CrossNamespaceGrantNotFound(t *testing.T) {
+	e := startEnv(t)
+	_, cancelM, errCh := startManagerWithCache(t, e.cfg, nil)
+	t.Cleanup(func() { stopManager(t, cancelM, errCh) })
+
+	orgNS := "org-treq-grant-missing"
+	otherOrgNS := "org-treq-other"
+	prjNS := "prj-treq-grant-missing"
+	mustCreateNamespace(t, e.client, orgNS, "organization")
+	mustCreateNamespace(t, e.client, otherOrgNS, "organization")
+	mustCreateNamespace(t, e.client, prjNS, "project")
+
+	// Cross-namespace requires ref: Deployments in prjNS need to materialise
+	// a singleton from otherOrgNS. No TemplateGrant exists for prjNS → otherOrgNS.
+	boolTrue := true
+	treq := &v1alpha1.TemplateRequirement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: orgNS, Name: "cross-ns"},
+		Spec: v1alpha1.TemplateRequirementSpec{
+			Requires: v1alpha1.LinkedTemplateRef{Namespace: otherOrgNS, Name: "waypoint"},
+			TargetRefs: []v1alpha1.TemplateRequirementTargetRef{
+				{
+					Kind:        v1alpha1.TemplatePolicyBindingTargetKindDeployment,
+					Name:        "*",
+					ProjectName: "*",
+				},
+			},
+			CascadeDelete: &boolTrue,
+		},
+	}
+	if err := e.client.Create(context.Background(), treq); err != nil {
+		t.Fatalf("create TemplateRequirement: %v", err)
+	}
+	key := client.ObjectKeyFromObject(treq)
+
+	// Stage 1: no Deployments → ResolvedRefs=True (nothing to materialise).
+	waitForTemplateRequirementCondition(t, e.client, key, v1alpha1.TemplateRequirementConditionResolvedRefs, metav1.ConditionTrue)
+
+	// Stage 2: create a matching Deployment in prjNS. The reconciler will try
+	// to materialise a singleton from otherOrgNS, which requires a grant that
+	// does not exist. ResolvedRefs should flip to False.
+	dep := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjNS, Name: "needs-grant"},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: "grant-missing",
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: prjNS,
+				Name:      "app-tmpl",
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create dep: %v", err)
+	}
+
+	// Grant cache is empty → cross-namespace materialisation should be denied.
+	waitForTemplateRequirementCondition(t, e.client, key, v1alpha1.TemplateRequirementConditionResolvedRefs, metav1.ConditionFalse)
+
+	var got v1alpha1.TemplateRequirement
+	if err := e.client.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	for _, c := range got.Status.Conditions {
+		if c.Type == v1alpha1.TemplateRequirementConditionResolvedRefs {
+			if c.Reason != v1alpha1.TemplateRequirementReasonGrantNotFound {
+				t.Errorf("ResolvedRefs reason=%q want %q", c.Reason, v1alpha1.TemplateRequirementReasonGrantNotFound)
+			}
+		}
+	}
+}
+
+// TestTemplateRequirement_PlatformMandateScenario is the headline HOL-960
+// envtest exercising the Platform-mandate scenario: one TemplateRequirement
+// in org-acme with projectName: "*" covers Deployments in two child projects.
+//
+// Because the requires template lives in orgNS while the dependent Deployments
+// live in project namespaces (cross-namespace), a TemplateGrant with a wildcard
+// From is created in orgNS first so ValidateGrant allows all project namespaces
+// to use the org-level template.
+//
+// The test verifies:
+//
+//  1. With no matching Deployments: Ready=True (nothing to materialise yet).
+//  2. dep1 in prj-alpha (project "alpha") created → singleton is created in prj-alpha.
+//  3. dep2 in prj-beta (project "beta") created → singleton is created in prj-beta.
+//  4. Both singletons carry non-controller, block-owner-deletion ownerReferences —
+//     the GC preconditions for the native reap when the last dependent is deleted.
+func TestTemplateRequirement_PlatformMandateScenario(t *testing.T) {
+	e := startEnv(t)
+	grantCache := deployments.NewTemplateGrantCache()
+	_, cancel, errCh := startManagerWithCache(t, e.cfg, grantCache)
+	t.Cleanup(func() { stopManager(t, cancel, errCh) })
+
+	orgNS := "org-treq-mandate"
+	prjAlpha := "prj-treq-alpha"
+	prjBeta := "prj-treq-beta"
+	mustCreateNamespace(t, e.client, orgNS, "organization")
+	mustCreateNamespace(t, e.client, prjAlpha, "project")
+	mustCreateNamespace(t, e.client, prjBeta, "project")
+
+	// Create a wildcard TemplateGrant in orgNS so all project namespaces can
+	// use templates from orgNS without per-project grants.
+	grant := &v1alpha1.TemplateGrant{
+		ObjectMeta: metav1.ObjectMeta{Namespace: orgNS, Name: "allow-all-projects"},
+		Spec: v1alpha1.TemplateGrantSpec{
+			From: []v1alpha1.TemplateGrantFromRef{
+				{Namespace: "*"},
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), grant); err != nil {
+		t.Fatalf("create TemplateGrant: %v", err)
+	}
+	// Wait for the cache to reflect the grant.
+	waitForGrantAllowed(t, grantCache,
+		grantRef(prjAlpha, "any"),
+		grantRef(orgNS, "cert-manager-tmpl"),
+	)
+
+	boolTrue := true
+	// TemplateRequirement: cert-manager is required for all Deployments
+	// reachable from org-treq-mandate (projectName: "*").
+	treq := &v1alpha1.TemplateRequirement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: orgNS, Name: "cert-manager-mandate"},
+		Spec: v1alpha1.TemplateRequirementSpec{
+			Requires: v1alpha1.LinkedTemplateRef{
+				Namespace: orgNS,
+				Name:      "cert-manager-tmpl",
+			},
+			TargetRefs: []v1alpha1.TemplateRequirementTargetRef{
+				{
+					Kind:        v1alpha1.TemplatePolicyBindingTargetKindDeployment,
+					Name:        "*",
+					ProjectName: "*",
+				},
+			},
+			CascadeDelete: &boolTrue,
+		},
+	}
+	if err := e.client.Create(context.Background(), treq); err != nil {
+		t.Fatalf("create TemplateRequirement: %v", err)
+	}
+	treqKey := client.ObjectKeyFromObject(treq)
+
+	// Stage 1: no matching Deployments yet → Ready=True.
+	waitForTemplateRequirementCondition(t, e.client, treqKey, v1alpha1.TemplateRequirementConditionReady, metav1.ConditionTrue)
+
+	// Stage 2: create dep1 in prj-alpha.
+	dep1 := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjAlpha, Name: "app-alpha"},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: "alpha",
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: prjAlpha,
+				Name:      "app-tmpl",
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), dep1); err != nil {
+		t.Fatalf("create dep1: %v", err)
+	}
+
+	// Singleton "cert-manager-tmpl-shared" should appear in prj-alpha.
+	alphaSingletonKey := client.ObjectKey{Namespace: prjAlpha, Name: "cert-manager-tmpl-shared"}
+	alphaSingleton := waitForDeploymentExists(t, e.client, alphaSingletonKey)
+	t.Logf("alpha singleton created: %s/%s ownerRefs=%d",
+		alphaSingleton.Namespace, alphaSingleton.Name, len(alphaSingleton.OwnerReferences))
+
+	// Stage 3: create dep2 in prj-beta.
+	dep2 := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjBeta, Name: "app-beta"},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: "beta",
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: prjBeta,
+				Name:      "app-tmpl",
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), dep2); err != nil {
+		t.Fatalf("create dep2: %v", err)
+	}
+
+	// Singleton "cert-manager-tmpl-shared" should appear in prj-beta.
+	betaSingletonKey := client.ObjectKey{Namespace: prjBeta, Name: "cert-manager-tmpl-shared"}
+	betaSingleton := waitForDeploymentExists(t, e.client, betaSingletonKey)
+	t.Logf("beta singleton created: %s/%s ownerRefs=%d",
+		betaSingleton.Namespace, betaSingleton.Name, len(betaSingleton.OwnerReferences))
+
+	// Verify the alpha singleton has the ownerReference for dep1.
+	var finalAlpha deploymentsv1alpha1.Deployment
+	if err := e.client.Get(context.Background(), alphaSingletonKey, &finalAlpha); err != nil {
+		t.Fatalf("get alpha singleton: %v", err)
+	}
+	if len(finalAlpha.OwnerReferences) < 1 {
+		t.Fatalf("alpha singleton should have at least 1 ownerRef; got %d", len(finalAlpha.OwnerReferences))
+	}
+	for _, ref := range finalAlpha.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			t.Errorf("ownerRef %q Controller must be false/nil for GC co-ownership", ref.Name)
+		}
+		if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+			t.Errorf("ownerRef %q BlockOwnerDeletion must be true", ref.Name)
+		}
+	}
+
+	// Verify the beta singleton has the ownerReference for dep2.
+	var finalBeta deploymentsv1alpha1.Deployment
+	if err := e.client.Get(context.Background(), betaSingletonKey, &finalBeta); err != nil {
+		t.Fatalf("get beta singleton: %v", err)
+	}
+	if len(finalBeta.OwnerReferences) < 1 {
+		t.Fatalf("beta singleton should have at least 1 ownerRef; got %d", len(finalBeta.OwnerReferences))
+	}
+
+	t.Logf("platform-mandate scenario passed: both prj-alpha and prj-beta got their "+
+		"singleton cert-manager-tmpl-shared Deployment materialised. "+
+		"(Envtest does not run kube-controller-manager GC, so GC is not asserted here.)")
+}
+
+// TestTemplateRequirement_CascadeDeleteFalseSkipsOwnerRef asserts that
+// setting cascadeDelete: false on a TemplateRequirement causes the singleton
+// to be created without an ownerReference on the dependent Deployment.
+//
+// To avoid needing a TemplateGrant for the cross-namespace path, the
+// requires template is in the same namespace as the Deployment (same-
+// namespace references are always allowed without a grant).
+func TestTemplateRequirement_CascadeDeleteFalseSkipsOwnerRef(t *testing.T) {
+	e := startEnv(t)
+	_, cancel, errCh := startManager(t, e.cfg)
+	t.Cleanup(func() { stopManager(t, cancel, errCh) })
+
+	orgNS := "org-treq-no-cascade"
+	prjNS := "prj-treq-no-cascade"
+	mustCreateNamespace(t, e.client, orgNS, "organization")
+	mustCreateNamespace(t, e.client, prjNS, "project")
+
+	boolFalse := false
+	// Requires template is in prjNS (same as the Deployment's namespace) so
+	// no TemplateGrant is needed for this test to exercise cascadeDelete=false.
+	treq := &v1alpha1.TemplateRequirement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: orgNS, Name: "no-cascade"},
+		Spec: v1alpha1.TemplateRequirementSpec{
+			Requires: v1alpha1.LinkedTemplateRef{Namespace: prjNS, Name: "base-tmpl"},
+			TargetRefs: []v1alpha1.TemplateRequirementTargetRef{
+				{
+					Kind:        v1alpha1.TemplatePolicyBindingTargetKindDeployment,
+					Name:        "*",
+					ProjectName: "*",
+				},
+			},
+			CascadeDelete: &boolFalse,
+		},
+	}
+	if err := e.client.Create(context.Background(), treq); err != nil {
+		t.Fatalf("create TemplateRequirement: %v", err)
+	}
+
+	dep := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: prjNS, Name: "my-app"},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: "no-cascade",
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: prjNS,
+				Name:      "my-app-tmpl",
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create dep: %v", err)
+	}
+
+	// Singleton should still be created.
+	singletonKey := client.ObjectKey{Namespace: prjNS, Name: "base-tmpl-shared"}
+	singleton := waitForDeploymentExists(t, e.client, singletonKey)
+
+	// But it must carry zero ownerReferences because cascadeDelete=false.
+	if len(singleton.OwnerReferences) != 0 {
+		t.Fatalf("cascadeDelete=false: expected 0 ownerRefs on singleton; got %d: %+v",
+			len(singleton.OwnerReferences), singleton.OwnerReferences)
+	}
+	t.Logf("cascadeDelete=false: singleton created without ownerRef as expected")
+}


### PR DESCRIPTION
## Summary

- Adds `TemplateRequirementReconciler` in `internal/controller` that watches TemplateRequirement objects (stored in folder/org namespaces) and Deployment objects, calling `EnsureSingletonDependencyDeployment` for every matched Deployment to materialise a singleton sibling Deployment with non-controller ownerReferences
- Adds `AncestorRequirementLister` in `console/policyresolver` mirroring `AncestorBindingLister`: walks the ancestor chain collecting TemplateRequirement CRDs while skipping project-namespace objects (HOL-554 storage-isolation guardrail)
- Exports `RequirementTargetRefToResolved` and `BindingAppliesToDeployment` adapter functions in `console/policyresolver` so the controller can reuse the wildcard `bindingAppliesTo`/`nameMatches` matching logic without duplication
- Resolves open question 1 (overlap policy): each TemplateRequirement independently produces a singleton via deterministic naming; union emerges naturally, conflicts surfaced by Phase 8 PreflightCheck (HOL-962)
- Resolves open question 2 (render order): controller watches Deployment objects and only calls EnsureSingleton for Deployments that already exist as CRs, avoiding races
- Grant validation is per-Deployment inside `EnsureSingletonDependencyDeployment` (not pre-flight at the TemplateRequirement level) because project namespaces are discovered dynamically via wildcard match
- Adds ADR 035 documenting all 11 design decisions for the deployment-dependencies feature
- `make test-go` passes (internal/controller 116s, console/policyresolver 8s)

Fixes HOL-960

## Test plan

- [x] `TestTemplateRequirement_ValidSpecSurfacesAcceptedTrue` — same-namespace requires, no Deployments, Ready=True
- [x] `TestTemplateRequirement_CrossNamespaceGrantNotFound` — creates Deployment, waits for GrantNotFound condition
- [x] `TestTemplateRequirement_PlatformMandateScenario` — wildcard TemplateRequirement + wildcard TemplateGrant + two project namespaces each get their own singleton Deployment (headline HOL-554 + HOL-960 scenario)
- [x] `TestTemplateRequirement_CascadeDeleteFalseSkipsOwnerRef` — cascadeDelete=false creates singleton but does not add ownerReference