### PR TITLE
feat(templates/examples): runnable examples for all three ADR 032 dependency scopes

### DIFF
--- a/console/templates/examples/all-scopes-v1.cue
+++ b/console/templates/examples/all-scopes-v1.cue
@@ -1,0 +1,231 @@
+// All three dependency scopes — project-level deployment template (ADR 032).
+// Composite example: a single template that exercises instance (Scope A),
+// project (Scope B), and remote-project (Scope C) dependency scopes from
+// ADR 032. The template deploys a minimal web application with an in-process
+// cache (Scope A), relies on a platform-mandated ConfigMap (Scope B), and
+// is exposed via a gateway-namespace HTTPRoute (Scope C).
+//
+// === Scope A — Deployment-Instance (TemplateDependency, same-namespace) ===
+//
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateDependency
+//   metadata:
+//     name: myapp-requires-valkey
+//     namespace: prj-my-project          # same as dependent
+//   spec:
+//     dependent:
+//       namespace: prj-my-project
+//       name: all-scopes                 # this template
+//     requires:
+//       namespace: prj-my-project        # same namespace → no TemplateGrant needed
+//       name: valkey
+//     cascadeDelete: true
+//
+// === Scope B — Project-Wide Mandate (TemplateRequirement, folder namespace) ===
+//
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateRequirement
+//   metadata:
+//     name: require-platform-config
+//     namespace: holos-folder-platform   # folder namespace (not a project namespace)
+//   spec:
+//     requires:
+//       namespace: prj-shared-infra
+//       name: shared-configmap
+//     targetRefs:
+//       - kind: Deployment
+//         name: "*"
+//         projectName: "*"
+//     cascadeDelete: true
+//
+// === Scope C — Remote-Project (TemplateDependency, cross-namespace) ===
+//
+//   # TemplateGrant in the gateway namespace authorises cross-namespace references.
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateGrant
+//   metadata:
+//     name: allow-projects
+//     namespace: prj-gateway-platform
+//   spec:
+//     from:
+//       - namespace: "*"
+//
+//   # TemplateDependency in the project namespace references the gateway template.
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateDependency
+//   metadata:
+//     name: myapp-requires-httproute
+//     namespace: prj-my-project
+//   spec:
+//     dependent:
+//       namespace: prj-my-project
+//       name: all-scopes
+//     requires:
+//       namespace: prj-gateway-platform   # different namespace → Scope C
+//       name: httproute-with-grant
+//     cascadeDelete: false
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "All Three Dependency Scopes (v1)"
+name:        "all-scopes-v1"
+description: "Composite example exercising Scope A (instance TemplateDependency), Scope B (project TemplateRequirement), and Scope C (remote-project TemplateDependency + TemplateGrant) from ADR 032. Deploys a ServiceAccount, Deployment, and Service; see template comments for the companion CRD objects."
+
+cueTemplate: """
+	// defaults declares the template's default values as concrete CUE data.
+	// The backend reads this block (via ExtractDefaults) to pre-fill the Create
+	// Deployment form. See ADR 027 for the authoritative pre-fill behavior.
+	defaults: #ProjectInput & {
+		name:        "all-scopes"
+		image:       "nginx"
+		tag:         "1.27-alpine"
+		port:        8080
+		description: "Composite demo: instance + project + remote-project dependency scopes."
+	}
+
+	// Use generated type definitions from api/v1alpha2 (prepended by renderer).
+	input: #ProjectInput & {
+		name:  *defaults.name | (string & =~"^[a-z][a-z0-9-]*$") // DNS label
+		image: *defaults.image | _
+		tag:   *defaults.tag | _
+		port:  *defaults.port | (>0 & <=65535)
+	}
+	platform: #PlatformInput
+
+	// _labels are the standard labels required on every resource.
+	// app.kubernetes.io/managed-by MUST equal "console.holos.run" or the
+	// render will be rejected.
+	_labels: {
+		"app.kubernetes.io/name":       input.name
+		"app.kubernetes.io/managed-by": "console.holos.run"
+	}
+
+	// _annotations are standard annotations applied to every resource.
+	_annotations: {
+		"console.holos.run/deployer-email": platform.claims.email
+	}
+
+	// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+	#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name:      Name
+			namespace: Namespace
+			...
+		}
+		...
+	}
+
+	// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+	#Cluster: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name: Name
+			...
+		}
+		...
+	}
+
+	// projectResources contains the Kubernetes resources rendered by this template.
+	//
+	// Scope A (instance): a TemplateDependency declares that this template
+	//   requires the valkey-v1 template as a same-namespace singleton.
+	//   The Valkey Service DNS name consumed: valkey.<platform.namespace>:6379.
+	//
+	// Scope B (project): a TemplateRequirement in a folder namespace mandates
+	//   that a shared-configmap-v1 singleton is present in every project
+	//   namespace before this template renders. The ConfigMap is mounted or
+	//   referenced by the application at runtime.
+	//
+	// Scope C (remote-project): a TemplateDependency in this project namespace
+	//   references httproute-with-grant-v1 in the gateway platform namespace.
+	//   A TemplateGrant in that namespace authorises the cross-namespace ref.
+	projectResources: {
+		namespacedResources: #Namespaced & {
+			(platform.namespace): {
+				// ServiceAccount provides a Kubernetes identity for the application pods.
+				ServiceAccount: (input.name): {
+					apiVersion: "v1"
+					kind:       "ServiceAccount"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+				}
+
+				// Deployment runs the application. In production, this deployment would
+				// have VALKEY_ADDR injected from the Scope A singleton Service and
+				// platform config loaded from the Scope B ConfigMap singleton.
+				Deployment: (input.name): {
+					apiVersion: "apps/v1"
+					kind:       "Deployment"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						replicas: 1
+						selector: matchLabels: "app.kubernetes.io/name": input.name
+						template: {
+							metadata: labels: _labels
+							spec: {
+								serviceAccountName: input.name
+								containers: [{
+									name:  input.name
+									image: input.image + ":" + input.tag
+									ports: [{containerPort: input.port, name: "http"}]
+									env: [
+										// Scope A: valkey singleton Service DNS name.
+										// Use string concatenation (not interpolation) so the template
+										// compiles cleanly in both the outer CUE file and the renderer.
+										{
+											name:  "VALKEY_ADDR"
+											value: "valkey." + platform.namespace + ".svc.cluster.local:6379"
+										},
+										// Scope B: platform-config ConfigMap key reference.
+										{
+											name: "PLATFORM_ORGANIZATION"
+											valueFrom: configMapKeyRef: {
+												name:     "platform-config"
+												key:      "organization"
+												optional: true
+											}
+										},
+									]
+								}]
+							}
+						}
+					}
+				}
+
+				// Service exposes the application on port 80 → container port.
+				// The Scope C HTTPRoute in the gateway namespace routes external
+				// traffic here via a cross-namespace backendRef.
+				Service: (input.name): {
+					apiVersion: "v1"
+					kind:       "Service"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						selector: "app.kubernetes.io/name": input.name
+						ports: [{port: 80, targetPort: "http", name: "http"}]
+					}
+				}
+			}
+		}
+
+		// clusterResources organizes cluster-scoped resources (none for this template).
+		clusterResources: #Cluster & {}
+	}
+	"""

