### PR TITLE
refactor(org-templates): migrate to ResourceGrid v1, add Clone CTA

### DIFF
--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
@@ -90,16 +90,7 @@ export function ConsolidatedTemplateEditorPage({
   // Resolve the selected project so the "Clone to project" CTA can build the
   // target URL without requiring additional user input. If no project is
   // currently selected, the CTA is rendered as disabled.
-  let selectedProject: string | null = null
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const projectCtx = useProject()
-    selectedProject = projectCtx.selectedProject
-  } catch {
-    // useProject throws when rendered outside the ProjectProvider (e.g. in
-    // unit tests). Gracefully degrade to no selected project.
-    selectedProject = null
-  }
+  const { selectedProject } = useProject()
 
   const [cueTemplate, setCueTemplate] = useState('')
   const [deleteOpen, setDeleteOpen] = useState(false)

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -23,6 +23,7 @@ import {
 import type { TemplateExample, TemplateDefaults } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
+import { useProject } from '@/lib/project-context'
 
 // templateDefaultsToCueInput converts a TemplateDefaults message into a CUE
 // input snippet suitable for pre-populating the Project Input textarea. Only
@@ -85,6 +86,20 @@ export function ConsolidatedTemplateEditorPage({
   const { data: templateDefaults } = useGetTemplateDefaults({ namespace, name })
   const updateMutation = useUpdateTemplate(namespace, name)
   const deleteMutation = useDeleteTemplate(namespace)
+
+  // Resolve the selected project so the "Clone to project" CTA can build the
+  // target URL without requiring additional user input. If no project is
+  // currently selected, the CTA is rendered as disabled.
+  let selectedProject: string | null = null
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const projectCtx = useProject()
+    selectedProject = projectCtx.selectedProject
+  } catch {
+    // useProject throws when rendered outside the ProjectProvider (e.g. in
+    // unit tests). Gracefully degrade to no selected project.
+    selectedProject = null
+  }
 
   const [cueTemplate, setCueTemplate] = useState('')
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -174,6 +189,28 @@ export function ConsolidatedTemplateEditorPage({
               <h2 className="text-xl font-semibold">{displayName}</h2>
             </div>
           </div>
+          {selectedProject ? (
+            <Link
+              to="/projects/$projectName/templates/new"
+              params={{ projectName: selectedProject }}
+              search={{ cloneSource: `${namespace}/${name}` }}
+              data-testid="clone-to-project-cta"
+            >
+              <Button variant="outline" size="sm">
+                Clone to project
+              </Button>
+            </Link>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled
+              title="Select a project in the sidebar to enable cloning"
+              data-testid="clone-to-project-cta-disabled"
+            >
+              Clone to project
+            </Button>
+          )}
           <Button
             variant="destructive"
             size="sm"

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-$namespace.$name.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-$namespace.$name.test.tsx
@@ -18,6 +18,35 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
       }),
     }),
     useNavigate: () => mockNavigate,
+    Link: ({
+      children,
+      to,
+      params,
+      search,
+      'data-testid': testId,
+    }: {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+      search?: Record<string, string>
+      'data-testid'?: string
+    }) => {
+      let href = to ?? '#'
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          href = href.replace(`$${k}`, v)
+        }
+      }
+      if (search) {
+        const qs = new URLSearchParams(search as Record<string, string>).toString()
+        if (qs) href = `${href}?${qs}`
+      }
+      return (
+        <a href={href} data-testid={testId}>
+          {children}
+        </a>
+      )
+    },
   }
 })
 
@@ -31,6 +60,15 @@ vi.mock('@/queries/templates', () => ({
     data: undefined,
     error: null,
     isFetching: false,
+  }),
+}))
+
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn().mockReturnValue({
+    selectedProject: null,
+    setSelectedProject: vi.fn(),
+    projects: [],
+    isLoading: false,
   }),
 }))
 
@@ -51,6 +89,7 @@ import {
 } from '@/queries/templates'
 import type { TemplateDefaults } from '@/queries/templates'
 import { toast } from 'sonner'
+import { useProject } from '@/lib/project-context'
 import { ConsolidatedTemplateEditorPage, templateDefaultsToCueInput } from './$namespace.$name'
 
 const EXAMPLE_HTTPROUTE = {
@@ -590,6 +629,55 @@ describe('ConsolidatedTemplateEditorPage', () => {
         name: /deleting/i,
       })
       expect(deletingButton).toBeDisabled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // HOL-975: "Clone to project" CTA
+  // ---------------------------------------------------------------------------
+
+  describe('Clone to project CTA (HOL-975)', () => {
+    it('renders a disabled Clone to project button when no project is selected', () => {
+      setupMocks()
+      ;(useProject as Mock).mockReturnValue({
+        selectedProject: null,
+        setSelectedProject: vi.fn(),
+        projects: [],
+        isLoading: false,
+      })
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+      const btn = screen.getByTestId('clone-to-project-cta-disabled')
+      expect(btn).toBeDisabled()
+    })
+
+    it('renders an enabled Clone to project link when a project is selected', () => {
+      setupMocks()
+      ;(useProject as Mock).mockReturnValue({
+        selectedProject: 'my-proj',
+        setSelectedProject: vi.fn(),
+        projects: [],
+        isLoading: false,
+      })
+      render(
+        <ConsolidatedTemplateEditorPage
+          orgName="test-org"
+          namespace="prj-billing"
+          name="web"
+        />,
+      )
+      const cta = screen.getByTestId('clone-to-project-cta')
+      expect(cta).toBeInTheDocument()
+      // The link should navigate to the project's new template page with the
+      // cloneSource query param encoding "namespace/name".
+      expect(cta.tagName).toBe('A')
+      expect(cta.getAttribute('href')).toContain('/projects/my-proj/templates/new')
+      expect(cta.getAttribute('href')).toContain('cloneSource=prj-billing%2Fweb')
     })
   })
 })

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-cross-scope.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-cross-scope.test.tsx
@@ -25,6 +25,31 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
       useParams: () => currentParams,
     }),
     useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      to,
