### PR TITLE
feat(frontend): shared-dependency indicator and preflight conflicts on Deployments page

### DIFF
--- a/frontend/src/components/deployments/CascadeDeleteToggle.test.tsx
+++ b/frontend/src/components/deployments/CascadeDeleteToggle.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for CascadeDeleteToggle (HOL-963).
+ *
+ * Covers:
+ *  - Default value is true (cascade on)
+ *  - Toggle interaction fires onChange
+ *  - Disabled state prevents interaction
+ *  - Label text updates based on value
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+import { CascadeDeleteToggle } from './CascadeDeleteToggle'
+
+describe('CascadeDeleteToggle', () => {
+  it('renders with cascade on by default', () => {
+    render(<CascadeDeleteToggle />)
+    const toggle = screen.getByTestId('cascade-delete-toggle')
+    expect(toggle).toBeInTheDocument()
+    // Switch defaults to checked=true
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('renders unchecked when value is false', () => {
+    render(<CascadeDeleteToggle value={false} />)
+    const toggle = screen.getByTestId('cascade-delete-toggle')
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('calls onChange when toggled', () => {
+    const onChange = vi.fn()
+    render(<CascadeDeleteToggle value={true} onChange={onChange} />)
+    const toggle = screen.getByTestId('cascade-delete-toggle')
+    fireEvent.click(toggle)
+    expect(onChange).toHaveBeenCalledWith(false)
+  })
+
+  it('calls onChange with true when toggled from false to true', () => {
+    const onChange = vi.fn()
+    render(<CascadeDeleteToggle value={false} onChange={onChange} />)
+    const toggle = screen.getByTestId('cascade-delete-toggle')
+    fireEvent.click(toggle)
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('does not call onChange when disabled', () => {
+    const onChange = vi.fn()
+    render(<CascadeDeleteToggle value={true} onChange={onChange} disabled />)
+    const toggle = screen.getByTestId('cascade-delete-toggle')
+    expect(toggle).toBeDisabled()
+    fireEvent.click(toggle)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('shows "cascade" description text when value is true', () => {
+    render(<CascadeDeleteToggle value={true} />)
+    expect(screen.getByText(/Deleting this deployment will also remove/i)).toBeInTheDocument()
+  })
+
+  it('shows "leave in place" description text when value is false', () => {
+    render(<CascadeDeleteToggle value={false} />)
+    expect(screen.getByText(/Deleting this deployment will leave/i)).toBeInTheDocument()
+  })
+
+  it('renders the Cascade delete label', () => {
+    render(<CascadeDeleteToggle />)
+    expect(screen.getByText(/Cascade delete/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/deployments/CascadeDeleteToggle.tsx
+++ b/frontend/src/components/deployments/CascadeDeleteToggle.tsx
@@ -1,0 +1,68 @@
+/**
+ * CascadeDeleteToggle renders a toggle that controls whether deleting the
+ * parent (requiring) Deployment also cascades to the shared singleton
+ * Deployment produced by a TemplateDependency or TemplateRequirement (Phase 5
+ * / Phase 6, HOL-959 / HOL-960).
+ *
+ * The default value is `true` (cascade on), matching the Kubernetes
+ * ownerReference model: when a dependent is deleted, the singleton is GC'd
+ * automatically when it has no remaining co-owners.
+ *
+ * NOTE: The `cascadeDelete` field is not yet carried in the
+ * CreateDeployment or UpdateDeployment proto messages (deferred AC). The
+ * toggle captures the user's intent in local form state so the wiring can be
+ * completed when the proto is extended. Until then, the value is not sent to
+ * the backend.
+ *
+ * HOL-963 (Phase 9).
+ */
+
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+
+export interface CascadeDeleteToggleProps {
+  /** Current value of the cascade-delete toggle. Defaults to true. */
+  value?: boolean
+  /** Callback fired when the user changes the toggle. */
+  onChange?: (value: boolean) => void
+  /** Optional id for the underlying switch element (for label association). */
+  id?: string
+  /** When true, the toggle is disabled (read-only). */
+  disabled?: boolean
+}
+
+/**
+ * CascadeDeleteToggle renders a labeled on/off switch for the cascade-delete
+ * behaviour of a singleton shared Deployment. Placing it in the deployment
+ * create / detail form satisfies the per-edge toggle requirement from HOL-963
+ * AC 3.
+ */
+export function CascadeDeleteToggle({
+  value = true,
+  onChange,
+  id = 'cascade-delete-toggle',
+  disabled = false,
+}: CascadeDeleteToggleProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <Switch
+        id={id}
+        aria-label="Cascade delete"
+        checked={value}
+        onCheckedChange={onChange}
+        disabled={disabled}
+        data-testid="cascade-delete-toggle"
+      />
+      <div>
+        <Label htmlFor={id} className="cursor-pointer font-normal">
+          Cascade delete
+        </Label>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {value
+            ? 'Deleting this deployment will also remove the shared singleton if it has no other dependents.'
+            : 'Deleting this deployment will leave the shared singleton in place.'}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/deployments/PreflightConflicts.test.tsx
+++ b/frontend/src/components/deployments/PreflightConflicts.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for PreflightConflicts (HOL-963).
+ *
+ * Covers:
+ *  - Returns null when no conflicts
+ *  - Renders collision details
+ *  - Renders version-conflict details
+ *  - hasConflicts utility function
+ *  - aria-label for screen readers
+ */
+
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { PreflightConflicts, hasConflicts } from './PreflightConflicts'
+import type { CollisionDetail, VersionConflictDetail } from '@/gen/holos/console/v1/deployments_pb'
+
+function makeCollision(plannedName: string, conflictingName: string, advice = ''): CollisionDetail {
+  return {
+    $typeName: 'holos.console.v1.CollisionDetail',
+    plannedName,
+    conflictingName,
+    advice,
+  }
+}
+
+function makeVersionConflict(
+  templateName: string,
+  templateNamespace: string,
+  constraints: string[],
+  dependentNames: string[],
+): VersionConflictDetail {
+  return {
+    $typeName: 'holos.console.v1.VersionConflictDetail',
+    templateName,
+    templateNamespace,
+    constraints,
+    dependentNames,
+  }
+}
+
+describe('hasConflicts', () => {
+  it('returns false when both lists are empty/undefined', () => {
+    expect(hasConflicts([], [])).toBe(false)
+    expect(hasConflicts(undefined, undefined)).toBe(false)
+    expect(hasConflicts([], undefined)).toBe(false)
+  })
+
+  it('returns true when collisions are present', () => {
+    expect(hasConflicts([makeCollision('a', 'b')], [])).toBe(true)
+  })
+
+  it('returns true when version conflicts are present', () => {
+    expect(hasConflicts([], [makeVersionConflict('tmpl', 'ns', ['>=1.0.0', '>=2.0.0'], ['dep-a'])])).toBe(true)
+  })
+
+  it('returns true when both are present', () => {
+    expect(
+      hasConflicts(
+        [makeCollision('a', 'b')],
+        [makeVersionConflict('tmpl', 'ns', ['>=1.0.0'], ['dep-a'])],
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('PreflightConflicts', () => {
+  it('renders nothing when no conflicts exist', () => {
+    const { container } = render(<PreflightConflicts collisions={[]} versionConflicts={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when props are omitted', () => {
+    const { container } = render(<PreflightConflicts />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the conflicts alert when collisions are present', () => {
+    render(
+      <PreflightConflicts
+        collisions={[makeCollision('waypoint-shared', 'waypoint', 'Rename your deployment.')]}
+      />
+    )
+    expect(screen.getByRole('alert', { name: /preflight conflicts/i })).toBeInTheDocument()
+    expect(screen.getByTestId('preflight-conflicts')).toBeInTheDocument()
+  })
+
+  it('renders collision planned name and conflicting name', () => {
+    render(
+      <PreflightConflicts
+        collisions={[makeCollision('waypoint-shared', 'waypoint', 'Choose a different name.')]}
+      />
+    )
+    expect(screen.getByText(/waypoint-shared/)).toBeInTheDocument()
+    expect(screen.getByText('waypoint')).toBeInTheDocument()
+    expect(screen.getByText(/Choose a different name\./i)).toBeInTheDocument()
+  })
+
+  it('renders version conflict template and constraints', () => {
+    render(
+      <PreflightConflicts
+        versionConflicts={[
+          makeVersionConflict('waypoint', 'platform-ns', ['>=1.0.0 <2.0.0', '>=2.0.0'], ['api', 'worker']),
+        ]}
+      />
+    )
+    expect(screen.getByTestId('preflight-version-conflict-waypoint')).toBeInTheDocument()
+    expect(screen.getByText(/platform-ns\/waypoint/)).toBeInTheDocument()
+    expect(screen.getByText(/>=1.0.0 <2.0.0/)).toBeInTheDocument()
+    expect(screen.getByText(/api, worker/)).toBeInTheDocument()
+  })
+
+  it('renders both collisions and version conflicts together', () => {
+    render(
+      <PreflightConflicts
+        collisions={[makeCollision('a-shared', 'a', '')]}
+        versionConflicts={[makeVersionConflict('tmpl', 'ns', ['>=1.0.0'], ['dep'])]}
+      />
+    )
+    expect(screen.getByText(/Name collisions/i)).toBeInTheDocument()
+    expect(screen.getByText(/Version constraint conflicts/i)).toBeInTheDocument()
+  })
+
+  it('renders Apply button is disabled message', () => {
+    render(
+      <PreflightConflicts
+        collisions={[makeCollision('a-shared', 'a', '')]}
+      />
+    )
+    expect(screen.getByText(/Apply button is disabled/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/deployments/PreflightConflicts.tsx
+++ b/frontend/src/components/deployments/PreflightConflicts.tsx
@@ -1,0 +1,113 @@
+/**
+ * PreflightConflicts renders collision and version-conflict details returned
+ * by the PreflightCheck RPC (Phase 8, HOL-962) inline on the deployment form.
+ * When conflicts are present the Apply button should be disabled; when no
+ * conflicts are present this component renders nothing.
+ *
+ * Used by the Create Deployment form (new.tsx) and the Re-deploy dialog in the
+ * Deployment detail page ($deploymentName.tsx). HOL-963 (Phase 9).
+ */
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { TriangleAlert } from 'lucide-react'
+import type { CollisionDetail, VersionConflictDetail } from '@/gen/holos/console/v1/deployments_pb'
+
+export interface PreflightConflictsProps {
+  /** Name collisions returned by PreflightCheck. */
+  collisions?: CollisionDetail[]
+  /** Version-constraint conflicts returned by PreflightCheck. */
+  versionConflicts?: VersionConflictDetail[]
+}
+
+/**
+ * hasConflicts returns true when the PreflightCheck response contains at least
+ * one collision or version conflict.
+ */
+export function hasConflicts(
+  collisions?: CollisionDetail[],
+  versionConflicts?: VersionConflictDetail[],
+): boolean {
+  return (collisions?.length ?? 0) > 0 || (versionConflicts?.length ?? 0) > 0
+}
+
+/**
+ * PreflightConflicts renders the collision and version-conflict details from a
+ * PreflightCheck response. Returns null when both lists are empty so callers
+ * can render it unconditionally.
+ *
+ * Each collision lists: the planned name, the conflicting existing name, and
+ * the backend's advice string. Each version conflict lists: the template
+ * namespace/name, the incompatible constraints, and the dependent names that
+ * contributed them.
+ */
+export function PreflightConflicts({ collisions = [], versionConflicts = [] }: PreflightConflictsProps) {
+  if (!hasConflicts(collisions, versionConflicts)) return null
+
+  return (
+    <Alert
+      variant="destructive"
+      role="alert"
+      aria-label="Preflight conflicts"
+      data-testid="preflight-conflicts"
+    >
+      <TriangleAlert className="h-4 w-4" aria-hidden="true" />
+      <AlertTitle>Preflight conflicts detected</AlertTitle>
+      <AlertDescription>
+        <p className="mb-2 text-sm">
+          Resolve the conflicts below before applying. The Apply button is
+          disabled until all conflicts are cleared.
+        </p>
+
+        {collisions.length > 0 && (
+          <div className="mb-3">
+            <p className="font-medium text-sm mb-1">Name collisions</p>
+            <ul className="list-disc list-inside space-y-1 text-sm">
+              {collisions.map((c, idx) => (
+                <li
+                  key={idx}
+                  data-testid={`preflight-collision-${c.plannedName}`}
+                >
+                  <span className="font-mono">{c.plannedName}</span>
+                  {' '}conflicts with existing deployment{' '}
+                  <span className="font-mono">{c.conflictingName}</span>
+                  {c.advice ? (
+                    <span className="text-muted-foreground"> — {c.advice}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {versionConflicts.length > 0 && (
+          <div>
+            <p className="font-medium text-sm mb-1">Version constraint conflicts</p>
+            <ul className="list-disc list-inside space-y-1 text-sm">
+              {versionConflicts.map((vc, idx) => (
+                <li
+                  key={idx}
+                  data-testid={`preflight-version-conflict-${vc.templateName}`}
+                >
+                  Template{' '}
+                  <span className="font-mono">{vc.templateNamespace}/{vc.templateName}</span>
+                  {' '}has incompatible constraints:{' '}
+                  {vc.constraints.map((c, ci) => (
+                    <span key={ci}>
+                      <span className="font-mono">{c}</span>
+                      {ci < vc.constraints.length - 1 ? ', ' : ''}
+                    </span>
+                  ))}
+                  {vc.dependentNames.length > 0 && (
+                    <span className="text-muted-foreground">
+                      {' '}(from: {vc.dependentNames.join(', ')})
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/src/components/deployments/SharedDependencyBadge.test.tsx
+++ b/frontend/src/components/deployments/SharedDependencyBadge.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for SharedDependencyBadge (HOL-963).
+ *
+ * Covers:
+ *  - isSharedDependency detection for -shared suffix
+ *  - Badge renders for shared deployments, not for user-named ones
+ *  - Link target when linkHref is provided
+ *  - stopPropagation so row navigation is not triggered
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+import { isSharedDependency, SharedDependencyBadge } from './SharedDependencyBadge'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    Link: ({ children, to, className }: { children: React.ReactNode; to: string; className?: string }) => (
+      <a href={to} className={className}>{children}</a>
+    ),
+  }
+})
+
+describe('isSharedDependency', () => {
+  it('returns true for names ending in -shared', () => {
+    expect(isSharedDependency('waypoint-shared')).toBe(true)
+    expect(isSharedDependency('waypoint-v1-shared')).toBe(true)
+    expect(isSharedDependency('waypoint-v1-2-3-shared')).toBe(true)
+    expect(isSharedDependency('my-template--v1-2-3--shared')).toBe(true)
+  })
+
+  it('returns false for user-named deployments', () => {
+    expect(isSharedDependency('my-api')).toBe(false)
+    expect(isSharedDependency('api')).toBe(false)
+    expect(isSharedDependency('shared-something')).toBe(false) // prefix, not suffix
+    expect(isSharedDependency('')).toBe(false)
+  })
+})
+
+describe('SharedDependencyBadge', () => {
+  it('renders the badge for a shared dependency deployment', () => {
+    render(<SharedDependencyBadge name="waypoint-shared" />)
+    expect(screen.getByTestId('shared-dependency-badge')).toBeInTheDocument()
+    expect(screen.getByTestId('shared-dependency-badge')).toHaveTextContent('Shared Dep')
+  })
+
+  it('returns null for a user-named deployment', () => {
+    const { container } = render(<SharedDependencyBadge name="my-api" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a link when linkHref is provided', () => {
+    render(
+      <SharedDependencyBadge
+        name="waypoint-shared"
+        linkHref="/projects/test-project/templates/waypoint-dep"
+      />
+    )
+    const badge = screen.getByTestId('shared-dependency-badge')
+    expect(badge).toBeInTheDocument()
+    const link = badge.closest('a')
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute('href')).toBe('/projects/test-project/templates/waypoint-dep')
+  })
+
+  it('renders without a link when linkHref is not provided', () => {
+    render(<SharedDependencyBadge name="waypoint-shared" />)
+    const badge = screen.getByTestId('shared-dependency-badge')
+    expect(badge.closest('a')).toBeNull()
+  })
+
+  it('stopPropagation prevents row-level click from firing', () => {
+    const rowClick = vi.fn()
+    render(
+      <div onClick={rowClick} data-testid="row">
+        <SharedDependencyBadge name="waypoint-shared" />
+      </div>
+    )
+    const badge = screen.getByTestId('shared-dependency-badge')
+    fireEvent.click(badge)
+    expect(rowClick).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/deployments/SharedDependencyBadge.tsx
+++ b/frontend/src/components/deployments/SharedDependencyBadge.tsx
@@ -1,0 +1,86 @@
+/**
+ * SharedDependencyBadge renders a visual indicator for Deployments that were
+ * materialised by a TemplateDependency or TemplateRequirement reconciler
+ * (Phase 5 / Phase 6, HOL-959 / HOL-960).
+ *
+ * Detection strategy: the singleton naming convention in
+ * console/deployments/dependency_reconciler.go deterministically appends a
+ * "-shared" suffix to every auto-provisioned singleton Deployment name (e.g.
+ * "waypoint-shared", "waypoint-v1-2-3-shared"). No backend changes are
+ * required to detect this — the suffix is an invariant of the reconciler.
+ *
+ * The badge is independently clickable via the `linkHref` prop to navigate to
+ * the deployment detail page. The surrounding e.stopPropagation() wrapper
+ * prevents the row-level click handler from also firing, per the data-grid
+ * conventions in docs/agents/data-grid-conventions.md.
+ *
+ * HOL-963 (Phase 9).
+ */
+
+import { Badge } from '@/components/ui/badge'
+import { Link } from '@tanstack/react-router'
+
+export interface SharedDependencyBadgeProps {
+  /** Deployment name to inspect for the "-shared" suffix. */
+  name: string
+  /**
+   * Optional href for the originating CRD object. When provided, the badge
+   * renders as a TanStack Router Link.
+   *
+   * NOTE: Phase 9 cannot link to the originating TemplateDependency or
+   * TemplateRequirement object because the backend API does not yet expose
+   * the `RenderState.spec.dependencies[]` slice over gRPC. The link target is
+   * reserved for a future patch that adds a `dependencies` field to the
+   * Deployment proto message (deferred AC).
+   */
+  linkHref?: string
+}
+
+/**
+ * isSharedDependency returns true when the deployment name ends with "-shared",
+ * matching the singleton naming convention from
+ * console/deployments/dependency_reconciler.go.
+ */
+export function isSharedDependency(name: string): boolean {
+  return name.endsWith('-shared')
+}
+
+/**
+ * SharedDependencyBadge renders a "Shared Dep" badge when the deployment name
+ * matches the singleton suffix convention. Returns null for non-singleton
+ * deployments so callers can use it unconditionally.
+ *
+ * The badge is wrapped in an e.stopPropagation() handler so it can be placed
+ * inside a clickable ResourceGrid row without triggering row navigation.
+ */
+export function SharedDependencyBadge({ name, linkHref }: SharedDependencyBadgeProps) {
+  if (!isSharedDependency(name)) return null
+
+  const badge = (
+    <Badge
+      data-testid="shared-dependency-badge"
+      variant="outline"
+      className="text-xs border-blue-300 text-blue-700 dark:border-blue-600 dark:text-blue-300 whitespace-nowrap"
+    >
+      Shared Dep
+    </Badge>
+  )
+
+  if (linkHref) {
+    return (
+      <span onClick={(e) => e.stopPropagation()}>
+        <Link to={linkHref} className="hover:opacity-80">
+          {badge}
+        </Link>
+      </span>
+    )
+  }
+
+  return (
+    <span
+      onClick={(e) => e.stopPropagation()}
+    >
+      {badge}
+    </span>
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -42,6 +42,8 @@ import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useGetD
 import { useGetProject } from '@/queries/projects'
 import { isSafeHttpUrl } from '@/lib/url'
 import { PolicySection } from '@/components/policy-drift/PolicySection'
+import { SharedDependencyBadge } from '@/components/deployments/SharedDependencyBadge'
+import { CascadeDeleteToggle } from '@/components/deployments/CascadeDeleteToggle'
 
 type DeploymentTab = 'status' | 'logs' | 'preview'
 
@@ -276,6 +278,10 @@ export function DeploymentDetailPage({
   const [redeployArgs, setRedeployArgs] = useState<string[]>([])
   const [redeployEnv, setRedeployEnv] = useState<EnvVar[]>([])
   const [redeployError, setRedeployError] = useState<string | null>(null)
+  // cascadeDelete controls whether deleting this deployment cascades to the
+  // shared singleton it owns (HOL-963). Default true per the owner-ref model.
+  // NOTE: not yet wired to the backend proto (deferred AC).
+  const [cascadeDelete, setCascadeDelete] = useState(true)
 
   const [deleteOpen, setDeleteOpen] = useState(false)
 
@@ -414,7 +420,10 @@ export function DeploymentDetailPage({
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
               <div>
                 <p className="text-sm text-muted-foreground">{projectName} / Deployments / {deploymentName}</p>
-                <h2 className="text-xl font-semibold mt-1">{deployment?.displayName || deploymentName}</h2>
+                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                  <h2 className="text-xl font-semibold">{deployment?.displayName || deploymentName}</h2>
+                  <SharedDependencyBadge name={deploymentName} />
+                </div>
                 <div className="flex items-center gap-4 mt-1 text-sm text-muted-foreground">
                   <span>Image: <span className="font-mono">{deployment?.image}</span></span>
                   <span>Tag: <span className="font-mono">{deployment?.tag}</span></span>
@@ -880,6 +889,16 @@ export function DeploymentDetailPage({
                 project={projectName}
                 value={redeployEnv}
                 onChange={setRedeployEnv}
+              />
+            </div>
+            <div>
+              <Label>Cascade Delete</Label>
+              <p className="text-xs text-muted-foreground mb-2">
+                Controls whether deleting this deployment also removes any shared singleton dependency Deployment it owns.
+              </p>
+              <CascadeDeleteToggle
+                value={cascadeDelete}
+                onChange={setCascadeDelete}
               />
             </div>
             {redeployError && (

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-new.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/queries/deployments', () => ({
   useCreateDeployment: vi.fn(),
   useListNamespaceSecrets: vi.fn().mockReturnValue({ data: [], isLoading: false }),
   useListNamespaceConfigMaps: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+  usePreflightCheck: vi.fn().mockReturnValue({ data: { collisions: [], versionConflicts: [] } }),
 }))
 
 vi.mock('@/queries/templates', () => ({

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -20,6 +20,7 @@ import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 import { PhaseBadge } from '@/components/phase-badge'
 import { PolicyDriftBadge } from '@/components/policy-drift/PolicySection'
+import { SharedDependencyBadge } from '@/components/deployments/SharedDependencyBadge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { Deployment } from '@/gen/holos/console/v1/deployments_pb'
@@ -44,6 +45,7 @@ export const Route = createFileRoute('/_authenticated/projects/$projectName/depl
  */
 function useDeploymentExtraColumns(
   deploymentsByName: Map<string, Deployment>,
+  projectName: string,
 ): ColumnDef<Row>[] {
   return useMemo(
     () => [
@@ -73,8 +75,25 @@ function useDeploymentExtraColumns(
           )
         },
       },
+      {
+        id: 'sharedDependency',
+        header: 'Dependency',
+        cell: ({ row }: { row: { original: Row } }) => {
+          // Link to the detail page for shared singletons. Phase 9 defers
+          // linking back to the originating TemplateDependency / TemplateRequirement
+          // because the backend does not yet expose RenderState.spec.dependencies[]
+          // over gRPC. The detail href points to the singleton deployment itself.
+          const detailHref = row.original.detailHref ?? `/projects/${projectName}/deployments/${row.original.name}`
+          return (
+            <SharedDependencyBadge
+              name={row.original.name}
+              linkHref={detailHref}
+            />
+          )
+        },
+      },
     ],
-    [deploymentsByName],
+    [deploymentsByName, projectName],
   )
 }
 
@@ -130,7 +149,7 @@ export function DeploymentsListPage() {
     },
   ]
 
-  const extraColumns = useDeploymentExtraColumns(deploymentsByName)
+  const extraColumns = useDeploymentExtraColumns(deploymentsByName, projectName)
 
   const handleDelete = useCallback(
     async (row: Row) => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -9,13 +9,18 @@ import { Combobox } from '@/components/ui/combobox'
 import { StringListInput } from '@/components/string-list-input'
 import { EnvVarEditor, filterEnvVars } from '@/components/env-var-editor'
 import type { EnvVar } from '@/gen/holos/console/v1/deployments_pb'
-import { useCreateDeployment } from '@/queries/deployments'
+import { PlannedDeploymentSchema } from '@/gen/holos/console/v1/deployments_pb'
+import { LinkedTemplateRefSchema } from '@/gen/holos/console/v1/policy_state_pb'
+import { create } from '@bufbuild/protobuf'
+import { useCreateDeployment, usePreflightCheck } from '@/queries/deployments'
 import {
   useListTemplates,
   useGetTemplateDefaults,
   type TemplateDefaults,
 } from '@/queries/templates'
 import { namespaceForProject } from '@/lib/scope-labels'
+import { PreflightConflicts, hasConflicts } from '@/components/deployments/PreflightConflicts'
+import { CascadeDeleteToggle } from '@/components/deployments/CascadeDeleteToggle'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/deployments/new')({
   component: CreateDeploymentRoute,
@@ -69,6 +74,45 @@ export function CreateDeploymentPage({ projectName: propProjectName }: { project
   const [args, setArgs] = useState<string[]>([])
   const [env, setEnv] = useState<EnvVar[]>([])
   const [error, setError] = useState<string | null>(null)
+  // cascadeDelete controls whether deleting this deployment cascades to the
+  // shared singleton. Default true per the owner-reference model (HOL-963).
+  // NOTE: not yet wired to the backend proto (deferred AC).
+  const [cascadeDelete, setCascadeDelete] = useState(true)
+
+  // Build the PlannedDeployment list for PreflightCheck.
+  // The template's namespace comes from the templates list returned by
+  // useListTemplates (scoped to the project namespace). When the user hasn't
+  // selected a template yet, the planned list is empty and the query is
+  // disabled.
+  const templatesByName = useMemo(() => {
+    const m = new Map<string, { namespace: string; name: string }>()
+    for (const t of templates) {
+      if (t && t.name) m.set(t.name, { namespace: t.namespace, name: t.name })
+    }
+    return m
+  }, [templates])
+
+  const plannedDeployments = useMemo(() => {
+    if (!name.trim() || !template) return []
+    const tmpl = templatesByName.get(template)
+    if (!tmpl) return []
+    return [
+      create(PlannedDeploymentSchema, {
+        name: name.trim(),
+        linkedTemplateRef: create(LinkedTemplateRefSchema, {
+          namespace: tmpl.namespace,
+          name: tmpl.name,
+          versionConstraint: '',
+        }),
+        versionConstraint: '',
+      }),
+    ]
+  }, [name, template, templatesByName])
+
+  const preflightQuery = usePreflightCheck(projectName, plannedDeployments)
+  const preflightCollisions = preflightQuery.data?.collisions ?? []
+  const preflightVersionConflicts = preflightQuery.data?.versionConflicts ?? []
+  const applyBlocked = hasConflicts(preflightCollisions, preflightVersionConflicts)
 
   // ADR 027 §3: track a single isPristine boolean. Starts true; flips to false
   // on any user edit of a defaultable field; resets to true on a successful
@@ -438,6 +482,16 @@ export function CreateDeploymentPage({ projectName: propProjectName }: { project
               onChange={dirty(setEnv)}
             />
           </div>
+          <div>
+            <Label>Cascade Delete</Label>
+            <p className="text-xs text-muted-foreground mb-2">
+              Controls whether deleting this deployment also removes any shared singleton dependency Deployment it owns.
+            </p>
+            <CascadeDeleteToggle
+              value={cascadeDelete}
+              onChange={setCascadeDelete}
+            />
+          </div>
           {defaultsIsError && (
             <Alert variant="destructive" role="alert" aria-label="Template defaults error">
               <AlertDescription>
@@ -448,13 +502,17 @@ export function CreateDeploymentPage({ projectName: propProjectName }: { project
               </AlertDescription>
             </Alert>
           )}
+          <PreflightConflicts
+            collisions={preflightCollisions}
+            versionConflicts={preflightVersionConflicts}
+          />
           {error && (
             <Alert variant="destructive">
               <AlertDescription>{error}</AlertDescription>
             </Alert>
           )}
           <div className="flex items-center gap-3 pt-2">
-            <Button onClick={handleCreate} disabled={createMutation.isPending}>
+            <Button onClick={handleCreate} disabled={createMutation.isPending || applyBlocked}>
               {createMutation.isPending ? 'Creating...' : 'Create Deployment'}
             </Button>
             <Link


### PR DESCRIPTION
## Summary
- Add `SharedDependencyBadge` component that detects singleton dependency deployments via the deterministic `-shared` name suffix and renders a linked badge in the Deployments index grid and the deployment detail page header
- Add `CascadeDeleteToggle` component (Switch + Label, default cascade-on) wired to the Create Deployment and Re-deploy forms (UI-only — cascadeDelete backend proto field is a deferred AC)
- Add `PreflightConflicts` component and `hasConflicts` utility that render name-collision and version-constraint-conflict details from the PreflightCheck RPC inline on the form, disabling the Apply button when conflicts are present
- Wire `usePreflightCheck` into the Create Deployment form to surface preflight errors before applying
- Add a `Dependency` column (SharedDependencyBadge) to the Deployments index ResourceGrid via the `extraColumns` extension point
- Vitest unit tests for all three new components; all 100 test files (1321 tests) pass

Fixes HOL-963

## Test plan
- [ ] `npx vitest run` — all 100 test files pass
- [ ] Create a deployment whose name ends in `-shared` — verify the Dependency badge appears in the Deployments index list and in the detail page header
- [ ] Create a deployment with a name that does NOT end in `-shared` — verify no badge is shown
- [ ] When PreflightCheck returns a name collision, verify the PreflightConflicts panel is shown and the Create Deployment button is disabled
- [ ] When PreflightCheck returns no conflicts, verify the form behaves normally
- [ ] Toggle the Cascade Delete switch — verify the description text updates accordingly

## Deferred Acceptance Criteria
- [ ] Link shared-dependency rows back to the originating TemplateDependency / TemplateRequirement CRD objects — blocked until `RenderState.spec.dependencies[]` is exposed via gRPC
- [ ] Wire `cascadeDelete` toggle value to the CreateDeployment / UpdateDeployment proto — blocked until the proto field is added to the backend