--- a/console/templates/examples/examples_test.go
+++ b/console/templates/examples/examples_test.go
@@ -22,8 +22,8 @@ func TestExamples(t *testing.T) {
 		t.Fatalf("Examples() error: %v", err)
 	}
 
-	// There must be exactly six examples.
-	if got, want := len(list), 6; got != want {
+	// There must be exactly ten examples.
+	if got, want := len(list), 10; got != want {
 		t.Fatalf("Examples() returned %d examples, want %d", got, want)
 	}
 
@@ -40,6 +40,11 @@ func TestExamples(t *testing.T) {
 		"project-namespace-reference-grant-v1",
 		"httpbin-v1",
 		"podinfo-v1",
+		// ADR 032 scope examples (HOL-983).
+		"valkey-v1",
+		"shared-configmap-v1",
+		"httproute-with-grant-v1",
+		"all-scopes-v1",
 	}
 	for _, name := range wantNames {
 		ex, ok := byName[name]
@@ -129,7 +134,9 @@ func buildPreviewProjectInput() string {
 // concrete objects, so they are excluded from the non-empty output assertion.
 func exampleResourcesEmitted(name string) bool {
 	switch name {
-	case "httproute-v1", "httpbin-v1", "podinfo-v1":
+	case "httproute-v1", "httpbin-v1", "podinfo-v1",
+		// ADR 032 scope examples (HOL-983): all produce concrete K8s resources.
+		"valkey-v1", "shared-configmap-v1", "httproute-with-grant-v1", "all-scopes-v1":
 		return true
 	default:
 		// Policy-only examples produce no concrete K8s resources but must still
@@ -313,4 +320,160 @@ func TestExamplePreviewRender_KnownExamples(t *testing.T) {
 			}
 		})
 	}
+
+	// ADR 032 scope examples (HOL-983): regression guards for each new scope example.
+
+	t.Run("valkey-v1", func(t *testing.T) {
+		// Scope A (instance): Valkey cache — same-namespace TemplateDependency.
+		ex, ok := byName["valkey-v1"]
+		if !ok {
+			t.Fatal("valkey-v1 example not found in registry")
+		}
+		grouped, err := adapter.RenderGrouped(
+			context.Background(),
+			ex.CueTemplate,
+			cuePlatformInput,
+			cueProjectInput,
+		)
+		if err != nil {
+			t.Fatalf("valkey-v1: RenderGrouped failed: %v", err)
+		}
+		var projectYAML strings.Builder
+		for _, r := range grouped.Project {
+			projectYAML.WriteString(r.YAML)
+		}
+		yaml := projectYAML.String()
+		if yaml == "" {
+			t.Error("valkey-v1: expected non-empty project_resources_yaml")
+		}
+		for _, kind := range []string{"kind: ServiceAccount", "kind: Deployment", "kind: Service"} {
+			if !strings.Contains(yaml, kind) {
+				t.Errorf("valkey-v1: project_resources_yaml must contain %q, got:\n%s", kind, yaml)
+			}
+		}
+		// Valkey Service must use the "valkey" named port (port number may be
+		// overridden by the preview project input seed, so check the name).
+		if !strings.Contains(yaml, "name: valkey") {
+			t.Errorf("valkey-v1: project_resources_yaml must use named port 'valkey', got:\n%s", yaml)
+		}
+		if len(grouped.Platform) > 0 {
+			t.Errorf("valkey-v1: expected empty platform resources, got %d", len(grouped.Platform))
+		}
+	})
+
+	t.Run("shared-configmap-v1", func(t *testing.T) {
+		// Scope B (project): shared ConfigMap mandated by TemplateRequirement.
+		ex, ok := byName["shared-configmap-v1"]
+		if !ok {
+			t.Fatal("shared-configmap-v1 example not found in registry")
+		}
+		grouped, err := adapter.RenderGrouped(
+			context.Background(),
+			ex.CueTemplate,
+			cuePlatformInput,
+			cueProjectInput,
+		)
+		if err != nil {
+			t.Fatalf("shared-configmap-v1: RenderGrouped failed: %v", err)
+		}
+		var projectYAML strings.Builder
+		for _, r := range grouped.Project {
+			projectYAML.WriteString(r.YAML)
+		}
+		yaml := projectYAML.String()
+		if yaml == "" {
+			t.Error("shared-configmap-v1: expected non-empty project_resources_yaml")
+		}
+		if !strings.Contains(yaml, "kind: ConfigMap") {
+			t.Errorf("shared-configmap-v1: project_resources_yaml must contain 'kind: ConfigMap', got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "apiVersion: v1") {
+			t.Errorf("shared-configmap-v1: project_resources_yaml must contain 'apiVersion: v1', got:\n%s", yaml)
+		}
+		// ConfigMap data must reference the gateway namespace (platform input).
+		if !strings.Contains(yaml, deployments.DefaultGatewayNamespace) {
+			t.Errorf("shared-configmap-v1: project_resources_yaml must reference gatewayNamespace %q, got:\n%s",
+				deployments.DefaultGatewayNamespace, yaml)
+		}
+	})
+
+	t.Run("httproute-with-grant-v1", func(t *testing.T) {
+		// Scope C (remote-project): HTTPRoute in gateway namespace with TemplateGrant wiring.
+		ex, ok := byName["httproute-with-grant-v1"]
+		if !ok {
+			t.Fatal("httproute-with-grant-v1 example not found in registry")
+		}
+		grouped, err := adapter.RenderGrouped(
+			context.Background(),
+			ex.CueTemplate,
+			cuePlatformInput,
+			cueProjectInput,
+		)
+		if err != nil {
+			t.Fatalf("httproute-with-grant-v1: RenderGrouped failed: %v", err)
+		}
+		var platformYAML strings.Builder
+		for _, r := range grouped.Platform {
+			platformYAML.WriteString(r.YAML)
+		}
+		yaml := platformYAML.String()
+		if yaml == "" {
+			t.Error("httproute-with-grant-v1: expected non-empty platform_resources_yaml")
+		}
+		if !strings.Contains(yaml, "kind: HTTPRoute") {
+			t.Errorf("httproute-with-grant-v1: platform_resources_yaml must contain 'kind: HTTPRoute', got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, "apiVersion: gateway.networking.k8s.io/v1") {
+			t.Errorf("httproute-with-grant-v1: must use apiVersion 'gateway.networking.k8s.io/v1', got:\n%s", yaml)
+		}
+		if !strings.Contains(yaml, deployments.DefaultGatewayNamespace) {
+			t.Errorf("httproute-with-grant-v1: must reference gatewayNamespace %q, got:\n%s",
+				deployments.DefaultGatewayNamespace, yaml)
+		}
+		// Scope C annotation must be present to document the dependency scope.
+		if !strings.Contains(yaml, "remote-project") {
+			t.Errorf("httproute-with-grant-v1: must annotate dependency-scope 'remote-project', got:\n%s", yaml)
+		}
+		if grouped.Project != nil && len(grouped.Project) > 0 {
+			t.Errorf("httproute-with-grant-v1: expected empty project resources for platform-only template, got %d", len(grouped.Project))
+		}
+	})
+
+	t.Run("all-scopes-v1", func(t *testing.T) {
+		// All three scopes: composite example exercising A + B + C.
+		ex, ok := byName["all-scopes-v1"]
+		if !ok {
+			t.Fatal("all-scopes-v1 example not found in registry")
+		}
+		grouped, err := adapter.RenderGrouped(
+			context.Background(),
+			ex.CueTemplate,
+			cuePlatformInput,
+			cueProjectInput,
+		)
+		if err != nil {
+			t.Fatalf("all-scopes-v1: RenderGrouped failed: %v", err)
+		}
+		var projectYAML strings.Builder
+		for _, r := range grouped.Project {
+			projectYAML.WriteString(r.YAML)
+		}
+		yaml := projectYAML.String()
+		if yaml == "" {
+			t.Error("all-scopes-v1: expected non-empty project_resources_yaml")
+		}
+		for _, kind := range []string{"kind: ServiceAccount", "kind: Deployment", "kind: Service"} {
+			if !strings.Contains(yaml, kind) {
+				t.Errorf("all-scopes-v1: project_resources_yaml must contain %q, got:\n%s", kind, yaml)
+			}
+		}
+		// Scope A: Valkey address must appear in the Deployment env.
+		if !strings.Contains(yaml, "VALKEY_ADDR") {
+			t.Errorf("all-scopes-v1: project_resources_yaml must contain VALKEY_ADDR env var (Scope A), got:\n%s", yaml)
+		}
+		// Scope B: shared ConfigMap key reference must appear.
+		if !strings.Contains(yaml, "platform-config") {
+			t.Errorf("all-scopes-v1: project_resources_yaml must reference platform-config ConfigMap (Scope B), got:\n%s", yaml)
+		}
+	})
 }

--- a/console/templates/examples/httproute-with-grant-v1.cue
+++ b/console/templates/examples/httproute-with-grant-v1.cue
@@ -1,7 +1,8 @@
 // HTTPRoute with TemplateGrant — folder-level platform template (Scope C: remote-project).
-// Emits an HTTPRoute in the org-configured ingress gateway namespace and a
-// TemplateGrant that authorises project namespaces to declare cross-namespace
-// dependencies on this gateway template.
+// Emits an HTTPRoute in the org-configured ingress gateway namespace.
+// A companion TemplateGrant (shown in the comments below) must be created in the
+// gateway platform namespace to authorise project namespaces to declare cross-namespace
+// TemplateDependency objects referencing this template.
 //
 // Demonstrates Scope C (remote-project scope) from ADR 032: a TemplateDependency
 // in a project namespace references a template owned by a different namespace

--- a/console/templates/examples/httproute-with-grant-v1.cue
+++ b/console/templates/examples/httproute-with-grant-v1.cue
@@ -1,0 +1,100 @@
+// HTTPRoute with TemplateGrant — folder-level platform template (Scope C: remote-project).
+// Emits an HTTPRoute in the org-configured ingress gateway namespace and a
+// TemplateGrant that authorises project namespaces to declare cross-namespace
+// dependencies on this gateway template.
+//
+// Demonstrates Scope C (remote-project scope) from ADR 032: a TemplateDependency
+// in a project namespace references a template owned by a different namespace
+// (the gateway platform namespace). The TemplateGrant in the gateway namespace
+// authorises the cross-namespace reference.
+//
+// Dependency wiring (TemplateGrant + TemplateDependency — Scope C from ADR 032):
+//
+//   # Step 1: TemplateGrant in the gateway/platform namespace authorises project namespaces.
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateGrant
+//   metadata:
+//     name: allow-project-namespaces
+//     namespace: prj-gateway-platform      # namespace that owns the gateway template
+//   spec:
+//     from:
+//       - namespace: "*"                   # allow any project namespace to reference
+//
+//   # Step 2: TemplateDependency in the app's project namespace (Scope C).
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateDependency
+//   metadata:
+//     name: my-app-requires-httproute
+//     namespace: prj-my-project
+//   spec:
+//     dependent:
+//       namespace: prj-my-project
+//       name: my-app
+//     requires:
+//       namespace: prj-gateway-platform    # different namespace → Scope C
+//       name: httproute-with-grant
+//     cascadeDelete: false                 # gateway lifecycle is decoupled from app
+//
+// Because requires.namespace != dependent.namespace this is Scope C (remote-project).
+// The TemplateGrant in prj-gateway-platform is mandatory; without it the
+// TemplateDependency reconciler sets ResolvedRefs=False/GrantNotFound.
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "HTTPRoute with TemplateGrant (v1)"
+name:        "httproute-with-grant-v1"
+description: "Exposes project services via an HTTPRoute in the org gateway namespace. Demonstrates Scope C (remote-project) from ADR 032: the TemplateGrant in the platform namespace authorises project TemplateDependency objects to declare a cross-namespace dependency on this template."
+
+cueTemplate: """
+	// input and platform are available because platform templates are unified with
+	// the deployment template before evaluation (ADR 016 Decision 8).
+	input: #ProjectInput & {
+		port: >0 & <=65535 | *8080
+	}
+	platform: #PlatformInput
+
+	// platformResources holds resources the platform team manages. The renderer
+	// reads these only from organization/folder-level templates — project templates
+	// that define platformResources are silently ignored (ADR 016 Decision 8).
+	platformResources: {
+		namespacedResources: (platform.gatewayNamespace): {
+			// HTTPRoute routes traffic from the gateway to the project Service on port 80.
+			// Lives in the gateway namespace (Scope C: remote-project dependency wiring).
+			HTTPRoute: (input.name): {
+				apiVersion: "gateway.networking.k8s.io/v1"
+				kind:       "HTTPRoute"
+				metadata: {
+					name:      input.name
+					namespace: platform.gatewayNamespace
+					labels: {
+						"app.kubernetes.io/managed-by": "console.holos.run"
+						"app.kubernetes.io/name":       input.name
+					}
+					// ADR 032 annotation: records the scope for observability.
+					annotations: {
+						"console.holos.run/dependency-scope": "remote-project"
+					}
+				}
+				spec: {
+					parentRefs: [{
+						group:     "gateway.networking.k8s.io"
+						kind:      "Gateway"
+						namespace: platform.gatewayNamespace
+						name:      "default"
+					}]
+					rules: [{
+						backendRefs: [{
+							name:      input.name
+							namespace: platform.namespace
+							port:      80
+						}]
+					}]
+				}
+			}
+		}
+		clusterResources: {}
+	}
+	"""

--- a/console/templates/examples/shared-configmap-v1.cue
+++ b/console/templates/examples/shared-configmap-v1.cue
@@ -1,0 +1,130 @@
+// Shared ConfigMap — project-level deployment template (Scope B: project dependency).
+// Produces a ConfigMap containing shared platform configuration consumed by
+// all deployments in the project namespace.
+//
+// Demonstrates Scope B (project scope) from ADR 032: a TemplateRequirement
+// stored in a folder or org namespace mandates that all matching deployments
+// in every reachable project have this singleton deployed first.
+//
+// Dependency wiring (TemplateRequirement — Scope B from ADR 032):
+//
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateRequirement
+//   metadata:
+//     name: all-projects-require-platform-config
+//     namespace: holos-folder-platform     # folder namespace (not a project namespace)
+//   spec:
+//     requires:
+//       namespace: prj-shared-infra        # project namespace that owns the template
+//       name: shared-configmap
+//     targetRefs:
+//       - kind: Deployment
+//         name: "*"           # all deployments
+//         projectName: "*"    # all projects reachable from holos-folder-platform
+//     cascadeDelete: true
+//
+// The TemplateRequirement must live in a folder or org namespace — it is
+// silently ignored (and rejected by admission policy) when stored in a project
+// namespace. Each matched deployment gets a singleton of this template in its
+// project namespace (ADR 032 Decision 1 Scope B).
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "Shared Platform ConfigMap (v1)"
+name:        "shared-configmap-v1"
+description: "Emits a shared ConfigMap with platform-wide configuration for all deployments in the project namespace. Demonstrates Scope B (project-wide mandate) from ADR 032: a TemplateRequirement in a folder namespace mandates a singleton of this template in every matching project."
+
+cueTemplate: """
+	// defaults declares the template's default values as concrete CUE data.
+	// The backend reads this block (via ExtractDefaults) to pre-fill the Create
+	// Deployment form. See ADR 027 for the authoritative pre-fill behavior.
+	defaults: #ProjectInput & {
+		name:        "platform-config"
+		description: "Shared platform configuration for all deployments."
+	}
+
+	// Use generated type definitions from api/v1alpha2 (prepended by renderer).
+	input: #ProjectInput & {
+		name: *defaults.name | (string & =~"^[a-z][a-z0-9-]*$") // DNS label
+	}
+	platform: #PlatformInput
+
+	// _labels are the standard labels required on every resource.
+	// app.kubernetes.io/managed-by MUST equal "console.holos.run" or the
+	// render will be rejected.
+	_labels: {
+		"app.kubernetes.io/name":       input.name
+		"app.kubernetes.io/managed-by": "console.holos.run"
+	}
+
+	// _annotations are standard annotations applied to every resource.
+	_annotations: {
+		"console.holos.run/deployer-email": platform.claims.email
+	}
+
+	// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+	#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name:      Name
+			namespace: Namespace
+			...
+		}
+		...
+	}
+
+	// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+	#Cluster: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name: Name
+			...
+		}
+		...
+	}
+
+	// projectResources collects all rendered Kubernetes resources.
+	// This is a Scope B (project-wide) dependency: the ConfigMap is placed in
+	// each project namespace by the singleton materialisation triggered by
+	// the TemplateRequirement in the folder namespace.
+	//
+	// ADR 032 Dependency Wiring (Scope B — project):
+	//   A TemplateRequirement in a folder namespace mandates that every
+	//   Deployment matching its targetRefs has a singleton of this template
+	//   deployed in the same project namespace. No per-project TemplateDependency
+	//   is needed — the TemplateRequirement is the single source of truth.
+	projectResources: {
+		namespacedResources: #Namespaced & {
+			(platform.namespace): {
+				// ConfigMap carries shared platform-wide configuration values.
+				// All deployments in the namespace can mount or reference this ConfigMap.
+				ConfigMap: (input.name): {
+					apiVersion: "v1"
+					kind:       "ConfigMap"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					data: {
+						// organization is the logical grouping name for this deployment.
+						organization: platform.organization
+						// project is the platform project name for label/annotation use.
+						project: platform.project
+						// namespace is the Kubernetes namespace for cross-resource references.
+						namespace: platform.namespace
+						// gatewayNamespace is the ingress gateway namespace for HTTPRoute wiring.
+						gatewayNamespace: platform.gatewayNamespace
+					}
+				}
+			}
+		}
+
+		// clusterResources organizes cluster-scoped resources (none for this template).
+		clusterResources: #Cluster & {}
+	}
+	"""

--- a/console/templates/examples/testdata/docs-snippets/cross-project-constraint/cross-project-constraint.cue
+++ b/console/templates/examples/testdata/docs-snippets/cross-project-constraint/cross-project-constraint.cue
@@ -1,0 +1,105 @@
+// Cross-project constraint — Project A constrains Project B (Scope B: project mandate).
+//
+// This demo snippet demonstrates ADR 032 Scope B: a TemplateRequirement in
+// project-a's folder namespace mandates that all deployments in project-b
+// (and all other projects in the same folder) require a singleton of the
+// "shared-configmap" template before they can render.
+//
+// The template itself is a simple project-level template that emits a
+// ConfigMap with shared configuration. The cross-project constraint is
+// expressed via the companion CRDs shown in the comments below.
+//
+// === Scope B CRD wiring: Project A constrains Project B ===
+//
+// Assuming:
+//   - project-a is in folder "platform-team-folder" (namespace: holos-folder-platform)
+//   - project-b is a sibling project under the same folder
+//   - shared-configmap template lives in project-a's namespace: prj-project-a
+//
+// Step 1: TemplateGrant in project-a's namespace authorises project-b to
+//         declare a cross-namespace dependency (Scope C enabled):
+//
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateGrant
+//   metadata:
+//     name: allow-sibling-projects
+//     namespace: prj-project-a
+//   spec:
+//     from:
+//       - namespace: "*"    # permit all sibling project namespaces
+//
+// Step 2: TemplateRequirement in the shared folder namespace mandates
+//         that all projects in the folder have the shared-configmap singleton
+//         (Scope B: project-wide mandate from the platform team):
+//
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateRequirement
+//   metadata:
+//     name: all-projects-require-platform-config
+//     namespace: holos-folder-platform    # folder namespace (not a project namespace)
+//   spec:
+//     requires:
+//       namespace: prj-project-a          # project-a owns the required template
+//       name: shared-configmap            # the template project-b must have
+//     targetRefs:
+//       - kind: Deployment
+//         name: "*"           # all deployments
+//         projectName: "*"    # all projects reachable via ancestor walk
+//     cascadeDelete: true
+//
+// This is a textbook "Project A constrains Project B" pattern from ADR 032:
+//   - The TemplateRequirement is owned by the platform team in the folder namespace.
+//   - The required template lives in project-a (owned by the platform team).
+//   - Project-b's deployments are mandated to have the singleton without any
+//     action by project-b's service owner — the mandate is authoritative.
+//
+// Note: This file is a CUE template body (not a registry example). It is
+// stored in holos-console-docs/demo/ as demo walkthrough material and mirrored
+// as a testdata/docs-snippets/ sync copy in holos-console. Both must compile
+// against the v1alpha2 generated schema (enforced by docs_sync_test.go).
+
+// platform is available because platform templates are unified with the
+// deployment template before evaluation (ADR 016 Decision 8).
+platform: #PlatformInput
+
+// projectResources emits the shared ConfigMap.
+// In Scope B, this template is instantiated as a singleton in every project
+// namespace matched by the TemplateRequirement's targetRefs.
+projectResources: {
+	namespacedResources: {
+		(platform.namespace): {
+			// ConfigMap carries shared platform-wide configuration values.
+			// Deployed as a singleton in every project namespace that the
+			// TemplateRequirement targets.
+			ConfigMap: "platform-config": {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: {
+					name:      "platform-config"
+					namespace: platform.namespace
+					labels: {
+						"app.kubernetes.io/managed-by": "console.holos.run"
+						"app.kubernetes.io/name":       "platform-config"
+					}
+					annotations: {
+						// Records the ADR scope for observability.
+						"console.holos.run/dependency-scope": "project"
+						// Records which project mandated this singleton.
+						"console.holos.run/required-by": "all-projects-require-platform-config"
+					}
+				}
+				data: {
+					// organization is the logical grouping name for this deployment.
+					organization: platform.organization
+					// project is the platform project name.
+					project: platform.project
+					// namespace is the Kubernetes namespace.
+					namespace: platform.namespace
+					// gatewayNamespace is the ingress gateway namespace.
+					gatewayNamespace: platform.gatewayNamespace
+				}
+			}
+		}
+	}
+	clusterResources: {}
+}

--- a/console/templates/examples/valkey-v1.cue
+++ b/console/templates/examples/valkey-v1.cue
@@ -1,0 +1,171 @@
+// Valkey cache — project-level deployment template (Scope A: instance dependency).
+// Produces a Valkey in-cluster cache: ServiceAccount, Deployment, and Service.
+// Demonstrates Scope A (deployment-instance scope) from ADR 032: the cache is
+// a per-deployment dependency declared by a TemplateDependency in the project
+// namespace so every app that needs Valkey declares its own singleton copy.
+//
+// Dependency wiring (TemplateDependency — Scope A from ADR 032):
+//
+//   apiVersion: templates.holos.run/v1alpha1
+//   kind: TemplateDependency
+//   metadata:
+//     name: my-app-requires-valkey
+//     namespace: prj-my-project          # same as dependent
+//   spec:
+//     dependent:
+//       namespace: prj-my-project
+//       name: my-app
+//     requires:
+//       namespace: prj-my-project        # same namespace → no TemplateGrant needed
+//       name: valkey
+//     cascadeDelete: true
+//
+// No TemplateGrant is required because requires.namespace == dependent.namespace
+// (same-namespace reference, ADR 032 Decision 1 Scope A).
+//
+// The top-level fields (displayName, name, description, cueTemplate) are the
+// registry metadata. The cueTemplate field contains the full CUE template body
+// as a multi-line string so the outer file is valid CUE while the body can
+// freely reference #PlatformInput, #ProjectInput, etc.
+
+displayName: "Valkey Cache (v1)"
+name:        "valkey-v1"
+description: "Deploys a Valkey in-cluster cache (ServiceAccount, Deployment, Service). Demonstrates Scope A (instance) from ADR 032: a per-deployment dependency declared via TemplateDependency in the project namespace."
+
+cueTemplate: """
+	// defaults declares the template's default values as concrete CUE data.
+	// The backend reads this block (via ExtractDefaults) to pre-fill the Create
+	// Deployment form. See ADR 027 for the authoritative pre-fill behavior.
+	defaults: #ProjectInput & {
+		name:        "valkey"
+		image:       "valkey/valkey"
+		tag:         "8.1-alpine"
+		port:        6379
+		description: "Valkey in-cluster cache (Redis-compatible)."
+	}
+
+	// Use generated type definitions from api/v1alpha2 (prepended by renderer).
+	// Additional CUE constraints narrow the generated types for this template.
+	input: #ProjectInput & {
+		name:  *defaults.name | (string & =~"^[a-z][a-z0-9-]*$") // DNS label
+		image: *defaults.image | _
+		tag:   *defaults.tag | _
+		port:  *defaults.port | (>0 & <=65535)
+	}
+	platform: #PlatformInput
+
+	// _labels are the standard labels required on every resource.
+	// app.kubernetes.io/managed-by MUST equal "console.holos.run" or the
+	// render will be rejected.
+	_labels: {
+		"app.kubernetes.io/name":       input.name
+		"app.kubernetes.io/managed-by": "console.holos.run"
+	}
+
+	// _annotations are standard annotations applied to every resource.
+	// console.holos.run/deployer-email records the identity of the user
+	// who last rendered and applied this resource.
+	_annotations: {
+		"console.holos.run/deployer-email": platform.claims.email
+	}
+
+	// #Namespaced constrains namespaced resource struct keys to match resource metadata.
+	// Structure: namespaced.<namespace>.<Kind>.<name>
+	// The struct path keys must match the corresponding resource metadata fields.
+	#Namespaced: [Namespace=string]: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name:      Name
+			namespace: Namespace
+			...
+		}
+		...
+	}
+
+	// #Cluster constrains cluster-scoped resource struct keys to match resource metadata.
+	// Structure: cluster.<Kind>.<name>
+	// The struct path keys must match the corresponding resource metadata fields.
+	#Cluster: [Kind=string]: [Name=string]: {
+		kind: Kind
+		metadata: {
+			name: Name
+			...
+		}
+		...
+	}
+
+	// projectResources collects all rendered Kubernetes resources.
+	// This is a Scope A (instance) dependency: the cache lives in the same
+	// project namespace as the app that depends on it.
+	//
+	// ADR 032 Dependency Wiring (Scope A — instance):
+	//   A separate TemplateDependency object (created by the service owner)
+	//   declares that every Deployment of "my-app" requires a singleton of
+	//   this "valkey" template in the same project namespace. Because
+	//   requires.namespace == dependent.namespace, no TemplateGrant is needed.
+	projectResources: {
+		namespacedResources: #Namespaced & {
+			(platform.namespace): {
+				// ServiceAccount provides a Kubernetes identity for the cache pods.
+				ServiceAccount: (input.name): {
+					apiVersion: "v1"
+					kind:       "ServiceAccount"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+				}
+
+				// Deployment runs the Valkey cache.
+				Deployment: (input.name): {
+					apiVersion: "apps/v1"
+					kind:       "Deployment"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						replicas: 1
+						selector: matchLabels: "app.kubernetes.io/name": input.name
+						template: {
+							metadata: labels: _labels
+							spec: {
+								serviceAccountName: input.name
+								containers: [{
+									name:  input.name
+									image: input.image + ":" + input.tag
+									ports: [{containerPort: input.port, name: "valkey"}]
+								}]
+							}
+						}
+					}
+				}
+
+				// Service exposes Valkey on port 6379 within the project namespace.
+				// Apps in the same namespace connect via the Kubernetes DNS name:
+				//   <input.name>.<platform.namespace>.svc.cluster.local:6379
+				Service: (input.name): {
+					apiVersion: "v1"
+					kind:       "Service"
+					metadata: {
+						name:        input.name
+						namespace:   platform.namespace
+						labels:      _labels
+						annotations: _annotations
+					}
+					spec: {
+						selector: "app.kubernetes.io/name": input.name
+						ports: [{port: input.port, targetPort: "valkey", name: "valkey"}]
+					}
+				}
+			}
+		}
+
+		// clusterResources organizes cluster-scoped resources (none for this template).
+		clusterResources: #Cluster & {}
+	}
+	"""

--- a/console/templates/handler_examples_test.go
+++ b/console/templates/handler_examples_test.go
@@ -33,7 +33,7 @@ func newExamplesTestHandler(t *testing.T) *Handler {
 }
 
 // TestListTemplateExamples_HappyPath verifies that ListTemplateExamples returns
-// exactly six examples (matching the six *.cue files embedded in the examples
+// exactly ten examples (matching the ten *.cue files embedded in the examples
 // package), each with non-empty fields, and sorted by name ascending.
 func TestListTemplateExamples_HappyPath(t *testing.T) {
 	handler := newExamplesTestHandler(t)
@@ -46,7 +46,7 @@ func TestListTemplateExamples_HappyPath(t *testing.T) {
 	}
 
 	got := resp.Msg.GetExamples()
-	const wantCount = 6
+	const wantCount = 10
 	if len(got) != wantCount {
 		t.Fatalf("ListTemplateExamples() returned %d examples, want %d", len(got), wantCount)
 	}
@@ -109,12 +109,16 @@ func TestListTemplateExamples_KnownNames(t *testing.T) {
 	}
 
 	wantNames := []string{
+		"all-scopes-v1",
 		"allowed-project-resource-kinds-v1",
 		"httpbin-v1",
 		"httproute-v1",
+		"httproute-with-grant-v1",
 		"podinfo-v1",
 		"project-namespace-description-annotation-v1",
 		"project-namespace-reference-grant-v1",
+		"shared-configmap-v1",
+		"valkey-v1",
 	}
 	for _, name := range wantNames {
 		if _, ok := byName[name]; !ok {

--- a/console/templates/handler_examples_test.go
+++ b/console/templates/handler_examples_test.go
@@ -1,7 +1,7 @@
 // handler_examples_test.go exercises the ListTemplateExamples RPC introduced
 // in HOL-797. The acceptance criteria are:
 //
-//   - The happy path returns exactly six examples (one per embedded *.cue file).
+//   - The happy path returns exactly ten examples (one per embedded *.cue file).
 //   - Results are sorted by name ascending so the UI can rely on a stable order.
 //   - Each entry has non-empty DisplayName, Description, and CueTemplate.
 package templates
@@ -91,7 +91,7 @@ func TestListTemplateExamples_SortedByName(t *testing.T) {
 	}
 }
 
-// TestListTemplateExamples_KnownNames verifies the six expected built-in
+// TestListTemplateExamples_KnownNames verifies the ten expected built-in
 // example slugs are present, anchoring the test to the actual embedded files.
 func TestListTemplateExamples_KnownNames(t *testing.T) {
 	handler := newExamplesTestHandler(t)


### PR DESCRIPTION
## Summary

- Adds four new CUE example templates to the registry (6 → 10 total), each demonstrating a distinct dependency scope from ADR 032:
  - **`valkey-v1`** — Scope A (instance): Valkey cache with same-namespace `TemplateDependency` (no `TemplateGrant` needed)
  - **`shared-configmap-v1`** — Scope B (project): shared ConfigMap mandated via `TemplateRequirement` in a folder namespace
  - **`httproute-with-grant-v1`** — Scope C (remote-project): HTTPRoute in gateway namespace with `TemplateGrant` + cross-namespace `TemplateDependency`
  - **`all-scopes-v1`** — composite example exercising Scopes A + B + C in one template
- Adds `testdata/docs-snippets/cross-project-constraint/` — pinned copy of the Project-A-constrains-Project-B demo snippet (authoritative version in holos-console-docs), enforced by `docs_sync_test.go`
- Updates `examples_test.go`: count 6 → 10, `wantNames` extended, `exampleResourcesEmitted` extended, per-example `TestExamplePreviewRender_KnownExamples` sub-tests added for all four new examples
- Updates `handler_examples_test.go`: `wantCount` 6 → 10, `wantNames` extended

Fixes HOL-983

## Test plan

- [x] `go test ./console/templates/...` passes (templates + examples packages)
- [x] `go test ./api/v1alpha2/...` passes (schema still valid)
- [x] Each new example compiles against the v1alpha2 generated schema (`TestExamples`)
- [x] Each new example renders non-empty output through the preview path (`TestExamplePreviewRender`)
- [x] Per-example assertions lock the contract: Valkey named port, ConfigMap with gateway namespace, HTTPRoute with `remote-project` annotation, all-scopes VALKEY_ADDR env + platform-config reference (`TestExamplePreviewRender_KnownExamples`)
- [x] `docs_sync_test.go` covers the new cross-project-constraint snippet

## ADR reference

ADR 032 (`holos-console-docs/docs/adrs/032-template-dependency-scopes.md`) is the source of truth for scope semantics. This PR is the first implementation phase that cites the ADR; merging advances the ADR status from Proposed → Accepted.