+      params,
+      search,
+      'data-testid': testId,
+    }: {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+      search?: Record<string, string>
+      'data-testid'?: string
+    }) => {
+      let href = to ?? '#'
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          href = href.replace(`$${k}`, v)
+        }
+      }
+      if (search) {
+        const qs = new URLSearchParams(search as Record<string, string>).toString()
+        if (qs) href = `${href}?${qs}`
+      }
+      return <a href={href} data-testid={testId}>{children}</a>
+    },
   }
 })
 
@@ -43,6 +68,15 @@ vi.mock('@/queries/templates', () => ({
 
 vi.mock('@/hooks/use-debounced-value', () => ({
   useDebouncedValue: vi.fn((value: unknown) => value),
+}))
+
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn().mockReturnValue({
+    selectedProject: null,
+    setSelectedProject: vi.fn(),
+    projects: [],
+    isLoading: false,
+  }),
 }))
 
 vi.mock('sonner', () => ({

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
@@ -5,7 +5,7 @@
  * and renders rows via ResourceGrid v1 with scope-aware detailHref values.
  */
 
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
@@ -1,7 +1,17 @@
-import { render, screen, fireEvent, within } from '@testing-library/react'
+/**
+ * Tests for the org templates index — ResourceGrid v1 migration (HOL-975).
+ *
+ * The page fans out across all org-reachable namespaces via useAllTemplatesForOrg
+ * and renders rows via ResourceGrid v1 with scope-aware detailHref values.
+ */
+
+import { render, screen, within } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+
+const mockNavigate = vi.fn()
+const mockSearch: Record<string, unknown> = {}
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -9,17 +19,21 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     ...actual,
     createFileRoute: () => () => ({
       useParams: () => ({ orgName: 'test-org' }),
+      useSearch: () => mockSearch,
+      fullPath: '/organizations/$orgName/templates/',
     }),
     Link: ({
       children,
       to,
       params,
+      search,
       title,
       className,
     }: {
       children: React.ReactNode
       to: string
       params?: Record<string, string>
+      search?: Record<string, string>
       title?: string
       className?: string
     }) => {
@@ -29,12 +43,17 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
           href = href.replace(`$${k}`, v)
         }
       }
+      if (search) {
+        const qs = new URLSearchParams(search).toString()
+        if (qs) href = `${href}?${qs}`
+      }
       return (
         <a href={href} title={title} className={className}>
           {children}
         </a>
       )
     },
+    useNavigate: () => mockNavigate,
   }
 })
 
@@ -52,6 +71,8 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
 import { useAllTemplatesForOrg } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -66,6 +87,7 @@ type TemplateFixture = {
   name: string
   namespace: string
   displayName: string
+  createdAt?: string
 }
 
 const ORG_NS = namespaceForOrg('test-org')
@@ -89,13 +111,20 @@ function setup(
   })
 }
 
