### PR TITLE
refactor(template-policies-bindings): cross-resource invalidation for deployment previews

### DIFF
--- a/frontend/src/queries/-templatePolicyBindings.test.ts
+++ b/frontend/src/queries/-templatePolicyBindings.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for templatePolicyBindings query hooks (HOL-972).
+ *
+ * Covers:
+ *  - invalidateDeploymentPreviews helper — wildcard and specific-ref cases
+ *  - useCreateTemplatePolicyBinding — invalidates bindings list AND deployment previews
+ *  - useUpdateTemplatePolicyBinding — invalidates bindings list, get, AND deployment previews
+ */
+
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { create } from '@bufbuild/protobuf'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import {
+  TemplatePolicyBindingTargetRefSchema,
+  TemplatePolicyBindingTargetKind,
+} from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
+import {
+  LinkedTemplatePolicyRefSchema,
+} from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
+import { keys } from '@/queries/keys'
+import {
+  invalidateDeploymentPreviews,
+  useCreateTemplatePolicyBinding,
+  useUpdateTemplatePolicyBinding,
+} from '@/queries/templatePolicyBindings'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function makeTargetRef(
+  kind: TemplatePolicyBindingTargetKind,
+  projectName: string,
+  name: string,
+) {
+  return create(TemplatePolicyBindingTargetRefSchema, { kind, projectName, name })
+}
+
+function makePolicyRef(namespace: string, name: string) {
+  return create(LinkedTemplatePolicyRefSchema, { namespace, name })
+}
+
+// ---------------------------------------------------------------------------
+// invalidateDeploymentPreviews unit tests
+// ---------------------------------------------------------------------------
+
+describe('invalidateDeploymentPreviews', () => {
+  let queryClient: QueryClient
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('invalidates the full render-preview subtree when a wildcard projectName is present', () => {
+    const refs = [
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, '*', 'api'),
+    ]
+    invalidateDeploymentPreviews(queryClient, refs)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+
+  it('invalidates the full render-preview subtree when a wildcard name is present', () => {
+    const refs = [
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', '*'),
+    ]
+    invalidateDeploymentPreviews(queryClient, refs)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+
+  it('invalidates the full render-preview subtree when both fields are wildcards', () => {
+    const refs = [
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, '*', '*'),
+    ]
+    invalidateDeploymentPreviews(queryClient, refs)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+
+  it('invalidates the full render-preview subtree when targetRefs is empty', () => {
+    invalidateDeploymentPreviews(queryClient, [])
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+
+  it('invalidates a specific deployment preview for a DEPLOYMENT-kind ref', () => {
+    const refs = [
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', 'api'),
+    ]
+    invalidateDeploymentPreviews(queryClient, refs)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.renderPreview('proj-a', 'api'),
+    })
+    // Must NOT blow away the entire subtree.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+
+  it('invalidates per-project preview subtree for PROJECT_TEMPLATE-kind ref', () => {
+    const refs = [
+      makeTargetRef(TemplatePolicyBindingTargetKind.PROJECT_TEMPLATE, 'proj-a', 'web-app'),
+    ]
+    invalidateDeploymentPreviews(queryClient, refs)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview', 'proj-a'],
+    })
+  })
+
+  it('invalidates multiple specific deployment previews when multiple concrete refs present', () => {
+    const refs = [
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', 'api'),
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-b', 'worker'),
+    ]
+    invalidateDeploymentPreviews(queryClient, refs)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.renderPreview('proj-a', 'api'),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.renderPreview('proj-b', 'worker'),
+    })
+  })
+
+  it('falls back to full subtree invalidation when any ref in a mixed list has a wildcard', () => {
+    const refs = [
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', 'api'),
+      makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, '*', 'worker'),
+    ]
+    invalidateDeploymentPreviews(queryClient, refs)
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mutation hook invalidation tests
+// ---------------------------------------------------------------------------
+
+describe('useCreateTemplatePolicyBinding mutation invalidation', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      createTemplatePolicyBinding: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('invalidates the bindings list on successful create', async () => {
+    const NS = 'holos-org-test-org'
+    const { result } = renderHook(
+      () => useCreateTemplatePolicyBinding(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'bind-a',
+        displayName: 'Bind A',
+        description: '',
+        policyRef: makePolicyRef(NS, 'require-http'),
+        targetRefs: [
+          makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', 'api'),
+        ],
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templatePolicyBindings.list(NS),
+    })
+  })
+
+  it('invalidates the specific deployment preview on create with concrete DEPLOYMENT ref', async () => {
+    const NS = 'holos-org-test-org'
+    const { result } = renderHook(
+      () => useCreateTemplatePolicyBinding(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'bind-a',
+        displayName: 'Bind A',
+        description: '',
+        policyRef: makePolicyRef(NS, 'require-http'),
+        targetRefs: [
+          makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', 'api'),
+        ],
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.renderPreview('proj-a', 'api'),
+    })
+  })
+
+  it('invalidates the full render-preview subtree on create with a wildcard DEPLOYMENT ref', async () => {
+    const NS = 'holos-org-test-org'
+    const { result } = renderHook(
+      () => useCreateTemplatePolicyBinding(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'bind-wildcard',
+        displayName: 'Wildcard Bind',
+        description: '',
+        policyRef: makePolicyRef(NS, 'require-http'),
+        targetRefs: [
+          makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, '*', '*'),
+        ],
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+})
+
+describe('useUpdateTemplatePolicyBinding mutation invalidation', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      updateTemplatePolicyBinding: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('invalidates list and get keys after update', async () => {
+    const NS = 'holos-org-test-org'
+    const { result } = renderHook(
+      () => useUpdateTemplatePolicyBinding(NS, 'bind-a'),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        policyRef: makePolicyRef(NS, 'require-http'),
+        targetRefs: [
+          makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', 'api'),
+        ],
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templatePolicyBindings.list(NS),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templatePolicyBindings.get(NS, 'bind-a'),
+    })
+  })
+
+  it('invalidates deployment preview after update with specific DEPLOYMENT ref', async () => {
+    const NS = 'holos-org-test-org'
+    const { result } = renderHook(
+      () => useUpdateTemplatePolicyBinding(NS, 'bind-a'),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        policyRef: makePolicyRef(NS, 'require-http'),
+        targetRefs: [
+          makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, 'proj-a', 'api'),
+        ],
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.deployments.renderPreview('proj-a', 'api'),
+    })
+  })
+
+  it('invalidates full render-preview subtree after update with wildcard ref', async () => {
+    const NS = 'holos-org-test-org'
+    const { result } = renderHook(
+      () => useUpdateTemplatePolicyBinding(NS, 'bind-a'),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        policyRef: makePolicyRef(NS, 'require-http'),
+        targetRefs: [
+          makeTargetRef(TemplatePolicyBindingTargetKind.DEPLOYMENT, '*', '*'),
+        ],
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['deployments', 'render-preview'],
+    })
+  })
+})

--- a/frontend/src/queries/-templatePolicyBindings.test.ts
+++ b/frontend/src/queries/-templatePolicyBindings.test.ts
@@ -16,8 +16,6 @@ import type { Mock } from 'vitest'
 import {
   TemplatePolicyBindingTargetRefSchema,
   TemplatePolicyBindingTargetKind,
-} from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
-import {
   LinkedTemplatePolicyRefSchema,
 } from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
 import { keys } from '@/queries/keys'

--- a/frontend/src/queries/templatePolicyBindings.ts
+++ b/frontend/src/queries/templatePolicyBindings.ts
@@ -8,6 +8,7 @@ import {
   useQueries,
   useMutation,
   useQueryClient,
+  type QueryClient,
 } from '@tanstack/react-query'
 import {
   TemplatePolicyBindingService,
@@ -29,6 +30,67 @@ import {
   type FanOutAggregate,
   type FanOutQueryState,
 } from '@/queries/templatePolicies'
+
+// WILDCARD is the sentinel value that matches any resource name or project
+// within a binding's scope (mirrors policyresolver.WildcardAny on the server).
+const WILDCARD = '*'
+
+/**
+ * invalidateDeploymentPreviews is called after a binding mutation to ensure
+ * that the deployment render-preview cache reflects the new policy state
+ * immediately, without requiring a manual refetch on the Deployment detail page.
+ *
+ * Invalidation strategy:
+ *   - If any targetRef contains a wildcard in `projectName` or `name`,
+ *     invalidate the full `['deployments', 'render-preview']` subtree so
+ *     every cached preview is refreshed (a wildcard binding may match any
+ *     deployment in any project).
+ *   - Otherwise, for each DEPLOYMENT-kind targetRef with a concrete
+ *     (projectName, name) pair, invalidate the specific preview key.
+ *   - PROJECT_TEMPLATE and PROJECT_NAMESPACE targetRef kinds also affect
+ *     deployment previews via the policy chain, so they trigger the broad
+ *     subtree invalidation when a wildcard is involved, or the per-project
+ *     subtree when no wildcard is present.
+ *
+ * This satisfies the AC in HOL-972: navigating to a matching deployment
+ * after creating or editing a binding shows policy-contributed resources
+ * without a manual refetch.
+ */
+export function invalidateDeploymentPreviews(
+  queryClient: QueryClient,
+  targetRefs: TemplatePolicyBindingTargetRef[],
+): void {
+  // Check for any wildcard — if present, blow away the whole preview subtree.
+  const hasWildcard = targetRefs.some(
+    (ref) => ref.projectName === WILDCARD || ref.name === WILDCARD,
+  )
+  if (hasWildcard || targetRefs.length === 0) {
+    // Invalidate all render-preview entries.
+    queryClient.invalidateQueries({
+      queryKey: ['deployments', 'render-preview'],
+    })
+    return
+  }
+
+  // Specific refs: invalidate each targeted deployment preview individually.
+  for (const ref of targetRefs) {
+    if (
+      ref.kind === TemplatePolicyBindingTargetKind.DEPLOYMENT &&
+      ref.projectName &&
+      ref.name
+    ) {
+      queryClient.invalidateQueries({
+        queryKey: keys.deployments.renderPreview(ref.projectName, ref.name),
+      })
+    } else if (ref.projectName) {
+      // PROJECT_TEMPLATE and PROJECT_NAMESPACE kinds affect all deployments
+      // in the project — invalidate the per-project render-preview subtree.
+      queryClient.invalidateQueries({
+        queryKey: ['deployments', 'render-preview', ref.projectName],
+      })
+    }
+  }
+}
 
 // Re-export generated types/enums used by UI consumers.
 export type { TemplatePolicyBinding, TemplatePolicyBindingTargetRef, LinkedTemplatePolicyRef }
@@ -181,8 +243,9 @@ export function useCreateTemplatePolicyBinding(namespace: string) {
         }),
       })
     },
