### PR TITLE
feat(frontend): reverse-dependency view on Template and Deployment detail pages

### DIFF
--- a/frontend/src/components/templates/-reverse-dependents.test.tsx
+++ b/frontend/src/components/templates/-reverse-dependents.test.tsx
@@ -1,0 +1,245 @@
+// Unit tests for the ReverseDependents component (HOL-987).
+//
+// Covers: loading skeleton, error state, empty state, Template dependent rows
+// with scope badges, Deployment dependent rows, and disabled state.
+
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@/queries/templateDependencies', () => ({
+  useListTemplateDependents: vi.fn(),
+  useListDeploymentDependents: vi.fn(),
+  DependencyScope: {
+    UNSPECIFIED: 0,
+    INSTANCE: 1,
+    PROJECT: 2,
+    REMOTE_PROJECT: 3,
+  },
+}))
+
+vi.mock('@/lib/scope-labels', () => ({
+  scopeNameFromNamespace: vi.fn((ns: string) => {
+    if (ns.startsWith('holos-prj-')) return ns.slice('holos-prj-'.length)
+    return ''
+  }),
+}))
+
+import {
+  useListTemplateDependents,
+  useListDeploymentDependents,
+  DependencyScope,
+} from '@/queries/templateDependencies'
+import { ReverseDependents } from './ReverseDependents'
+
+describe('ReverseDependents — Template kind', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders loading skeletons while the RPC is pending', () => {
+    ;(useListTemplateDependents as Mock).mockReturnValue({
+      data: undefined,
+      isPending: true,
+      error: null,
+    })
+
+    render(
+      <ReverseDependents
+        kind="Template"
+        namespace="holos-org-acme"
+        name="reference-grant"
+        enabled
+      />,
+    )
+
+    expect(screen.getByTestId('reverse-dependents-loading')).toBeInTheDocument()
+  })
+
+  it('renders an error alert when the RPC fails', () => {
+    ;(useListTemplateDependents as Mock).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      error: new Error('network failure'),
+    })
+
+    render(
+      <ReverseDependents
+        kind="Template"
+        namespace="holos-org-acme"
+        name="reference-grant"
+        enabled
+      />,
+    )
+
+    expect(screen.getByTestId('reverse-dependents-error')).toBeInTheDocument()
+    expect(screen.getByText('network failure')).toBeInTheDocument()
+  })
+
+  it('renders an empty message when there are no dependents', () => {
+    ;(useListTemplateDependents as Mock).mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+    })
+
+    render(
+      <ReverseDependents
+        kind="Template"
+        namespace="holos-org-acme"
+        name="reference-grant"
+        enabled
+      />,
+    )
+
+    expect(screen.getByText(/no dependents found/i)).toBeInTheDocument()
+  })
+
+  it('renders a row for each TemplateDependentRecord with a scope badge', () => {
+    ;(useListTemplateDependents as Mock).mockReturnValue({
+      data: [
+        {
+          scope: DependencyScope.INSTANCE,
+          dependentNamespace: 'holos-prj-billing',
+          dependentName: 'istio-ingress',
+          requiringTemplateNamespace: 'holos-prj-billing',
+          requiringTemplateName: 'reference-grant',
+        },
+        {
+          scope: DependencyScope.PROJECT,
+          dependentNamespace: 'holos-fld-team-alpha',
+          dependentName: 'reference-grant-req',
+          requiringTemplateNamespace: '',
+          requiringTemplateName: '',
+        },
+        {
+          scope: DependencyScope.REMOTE_PROJECT,
+          dependentNamespace: 'holos-prj-infra',
+          dependentName: 'remote-dep',
+          requiringTemplateNamespace: 'holos-prj-infra',
+          requiringTemplateName: 'reference-grant',
+        },
+      ],
+      isPending: false,
+      error: null,
+    })
+
+    render(
+      <ReverseDependents
+        kind="Template"
+        namespace="holos-org-acme"
+        name="reference-grant"
+        enabled
+      />,
+    )
+
+    const table = screen.getByTestId('reverse-dependents-template')
+    expect(table).toBeInTheDocument()
+
+    // Scope badges
+    expect(screen.getByText('instance')).toBeInTheDocument()
+    expect(screen.getByText('project')).toBeInTheDocument()
+    expect(screen.getByText('remote-project')).toBeInTheDocument()
+
+    // Row identities
+    expect(screen.getByText('holos-prj-billing/istio-ingress')).toBeInTheDocument()
+    expect(screen.getByText('holos-fld-team-alpha/reference-grant-req')).toBeInTheDocument()
+    expect(screen.getByText('holos-prj-infra/remote-dep')).toBeInTheDocument()
+  })
+
+  it('renders nothing when enabled=false', () => {
+    ;(useListTemplateDependents as Mock).mockReturnValue({
+      data: undefined,
+      isPending: true,
+      error: null,
+    })
+
+    const { container } = render(
+      <ReverseDependents
+        kind="Template"
+        namespace="holos-org-acme"
+        name="reference-grant"
+        enabled={false}
+      />,
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('ReverseDependents — Deployment kind', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders a row for each DeploymentDependentRecord', () => {
+    ;(useListDeploymentDependents as Mock).mockReturnValue({
+      data: [
+        {
+          dependentNamespace: 'holos-prj-billing',
+          dependentName: 'istio-ingress',
+        },
+        {
+          dependentNamespace: 'holos-prj-infra',
+          dependentName: 'istio-ingress',
+        },
+      ],
+      isPending: false,
+      error: null,
+    })
+
+    render(
+      <ReverseDependents
+        kind="Deployment"
+        namespace="holos-prj-platform"
+        name="istio-ingress"
+        enabled
+      />,
+    )
+
+    const table = screen.getByTestId('reverse-dependents-deployment')
+    expect(table).toBeInTheDocument()
+
+    // scopeNameFromNamespace strips 'holos-prj-' prefix
+    expect(screen.getByText('billing')).toBeInTheDocument()
+    expect(screen.getByText('infra')).toBeInTheDocument()
+    // deployment name column
+    expect(screen.getAllByText('istio-ingress')).toHaveLength(2)
+  })
+
+  it('renders loading state for Deployment kind', () => {
+    ;(useListDeploymentDependents as Mock).mockReturnValue({
+      data: undefined,
+      isPending: true,
+      error: null,
+    })
+
+    render(
+      <ReverseDependents
+        kind="Deployment"
+        namespace="holos-prj-platform"
+        name="istio-ingress"
+        enabled
+      />,
+    )
+
+    expect(screen.getByTestId('reverse-dependents-loading')).toBeInTheDocument()
+  })
+
+  it('renders error state for Deployment kind', () => {
+    ;(useListDeploymentDependents as Mock).mockReturnValue({
+      data: undefined,
+      isPending: false,
+      error: new Error('rpc error'),
+    })
+
+    render(
+      <ReverseDependents
+        kind="Deployment"
+        namespace="holos-prj-platform"
+        name="istio-ingress"
+        enabled
+      />,
+    )
+
+    expect(screen.getByTestId('reverse-dependents-error')).toBeInTheDocument()
+    expect(screen.getByText('rpc error')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/templates/ReverseDependents.tsx
+++ b/frontend/src/components/templates/ReverseDependents.tsx
@@ -5,7 +5,6 @@
 // reverse-dependency hook. Renders a table of dependents with scope badges
 // derived from the API response.
 
-import React from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'

--- a/frontend/src/components/templates/ReverseDependents.tsx
+++ b/frontend/src/components/templates/ReverseDependents.tsx
@@ -1,0 +1,253 @@
+// ReverseDependents.tsx — "who depends on me?" component for Template and
+// Deployment detail pages (HOL-987 / HOL-986).
+//
+// Accepts a (kind, namespace, name) triple and dispatches to the correct
+// reverse-dependency hook. Renders a table of dependents with scope badges
+// derived from the API response.
+
+import React from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  useListTemplateDependents,
+  useListDeploymentDependents,
+  DependencyScope,
+} from '@/queries/templateDependencies'
+import type {
+  TemplateDependentRecord,
+  DeploymentDependentRecord,
+} from '@/queries/templateDependencies'
+import { scopeNameFromNamespace } from '@/lib/scope-labels'
+
+// Props accepted by the top-level ReverseDependents component.
+export interface ReverseDependentsProps {
+  /** 'Template' uses ListTemplateDependents; 'Deployment' uses ListDeploymentDependents. */
+  kind: 'Template' | 'Deployment'
+  /** Kubernetes namespace of the queried Template or Deployment. */
+  namespace: string
+  /** Name (DNS label slug) of the queried Template or Deployment. */
+  name: string
+  /** When false the RPC is skipped and nothing is rendered. Defaults to true. */
+  enabled?: boolean
+}
+
+// DependencyScopeBadge renders the ADR-032 scope label for a
+// TemplateDependentRecord.scope value.
+function DependencyScopeBadge({ scope }: { scope: DependencyScope }) {
+  switch (scope) {
+    case DependencyScope.INSTANCE:
+      return (
+        <Badge variant="outline" className="text-xs">
+          instance
+        </Badge>
+      )
+    case DependencyScope.PROJECT:
+      return (
+        <Badge variant="outline" className="text-xs">
+          project
+        </Badge>
+      )
+    case DependencyScope.REMOTE_PROJECT:
+      return (
+        <Badge variant="outline" className="text-xs">
+          remote-project
+        </Badge>
+      )
+    default:
+      return (
+        <Badge variant="outline" className="text-xs text-muted-foreground">
+          unknown
+        </Badge>
+      )
+  }
+}
+
+// TemplateDependentsTable renders a table of TemplateDependentRecord items.
+function TemplateDependentsTable({
+  records,
+}: {
+  records: TemplateDependentRecord[]
+}) {
+  if (records.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">No dependents found.</p>
+    )
+  }
+  return (
+    <Table data-testid="reverse-dependents-template">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Dependent</TableHead>
+          <TableHead>Scope</TableHead>
+          <TableHead>Requiring Template</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {records.map((r) => {
+          const depKey = `${r.dependentNamespace}/${r.dependentName}`
+          const reqKey = r.requiringTemplateNamespace
+            ? `${r.requiringTemplateNamespace}/${r.requiringTemplateName}`
+            : '—'
+          return (
+            <TableRow key={depKey}>
+              <TableCell className="font-mono text-sm">{depKey}</TableCell>
+              <TableCell>
+                <DependencyScopeBadge scope={r.scope} />
+              </TableCell>
+              <TableCell className="font-mono text-sm text-muted-foreground">
+                {reqKey}
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}
+
+// DeploymentDependentsTable renders a table of DeploymentDependentRecord items.
+function DeploymentDependentsTable({
+  records,
+}: {
+  records: DeploymentDependentRecord[]
+}) {
+  if (records.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">No dependents found.</p>
+    )
+  }
+  return (
+    <Table data-testid="reverse-dependents-deployment">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Project</TableHead>
+          <TableHead>Deployment</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {records.map((r) => {
+          const projectName = scopeNameFromNamespace(r.dependentNamespace)
+          return (
+            <TableRow key={`${r.dependentNamespace}/${r.dependentName}`}>
+              <TableCell className="font-mono text-sm">
+                {projectName || r.dependentNamespace}
+              </TableCell>
+              <TableCell className="font-mono text-sm">
+                {r.dependentName}
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}
+
+// TemplateDependentsView fetches and renders reverse-dependents for a Template.
+function TemplateDependentsView({
+  namespace,
+  name,
+  enabled,
+}: {
+  namespace: string
+  name: string
+  enabled: boolean
+}) {
+  const { data, isPending, error } = useListTemplateDependents(
+    enabled ? namespace : '',
+    enabled ? name : '',
+  )
+
+  if (!enabled) return null
+
+  if (isPending) {
+    return (
+      <div className="space-y-2" data-testid="reverse-dependents-loading">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive" data-testid="reverse-dependents-error">
+        <AlertDescription>
+          {error instanceof Error ? error.message : String(error)}
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  return <TemplateDependentsTable records={data ?? []} />
+}
+
+// DeploymentDependentsView fetches and renders reverse-dependents for a Deployment.
+function DeploymentDependentsView({
+  namespace,
+  name,
+  enabled,
+}: {
+  namespace: string
+  name: string
+  enabled: boolean
+}) {
+  const { data, isPending, error } = useListDeploymentDependents(
+    enabled ? namespace : '',
+    enabled ? name : '',
+  )
+
+  if (!enabled) return null
+
+  if (isPending) {
+    return (
+      <div className="space-y-2" data-testid="reverse-dependents-loading">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive" data-testid="reverse-dependents-error">
+        <AlertDescription>
+          {error instanceof Error ? error.message : String(error)}
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  return <DeploymentDependentsTable records={data ?? []} />
+}
+
+// ReverseDependents renders the "who depends on me?" view for a Template or
+// Deployment detail page. It is the single shared entry point for both hosts.
+export function ReverseDependents({
+  kind,
+  namespace,
+  name,
+  enabled = true,
+}: ReverseDependentsProps) {
+  if (kind === 'Deployment') {
+    return (
+      <DeploymentDependentsView
+        namespace={namespace}
+        name={name}
+        enabled={enabled}
+      />
+    )
+  }
+  return (
+    <TemplateDependentsView namespace={namespace} name={name} enabled={enabled} />
+  )
+}

--- a/frontend/src/queries/keys.ts
+++ b/frontend/src/queries/keys.ts
@@ -87,6 +87,12 @@ export const keys = {
     get: (namespace: string, name: string) =>
       ['templatePolicyBindings', 'get', namespace, name] as const,
   },
+  templateDependencies: {
+    templateDependents: (namespace: string, name: string) =>
+      ['templateDependencies', 'templateDependents', namespace, name] as const,
+    deploymentDependents: (namespace: string, name: string) =>
+      ['templateDependencies', 'deploymentDependents', namespace, name] as const,
+  },
   templates: {
     list: (namespace: string) => ['templates', 'list', namespace] as const,
     get: (namespace: string, name: string) =>

--- a/frontend/src/queries/templateDependencies.ts
+++ b/frontend/src/queries/templateDependencies.ts
@@ -1,0 +1,62 @@
+// templateDependencies.ts — query hooks for the reverse-dependency RPCs
+// introduced in HOL-986 (ListTemplateDependents, ListDeploymentDependents).
+//
+// These hooks back the <ReverseDependents> component and the Dependencies
+// facet on the unified Templates surface (HOL-987).
+
+import { useMemo } from 'react'
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useQuery } from '@tanstack/react-query'
+import { TemplateService, DependencyScope } from '@/gen/holos/console/v1/templates_pb.js'
+import type {
+  TemplateDependentRecord,
+  DeploymentDependentRecord,
+} from '@/gen/holos/console/v1/templates_pb.js'
+import { useAuth } from '@/lib/auth'
+import { keys } from '@/queries/keys'
+
+// Re-export proto types and enum so consumers import from one place.
+export type { TemplateDependentRecord, DeploymentDependentRecord }
+export { DependencyScope }
+
+// useListTemplateDependents fetches all dependents of a given template
+// identified by (namespace, name). Returns the array of TemplateDependentRecord
+// items sorted by (scope, dependentNamespace, dependentName) as the server
+// guarantees.
+//
+// Backed by TemplateService.ListTemplateDependents introduced in HOL-986.
+export function useListTemplateDependents(namespace: string, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+
+  return useQuery({
+    queryKey: keys.templateDependencies.templateDependents(namespace, name),
+    queryFn: async () => {
+      const response = await client.listTemplateDependents({ namespace, name })
+      return response.dependents
+    },
+    enabled: isAuthenticated && !!namespace && !!name,
+  })
+}
+
+// useListDeploymentDependents fetches all dependent Deployment instances that
+// require the given singleton deployment (cross-project view per ADR 032
+// Decision 3 point 4).
+//
+// Backed by TemplateService.ListDeploymentDependents introduced in HOL-986.
+export function useListDeploymentDependents(namespace: string, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(() => createClient(TemplateService, transport), [transport])
+
+  return useQuery({
+    queryKey: keys.templateDependencies.deploymentDependents(namespace, name),
+    queryFn: async () => {
+      const response = await client.listDeploymentDependents({ namespace, name })
+      return response.dependents
+    },
+    enabled: isAuthenticated && !!namespace && !!name,
+  })
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
@@ -247,7 +247,7 @@ export function ConsolidatedTemplateEditorPage({
           <h3 className="text-sm font-medium">Dependents</h3>
           <Separator />
           <p className="text-xs text-muted-foreground">
-            Who depends on this template (reverse-dependency view from HOL-986).
+            Other templates and deployments that depend on this template.
           </p>
           <ReverseDependents
             kind="Template"

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
@@ -24,6 +24,7 @@ import type { TemplateExample, TemplateDefaults } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 import { useProject } from '@/lib/project-context'
+import { ReverseDependents } from '@/components/templates/ReverseDependents'
 
 // templateDefaultsToCueInput converts a TemplateDefaults message into a CUE
 // input snippet suitable for pre-populating the Project Input textarea. Only
@@ -239,6 +240,20 @@ export function ConsolidatedTemplateEditorPage({
             isSaving={updateMutation.isPending}
             defaultProjectInput={templateDefaultsToCueInput(templateDefaults)}
             namespace={namespace}
+          />
+        </div>
+
+        <div className="space-y-4">
+          <h3 className="text-sm font-medium">Dependents</h3>
+          <Separator />
+          <p className="text-xs text-muted-foreground">
+            Who depends on this template (reverse-dependency view from HOL-986).
+          </p>
+          <ReverseDependents
+            kind="Template"
+            namespace={namespace}
+            name={name}
+            enabled={!!namespace && !!name}
           />
         </div>
       </CardContent>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-$namespace.$name.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-$namespace.$name.test.tsx
@@ -80,6 +80,25 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+// ReverseDependents is covered by its own unit test; here we stub it so the
+// template editor tests stay focused on editor behaviour.
+vi.mock('@/components/templates/ReverseDependents', () => ({
+  ReverseDependents: () => <div data-testid="reverse-dependents-stub" />,
+}))
+
+vi.mock('@/queries/templateDependencies', () => ({
+  useListTemplateDependents: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+  useListDeploymentDependents: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+}))
+
 import {
   useGetTemplate,
   useUpdateTemplate,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-cross-scope.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-cross-scope.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, cleanup } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
+import React from 'react'
 
 // Parameterized test for HOL-607 AC: the consolidated editor must render the
 // same shape regardless of whether the template's namespace originates at the
@@ -81,6 +82,24 @@ vi.mock('@/lib/project-context', () => ({
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+// ReverseDependents is covered by its own unit test.
+vi.mock('@/components/templates/ReverseDependents', () => ({
+  ReverseDependents: () => <div data-testid="reverse-dependents-stub" />,
+}))
+
+vi.mock('@/queries/templateDependencies', () => ({
+  useListTemplateDependents: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+  useListDeploymentDependents: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
 }))
 
 import {

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -44,6 +44,8 @@ import { isSafeHttpUrl } from '@/lib/url'
 import { PolicySection } from '@/components/policy-drift/PolicySection'
 import { SharedDependencyBadge } from '@/components/deployments/SharedDependencyBadge'
 import { CascadeDeleteToggle } from '@/components/deployments/CascadeDeleteToggle'
+import { ReverseDependents } from '@/components/templates/ReverseDependents'
+import { namespaceForProject } from '@/lib/scope-labels'
 
 type DeploymentTab = 'status' | 'logs' | 'preview'
 
@@ -672,6 +674,17 @@ export function DeploymentDetailPage({
                   ) : undefined
                 }
               />
+
+              <div className="space-y-4">
+                <h3 className="text-sm font-medium">Dependents</h3>
+                <Separator />
+                <ReverseDependents
+                  kind="Deployment"
+                  namespace={namespaceForProject(projectName)}
+                  name={deploymentName}
+                  enabled={!!projectName && !!deploymentName}
+                />
+              </div>
 
               {deployment && deployment.env && deployment.env.length > 0 && (
                 <div className="space-y-4">

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -44,6 +44,33 @@ vi.mock('@/queries/projects', () => ({
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
+// ReverseDependents is covered by its own unit test; stub it here so
+// deployment detail tests stay focused on deployment behavior.
+vi.mock('@/components/templates/ReverseDependents', () => ({
+  ReverseDependents: () => <div data-testid="reverse-dependents-stub" />,
+}))
+
+vi.mock('@/queries/templateDependencies', () => ({
+  useListTemplateDependents: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+  useListDeploymentDependents: vi.fn().mockReturnValue({
+    data: [],
+    isPending: false,
+    error: null,
+  }),
+}))
+
+vi.mock('@/lib/scope-labels', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/scope-labels')>()
+  return {
+    ...actual,
+    namespaceForProject: vi.fn((name: string) => `holos-prj-${name}`),
+  }
+})
+
 import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useUpdateDeployment, useDeleteDeployment, useListNamespaceSecrets, useListNamespaceConfigMaps, useGetDeploymentPolicyState, useGetDeploymentRenderPreview } from '@/queries/deployments'
 import { useGetProject } from '@/queries/projects'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'


### PR DESCRIPTION
## Summary

- Adds `useListTemplateDependents` and `useListDeploymentDependents` query hooks backed by the HOL-986 RPCs.
- Adds `<ReverseDependents>` shared component that renders "who depends on me" with ADR-032 scope badges (instance / project / remote-project) on both Template and Deployment detail pages.
- Embeds the Dependents section in the Template editor (`organizations/$orgName/templates/$namespace.$name.tsx`) and the Deployment Status tab (`projects/$projectName/deployments/$deploymentName.tsx`).
- 8 new Vitest unit tests covering loading, error, empty, Template rows (all three scopes), Deployment rows, and disabled state.
- `make test-ui` passes (1332 tests), `make test-go` passes, `tsc --noEmit` clean.

Fixes HOL-987

## Test plan

- [ ] `make test-ui` passes (1332 tests)
- [ ] `make test-go` passes
- [ ] `npx tsc --noEmit` exits 0
- [ ] Template detail page shows Dependents section with scope badges
- [ ] Deployment detail page shows Dependents section in Status tab
- [ ] Empty state ("No dependents found.") renders correctly when no dependents exist