### PR TITLE
chore(cleanup): remove dead fan-out hooks, update AGENTS.md and audit doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ entry and WorkspaceMenu improvements. Key files:
 | `docs/ui/selected-entity-state.md` | HOL-931 | Selected-entity state contract; read-precedence rules; creation-page invariants |
 | `docs/agents/data-grid-conventions.md` | HOL-940 | Data grid conventions: clickable resource IDs and fully-clickable rows |
 | `docs/agents/frontend-audit-2026-04.md` | HOL-943 | Phase 2 audit baseline — current frontend architecture, gaps, and target conventions |
+| `frontend/src/queries/templateDependencies.ts` | HOL-986 | `useListTemplateDependents` / `useListDeploymentDependents` reverse-dep query hooks |
+| `frontend/src/components/templates/ReverseDependents.tsx` | HOL-987 | "Who depends on me" section with ADR-032 scope badges (instance / project / remote-project) |
 
 **Deleted (HOL-914)**: `frontend/src/components/resource-manager/` and
 `frontend/src/routes/_authenticated/resource-manager/` were removed when the

--- a/docs/agents/frontend-audit-2026-04.md
+++ b/docs/agents/frontend-audit-2026-04.md
@@ -39,6 +39,7 @@ Query hooks live in `frontend/src/queries/`:
 - `projects.ts`
 - `resources.ts`
 - `secrets.ts`
+- `templateDependencies.ts` — `useListTemplateDependents`, `useListDeploymentDependents` (HOL-986)
 - `templatePolicies.ts`
 - `templatePolicyBindings.ts`
 - `templates.ts`
