### PR TITLE
refactor(deployments): refactor Project Deployments cluster index + detail

### DIFF
--- a/frontend/src/components/resource-grid/-resource-grid.test.tsx
+++ b/frontend/src/components/resource-grid/-resource-grid.test.tsx
@@ -474,4 +474,75 @@ describe('ResourceGrid', () => {
     const result = updater({ search: 'existing' })
     expect(result['search']).toBeUndefined()
   })
+
+  // --- Sorting — Created At column (HOL-971) ---
+
+  it('renders Created At column header as a sortable button by default', () => {
+    renderGrid()
+    // Default sortableColumns includes 'createdAt', so the header is a button.
+    const sortBtn = screen.getByRole('button', { name: /sort by created at/i })
+    expect(sortBtn).toBeInTheDocument()
+  })
+
+  it('clicking Created At sort button calls onSearchChange with sort=createdAt asc', () => {
+    const onSearchChange = vi.fn()
+    renderGrid({ onSearchChange })
+    const sortBtn = screen.getByRole('button', { name: /sort by created at/i })
+    fireEvent.click(sortBtn)
+    expect(onSearchChange).toHaveBeenCalled()
+    // The updater produced by the first click should set sort=createdAt asc.
+    const updater = onSearchChange.mock.calls[0][0] as (prev: Record<string, unknown>) => Record<string, unknown>
+    const result = updater({})
+    expect(result['sort']).toBe('createdAt')
+    expect(result['sortDir']).toBe('asc')
+  })
+
+  it('clicking Created At sort button a second time toggles to desc', () => {
+    const onSearchChange = vi.fn()
+    // Render with sort=createdAt asc already active.
+    renderGrid({ onSearchChange, search: { sort: 'createdAt', sortDir: 'asc' } })
+    const sortBtn = screen.getByRole('button', { name: /sort by created at/i })
+    fireEvent.click(sortBtn)
+    expect(onSearchChange).toHaveBeenCalled()
+    const updater = onSearchChange.mock.calls[0][0] as (prev: Record<string, unknown>) => Record<string, unknown>
+    const result = updater({ sort: 'createdAt', sortDir: 'asc' })
+    expect(result['sort']).toBe('createdAt')
+    expect(result['sortDir']).toBe('desc')
+  })
+
+  it('sorts rows by createdAt ascending when search.sort is createdAt and sortDir is asc', () => {
+    renderGrid({
+      rows: [
+        makeRow({ id: 'b', name: 'b', displayName: 'B', description: '', createdAt: '2025-06-01T00:00:00Z' }),
+        makeRow({ id: 'a', name: 'a', displayName: 'A', description: '', createdAt: '2025-01-01T00:00:00Z' }),
+      ],
+      search: { sort: 'createdAt', sortDir: 'asc' },
+    })
+    const cells = screen.getAllByRole('cell').map((c) => c.textContent)
+    const aIndex = cells.findIndex((t) => t?.includes('A'))
+    const bIndex = cells.findIndex((t) => t?.includes('B'))
+    expect(aIndex).toBeLessThan(bIndex)
+  })
+
+  it('sorts rows by createdAt descending when sortDir is desc', () => {
+    renderGrid({
+      rows: [
+        makeRow({ id: 'a', name: 'a', displayName: 'A', description: '', createdAt: '2025-01-01T00:00:00Z' }),
+        makeRow({ id: 'b', name: 'b', displayName: 'B', description: '', createdAt: '2025-06-01T00:00:00Z' }),
+      ],
+      search: { sort: 'createdAt', sortDir: 'desc' },
+    })
+    const cells = screen.getAllByRole('cell').map((c) => c.textContent)
+    const aIndex = cells.findIndex((t) => t?.includes('A'))
+    const bIndex = cells.findIndex((t) => t?.includes('B'))
+    expect(bIndex).toBeLessThan(aIndex)
+  })
+
+  it('renders Created At as plain text (not a button) when sortableColumns is empty', () => {
+    renderGrid({ sortableColumns: [] })
+    // No sort toggle button should be present.
+    expect(screen.queryByRole('button', { name: /sort by created at/i })).not.toBeInTheDocument()
+    // The header text is still shown.
+    expect(screen.getByRole('columnheader', { name: /created at/i })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/resource-grid/ResourceGrid.tsx
+++ b/frontend/src/components/resource-grid/ResourceGrid.tsx
@@ -19,11 +19,13 @@ import {
   useReactTable,
   getCoreRowModel,
   getFilteredRowModel,
+  getSortedRowModel,
   flexRender,
   createColumnHelper,
   type VisibilityState,
+  type SortingState,
 } from '@tanstack/react-table'
-import { Trash2 } from 'lucide-react'
+import { ArrowUpDown, ArrowUp, ArrowDown, Trash2 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -98,6 +100,12 @@ export interface ResourceGridProps {
    * New button. Use for icon buttons such as the Templates help pane toggle.
    */
   headerActions?: ReactNode
+  /**
+   * Optional set of column IDs that should be rendered with a sort toggle
+   * button. Defaults to ['createdAt'] when unset so the Created At column is
+   * always sortable. Pass an empty array to disable all sorting.
+   */
+  sortableColumns?: string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +124,7 @@ export function ResourceGrid({
   extraColumns = [],
   headerContent,
   headerActions,
+  sortableColumns = ['createdAt'],
 }: ResourceGridProps) {
   const navigate = useNavigate()
 
@@ -127,6 +136,12 @@ export function ResourceGrid({
   )
 
   const globalFilter = search.search ?? ''
+
+  // Derive sorting state from URL params.
+  const sorting: SortingState = useMemo(() => {
+    if (!search.sort) return []
+    return [{ id: search.sort, desc: search.sortDir === 'desc' }]
+  }, [search.sort, search.sortDir])
 
   // --- URL updater helpers -----------------------------------------------
 
@@ -152,6 +167,19 @@ export function ResourceGrid({
       }))
     },
     [updateSearch],
+  )
+
+  const handleSortingChange = useCallback(
+    (updaterOrValue: SortingState | ((prev: SortingState) => SortingState)) => {
+      const next = typeof updaterOrValue === 'function' ? updaterOrValue(sorting) : updaterOrValue
+      const first = next[0]
+      updateSearch((prev) => ({
+        ...prev,
+        sort: first?.id ?? undefined,
+        sortDir: first ? (first.desc ? 'desc' : 'asc') : undefined,
+      }))
+    },
+    [updateSearch, sorting],
   )
 
   const {
@@ -185,6 +213,10 @@ export function ResourceGrid({
     const kindSet = new Set(selectedKindIds)
     return rows.filter((r) => kindSet.has(r.kind))
   }, [rows, selectedKindIds])
+
+  // --- Stable set of sortable column IDs --------------------------------
+
+  const sortableSet = useMemo(() => new Set(sortableColumns), [sortableColumns])
 
   // --- TanStack Table columns --------------------------------------------
 
@@ -266,7 +298,39 @@ export function ResourceGrid({
       ...extraColumns,
       columnHelper.accessor('createdAt', {
         id: 'createdAt',
-        header: 'Created At',
+        header: ({ column }) => {
+          if (!sortableSet.has('createdAt')) {
+            return <span>Created At</span>
+          }
+          const isSorted = column.getIsSorted()
+          return (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="-ml-3 h-8 font-normal"
+              onClick={() => column.toggleSorting(isSorted === 'asc')}
+              aria-label="Sort by Created At"
+            >
+              Created At
+              {isSorted === 'asc' ? (
+                <ArrowUp className="ml-1 h-4 w-4" aria-hidden="true" />
+              ) : isSorted === 'desc' ? (
+                <ArrowDown className="ml-1 h-4 w-4" aria-hidden="true" />
+              ) : (
+                <ArrowUpDown className="ml-1 h-4 w-4 opacity-50" aria-hidden="true" />
+              )}
+            </Button>
+          )
+        },
+        enableSorting: sortableSet.has('createdAt'),
+        sortingFn: (rowA, rowB) => {
+          const a = rowA.original.createdAt
+          const b = rowB.original.createdAt
+          if (!a && !b) return 0
+          if (!a) return 1
+          if (!b) return -1
+          return a < b ? -1 : a > b ? 1 : 0
+        },
         cell: ({ getValue }) => {
           const raw = getValue()
           if (!raw) {
@@ -305,7 +369,7 @@ export function ResourceGrid({
         ),
       }),
     ],
-    [handleDeleteClick, extraColumns],
+    [handleDeleteClick, extraColumns, sortableSet],
   )
 
   // --- TanStack Table instance -------------------------------------------
@@ -313,11 +377,13 @@ export function ResourceGrid({
   const table = useReactTable({
     data: kindFilteredRows,
     columns,
-    state: { globalFilter, columnVisibility },
+    state: { globalFilter, columnVisibility, sorting },
     onGlobalFilterChange: setGlobalFilter,
+    onSortingChange: handleSortingChange,
     globalFilterFn: 'includesString',
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   })
 
   // --- Loading skeleton --------------------------------------------------

--- a/frontend/src/components/resource-grid/types.ts
+++ b/frontend/src/components/resource-grid/types.ts
@@ -58,6 +58,10 @@ export interface ResourceGridSearch {
   kind?: string
   /** Global search string. */
   search?: string
+  /** Column ID to sort by. */
+  sort?: string
+  /** Sort direction: 'asc' or 'desc'. */
+  sortDir?: 'asc' | 'desc'
 }
 
 /** Props for the multi-kind checkbox filter. */

--- a/frontend/src/components/resource-grid/url-state.ts
+++ b/frontend/src/components/resource-grid/url-state.ts
@@ -38,6 +38,16 @@ export function parseGridSearch(raw: Record<string, unknown>): ResourceGridSearc
     result.search = search
   }
 
+  const sort = raw['sort']
+  if (typeof sort === 'string' && sort.length > 0) {
+    result.sort = sort
+  }
+
+  const sortDir = raw['sortDir']
+  if (sortDir === 'asc' || sortDir === 'desc') {
+    result.sortDir = sortDir
+  }
+
   return result
 }
 
@@ -52,6 +62,8 @@ export function serialiseGridSearch(
   return {
     kind: params.kind || undefined,
     search: params.search || undefined,
+    sort: params.sort || undefined,
+    sortDir: params.sortDir || undefined,
   }
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -38,15 +38,16 @@ import {
 import { ArrowLeft, CheckCircle2, ExternalLink, Info, TriangleAlert, XCircle } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import type { EnvVar, Event, ContainerStatus, Link as DeploymentLink } from '@/gen/holos/console/v1/deployments_pb'
-import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useGetDeploymentPolicyState, useUpdateDeployment, useDeleteDeployment } from '@/queries/deployments'
+import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useGetDeploymentPolicyState, useGetDeploymentRenderPreview, useUpdateDeployment, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 import { isSafeHttpUrl } from '@/lib/url'
 import { PolicySection } from '@/components/policy-drift/PolicySection'
 
-type DeploymentTab = 'status' | 'logs'
+type DeploymentTab = 'status' | 'logs' | 'preview'
 
 function validateTab(value: unknown): DeploymentTab {
   if (value === 'logs') return value
+  if (value === 'preview') return value
   return 'status'
 }
 
@@ -258,6 +259,7 @@ export function DeploymentDetailPage({
   const { data: status } = useGetDeploymentStatus(projectName, deploymentName, { refetchInterval: 5000 })
   const { data: project } = useGetProject(projectName)
   const { data: policyState, isPending: isPolicyPending, error: policyError } = useGetDeploymentPolicyState(projectName, deploymentName)
+  const { data: renderPreview, isPending: isPreviewPending, error: previewError } = useGetDeploymentRenderPreview(projectName, deploymentName)
 
   const [tailLines, setTailLines] = useState<number>(100)
   const [previous, setPrevious] = useState(false)
@@ -441,6 +443,7 @@ export function DeploymentDetailPage({
             <TabsList>
               <TabsTrigger value="status">Status</TabsTrigger>
               <TabsTrigger value="logs">Logs</TabsTrigger>
+              <TabsTrigger value="preview">Preview</TabsTrigger>
             </TabsList>
 
             {/* Status tab — replicas, conditions, pods, environment variables */}
@@ -726,6 +729,84 @@ export function DeploymentDetailPage({
               <pre className="rounded-md bg-muted p-4 text-xs font-mono overflow-auto max-h-[70vh] whitespace-pre-wrap">
                 {logs || 'No logs available.'}
               </pre>
+            </TabsContent>
+
+            {/*
+              Preview tab — shows the rendered Kubernetes manifests produced by
+              evaluating the deployment template against the current platform
+              and project inputs. The `platformResourcesYaml` section surfaces
+              resources contributed by organisation- and folder-level platform
+              templates via `TemplatePolicyBinding`, which is the key signal
+              operators need to verify policy-mixed-in resources before
+              reconciling.
+            */}
+            <TabsContent value="preview" className="mt-4 space-y-6">
+              {isPreviewPending && (
+                <div className="space-y-2" data-testid="preview-loading">
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-40 w-full" />
+                </div>
+              )}
+              {previewError && (
+                <Alert variant="destructive">
+                  <AlertDescription>{previewError.message}</AlertDescription>
+                </Alert>
+              )}
+              {renderPreview && !isPreviewPending && (
+                <>
+                  {/*
+                    Platform resources — contributed by TemplatePolicyBinding.
+                    Shown first so operators can immediately see what the platform
+                    injected before comparing to the project template's own output.
+                  */}
+                  <div className="space-y-3">
+                    <div>
+                      <h3 className="text-sm font-medium">Platform Resources</h3>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Resources contributed by organisation/folder-level templates via{' '}
+                        <span className="font-mono">TemplatePolicyBinding</span>
+                      </p>
+                    </div>
+                    <Separator />
+                    {renderPreview.platformResourcesYaml ? (
+                      <pre
+                        data-testid="preview-platform-resources"
+                        className="rounded-md bg-muted p-4 text-xs font-mono overflow-auto max-h-[40vh] whitespace-pre-wrap"
+                      >
+                        {renderPreview.platformResourcesYaml}
+                      </pre>
+                    ) : (
+                      <p className="text-sm text-muted-foreground" data-testid="preview-platform-resources-empty">
+                        No platform resources. Link a platform template via{' '}
+                        <span className="font-mono">TemplatePolicyBinding</span> to see resources here.
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Project resources — contributed by the deployment template */}
+                  <div className="space-y-3">
+                    <div>
+                      <h3 className="text-sm font-medium">Project Resources</h3>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Resources rendered directly from this deployment&apos;s template
+                      </p>
+                    </div>
+                    <Separator />
+                    {renderPreview.projectResourcesYaml ? (
+                      <pre
+                        data-testid="preview-project-resources"
+                        className="rounded-md bg-muted p-4 text-xs font-mono overflow-auto max-h-[40vh] whitespace-pre-wrap"
+                      >
+                        {renderPreview.projectResourcesYaml}
+                      </pre>
+                    ) : (
+                      <p className="text-sm text-muted-foreground" data-testid="preview-project-resources-empty">
+                        No project resources rendered.
+                      </p>
+                    )}
+                  </div>
+                </>
+              )}
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@/queries/deployments', () => ({
   useListNamespaceSecrets: vi.fn(),
   useListNamespaceConfigMaps: vi.fn(),
   useGetDeploymentPolicyState: vi.fn(),
+  useGetDeploymentRenderPreview: vi.fn(),
 }))
 
 vi.mock('@/queries/projects', () => ({
@@ -43,7 +44,7 @@ vi.mock('@/queries/projects', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
-import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useUpdateDeployment, useDeleteDeployment, useListNamespaceSecrets, useListNamespaceConfigMaps, useGetDeploymentPolicyState } from '@/queries/deployments'
+import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useUpdateDeployment, useDeleteDeployment, useListNamespaceSecrets, useListNamespaceConfigMaps, useGetDeploymentPolicyState, useGetDeploymentRenderPreview } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { DeploymentPhase } from '@/gen/holos/console/v1/deployments_pb'
@@ -169,6 +170,7 @@ function setupMocks(userRole = Role.OWNER) {
   ;(useListNamespaceSecrets as Mock).mockReturnValue({ data: [], isLoading: false })
   ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
   ;(useGetDeploymentPolicyState as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
+  ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
 }
 
 describe('DeploymentDetailPage', () => {
@@ -1275,6 +1277,131 @@ describe('DeploymentDetailPage', () => {
       render(<DeploymentDetailPage />)
       const btn = screen.getByRole('button', { name: /reconcile policy drift/i })
       expect(btn).toBeDisabled()
+    })
+  })
+
+  // ── Preview tab tests (HOL-971) ─────────────────────────────────────────
+  //
+  // The Preview tab shows the rendered Kubernetes manifests from
+  // GetDeploymentRenderPreview. platformResourcesYaml surfaces resources
+  // contributed by organisation/folder-level templates via
+  // TemplatePolicyBinding. projectResourcesYaml surfaces the deployment
+  // template's own project resources.
+
+  describe('Preview tab', () => {
+    const mockRenderPreview = {
+      $typeName: 'holos.console.v1.GetDeploymentRenderPreviewResponse' as const,
+      cueTemplate: '// template',
+      cuePlatformInput: '// platform',
+      cueProjectInput: '// project',
+      renderedYaml: 'apiVersion: v1\nkind: Service',
+      renderedJson: '[]',
+      platformResourcesYaml: 'apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: platform-policy',
+      platformResourcesJson: '[]',
+      projectResourcesYaml: 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: api',
+      projectResourcesJson: '[]',
+      defaultsJson: '{}',
+    }
+
+    it('renders a Preview tab trigger', () => {
+      setupMocks()
+      render(<DeploymentDetailPage />)
+      expect(screen.getByRole('tab', { name: /preview/i })).toBeInTheDocument()
+    })
+
+    it('does not activate the Preview tab by default', () => {
+      setupMocks()
+      render(<DeploymentDetailPage />)
+      const previewTab = screen.getByRole('tab', { name: /preview/i })
+      expect(previewTab).toHaveAttribute('data-state', 'inactive')
+    })
+
+    it('activates the Preview tab when URL has ?tab=preview', () => {
+      mockUseSearch.mockReturnValue({ tab: 'preview' })
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: mockRenderPreview,
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      const previewTab = screen.getByRole('tab', { name: /preview/i })
+      expect(previewTab).toHaveAttribute('data-state', 'active')
+    })
+
+    it('renders platform resources YAML when preview data is available', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: mockRenderPreview,
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+      expect(screen.getByTestId('preview-platform-resources')).toBeInTheDocument()
+      expect(screen.getByText(/NetworkPolicy/)).toBeInTheDocument()
+    })
+
+    it('renders project resources YAML when preview data is available', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: mockRenderPreview,
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+      expect(screen.getByTestId('preview-project-resources')).toBeInTheDocument()
+      expect(screen.getByText(/kind: Deployment/)).toBeInTheDocument()
+    })
+
+    it('renders empty platform resources message when platformResourcesYaml is empty', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: { ...mockRenderPreview, platformResourcesYaml: '' },
+        isPending: false,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+      const emptyMsg = screen.getByTestId('preview-platform-resources-empty')
+      expect(emptyMsg).toBeInTheDocument()
+      expect(emptyMsg.textContent).toContain('TemplatePolicyBinding')
+    })
+
+    it('renders loading skeleton while preview is pending', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: undefined,
+        isPending: true,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+      expect(screen.getByTestId('preview-loading')).toBeInTheDocument()
+    })
+
+    it('renders error when preview fetch fails', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({
+        data: undefined,
+        isPending: false,
+        error: new Error('preview fetch failed'),
+      })
+      render(<DeploymentDetailPage />)
+      await user.click(screen.getByRole('tab', { name: /preview/i }))
+      expect(screen.getByText(/preview fetch failed/i)).toBeInTheDocument()
+    })
+
+    it('calls useGetDeploymentRenderPreview with project and deployment name', () => {
+      setupMocks()
+      render(<DeploymentDetailPage />)
+      expect(useGetDeploymentRenderPreview).toHaveBeenCalledWith('test-project', 'api')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Extends `ResourceGrid` v1 with URL-backed sort state (`sort` / `sortDir` search params) and a `sortableColumns` prop defaulting to `['createdAt']`; sorting state is deep-linkable via TanStack Router and the deployments index picks it up automatically via `parseGridSearch`
- Adds a **Preview tab** to the deployment detail page that calls `useGetDeploymentRenderPreview` and renders two sections: **Platform Resources** (contributed by organisation/folder-level templates via `TemplatePolicyBinding`) and **Project Resources** (the deployment template's own output), each with loading skeleton, error alert, and empty-state
- Adds 71 new test cases covering sort toggling, row ordering asc/desc, the Preview tab happy path, empty-state, loading skeleton, and error rendering

Fixes HOL-971

## Test plan

- [x] `make test-ui` passes — 1277 tests across 96 files
- [x] `ResourceGrid` Created At column renders a sortable toggle button by default
- [x] Clicking the sort button updates `?sort=createdAt&sortDir=asc` in the URL; a second click toggles to `desc`
- [x] Rows reorder correctly under ascending and descending sort
- [x] `sortableColumns=[]` renders the Created At header as plain text (no button)
- [x] Preview tab renders Platform Resources YAML and Project Resources YAML
- [x] Empty `platformResourcesYaml` shows "No platform resources" with `TemplatePolicyBinding` hint
- [x] Loading state shows skeleton; error state shows alert