### PR TITLE
chore(frontend): guard against future stale-state nav reads

### DIFF
--- a/docs/agents/frontend-architecture.md
+++ b/docs/agents/frontend-architecture.md
@@ -34,6 +34,18 @@ Use the resource URL convention from
 Use full plural nouns for scoped route prefixes: `organizations`, `projects`,
 and `folders`. Do not reintroduce `/orgs/...`.
 
+## Routing Hook Conventions
+
+Use `useLocation()` or `useRouterState({ select })` for any route reads that
+happen during render — they are reactive subscriptions and will re-render the
+component when the location changes.
+
+`router.state` is a non-reactive snapshot. Reserve it exclusively for one-shot
+reads inside event handlers (e.g. capturing the current path at click time for
+a `returnTo` param). Never read `router.state.location.*` from a component's
+render body; doing so produces stale UI that does not update on client-side
+navigation (the bug fixed in HOL-968).
+
 ## `returnTo` Pattern
 
 Creation flows pass the caller's current location in a `returnTo` search param

--- a/frontend/src/lib/return-to.ts
+++ b/frontend/src/lib/return-to.ts
@@ -22,6 +22,9 @@
  * In a link/button that opens a creation page:
  *
  *   import { buildReturnTo } from '@/lib/return-to'
+ *   // router.state.location is a one-shot snapshot captured at click time inside
+ *   // an event handler — intentionally not reactive.  Use useLocation() for any
+ *   // route reads that need to re-render on navigation.
  *   const search = { returnTo: buildReturnTo(router.state.location) }
  *   <Link to="/organization/new" search={search}>New Org</Link>
  *


### PR DESCRIPTION
## Summary

- Adds a `## Routing Hook Conventions` section to `docs/agents/frontend-architecture.md` documenting the rule: use `useLocation()` / `useRouterState({ select })` for reactive route reads in render; reserve `router.state` for one-shot reads inside event handlers only.
- Annotates the `router.state.location` usage example in `frontend/src/lib/return-to.ts` JSDoc with an explicit comment explaining the intentional snapshot pattern so future readers do not mistake it for a reactive read.

Fixes HOL-969

## Test plan

- [x] `grep -rn 'router\.state\.location' frontend/src/` returns only comment-only hits (JSDoc in `return-to.ts` and a historical-bug comment in `app-sidebar.test.tsx`); no component reads it in render
- [x] All 1353 UI unit tests pass (`make test-ui`)
- [x] `make vet` passes
- [x] Pre-existing lint (42 issues identical on `origin/main` before this branch) and Go envtest port-conflict failures are not introduced by this PR