-describe('OrgTemplatesIndexPage', () => {
-  beforeEach(() => vi.clearAllMocks())
+describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.keys(mockSearch).forEach((k) => delete mockSearch[k])
+  })
+
+  // ---------------------------------------------------------------------------
+  // Loading and error states
+  // ---------------------------------------------------------------------------
 
   it('renders loading skeletons while the fan-out is pending', () => {
     setup([], Role.OWNER, { isPending: true })
     render(<OrgTemplatesIndexPage orgName="test-org" />)
-    expect(screen.getByTestId('templates-loading')).toBeInTheDocument()
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
   })
 
   it('renders the full-page error when the fan-out fails with no data', () => {
@@ -108,7 +137,7 @@ describe('OrgTemplatesIndexPage', () => {
 
   it('renders an inline partial-error banner when some rows loaded', () => {
     ;(useAllTemplatesForOrg as Mock).mockReturnValue({
-      data: [{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' }],
+      data: [{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' }],
       isPending: false,
       error: new Error('folders unavailable'),
     })
@@ -120,191 +149,209 @@ describe('OrgTemplatesIndexPage', () => {
     render(<OrgTemplatesIndexPage orgName="test-org" />)
     expect(screen.getByText('Gateway')).toBeInTheDocument()
     expect(screen.getByRole('table')).toBeInTheDocument()
-    expect(screen.getByTestId('templates-partial-error')).toBeInTheDocument()
+    expect(screen.getByTestId('resource-grid-partial-error')).toBeInTheDocument()
     expect(screen.getByText('folders unavailable')).toBeInTheDocument()
   })
 
   it('renders the empty state when no templates exist', () => {
     setup([])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
-    expect(screen.getByText(/no templates yet/i)).toBeInTheDocument()
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
   })
 
+  // ---------------------------------------------------------------------------
+  // Row rendering
+  // ---------------------------------------------------------------------------
+
   it('renders a row for each template across scopes', () => {
     setup([
-      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' },
-      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend' },
-      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service' },
+      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' },
+      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend', createdAt: '' },
+      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
     ])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
 
-    const rows = screen.getAllByRole('row')
-    // 1 header + 3 body rows
-    expect(rows).toHaveLength(4)
-
-    expect(within(rows[1]).getByText('Gateway')).toBeInTheDocument()
-    expect(within(rows[1]).getByText(ORG_NS)).toBeInTheDocument()
-    expect(within(rows[2]).getByText('Backend')).toBeInTheDocument()
-    expect(within(rows[2]).getByText(FOLDER_NS)).toBeInTheDocument()
-    expect(within(rows[3]).getByText('Web Service')).toBeInTheDocument()
-    expect(within(rows[3]).getByText(PROJECT_NS)).toBeInTheDocument()
+    expect(screen.getByText('Gateway')).toBeInTheDocument()
+    expect(screen.getByText('Backend')).toBeInTheDocument()
+    expect(screen.getByText('Web Service')).toBeInTheDocument()
   })
 
   it('routes org-scoped rows to the org editor', () => {
-    setup([{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' }])
+    setup([{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' }])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
-    const link = screen.getByRole('link', { name: 'Gateway' })
-    expect(link).toHaveAttribute(
-      'href',
-      `/organizations/test-org/templates/${ORG_NS}/gateway`,
-    )
-  })
-
-  it('routes folder-scoped rows to the folder template editor', () => {
-    setup([
-      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend' },
-    ])
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    const link = screen.getByRole('link', { name: 'Backend' })
-    expect(link).toHaveAttribute(
-      'href',
-      '/folders/team-a/templates/backend',
-    )
-  })
-
-  it('routes project-scoped rows to the project template editor', () => {
-    setup([
-      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service' },
-    ])
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    const link = screen.getByRole('link', { name: 'Web Service' })
-    expect(link).toHaveAttribute(
-      'href',
-      '/projects/billing/templates/web',
-    )
-  })
-
-  it('renders a plain span for unknown namespaces', () => {
-    // Stale caches or proto drift could surface an unrecognizable namespace.
-    // Rather than forge a 404 link, the cell must render as plain text.
-    setup([{ name: 'strange', namespace: 'mystery-ns', displayName: 'Strange' }])
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    expect(screen.queryByRole('link', { name: 'Strange' })).toBeNull()
-    expect(screen.getByText('Strange')).toBeInTheDocument()
-  })
-
-  it('falls back to the slug when displayName is empty', () => {
-    setup([{ name: 'ops', namespace: ORG_NS, displayName: '' }])
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    const links = screen.getAllByRole('link', { name: 'ops' })
+    // The Resource ID cell and display name cell both link to the detail page.
+    const links = screen.getAllByRole('link', { name: /gateway/i })
     expect(
       links.some(
         (l) =>
-          l.getAttribute('href') === `/organizations/test-org/templates/${ORG_NS}/ops`,
+          l.getAttribute('href') ===
+          `/organizations/test-org/templates/${ORG_NS}/gateway`,
       ),
     ).toBe(true)
   })
 
-  it('filters rows via the global search input by display name', () => {
+  it('routes folder-scoped rows to the folder template editor', () => {
     setup([
-      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' },
-      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend' },
+      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend', createdAt: '' },
     ])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
-
-    expect(screen.getAllByRole('row')).toHaveLength(3)
-
-    const search = screen.getByLabelText(/search templates/i)
-    fireEvent.change(search, { target: { value: 'Gate' } })
-
-    const rowsAfter = screen.getAllByRole('row')
-    expect(rowsAfter).toHaveLength(2)
-    expect(within(rowsAfter[1]).getByText('Gateway')).toBeInTheDocument()
-  })
-
-  it('filters rows by namespace', () => {
-    setup([
-      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' },
-      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service' },
-    ])
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-
-    const search = screen.getByLabelText(/search templates/i)
-    fireEvent.change(search, { target: { value: PROJECT_NS } })
-
-    const rows = screen.getAllByRole('row')
-    expect(rows).toHaveLength(2)
-    expect(within(rows[1]).getByText('Web Service')).toBeInTheDocument()
-  })
-
-  it('filters rows by slug name', () => {
-    setup([
-      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' },
-      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend' },
-    ])
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-
-    const search = screen.getByLabelText(/search templates/i)
-    fireEvent.change(search, { target: { value: 'back' } })
-
-    const rows = screen.getAllByRole('row')
-    expect(rows).toHaveLength(2)
-    expect(within(rows[1]).getByText('Backend')).toBeInTheDocument()
-  })
-
-  it('renders the Create Template button for org OWNERs', () => {
-    setup([], Role.OWNER)
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    const link = screen.getByRole('link', { name: /create template/i })
-    expect(link).toHaveAttribute('href', '/organizations/test-org/templates/new')
-  })
-
-  it('hides the Create Template button for non-OWNER users', () => {
-    setup([], Role.VIEWER)
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    const links = screen.getAllByRole('link', { name: /backend/i })
     expect(
-      screen.queryByRole('link', { name: /create template/i }),
-    ).not.toBeInTheDocument()
+      links.some(
+        (l) => l.getAttribute('href') === '/folders/team-a/templates/backend',
+      ),
+    ).toBe(true)
   })
 
-  it('empty state prompts OWNERs to create a template', () => {
-    setup([], Role.OWNER)
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    expect(
-      screen.getByText(/no templates yet\. create one to get started/i),
-    ).toBeInTheDocument()
-  })
-
-  it('empty state directs non-OWNERs to ask an owner', () => {
-    setup([], Role.VIEWER)
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    expect(
-      screen.getByText(/ask an organization owner to create one/i),
-    ).toBeInTheDocument()
-  })
-
-  // HOL-793: Scope column teaches users which rows live where at a glance.
-  it('renders a Scope column with a badge per row', () => {
+  it('routes project-scoped rows to the project template editor', () => {
     setup([
-      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' },
-      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend' },
-      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service' },
+      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
     ])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    const links = screen.getAllByRole('link', { name: /web service/i })
+    expect(
+      links.some(
+        (l) => l.getAttribute('href') === '/projects/billing/templates/web',
+      ),
+    ).toBe(true)
+  })
+
+  it('falls back to the slug when displayName is empty', () => {
+    setup([{ name: 'ops', namespace: ORG_NS, displayName: '', createdAt: '' }])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    const links = screen.getAllByRole('link', { name: /^ops$/i })
+    expect(
+      links.some(
+        (l) =>
+          l.getAttribute('href') ===
+          `/organizations/test-org/templates/${ORG_NS}/ops`,
+      ),
+    ).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Scope badge column
+  // ---------------------------------------------------------------------------
+
+  it('renders a Scope column header', () => {
+    setup([{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' }])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
     expect(
       screen.getByRole('columnheader', { name: /^scope$/i }),
     ).toBeInTheDocument()
+  })
+
+  it('renders scope badges for org, folder, and project rows', () => {
+    setup([
+      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' },
+      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend', createdAt: '' },
+      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
+    ])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
     expect(screen.getByText('Organization: test-org')).toBeInTheDocument()
     expect(screen.getByText('Folder: team-a')).toBeInTheDocument()
     expect(screen.getByText('Project: billing')).toBeInTheDocument()
   })
 
+  // ---------------------------------------------------------------------------
+  // Create CTA
+  // ---------------------------------------------------------------------------
+
+  it('renders a Create Template / New button for org OWNERs', () => {
+    setup([], Role.OWNER)
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    // ResourceGrid renders a "New Template" button linking to the newHref.
+    const newLink = screen.getByRole('link', { name: /template/i })
+    expect(newLink).toHaveAttribute('href', '/organizations/test-org/templates/new')
+  })
+
+  it('hides the Create button for non-OWNER users', () => {
+    setup([], Role.VIEWER)
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    // When canCreate is false, ResourceGrid suppresses the New button.
+    expect(
+      screen.queryByRole('link', { name: /template/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Scope filter dropdown
+  // ---------------------------------------------------------------------------
+
   it('renders a scope filter select in the toolbar', () => {
-    setup([{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway' }])
+    setup([{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' }])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
     expect(
       screen.getByRole('combobox', { name: /filter by scope/i }),
     ).toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Namespace column
+  // ---------------------------------------------------------------------------
+
+  it('renders a Namespace column header', () => {
+    setup([{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' }])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    expect(
+      screen.getByRole('columnheader', { name: /namespace/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the namespace value for each row', () => {
+    setup([
+      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' },
+    ])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    // Namespace column renders the raw namespace string.
+    const ns = screen.getAllByText(ORG_NS)
+    expect(ns.length).toBeGreaterThan(0)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Scope filtering via URL state
+  // ---------------------------------------------------------------------------
+
+  it('filters to only org-scoped rows when scope=org is set in search', () => {
+    mockSearch['scope'] = 'org'
+    setup([
+      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' },
+      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
+    ])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Gateway')).toBeInTheDocument()
+    expect(screen.queryByText('Web Service')).not.toBeInTheDocument()
+  })
+
+  it('filters to only project-scoped rows when scope=project is set in search', () => {
+    mockSearch['scope'] = 'project'
+    setup([
+      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' },
+      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
+    ])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    expect(screen.queryByText('Gateway')).not.toBeInTheDocument()
+    expect(screen.getByText('Web Service')).toBeInTheDocument()
+  })
+
+  it('shows all rows when no scope filter is set', () => {
+    setup([
+      { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' },
+      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
+    ])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Gateway')).toBeInTheDocument()
+    expect(screen.getByText('Web Service')).toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Grid title
+  // ---------------------------------------------------------------------------
+
+  it('renders the grid title with orgName', () => {
+    setup([])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    expect(screen.getByText('test-org / Templates')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
@@ -24,10 +24,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { createColumnHelper } from '@tanstack/react-table'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
+import type { ColumnDef } from '@tanstack/react-table'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useAllTemplatesForOrg } from '@/queries/templates'
@@ -77,15 +77,14 @@ function OrgTemplatesIndexRoute() {
 // Extra columns: Scope badge + Namespace
 // ---------------------------------------------------------------------------
 
-const columnHelper = createColumnHelper<Row>()
-
-const extraColumns = [
-  columnHelper.accessor('namespace', {
+const extraColumns: ColumnDef<Row>[] = [
+  {
     id: 'scope',
     header: 'Scope',
     enableSorting: false,
-    cell: ({ getValue }) => {
-      const ns = getValue()
+    accessorFn: (row) => row.namespace,
+    cell: ({ row }) => {
+      const ns = row.original.namespace
       const label = scopeDisplayLabel(ns)
       const name = scopeNameFromNamespace(ns)
       if (!label) {
@@ -102,17 +101,18 @@ const extraColumns = [
         </Badge>
       )
     },
-  }),
-  columnHelper.accessor('namespace', {
+  },
+  {
     id: 'namespace',
     header: 'Namespace',
     enableSorting: false,
-    cell: ({ getValue }) => (
+    accessorFn: (row) => row.namespace,
+    cell: ({ row }) => (
       <span className="text-muted-foreground font-mono text-sm">
-        {getValue()}
+        {row.original.namespace}
       </span>
     ),
-  }),
+  },
 ]
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
@@ -1,25 +1,22 @@
-import { useState, useMemo } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
-import {
-  useReactTable,
-  getCoreRowModel,
-  getFilteredRowModel,
-  flexRender,
-  createColumnHelper,
-} from '@tanstack/react-table'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+/**
+ * Org-scope Platform Templates index — migrated to ResourceGrid v1 (HOL-975).
+ *
+ * Shows all templates reachable from the org root (org, folder, project scopes)
+ * via the useAllTemplatesForOrg fan-out hook. Each row carries a scope-aware
+ * detailHref so both the resource ID cell and the full row are clickable.
+ *
+ * Extra columns added via the ResourceGrid `extraColumns` prop:
+ *   - Scope    — badge indicating org / folder / project + the owner name
+ *   - Namespace — raw namespace string for operator debugging
+ *
+ * A scope dropdown filter (preserved from the pre-refactor page) is rendered
+ * above the grid via the ResourceGrid `headerContent` slot. Selecting a scope
+ * replaces the URL `?scope=` param so the filter survives refreshes.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Badge } from '@/components/ui/badge'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import {
   Select,
   SelectContent,
@@ -27,18 +24,47 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Skeleton } from '@/components/ui/skeleton'
+import { createColumnHelper } from '@tanstack/react-table'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useAllTemplatesForOrg } from '@/queries/templates'
 import { useGetOrganization } from '@/queries/organizations'
-import type { Template } from '@/gen/holos/console/v1/templates_pb'
 import {
-  scopeDisplayLabel,
   scopeLabelFromNamespace,
   scopeNameFromNamespace,
+  scopeDisplayLabel,
 } from '@/lib/scope-labels'
 
+// ---------------------------------------------------------------------------
+// Route search — extends ResourceGridSearch with the scope filter
+// ---------------------------------------------------------------------------
+
+export interface OrgTemplatesSearch extends ResourceGridSearch {
+  /** Optional scope filter: 'org' | 'folder' | 'project'. Absent = all. */
+  scope?: 'org' | 'folder' | 'project'
+}
+
+type ScopeFilter = 'all' | 'org' | 'folder' | 'project'
+
+function parseOrgTemplatesSearch(raw: Record<string, unknown>): OrgTemplatesSearch {
+  const base = parseGridSearch(raw)
+  const result: OrgTemplatesSearch = { ...base }
+  const scope = raw['scope']
+  if (scope === 'org' || scope === 'folder' || scope === 'project') {
+    result.scope = scope
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
 export const Route = createFileRoute('/_authenticated/organizations/$orgName/templates/')({
+  validateSearch: parseOrgTemplatesSearch,
   component: OrgTemplatesIndexRoute,
 })
 
@@ -47,13 +73,51 @@ function OrgTemplatesIndexRoute() {
   return <OrgTemplatesIndexPage orgName={orgName} />
 }
 
-const columnHelper = createColumnHelper<Template>()
+// ---------------------------------------------------------------------------
+// Extra columns: Scope badge + Namespace
+// ---------------------------------------------------------------------------
 
-// HOL-793: the scope filter narrows the grid to rows of a single scope. The
-// `project` option is shown even though templates at project scope are
-// browsed from the project sidebar — the org-level view is for discovery
-// across all scopes, and filtering lets users zero in on one.
-type ScopeFilter = 'all' | 'org' | 'folder' | 'project'
+const columnHelper = createColumnHelper<Row>()
+
+const extraColumns = [
+  columnHelper.accessor('namespace', {
+    id: 'scope',
+    header: 'Scope',
+    enableSorting: false,
+    cell: ({ getValue }) => {
+      const ns = getValue()
+      const label = scopeDisplayLabel(ns)
+      const name = scopeNameFromNamespace(ns)
+      if (!label) {
+        return (
+          <Badge variant="outline" className="text-xs">
+            unknown
+          </Badge>
+        )
+      }
+      return (
+        <Badge variant="outline" className="text-xs">
+          {label}
+          {name ? `: ${name}` : ''}
+        </Badge>
+      )
+    },
+  }),
+  columnHelper.accessor('namespace', {
+    id: 'namespace',
+    header: 'Namespace',
+    enableSorting: false,
+    cell: ({ getValue }) => (
+      <span className="text-muted-foreground font-mono text-sm">
+        {getValue()}
+      </span>
+    ),
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
 
 export function OrgTemplatesIndexPage({
   orgName: propOrgName,
@@ -67,286 +131,155 @@ export function OrgTemplatesIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const search = Route.useSearch() as OrgTemplatesSearch
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  const scopeFilter: ScopeFilter = search.scope ?? 'all'
+
+  // Fan-out across all namespaces reachable from the org root.
   const { data, isPending, error } = useAllTemplatesForOrg(orgName)
   const { data: org } = useGetOrganization(orgName)
-  // When orgName is empty the fan-out is effectively disabled: isPending is
-  // false (idle) and data is `[]`. The skeleton branch still needs to cover
-  // the authenticated-but-resolving case, so gate on isPending AND data not
-  // yet materialized.
-  const templates = useMemo(() => data ?? [], [data])
 
+  const templates = useMemo(() => data ?? [], [data])
   const userRole = org?.userRole ?? Role.VIEWER
-  // Creation at org scope requires OWNER. Folder/project-scope creates use
-  // their own scoped routes (HOL-793 explicitly leaves those flows alone).
   const canWrite = userRole === Role.OWNER
 
-  const [globalFilter, setGlobalFilter] = useState('')
-  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all')
+  // ---------------------------------------------------------------------------
+  // Build rows — scope-filtered, with scope-aware detailHref
+  // ---------------------------------------------------------------------------
 
-  const rows = useMemo(() => {
-    if (scopeFilter === 'all') return templates
-    return templates.filter(
-      (t) => scopeLabelFromNamespace(t.namespace) === scopeFilter,
-    )
-  }, [templates, scopeFilter])
+  const rows: Row[] = useMemo(() => {
+    const all = templates.map((t): Row => {
+      const scope = scopeLabelFromNamespace(t.namespace)
+      const scopeName = scopeNameFromNamespace(t.namespace)
+      let detailHref: string | undefined
 
-  const columns = useMemo(
+      if (scope === 'org') {
+        detailHref = `/organizations/${orgName}/templates/${t.namespace}/${t.name}`
+      } else if (scope === 'folder' && scopeName) {
+        detailHref = `/folders/${scopeName}/templates/${t.name}`
+      } else if (scope === 'project' && scopeName) {
+        detailHref = `/projects/${scopeName}/templates/${t.name}`
+      }
+
+      return {
+        kind: 'Template',
+        name: t.name,
+        namespace: t.namespace,
+        id: t.name,
+        parentId: scopeName || t.namespace,
+        parentLabel: scopeName || t.namespace,
+        displayName: t.displayName || t.name,
+        description: t.description ?? '',
+        createdAt: t.createdAt ?? '',
+        detailHref,
+      }
+    })
+
+    if (scopeFilter === 'all') return all
+    return all.filter((r) => scopeLabelFromNamespace(r.namespace) === scopeFilter)
+  }, [templates, orgName, scopeFilter])
+
+  // ---------------------------------------------------------------------------
+  // Kind definitions
+  // ---------------------------------------------------------------------------
+
+  const kinds = useMemo(
     () => [
-      columnHelper.accessor((row) => row.displayName || row.name, {
-        id: 'displayName',
-        header: 'Display Name',
-        cell: ({ row }) => {
-          const t = row.original
-          const label = t.displayName || t.name
-          const scope = scopeLabelFromNamespace(t.namespace)
-          // Scope-aware link. A namespace that does not match any known
-          // prefix renders as plain text so we never forge a link to a 404.
-          if (scope === 'org') {
-            return (
-              <Link
-                to="/organizations/$orgName/templates/$namespace/$name"
-                params={{ orgName, namespace: t.namespace, name: t.name }}
-                title={t.name}
-                className="hover:underline font-medium"
-              >
-                {label}
-              </Link>
-            )
-          }
-          if (scope === 'folder') {
-            const folderName = scopeNameFromNamespace(t.namespace)
-            if (folderName) {
-              return (
-                <Link
-                  to="/folders/$folderName/templates/$templateName"
-                  params={{ folderName, templateName: t.name }}
-                  title={t.name}
-                  className="hover:underline font-medium"
-                >
-                  {label}
-                </Link>
-              )
-            }
-          }
-          if (scope === 'project') {
-            const projectName = scopeNameFromNamespace(t.namespace)
-            if (projectName) {
-              return (
-                <Link
-                  to="/projects/$projectName/templates/$templateName"
-                  params={{ projectName, templateName: t.name }}
-                  title={t.name}
-                  className="hover:underline font-medium"
-                >
-                  {label}
-                </Link>
-              )
-            }
-          }
-          return (
-            <span className="font-medium" title={t.name}>
-              {label}
-            </span>
-          )
-        },
-      }),
-      columnHelper.accessor((row) => scopeCellText(row.namespace), {
-        id: 'scope',
-        header: 'Scope',
-        cell: ({ row }) => <ScopeBadge namespace={row.original.namespace} />,
-      }),
-      columnHelper.accessor('namespace', {
-        header: 'Namespace',
-        cell: ({ getValue }) => (
-          <span className="text-muted-foreground font-mono text-sm">
-            {getValue()}
-          </span>
-        ),
-      }),
-      columnHelper.accessor('name', {
-        header: 'Name',
-        cell: ({ getValue }) => (
-          <span className="text-muted-foreground font-mono text-sm">
-            {getValue()}
-          </span>
-        ),
-      }),
+      {
+        id: 'Template',
+        label: 'Template',
+        newHref: `/organizations/${orgName}/templates/new`,
+        canCreate: canWrite,
+      },
     ],
-    [orgName],
+    [orgName, canWrite],
   )
 
-  const table = useReactTable({
-    data: rows,
-    columns,
-    state: { globalFilter },
-    onGlobalFilterChange: setGlobalFilter,
-    globalFilterFn: 'includesString',
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-  })
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
 
-  const queryDisabled = orgName === ''
-  if (isPending || queryDisabled) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>Templates</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-2" data-testid="templates-loading">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    )
-  }
+  const handleDelete = useCallback(async (_row: Row) => {
+    // Org templates index shows templates from multiple scopes; deletion is
+    // handled from each template's own detail/editor page. This index is
+    // read-only for delete actions — the ResourceGrid delete button is not
+    // rendered when onDelete is undefined, but we provide a no-op so the type
+    // is satisfied. Actual deletion is on the detail page.
+    throw new Error('Delete from the template detail page.')
+  }, [])
 
-  // Fall through to the full grid when the fan-out has both an error and
-  // partial data, so successfully-loaded rows remain visible. The banner
-  // below the header surfaces the error without blanking the table.
-  if (error && templates.length === 0) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <Alert variant="destructive">
-            <AlertDescription>{error.message}</AlertDescription>
-          </Alert>
-        </CardContent>
-      </Card>
-    )
-  }
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => {
+          const typedPrev = prev as OrgTemplatesSearch
+          const updated = updater(typedPrev)
+          const next: OrgTemplatesSearch = { ...updated }
+          if (typedPrev.scope) {
+            next.scope = typedPrev.scope
+          }
+          return next
+        },
+      })
+    },
+    [navigate],
+  )
+
+  const handleScopeChange = useCallback(
+    (value: string) => {
+      const scope = value as ScopeFilter
+      navigate({
+        search: (prev) => {
+          const typedPrev = prev as OrgTemplatesSearch
+          const next: OrgTemplatesSearch = { ...typedPrev }
+          if (scope === 'all') {
+            delete next.scope
+          } else {
+            next.scope = scope as 'org' | 'folder' | 'project'
+          }
+          return next
+        },
+      })
+    },
+    [navigate],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Scope filter toolbar content (rendered in ResourceGrid headerContent slot)
+  // ---------------------------------------------------------------------------
+
+  const scopeFilterContent = (
+    <div className="flex items-center gap-2 pb-3">
+      <Select value={scopeFilter} onValueChange={handleScopeChange}>
+        <SelectTrigger className="w-[180px]" aria-label="Filter by scope">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All scopes</SelectItem>
+          <SelectItem value="org">Organization</SelectItem>
+          <SelectItem value="folder">Folder</SelectItem>
+          <SelectItem value="project">Project</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
 
   return (
-    <Card>
-      <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-        <div>
-          <p className="text-sm text-muted-foreground">
-            {orgName} / Templates
-          </p>
-          <CardTitle className="mt-1">Templates</CardTitle>
-        </div>
-        {canWrite && (
-          <Link to="/organizations/$orgName/templates/new" params={{ orgName }}>
-            <Button size="sm">Create Template</Button>
-          </Link>
-        )}
-      </CardHeader>
-      <CardContent>
-        {error && (
-          <Alert
-            variant="destructive"
-            className="mb-4"
-            data-testid="templates-partial-error"
-          >
-            <AlertDescription>{error.message}</AlertDescription>
-          </Alert>
-        )}
-        {templates.length === 0 ? (
-          <div className="flex flex-col items-center gap-3 py-8 text-center">
-            <p className="text-muted-foreground">
-              No templates yet.
-              {canWrite
-                ? ' Create one to get started.'
-                : ' Ask an organization owner to create one.'}
-            </p>
-          </div>
-        ) : (
-          <>
-            <div className="mb-3 flex flex-col sm:flex-row gap-2 sm:items-center">
-              <Input
-                placeholder="Search templates…"
-                value={globalFilter}
-                onChange={(e) => setGlobalFilter(e.target.value)}
-                className="max-w-sm"
-                aria-label="Search templates"
-              />
-              <Select
-                value={scopeFilter}
-                onValueChange={(v) => setScopeFilter(v as ScopeFilter)}
-              >
-                <SelectTrigger
-                  className="w-[180px]"
-                  aria-label="Filter by scope"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All scopes</SelectItem>
-                  <SelectItem value="org">Organization</SelectItem>
-                  <SelectItem value="folder">Folder</SelectItem>
-                  <SelectItem value="project">Project</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            {rows.length === 0 && (
-              <div className="mb-3 rounded-md border border-dashed border-border p-4 text-center">
-                <p className="text-sm text-muted-foreground">
-                  No templates match the current filters.
-                </p>
-              </div>
-            )}
-            <Table>
-              <TableHeader>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <TableRow key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <TableHead key={header.id}>
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext(),
-                            )}
-                      </TableHead>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableHeader>
-              <TableBody>
-                {table.getRowModel().rows.map((row) => (
-                  <TableRow key={row.id}>
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </>
-        )}
-      </CardContent>
-    </Card>
+    <ResourceGrid
+      title={`${orgName} / Templates`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending || orgName === ''}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+      extraColumns={extraColumns}
+      headerContent={scopeFilterContent}
+      sortableColumns={['createdAt']}
+    />
   )
 }
 
-function scopeCellText(namespace: string): string {
-  const label = scopeDisplayLabel(namespace)
-  const name = scopeNameFromNamespace(namespace)
-  if (!label) return ''
-  return name ? `${label}: ${name}` : label
-}
-
-function ScopeBadge({ namespace }: { namespace: string }) {
-  const label = scopeDisplayLabel(namespace)
-  const name = scopeNameFromNamespace(namespace)
-  if (!label) {
-    return (
-      <Badge variant="outline" className="text-xs">
-        unknown
-      </Badge>
-    )
-  }
-  return (
-    <Badge variant="outline" className="text-xs">
-      {label}
-      {name ? `: ${name}` : ''}
-    </Badge>
-  )
-}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new-wrapper.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new-wrapper.test.tsx
@@ -171,4 +171,35 @@ describe('CloneTemplatePage (HOL-974)', () => {
     render(<CloneTemplatePage projectName="my-proj" />)
     expect(useCloneTemplate).toHaveBeenCalledWith('project-my-proj')
   })
+
+  // -------------------------------------------------------------------------
+  // HOL-975: cloneSource pre-selection
+  // -------------------------------------------------------------------------
+
+  it('pre-selects the source when cloneSource matches a linkable template', async () => {
+    render(
+      <CloneTemplatePage
+        projectName="my-proj"
+        cloneSource="org-my-org/httpbin"
+      />,
+    )
+    // After the effect runs, the slug field should be pre-populated from the
+    // matched template's display name.
+    const slugField = screen.getByLabelText('Name slug') as HTMLInputElement
+    await waitFor(() => {
+      expect(slugField.value).toBe('httpbin-v1')
+    })
+  })
+
+  it('does not pre-select when cloneSource does not match any linkable template', async () => {
+    render(
+      <CloneTemplatePage
+        projectName="my-proj"
+        cloneSource="org-my-org/nonexistent"
+      />,
+    )
+    const slugField = screen.getByLabelText('Name slug') as HTMLInputElement
+    // Slug should remain empty because no template matches.
+    expect(slugField.value).toBe('')
+  })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -1,5 +1,5 @@
 /**
- * Project-scoped template clone page (HOL-974).
+ * Project-scoped template clone page (HOL-974, HOL-975).
  *
  * The Service Owner selects a source from the organization's platform
  * templates (ancestor-scope linkable templates) and gives the clone a
@@ -10,9 +10,13 @@
  * enabled ancestor-scope (org/folder) templates that can be cloned into
  * the project namespace. This is the "clone-as-authoring" flow described
  * in HOL-974.
+ *
+ * HOL-975: accepts an optional `cloneSource` search param encoding
+ * "namespace/name" to pre-select a platform template when navigating from
+ * the org-scope template detail page via the "Clone to project" CTA.
  */
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -26,19 +30,42 @@ import {
 } from '@/queries/templates'
 import { namespaceForProject } from '@/lib/scope-labels'
 
+// ---------------------------------------------------------------------------
+// Route search — optional clone source pre-selection (HOL-975)
+// ---------------------------------------------------------------------------
+
+export interface CloneTemplateSearch {
+  /** Encoded as "namespace/name". Set by the org template detail "Clone to project" CTA. */
+  cloneSource?: string
+}
+
+function parseCloneTemplateSearch(raw: Record<string, unknown>): CloneTemplateSearch {
+  const result: CloneTemplateSearch = {}
+  const cloneSource = raw['cloneSource']
+  if (typeof cloneSource === 'string' && cloneSource.length > 0) {
+    result.cloneSource = cloneSource
+  }
+  return result
+}
+
 export const Route = createFileRoute('/_authenticated/projects/$projectName/templates/new')({
+  validateSearch: parseCloneTemplateSearch,
   component: CloneTemplateRoute,
 })
 
 function CloneTemplateRoute() {
   const { projectName } = Route.useParams()
-  return <CloneTemplatePage projectName={projectName} />
+  const search = Route.useSearch() as CloneTemplateSearch
+  return <CloneTemplatePage projectName={projectName} cloneSource={search.cloneSource} />
 }
 
 export function CloneTemplatePage({
   projectName,
+  cloneSource,
 }: {
   projectName: string
+  /** Optional "namespace/name" pre-selection from the org template detail CTA. */
+  cloneSource?: string
 }) {
   const navigate = useNavigate()
   const namespace = namespaceForProject(projectName)
@@ -54,6 +81,30 @@ export function CloneTemplatePage({
   const [displayName, setDisplayName] = useState('')
   const [name, setName] = useState('')
   const [error, setError] = useState<string | null>(null)
+
+  // Pre-select the source from the cloneSource query param (HOL-975).
+  // Only fires once when templates have loaded and a cloneSource param is present.
+  useEffect(() => {
+    if (!cloneSource || sourcesLoading || linkableTemplates.length === 0) return
+    const slash = cloneSource.indexOf('/')
+    if (slash < 0) return
+    const preNs = cloneSource.slice(0, slash)
+    const preName = cloneSource.slice(slash + 1)
+    const match = linkableTemplates.find(
+      (t) => t.namespace === preNs && t.name === preName,
+    )
+    if (match) {
+      setSourceNamespace(preNs)
+      setSourceName(preName)
+      if (!displayName) {
+        const label = match.displayName || match.name
+        setDisplayName(label)
+        setName(label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''))
+      }
+    }
+  // Run only when linkableTemplates becomes non-empty for the first time, or cloneSource changes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cloneSource, sourcesLoading, linkableTemplates.length])
 
   const slugify = (val: string) =>
     val.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')


### PR DESCRIPTION
## Summary

- Migrates `organizations/$orgName/templates/index.tsx` from manual `useReactTable` state to **ResourceGrid v1** with `parseGridSearch`, URL-persisted scope filter (`?scope=`), and scope-aware `detailHref` per row (org → org editor, folder → folder editor, project → project editor).
- Adds extra columns (Scope badge, Namespace) via the ResourceGrid `extraColumns` prop, consistent with the project templates index.
- Adds a **"Clone to project" CTA** to the org template detail page (`$namespace.$name.tsx`): when a project is selected via `useProject()`, the button links to `/projects/$projectName/templates/new?cloneSource=namespace/name`; otherwise renders as a disabled button.
- Updates the project templates clone page (`new.tsx`) to accept `?cloneSource=` search param and pre-select the matching template on mount — wiring the org→project authoring flow end-to-end.

Fixes HOL-975

## Test plan

- [x] `make test-ui` — 1339 tests pass, 0 failures
- [x] Index: loading, error, partial-error, empty state, row routing, scope badges, Namespace column, Create CTA, scope filter dropdown, URL-driven scope filter
- [x] Detail: Clone CTA disabled when no project selected; Clone CTA links to correct URL with `cloneSource` param when project is selected
- [x] Clone page: pre-selects source when `cloneSource` matches a linkable template; no pre-select on mismatch
- [x] Cross-scope equivalence: org/folder/project templates all render identically on the editor page