@@ -65,10 +66,11 @@ return useQuery({
 })
 ```
 
-Fan-out hooks, such as `useAllTemplatesForOrg`,
-`useAllTemplatePoliciesForOrg`, and `useAllTemplatePolicyBindingsForOrg`, keep
-the same auth/parameter guard but compose multiple queries with
-`aggregateFanOut` so partial data can render with a warning.
+Fan-out hooks, such as `useAllTemplatesForOrg`, keep the same auth/parameter
+guard but compose multiple queries with `aggregateFanOut` so partial data can
+render with a warning. `useAllTemplatePoliciesForOrg` and
+`useAllTemplatePolicyBindingsForOrg` were removed in HOL-989 (no route
+consumers).
 
 ### Grid inventory
 
@@ -207,5 +209,7 @@ direct component test and callers only need page-level rendering coverage.
   calls are still needed.
 - Move org/folder TemplatePolicy and TemplatePolicyBinding list pages onto
   `ResourceGrid` if their UX should match project-scoped resource lists.
-- Replace client fan-out with server-side search/list RPCs when backend support
-  is available.
+- Replace client fan-out (`useAllTemplatesForOrg`) with server-side search/list
+  RPCs when backend support is available.
+- Remove `useAllTemplatePoliciesForOrg` and `useAllTemplatePolicyBindingsForOrg`.
+  **Done in HOL-989**: both hooks had no route consumers and were deleted.

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -5,7 +5,6 @@ import { useTransport } from '@connectrpc/connect-query'
 import {
   keepPreviousData,
   useQuery,
-  useQueries,
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query'
@@ -20,9 +19,6 @@ import type {
   LinkableTemplatePolicy,
 } from '@/gen/holos/console/v1/template_policies_pb.js'
 import { useAuth } from '@/lib/auth'
-import { useListFolders } from '@/queries/folders'
-import type { Folder } from '@/gen/holos/console/v1/folders_pb.js'
-import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
 import { keys } from '@/queries/keys'
 
 // Re-export generated types/enums used by UI consumers. HOL-600 removed
@@ -133,90 +129,6 @@ export function aggregateFanOut<T>(
     if (q.data) data.push(...q.data)
   }
   return { data, isPending: false, error }
-}
-
-// Module-level sentinel so the `folders` useMemo fallback preserves reference
-// identity across renders when the folders list is still pending or empty.
-const EMPTY_FOLDERS: readonly Folder[] = []
-
-// useAllTemplatePoliciesForOrg fans a ListTemplatePolicies call across every
-// namespace reachable from an organization root — the org namespace plus one
-// namespace per folder visible to the caller — and flattens the results into
-// one array. HOL-608 AC requires the unified Template Policies index to show
-// org- and folder-scoped policies together, but TemplatePolicyService has no
-// SearchTemplatePolicies RPC (tracked in HOL-590 as the eventual server-side
-// consolidation). Until that lands this hook is the client-side fan-out.
-//
-// See aggregateFanOut for the exact pending / error semantics.
-export function useAllTemplatePoliciesForOrg(
-  orgName: string,
-): FanOutAggregate<TemplatePolicy> {
-  const { isAuthenticated } = useAuth()
-  const transport = useTransport()
-  const client = useMemo(
-    () => createClient(TemplatePolicyService, transport),
-    [transport],
-  )
-  const orgNamespace = namespaceForOrg(orgName)
-  const foldersQuery = useListFolders(orgName)
-  const folders = useMemo(
-    () => foldersQuery.data ?? EMPTY_FOLDERS,
-    [foldersQuery.data],
-  )
-
-  const folderQueries = useQueries({
-    queries: folders.map((folder) => ({
-      queryKey: keys.templatePolicies.list(namespaceForFolder(folder.name)),
-      queryFn: async (): Promise<TemplatePolicy[]> => {
-        const response = await client.listTemplatePolicies({
-          namespace: namespaceForFolder(folder.name),
-        })
-        return response.policies
-      },
-      enabled: isAuthenticated && !!folder.name,
-    })),
-  })
-
-  const orgQuery = useQuery({
-    queryKey: keys.templatePolicies.list(orgNamespace),
-    queryFn: async () => {
-      const response = await client.listTemplatePolicies({
-        namespace: orgNamespace,
-      })
-      return response.policies
-    },
-    enabled: isAuthenticated && !!orgNamespace,
-  })
-
-  // Model the folders-list query as one more input to aggregateFanOut.
-  // When folders are still loading we want the aggregate to report pending
-  // (nothing has materialized yet). When the folders-list errored we want
-  // the caller to see the error alongside any org-scoped policies that did
-  // resolve, rather than blanking the whole grid on a structural failure.
-  // Wrapping the folders query in a FanOutQueryState<TemplatePolicy[]>
-  // (with data always [] on success) gives us both behaviors for free.
-  const foldersAsQuery: FanOutQueryState<TemplatePolicy[]> = {
-    data: foldersQuery.data === undefined ? undefined : [],
-    error: foldersQuery.error,
-    isPending: foldersQuery.isPending,
-    fetchStatus: foldersQuery.fetchStatus,
-  }
-
-  return aggregateFanOut<TemplatePolicy>([
-    foldersAsQuery,
-    {
-      data: orgQuery.data,
-      error: orgQuery.error,
-      isPending: orgQuery.isPending,
-      fetchStatus: orgQuery.fetchStatus,
-    },
-    ...folderQueries.map((q) => ({
-      data: q.data,
-      error: q.error,
-      isPending: q.isPending,
-      fetchStatus: q.fetchStatus,
-    })),
-  ])
 }
 
 // useGetTemplatePolicy fetches a single policy by name within a namespace.

--- a/frontend/src/queries/templatePolicyBindings.ts
+++ b/frontend/src/queries/templatePolicyBindings.ts
@@ -5,7 +5,6 @@ import { useTransport } from '@connectrpc/connect-query'
 import {
   keepPreviousData,
   useQuery,
-  useQueries,
   useMutation,
   useQueryClient,
   type QueryClient,
@@ -21,15 +20,7 @@ import type {
   LinkedTemplatePolicyRef,
 } from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
 import { useAuth } from '@/lib/auth'
-import { useListFolders } from '@/queries/folders'
-import type { Folder } from '@/gen/holos/console/v1/folders_pb.js'
-import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
 import { keys } from '@/queries/keys'
-import {
-  aggregateFanOut,
-  type FanOutAggregate,
-  type FanOutQueryState,
-} from '@/queries/templatePolicies'
 
 // WILDCARD is the sentinel value that matches any resource name or project
 // within a binding's scope (mirrors policyresolver.WildcardAny on the server).
@@ -114,87 +105,6 @@ export function useListTemplatePolicyBindings(namespace: string) {
     enabled: isAuthenticated && !!namespace,
     placeholderData: keepPreviousData,
   })
-}
-
-// Module-level sentinel preserves reference identity across renders when the
-// folders list is still pending or empty.
-const EMPTY_FOLDERS: readonly Folder[] = []
-
-// useAllTemplatePolicyBindingsForOrg fans a ListTemplatePolicyBindings call
-// across every namespace reachable from an organization root — the org
-// namespace plus one namespace per folder visible to the caller — and
-// flattens the results into one array. Bindings live only at org or folder
-// scope (HOL-590), so project namespaces are not fanned out.
-//
-// Used by the unified org-level Template Policy Bindings index (HOL-793).
-// Semantics match useAllTemplatePoliciesForOrg; partial data + error is
-// preserved so the caller can keep successfully-loaded rows visible while
-// rendering a warning banner.
-export function useAllTemplatePolicyBindingsForOrg(
-  orgName: string,
-): FanOutAggregate<TemplatePolicyBinding> {
-  const { isAuthenticated } = useAuth()
-  const transport = useTransport()
-  const client = useMemo(
-    () => createClient(TemplatePolicyBindingService, transport),
-    [transport],
-  )
-  const orgNamespace = namespaceForOrg(orgName)
-  const foldersQuery = useListFolders(orgName)
-  const folders = useMemo(
-    () => foldersQuery.data ?? EMPTY_FOLDERS,
-    [foldersQuery.data],
-  )
-
-  const folderQueries = useQueries({
-    queries: folders.map((folder) => ({
-      queryKey: keys.templatePolicyBindings.list(namespaceForFolder(folder.name)),
-      queryFn: async (): Promise<TemplatePolicyBinding[]> => {
-        const response = await client.listTemplatePolicyBindings({
-          namespace: namespaceForFolder(folder.name),
-        })
-        return response.bindings
-      },
-      enabled: isAuthenticated && !!folder.name,
-    })),
-  })
-
-  const orgQuery = useQuery({
-    queryKey: keys.templatePolicyBindings.list(orgNamespace),
-    queryFn: async () => {
-      const response = await client.listTemplatePolicyBindings({
-        namespace: orgNamespace,
-      })
-      return response.bindings
-    },
-    enabled: isAuthenticated && !!orgNamespace,
-  })
-
-  // Wrap the folders-list query as a FanOutQueryState<TemplatePolicyBinding[]>
-  // with data=[] on success so other scopes' rows keep rendering when the
-  // folders list itself errors.
-  const foldersAsQuery: FanOutQueryState<TemplatePolicyBinding[]> = {
-    data: foldersQuery.data === undefined ? undefined : [],
-    error: foldersQuery.error,
-    isPending: foldersQuery.isPending,
-    fetchStatus: foldersQuery.fetchStatus,
-  }
-
-  return aggregateFanOut<TemplatePolicyBinding>([
-    foldersAsQuery,
-    {
-      data: orgQuery.data,
-      error: orgQuery.error,
-      isPending: orgQuery.isPending,
-      fetchStatus: orgQuery.fetchStatus,
-    },
-    ...folderQueries.map((q) => ({
-      data: q.data,
-      error: q.error,
-      isPending: q.isPending,
-      fetchStatus: q.fetchStatus,
-    })),
-  ])
 }
 
 // useGetTemplatePolicyBinding fetches a single binding by name within a namespace.

--- a/frontend/src/queries/templates.ts
+++ b/frontend/src/queries/templates.ts
@@ -108,18 +108,17 @@ const EMPTY_PROJECTS: readonly Project[] = []
 // useAllTemplatesForOrg fans a ListTemplates call across every namespace
 // reachable from an organization root — the org namespace, every folder
 // namespace, and every project namespace visible to the caller — and flattens
-// the results into one array. HOL-793 uses this to render the unified
-// org-level Templates index with scope indicators and filters without
-// requiring a server-side SearchTemplates fan-out. TemplateService exposes
+// the results into one array. Used by the org-level Templates index
+// (organizations/$orgName/templates) to show scope indicators and filters
+// without a server-side SearchTemplates fan-out. TemplateService exposes
 // `SearchTemplates`, but it returns proto Template payloads scoped by the
 // caller's `organization` filter only, without breaking out folder/project
 // results — and the current UI needs the per-namespace list semantics for
-// correct cache invalidation. Once server-side listing lands (tracked in
-// HOL-590), this hook should be retired in favor of SearchTemplates.
+// correct cache invalidation. Once server-side listing lands, this hook
+// should be retired in favor of SearchTemplates.
 //
-// Semantics match useAllTemplatePoliciesForOrg: partial data + error is
-// preserved so the caller can keep successfully-loaded rows visible while
-// rendering a warning banner.
+// Partial data + error is preserved so the caller can keep successfully-loaded
+// rows visible while rendering a warning banner.
 export function useAllTemplatesForOrg(orgName: string): FanOutAggregate<Template> {
   const { isAuthenticated } = useAuth()
   const transport = useTransport()


### PR DESCRIPTION
## Summary

- Removes `useAllTemplatePoliciesForOrg` from `frontend/src/queries/templatePolicies.ts` — no route consumers; the org-level template-policies index uses `useListTemplatePolicies` directly.
- Removes `useAllTemplatePolicyBindingsForOrg` from `frontend/src/queries/templatePolicyBindings.ts` — no route consumers; all binding pages use `useListTemplatePolicyBindings` directly.
- Cleans up associated dead imports in both files (`useListFolders`, `useQueries`, `EMPTY_FOLDERS` sentinel, `namespaceForFolder`, `namespaceForOrg`, fan-out types from templatePolicies).
- Updates `AGENTS.md` MVP UI table with HOL-986/HOL-987 entries (`templateDependencies.ts` query module, `ReverseDependents` component).
- Updates `docs/agents/frontend-audit-2026-04.md` query inventory and follow-up list to record the removals and the HOL-986 addition.
- Updates stale `templates.ts` comment that referenced "HOL-793" with a current description.

The `aggregateFanOut` helper and its exported types (`FanOutAggregate`, `FanOutQueryState`) are retained in `templatePolicies.ts` because `useAllTemplatesForOrg` (still live in the org templates index) cross-imports them.

Fixes HOL-989

## Test plan

- [x] `npx tsc --noEmit` exits 0 (clean)
- [x] `make test-ui` passes (1353 tests, unchanged from baseline)
- [x] `make test-go` passes
- [x] `make vet` clean
- [x] `make check-imports` clean

## Deferred Acceptance Criteria

- [ ] Org-level `template-policies`, `template-bindings`, and folder-level `template-policy-bindings` routes are not reachable via sidebar nav but remain live and functional. Collapsing them into a unified surface (HOL-987's original four-facet vision) is deferred until a follow-up issue under HOL-981 is created and scoped.