-    onSuccess: () => {
+    onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: keys.templatePolicyBindings.list(namespace) })
+      invalidateDeploymentPreviews(queryClient, params.targetRefs)
     },
   })
 }
@@ -217,9 +280,10 @@ export function useUpdateTemplatePolicyBinding(
         }),
       })
     },
-    onSuccess: () => {
+    onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: keys.templatePolicyBindings.list(namespace) })
       queryClient.invalidateQueries({ queryKey: keys.templatePolicyBindings.get(namespace, name) })
+      invalidateDeploymentPreviews(queryClient, params.targetRefs)
     },
   })
 }


### PR DESCRIPTION
## Summary

- Adds `invalidateDeploymentPreviews()` to `templatePolicyBindings.ts` with a wildcard-aware strategy: wildcard `targetRefs` invalidate the full `['deployments', 'render-preview']` subtree; specific `DEPLOYMENT`-kind refs invalidate the exact preview key; `PROJECT_TEMPLATE` refs invalidate the per-project subtree.
- Wires the helper into `useCreateTemplatePolicyBinding` and `useUpdateTemplatePolicyBinding` `onSuccess` callbacks so the deployment render-preview cache is immediately invalidated after each binding mutation.
- Adds `frontend/src/queries/-templatePolicyBindings.test.ts` with 14 focused tests covering the invalidation helper and both mutation hooks.

Fixes HOL-972

## Test plan

- [ ] Run `make test-ui` — all 1291 tests pass (97 test files)
- [ ] Create a new `TemplatePolicyBinding` targeting a known deployment; navigate to that deployment's detail page and verify the Preview tab shows policy-contributed resources without manual refetch
- [ ] Edit an existing binding with a wildcard `projectName: "*"`; verify the preview cache is refreshed for all deployments
- [ ] Existing tests for `OrgTemplatePoliciesIndexPage`, `OrgTemplateBindingsIndexPage`, and detail pages continue to pass