### PR TITLE
feat(templates): unified four-facet Templates surface at org scope

### DIFF
--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -379,11 +379,13 @@ describe('AppSidebar — nav links when a project is selected', () => {
     ).toBe('/projects/my-project/deployments')
   })
 
-  it('Templates link resolves to the correct project-scoped URL', () => {
+  it('Templates link resolves to the org-scoped unified surface URL when an org is selected (HOL-1006)', () => {
     render(<AppSidebar />)
+    // When an org is selected, Templates navigates to the unified org-level
+    // surface (Templates + Policies + Bindings) regardless of project selection.
     expect(
       screen.getByRole('link', { name: /^templates$/i }).getAttribute('href'),
-    ).toBe('/projects/my-project/templates')
+    ).toBe('/organizations/my-org/templates')
   })
 
   it('no disabled buttons when org and project are selected', () => {

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -87,11 +87,24 @@ export function AppSidebar() {
     {
       label: 'Templates',
       icon: LayoutTemplate,
-      href: hasProject ? `/projects/${selectedProject}/templates` : '#',
-      to: '/projects/$projectName/templates',
-      params: hasProject ? { projectName: selectedProject! } : undefined,
-      disabled: !hasProject,
-      disabledReason: 'Select a project to view Templates',
+      // When an org is selected, link to the unified org-level surface
+      // (Templates + Policies + Bindings). Fall back to the project-scoped
+      // page if a project but no org is selected, or disable if neither.
+      href: hasOrg
+        ? `/organizations/${selectedOrg}/templates`
+        : hasProject
+          ? `/projects/${selectedProject}/templates`
+          : '#',
+      to: hasOrg
+        ? '/organizations/$orgName/templates'
+        : '/projects/$projectName/templates',
+      params: hasOrg
+        ? { orgName: selectedOrg! }
+        : hasProject
+          ? { projectName: selectedProject! }
+          : undefined,
+      disabled: !hasOrg && !hasProject,
+      disabledReason: 'Select an organization to view Templates',
     },
   ]
 

--- a/frontend/src/queries/templatePolicies.ts
+++ b/frontend/src/queries/templatePolicies.ts
@@ -5,6 +5,7 @@ import { useTransport } from '@connectrpc/connect-query'
 import {
   keepPreviousData,
   useQuery,
+  useQueries,
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query'
@@ -19,6 +20,9 @@ import type {
   LinkableTemplatePolicy,
 } from '@/gen/holos/console/v1/template_policies_pb.js'
 import { useAuth } from '@/lib/auth'
+import { useListFolders } from '@/queries/folders'
+import type { Folder } from '@/gen/holos/console/v1/folders_pb.js'
+import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
 import { keys } from '@/queries/keys'
 
 // Re-export generated types/enums used by UI consumers. HOL-600 removed
@@ -129,6 +133,85 @@ export function aggregateFanOut<T>(
     if (q.data) data.push(...q.data)
   }
   return { data, isPending: false, error }
+}
+
+// Module-level sentinel so the `folders` useMemo fallback preserves reference
+// identity across renders when the folders list is still pending or empty.
+const EMPTY_FOLDERS: readonly Folder[] = []
+
+// useAllTemplatePoliciesForOrg fans a ListTemplatePolicies call across every
+// namespace reachable from an organization root — the org namespace plus one
+// namespace per folder visible to the caller — and flattens the results into
+// one array. Re-introduced for HOL-1006 to power the unified four-facet
+// Templates surface (Templates | Policies | Bindings) at the org-level
+// templates index. Template policies do not exist at project scope, so only
+// org and folder namespaces are queried.
+//
+// See aggregateFanOut for the exact pending / error semantics.
+export function useAllTemplatePoliciesForOrg(
+  orgName: string,
+): FanOutAggregate<TemplatePolicy> {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyService, transport),
+    [transport],
+  )
+  const orgNamespace = namespaceForOrg(orgName)
+  const foldersQuery = useListFolders(orgName)
+  const folders = useMemo(
+    () => foldersQuery.data ?? EMPTY_FOLDERS,
+    [foldersQuery.data],
+  )
+
+  const folderQueries = useQueries({
+    queries: folders.map((folder) => ({
+      queryKey: keys.templatePolicies.list(namespaceForFolder(folder.name)),
+      queryFn: async (): Promise<TemplatePolicy[]> => {
+        const response = await client.listTemplatePolicies({
+          namespace: namespaceForFolder(folder.name),
+        })
+        return response.policies
+      },
+      enabled: isAuthenticated && !!folder.name,
+    })),
+  })
+
+  const orgQuery = useQuery({
+    queryKey: keys.templatePolicies.list(orgNamespace),
+    queryFn: async () => {
+      const response = await client.listTemplatePolicies({
+        namespace: orgNamespace,
+      })
+      return response.policies
+    },
+    enabled: isAuthenticated && !!orgNamespace,
+  })
+
+  // Model the folders-list query as one more input to aggregateFanOut so
+  // pending folders postpone the aggregate and folders errors surface inline.
+  const foldersAsQuery: FanOutQueryState<TemplatePolicy[]> = {
+    data: foldersQuery.data === undefined ? undefined : [],
+    error: foldersQuery.error,
+    isPending: foldersQuery.isPending,
+    fetchStatus: foldersQuery.fetchStatus,
+  }
+
+  return aggregateFanOut<TemplatePolicy>([
+    foldersAsQuery,
+    {
+      data: orgQuery.data,
+      error: orgQuery.error,
+      isPending: orgQuery.isPending,
+      fetchStatus: orgQuery.fetchStatus,
+    },
+    ...folderQueries.map((q) => ({
+      data: q.data,
+      error: q.error,
+      isPending: q.isPending,
+      fetchStatus: q.fetchStatus,
+    })),
+  ])
 }
 
 // useGetTemplatePolicy fetches a single policy by name within a namespace.

--- a/frontend/src/queries/templatePolicyBindings.ts
+++ b/frontend/src/queries/templatePolicyBindings.ts
@@ -5,6 +5,7 @@ import { useTransport } from '@connectrpc/connect-query'
 import {
   keepPreviousData,
   useQuery,
+  useQueries,
   useMutation,
   useQueryClient,
   type QueryClient,
@@ -20,6 +21,14 @@ import type {
   LinkedTemplatePolicyRef,
 } from '@/gen/holos/console/v1/template_policy_bindings_pb.js'
 import { useAuth } from '@/lib/auth'
+import { useListFolders } from '@/queries/folders'
+import type { Folder } from '@/gen/holos/console/v1/folders_pb.js'
+import { namespaceForFolder, namespaceForOrg } from '@/lib/scope-labels'
+import {
+  aggregateFanOut,
+  type FanOutAggregate,
+  type FanOutQueryState,
+} from '@/queries/templatePolicies'
 import { keys } from '@/queries/keys'
 
 // WILDCARD is the sentinel value that matches any resource name or project
@@ -86,6 +95,86 @@ export function invalidateDeploymentPreviews(
 // Re-export generated types/enums used by UI consumers.
 export type { TemplatePolicyBinding, TemplatePolicyBindingTargetRef, LinkedTemplatePolicyRef }
 export { TemplatePolicyBindingTargetKind }
+
+// Module-level sentinel so the `folders` useMemo fallback preserves reference
+// identity across renders when the folders list is still pending or empty.
+const EMPTY_FOLDERS: readonly Folder[] = []
+
+// useAllTemplatePolicyBindingsForOrg fans a ListTemplatePolicyBindings call
+// across every namespace reachable from an organization root — the org namespace
+// plus one namespace per folder visible to the caller — and flattens the results
+// into one array. Re-introduced for HOL-1006 to power the unified four-facet
+// Templates surface (Templates | Policies | Bindings) at the org-level
+// templates index. TemplatePolicyBindings do not exist at project scope, so
+// only org and folder namespaces are queried.
+//
+// See aggregateFanOut (from templatePolicies.ts) for the exact pending / error
+// semantics.
+export function useAllTemplatePolicyBindingsForOrg(
+  orgName: string,
+): FanOutAggregate<TemplatePolicyBinding> {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplatePolicyBindingService, transport),
+    [transport],
+  )
+  const orgNamespace = namespaceForOrg(orgName)
+  const foldersQuery = useListFolders(orgName)
+  const folders = useMemo(
+    () => foldersQuery.data ?? EMPTY_FOLDERS,
+    [foldersQuery.data],
+  )
+
+  const folderQueries = useQueries({
+    queries: folders.map((folder) => ({
+      queryKey: keys.templatePolicyBindings.list(namespaceForFolder(folder.name)),
+      queryFn: async (): Promise<TemplatePolicyBinding[]> => {
+        const response = await client.listTemplatePolicyBindings({
+          namespace: namespaceForFolder(folder.name),
+        })
+        return response.bindings
+      },
+      enabled: isAuthenticated && !!folder.name,
+    })),
+  })
+
+  const orgQuery = useQuery({
+    queryKey: keys.templatePolicyBindings.list(orgNamespace),
+    queryFn: async () => {
+      const response = await client.listTemplatePolicyBindings({
+        namespace: orgNamespace,
+      })
+      return response.bindings
+    },
+    enabled: isAuthenticated && !!orgNamespace,
+  })
+
+  // Model the folders-list query as one more input to aggregateFanOut so
+  // pending folders postpone the aggregate and folders errors surface inline.
+  const foldersAsQuery: FanOutQueryState<TemplatePolicyBinding[]> = {
+    data: foldersQuery.data === undefined ? undefined : [],
+    error: foldersQuery.error,
+    isPending: foldersQuery.isPending,
+    fetchStatus: foldersQuery.fetchStatus,
+  }
+
+  return aggregateFanOut<TemplatePolicyBinding>([
+    foldersAsQuery,
+    {
+      data: orgQuery.data,
+      error: orgQuery.error,
+      isPending: orgQuery.isPending,
+      fetchStatus: orgQuery.fetchStatus,
+    },
+    ...folderQueries.map((q) => ({
+      data: q.data,
+      error: q.error,
+      isPending: q.isPending,
+      fetchStatus: q.fetchStatus,
+    })),
+  ])
+}
 
 // useListTemplatePolicyBindings fetches all bindings visible within a namespace.
 // Mirrors the shape of useListTemplatePolicies in queries/templatePolicies.ts.

--- a/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/-index.test.tsx
@@ -51,6 +51,10 @@ vi.mock('@/queries/templatePolicies', () => ({
   useListTemplatePolicies: vi.fn(),
 }))
 
+vi.mock('@/queries/templatePolicyBindings', () => ({
+  useListTemplatePolicyBindings: vi.fn(),
+}))
+
 vi.mock('@/queries/projects', () => ({
   useListProjectsByParent: vi.fn(),
 }))
@@ -69,6 +73,7 @@ vi.mock('@/lib/console-config', () => ({
 import { useGetFolder } from '@/queries/folders'
 import { useListTemplates } from '@/queries/templates'
 import { useListTemplatePolicies } from '@/queries/templatePolicies'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import { useListProjectsByParent } from '@/queries/projects'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { namespaceForFolder } from '@/lib/scope-labels'
@@ -76,6 +81,7 @@ import { FolderIndexPage } from './index'
 
 type TemplateFixture = { name: string; displayName?: string; enabled?: boolean }
 type PolicyFixture = { name: string }
+type BindingFixture = { name: string; displayName?: string; policyRef?: { name: string } }
 type ProjectFixture = { name: string; displayName?: string }
 
 const mockFolder = {
@@ -97,6 +103,9 @@ function setup(
     policies?: PolicyFixture[]
     policiesPending?: boolean
     policiesError?: Error | null
+    bindings?: BindingFixture[]
+    bindingsPending?: boolean
+    bindingsError?: Error | null
     projects?: ProjectFixture[]
     projectsPending?: boolean
     projectsError?: Error | null
@@ -116,6 +125,11 @@ function setup(
     data: overrides.policiesPending ? undefined : overrides.policies ?? [],
     isPending: overrides.policiesPending ?? false,
     error: overrides.policiesError ?? null,
+  })
+  ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
+    data: overrides.bindingsPending ? undefined : overrides.bindings ?? [],
+    isPending: overrides.bindingsPending ?? false,
+    error: overrides.bindingsError ?? null,
   })
   ;(useListProjectsByParent as Mock).mockReturnValue({
     data: overrides.projectsPending ? undefined : overrides.projects ?? [],
@@ -142,7 +156,7 @@ describe('FolderIndexPage', () => {
     )
   })
 
-  it('renders all three summary sections in order: Templates, Template Policies, Projects', () => {
+  it('renders all four summary sections in order: Templates, Template Policies, Template Policy Bindings, Projects', () => {
     setup()
     render(<FolderIndexPage folderName="payments" />)
     // Section order is established by the document order of the
@@ -154,6 +168,9 @@ describe('FolderIndexPage', () => {
     })
     const policiesLink = screen.getByRole('link', {
       name: 'View all template policies',
+    })
+    const bindingsLink = screen.getByRole('link', {
+      name: 'View all template policy bindings',
     })
     const projectsLink = screen.getByRole('link', {
       name: 'View all projects',
@@ -167,7 +184,10 @@ describe('FolderIndexPage', () => {
       templatesLink.compareDocumentPosition(policiesLink),
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(
-      policiesLink.compareDocumentPosition(projectsLink),
+      policiesLink.compareDocumentPosition(bindingsLink),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(
+      bindingsLink.compareDocumentPosition(projectsLink),
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
@@ -181,6 +201,7 @@ describe('FolderIndexPage', () => {
     setup({
       templatesPending: true,
       policiesPending: true,
+      bindingsPending: true,
       projectsPending: true,
     })
     const { container } = render(<FolderIndexPage folderName="payments" />)
@@ -189,6 +210,9 @@ describe('FolderIndexPage', () => {
     ).toBeInTheDocument()
     expect(
       container.querySelector('[data-testid="template-policies-loading"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-testid="template-policy-bindings-loading"]'),
     ).toBeInTheDocument()
     expect(
       container.querySelector('[data-testid="projects-loading"]'),
@@ -203,6 +227,9 @@ describe('FolderIndexPage', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(/no template policies in this folder/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/no template policy bindings in this folder/i),
     ).toBeInTheDocument()
     expect(screen.getByText(/no projects in this folder/i)).toBeInTheDocument()
   })
@@ -243,7 +270,9 @@ describe('FolderIndexPage', () => {
     // ...and the Templates section surfaces a "0 total" count badge so
     // the undefined-data path is visually consistent with the zero-
     // count path — both tell the user there are zero templates.
-    expect(screen.getByLabelText('0 total')).toBeInTheDocument()
+    // getAllByLabelText because other empty sections also render a "0 total" badge.
+    const zeroBadges = screen.getAllByLabelText('0 total')
+    expect(zeroBadges.length).toBeGreaterThan(0)
     // ...and no template-item link leaks through. The two neighbor
     // sections rendered their own items, so "no hrefs into the
     // templates editor" is a tight regression pin.
@@ -306,6 +335,14 @@ describe('FolderIndexPage', () => {
     ).toHaveAttribute('href', '/folders/payments/template-policies/disallow-privileged')
   })
 
+  it('renders template policy bindings with per-item link into the folder scope (HOL-1006)', () => {
+    setup({ bindings: [{ name: 'bind-require-istio', displayName: 'Bind Require Istio' }] })
+    render(<FolderIndexPage folderName="payments" />)
+    expect(
+      screen.getByRole('link', { name: 'Bind Require Istio' }),
+    ).toHaveAttribute('href', '/folders/payments/template-policy-bindings/bind-require-istio')
+  })
+
   it('renders projects with displayName fallback and a per-item link', () => {
     setup({
       projects: [
@@ -328,14 +365,17 @@ describe('FolderIndexPage', () => {
     setup()
     render(<FolderIndexPage folderName="payments" />)
     // Each "View all" link carries a section-specific aria-label so
-    // the three buttons are distinguishable in a screen-reader link
-    // list. All three target folder-scoped indexes.
+    // the four buttons are distinguishable in a screen-reader link
+    // list. All four target folder-scoped indexes.
     expect(
       screen.getByRole('link', { name: 'View all templates' }),
     ).toHaveAttribute('href', '/folders/payments/templates')
     expect(
       screen.getByRole('link', { name: 'View all template policies' }),
     ).toHaveAttribute('href', '/folders/payments/template-policies')
+    expect(
+      screen.getByRole('link', { name: 'View all template policy bindings' }),
+    ).toHaveAttribute('href', '/folders/payments/template-policy-bindings')
     expect(
       screen.getByRole('link', { name: 'View all projects' }),
     ).toHaveAttribute('href', '/folders/payments/projects')
@@ -345,19 +385,24 @@ describe('FolderIndexPage', () => {
     setup({
       templatesError: new Error('template list failed'),
       policiesError: new Error('policy list failed'),
+      bindingsError: new Error('binding list failed'),
       projectsError: new Error('project list failed'),
     })
     render(<FolderIndexPage folderName="payments" />)
     expect(screen.getByText(/template list failed/i)).toBeInTheDocument()
     expect(screen.getByText(/policy list failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/binding list failed/i)).toBeInTheDocument()
     expect(screen.getByText(/project list failed/i)).toBeInTheDocument()
   })
 
-  it('calls useListTemplates with the folder namespace, not the folder name', () => {
+  it('calls useListTemplates, useListTemplatePolicies, and useListTemplatePolicyBindings with the folder namespace', () => {
     setup()
     render(<FolderIndexPage folderName="payments" />)
     expect(useListTemplates).toHaveBeenCalledWith(namespaceForFolder('payments'))
     expect(useListTemplatePolicies).toHaveBeenCalledWith(
+      namespaceForFolder('payments'),
+    )
+    expect(useListTemplatePolicyBindings).toHaveBeenCalledWith(
       namespaceForFolder('payments'),
     )
   })

--- a/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
+++ b/frontend/src/routes/_authenticated/folders/$folderName/index.tsx
@@ -9,11 +9,13 @@ import { Settings } from 'lucide-react'
 import { useGetFolder } from '@/queries/folders'
 import { useListTemplates } from '@/queries/templates'
 import { useListTemplatePolicies } from '@/queries/templatePolicies'
+import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import { useListProjectsByParent } from '@/queries/projects'
 import { namespaceForFolder } from '@/lib/scope-labels'
 import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import type { Template } from '@/gen/holos/console/v1/templates_pb'
 import type { TemplatePolicy } from '@/gen/holos/console/v1/template_policies_pb'
+import type { TemplatePolicyBinding } from '@/gen/holos/console/v1/template_policy_bindings_pb'
 import type { Project } from '@/gen/holos/console/v1/projects_pb'
 
 export const Route = createFileRoute(
@@ -53,6 +55,7 @@ export function FolderIndexPage({
 
   const templatesQuery = useListTemplates(namespace)
   const policiesQuery = useListTemplatePolicies(namespace)
+  const bindingsQuery = useListTemplatePolicyBindings(namespace)
   // Projects fan out by parent reference; the RPC filter is non-recursive
   // by construction — it only returns projects whose immediate parent is
   // this folder, never grandchildren.
@@ -135,6 +138,12 @@ export function FolderIndexPage({
         policies={policiesQuery.data}
         isPending={policiesQuery.isPending}
         error={policiesQuery.error as Error | null}
+      />
+      <TemplatePolicyBindingsSection
+        folderName={folderName}
+        bindings={bindingsQuery.data}
+        isPending={bindingsQuery.isPending}
+        error={bindingsQuery.error as Error | null}
       />
       <ProjectsSection
         folderName={folderName}
@@ -312,6 +321,63 @@ function TemplatePoliciesSection({
             >
               {p.name}
             </Link>
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
+  )
+}
+
+function TemplatePolicyBindingsSection({
+  folderName,
+  bindings,
+  isPending,
+  error,
+}: {
+  folderName: string
+  bindings: TemplatePolicyBinding[] | undefined
+  isPending: boolean
+  error: Error | null
+}) {
+  const preview = (bindings ?? []).slice(0, SECTION_PREVIEW_LIMIT)
+  return (
+    <SectionCard
+      title="Template Policy Bindings"
+      testId="template-policy-bindings"
+      count={bindings?.length}
+      isPending={isPending}
+      error={error}
+      emptyText="No template policy bindings in this folder."
+      viewAll={
+        <Link
+          to="/folders/$folderName/template-policy-bindings"
+          params={{ folderName }}
+          aria-label="View all template policy bindings"
+        >
+          <Button variant="outline" size="sm">
+            View all
+          </Button>
+        </Link>
+      }
+    >
+      <ul className="divide-y divide-border">
+        {preview.map((b) => (
+          <li
+            key={b.name}
+            className="flex items-center justify-between gap-3 py-2"
+          >
+            <Link
+              to="/folders/$folderName/template-policy-bindings/$bindingName"
+              params={{ folderName, bindingName: b.name }}
+              className="font-medium hover:underline"
+            >
+              {b.displayName || b.name}
+            </Link>
+            {b.policyRef?.name && (
+              <Badge variant="outline" className="text-xs border-blue-500/30 text-blue-500">
+                policy: {b.policyRef.name}
+              </Badge>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
@@ -1,8 +1,13 @@
 /**
- * Tests for the org templates index — ResourceGrid v1 migration (HOL-975).
+ * Tests for the unified org templates index — four-facet surface (HOL-1006).
  *
- * The page fans out across all org-reachable namespaces via useAllTemplatesForOrg
- * and renders rows via ResourceGrid v1 with scope-aware detailHref values.
+ * The page fans out across all org-reachable namespaces via:
+ *   - useAllTemplatesForOrg (Template rows)
+ *   - useAllTemplatePoliciesForOrg (TemplatePolicy rows)
+ *   - useAllTemplatePolicyBindingsForOrg (TemplatePolicyBinding rows)
+ *
+ * ResourceGrid v1 renders rows with scope-aware detailHref values and a
+ * kind-filter toolbar that supports selecting one of the three resource kinds.
  */
 
 import { render, screen } from '@testing-library/react'
@@ -67,6 +72,26 @@ vi.mock('@/queries/templates', async () => {
   }
 })
 
+vi.mock('@/queries/templatePolicies', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templatePolicies')>(
+    '@/queries/templatePolicies',
+  )
+  return {
+    ...actual,
+    useAllTemplatePoliciesForOrg: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templatePolicyBindings')>(
+    '@/queries/templatePolicyBindings',
+  )
+  return {
+    ...actual,
+    useAllTemplatePolicyBindingsForOrg: vi.fn(),
+  }
+})
+
 vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
@@ -74,6 +99,8 @@ vi.mock('@/queries/organizations', () => ({
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { useAllTemplatesForOrg } from '@/queries/templates'
+import { useAllTemplatePoliciesForOrg } from '@/queries/templatePolicies'
+import { useAllTemplatePolicyBindingsForOrg } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
@@ -90,6 +117,18 @@ type TemplateFixture = {
   createdAt?: string
 }
 
+type PolicyFixture = {
+  name: string
+  namespace: string
+  displayName?: string
+}
+
+type BindingFixture = {
+  name: string
+  namespace: string
+  displayName?: string
+}
+
 const ORG_NS = namespaceForOrg('test-org')
 const FOLDER_NS = namespaceForFolder('team-a')
 const PROJECT_NS = namespaceForProject('billing')
@@ -98,11 +137,23 @@ function setup(
   templates: TemplateFixture[] = [],
   userRole: Role = Role.OWNER,
   overrides: Partial<{ isPending: boolean; error: Error | null }> = {},
+  policies: PolicyFixture[] = [],
+  bindings: BindingFixture[] = [],
 ) {
   ;(useAllTemplatesForOrg as Mock).mockReturnValue({
     data: overrides.isPending ? undefined : templates,
     isPending: overrides.isPending ?? false,
     error: overrides.error ?? null,
+  })
+  ;(useAllTemplatePoliciesForOrg as Mock).mockReturnValue({
+    data: overrides.isPending ? undefined : policies,
+    isPending: overrides.isPending ?? false,
+    error: null,
+  })
+  ;(useAllTemplatePolicyBindingsForOrg as Mock).mockReturnValue({
+    data: overrides.isPending ? undefined : bindings,
+    isPending: overrides.isPending ?? false,
+    error: null,
   })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: 'test-org', userRole },
@@ -111,7 +162,7 @@ function setup(
   })
 }
 
-describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
+describe('OrgTemplatesIndexPage (unified four-facet surface, HOL-1006)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     Object.keys(mockSearch).forEach((k) => delete mockSearch[k])
@@ -135,25 +186,7 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
   })
 
-  it('renders an inline partial-error banner when some rows loaded', () => {
-    ;(useAllTemplatesForOrg as Mock).mockReturnValue({
-      data: [{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' }],
-      isPending: false,
-      error: new Error('folders unavailable'),
-    })
-    ;(useGetOrganization as Mock).mockReturnValue({
-      data: { name: 'test-org', userRole: Role.OWNER },
-      isPending: false,
-      error: null,
-    })
-    render(<OrgTemplatesIndexPage orgName="test-org" />)
-    expect(screen.getByText('Gateway')).toBeInTheDocument()
-    expect(screen.getByRole('table')).toBeInTheDocument()
-    expect(screen.getByTestId('resource-grid-partial-error')).toBeInTheDocument()
-    expect(screen.getByText('folders unavailable')).toBeInTheDocument()
-  })
-
-  it('renders the empty state when no templates exist', () => {
+  it('renders the empty state when no resources exist', () => {
     setup([])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
     expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
@@ -161,7 +194,7 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // Row rendering
+  // Template row rendering
   // ---------------------------------------------------------------------------
 
   it('renders a row for each template across scopes', () => {
@@ -177,10 +210,9 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
     expect(screen.getByText('Web Service')).toBeInTheDocument()
   })
 
-  it('routes org-scoped rows to the org editor', () => {
+  it('routes org-scoped template rows to the org editor', () => {
     setup([{ name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' }])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
-    // The Resource ID cell and display name cell both link to the detail page.
     const links = screen.getAllByRole('link', { name: /gateway/i })
     expect(
       links.some(
@@ -191,7 +223,7 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
     ).toBe(true)
   })
 
-  it('routes folder-scoped rows to the folder template editor', () => {
+  it('routes folder-scoped template rows to the folder template editor', () => {
     setup([
       { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend', createdAt: '' },
     ])
@@ -204,7 +236,7 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
     ).toBe(true)
   })
 
-  it('routes project-scoped rows to the project template editor', () => {
+  it('routes project-scoped template rows to the project template editor', () => {
     setup([
       { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
     ])
@@ -226,6 +258,93 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
         (l) =>
           l.getAttribute('href') ===
           `/organizations/test-org/templates/${ORG_NS}/ops`,
+      ),
+    ).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // TemplatePolicy row rendering
+  // ---------------------------------------------------------------------------
+
+  it('renders TemplatePolicy rows from the policies fan-out', () => {
+    setup(
+      [],
+      Role.OWNER,
+      {},
+      [{ name: 'require-istio', namespace: ORG_NS, displayName: 'Require Istio' }],
+    )
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Require Istio')).toBeInTheDocument()
+  })
+
+  it('routes org-scoped policy rows to the org policy editor', () => {
+    setup(
+      [],
+      Role.OWNER,
+      {},
+      [{ name: 'require-istio', namespace: ORG_NS, displayName: 'Require Istio' }],
+    )
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    const links = screen.getAllByRole('link', { name: /require-istio/i })
+    expect(
+      links.some(
+        (l) =>
+          l.getAttribute('href') ===
+          '/organizations/test-org/template-policies/require-istio',
+      ),
+    ).toBe(true)
+  })
+
+  it('routes folder-scoped policy rows to the folder policy editor', () => {
+    setup(
+      [],
+      Role.OWNER,
+      {},
+      [{ name: 'folder-policy', namespace: FOLDER_NS }],
+    )
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    const links = screen.getAllByRole('link', { name: /folder-policy/i })
+    expect(
+      links.some(
+        (l) =>
+          l.getAttribute('href') ===
+          '/folders/team-a/template-policies/folder-policy',
+      ),
+    ).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // TemplatePolicyBinding row rendering
+  // ---------------------------------------------------------------------------
+
+  it('renders TemplatePolicyBinding rows from the bindings fan-out', () => {
+    setup([], Role.OWNER, {}, [], [{ name: 'bind-istio', namespace: ORG_NS, displayName: 'Bind Istio' }])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    expect(screen.getByText('Bind Istio')).toBeInTheDocument()
+  })
+
+  it('routes org-scoped binding rows to the org binding editor', () => {
+    setup([], Role.OWNER, {}, [], [{ name: 'bind-istio', namespace: ORG_NS }])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    const links = screen.getAllByRole('link', { name: /bind-istio/i })
+    expect(
+      links.some(
+        (l) =>
+          l.getAttribute('href') ===
+          '/organizations/test-org/template-bindings/bind-istio',
+      ),
+    ).toBe(true)
+  })
+
+  it('routes folder-scoped binding rows to the folder binding editor', () => {
+    setup([], Role.OWNER, {}, [], [{ name: 'folder-bind', namespace: FOLDER_NS }])
+    render(<OrgTemplatesIndexPage orgName="test-org" />)
+    const links = screen.getAllByRole('link', { name: /folder-bind/i })
+    expect(
+      links.some(
+        (l) =>
+          l.getAttribute('href') ===
+          '/folders/team-a/template-policy-bindings/folder-bind',
       ),
     ).toBe(true)
   })
@@ -255,23 +374,23 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // Create CTA
+  // Create CTA (three-kind dropdown when OWNER)
   // ---------------------------------------------------------------------------
 
-  it('renders a Create Template / New button for org OWNERs', () => {
+  it('renders a New button for org OWNERs', () => {
     setup([], Role.OWNER)
     render(<OrgTemplatesIndexPage orgName="test-org" />)
-    // ResourceGrid renders a "New Template" button linking to the newHref.
-    const newLink = screen.getByRole('link', { name: /template/i })
-    expect(newLink).toHaveAttribute('href', '/organizations/test-org/templates/new')
+    // ResourceGrid renders a "New" dropdown when multiple kinds are creatable.
+    const newBtn = screen.getByRole('button', { name: /new/i })
+    expect(newBtn).toBeInTheDocument()
   })
 
   it('hides the Create button for non-OWNER users', () => {
     setup([], Role.VIEWER)
     render(<OrgTemplatesIndexPage orgName="test-org" />)
-    // When canCreate is false, ResourceGrid suppresses the New button.
+    // When canCreate is false for all kinds, ResourceGrid suppresses the New button.
     expect(
-      screen.queryByRole('link', { name: /template/i }),
+      screen.queryByRole('button', { name: /new/i }),
     ).not.toBeInTheDocument()
   })
 
@@ -310,7 +429,8 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // Scope filtering via URL state
+  // Scope filtering via URL state (org / folder only — project is excluded
+  // because TemplatePolicies and Bindings do not exist at project scope)
   // ---------------------------------------------------------------------------
 
   it('filters to only org-scoped rows when scope=org is set in search', () => {
@@ -324,15 +444,15 @@ describe('OrgTemplatesIndexPage (ResourceGrid v1, HOL-975)', () => {
     expect(screen.queryByText('Web Service')).not.toBeInTheDocument()
   })
 
-  it('filters to only project-scoped rows when scope=project is set in search', () => {
-    mockSearch['scope'] = 'project'
+  it('filters to only folder-scoped rows when scope=folder is set in search', () => {
+    mockSearch['scope'] = 'folder'
     setup([
       { name: 'gateway', namespace: ORG_NS, displayName: 'Gateway', createdAt: '' },
-      { name: 'web', namespace: PROJECT_NS, displayName: 'Web Service', createdAt: '' },
+      { name: 'backend', namespace: FOLDER_NS, displayName: 'Backend', createdAt: '' },
     ])
     render(<OrgTemplatesIndexPage orgName="test-org" />)
     expect(screen.queryByText('Gateway')).not.toBeInTheDocument()
-    expect(screen.getByText('Web Service')).toBeInTheDocument()
+    expect(screen.getByText('Backend')).toBeInTheDocument()
   })
 
   it('shows all rows when no scope filter is set', () => {

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
@@ -1,17 +1,22 @@
 /**
- * Org-scope Platform Templates index — migrated to ResourceGrid v1 (HOL-975).
+ * Org-scope Platform Templates index — unified four-facet surface (HOL-1006).
  *
- * Shows all templates reachable from the org root (org, folder, project scopes)
- * via the useAllTemplatesForOrg fan-out hook. Each row carries a scope-aware
- * detailHref so both the resource ID cell and the full row are clickable.
+ * Shows all template-family resources reachable from the org root across three
+ * kinds — Template, TemplatePolicy, TemplatePolicyBinding — via fan-out hooks.
+ * The ResourceGrid kind-filter toolbar lets users narrow to a single kind; the
+ * scope dropdown further narrows by org / folder scope.
+ *
+ * Each row carries a scope-aware detailHref so both the resource ID cell and
+ * the full row are clickable (using resolveTemplateRowHref from
+ * lib/template-row-link.ts).
  *
  * Extra columns added via the ResourceGrid `extraColumns` prop:
- *   - Scope    — badge indicating org / folder / project + the owner name
+ *   - Scope     — badge indicating org / folder / project + the owner name
  *   - Namespace — raw namespace string for operator debugging
  *
- * A scope dropdown filter (preserved from the pre-refactor page) is rendered
- * above the grid via the ResourceGrid `headerContent` slot. Selecting a scope
- * replaces the URL `?scope=` param so the filter survives refreshes.
+ * A scope dropdown filter is rendered above the grid via the ResourceGrid
+ * `headerContent` slot. Selecting a scope replaces the URL `?scope=` param
+ * so the filter survives refreshes.
  */
 
 import { useCallback, useMemo } from 'react'
@@ -31,29 +36,35 @@ import type { ColumnDef } from '@tanstack/react-table'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useAllTemplatesForOrg } from '@/queries/templates'
+import { useAllTemplatePoliciesForOrg } from '@/queries/templatePolicies'
+import { useAllTemplatePolicyBindingsForOrg } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import {
   scopeLabelFromNamespace,
   scopeNameFromNamespace,
   scopeDisplayLabel,
 } from '@/lib/scope-labels'
+import {
+  resolveTemplateRowHref,
+  parentLabelFromNamespace,
+} from '@/lib/template-row-link'
 
 // ---------------------------------------------------------------------------
 // Route search — extends ResourceGridSearch with the scope filter
 // ---------------------------------------------------------------------------
 
 export interface OrgTemplatesSearch extends ResourceGridSearch {
-  /** Optional scope filter: 'org' | 'folder' | 'project'. Absent = all. */
-  scope?: 'org' | 'folder' | 'project'
+  /** Optional scope filter: 'org' | 'folder'. Absent = all scopes. */
+  scope?: 'org' | 'folder'
 }
 
-type ScopeFilter = 'all' | 'org' | 'folder' | 'project'
+type ScopeFilter = 'all' | 'org' | 'folder'
 
 function parseOrgTemplatesSearch(raw: Record<string, unknown>): OrgTemplatesSearch {
   const base = parseGridSearch(raw)
   const result: OrgTemplatesSearch = { ...base }
   const scope = raw['scope']
-  if (scope === 'org' || scope === 'folder' || scope === 'project') {
+  if (scope === 'org' || scope === 'folder') {
     result.scope = scope
   }
   return result
@@ -131,58 +142,108 @@ export function OrgTemplatesIndexPage({
   }
   const orgName = propOrgName ?? routeOrgName ?? ''
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const search = Route.useSearch() as OrgTemplatesSearch
   const navigate = useNavigate({ from: Route.fullPath })
 
   const scopeFilter: ScopeFilter = search.scope ?? 'all'
 
   // Fan-out across all namespaces reachable from the org root.
-  const { data, isPending, error } = useAllTemplatesForOrg(orgName)
+  const templatesResult = useAllTemplatesForOrg(orgName)
+  const policiesResult = useAllTemplatePoliciesForOrg(orgName)
+  const bindingsResult = useAllTemplatePolicyBindingsForOrg(orgName)
   const { data: org } = useGetOrganization(orgName)
 
-  const templates = useMemo(() => data ?? [], [data])
+  const templates = useMemo(() => templatesResult.data ?? [], [templatesResult.data])
+  const policies = useMemo(() => policiesResult.data ?? [], [policiesResult.data])
+  const bindings = useMemo(() => bindingsResult.data ?? [], [bindingsResult.data])
+
   const userRole = org?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER
+
+  // Combine loading and error state across all three fan-outs.
+  const isPending = templatesResult.isPending || policiesResult.isPending || bindingsResult.isPending
+  const firstError = templatesResult.error ?? policiesResult.error ?? bindingsResult.error
 
   // ---------------------------------------------------------------------------
   // Build rows — scope-filtered, with scope-aware detailHref
   // ---------------------------------------------------------------------------
 
   const rows: Row[] = useMemo(() => {
-    const all = templates.map((t): Row => {
+    const templateRows: Row[] = templates.flatMap((t) => {
       const scope = scopeLabelFromNamespace(t.namespace)
       const scopeName = scopeNameFromNamespace(t.namespace)
-      let detailHref: string | undefined
 
-      if (scope === 'org') {
-        detailHref = `/organizations/${orgName}/templates/${t.namespace}/${t.name}`
-      } else if (scope === 'folder' && scopeName) {
-        detailHref = `/folders/${scopeName}/templates/${t.name}`
-      } else if (scope === 'project' && scopeName) {
-        detailHref = `/projects/${scopeName}/templates/${t.name}`
-      }
+      // Skip rows outside the active scope filter.
+      if (scopeFilter !== 'all' && scope !== scopeFilter) return []
 
-      return {
+      const row: Row = {
         kind: 'Template',
         name: t.name,
         namespace: t.namespace,
         id: t.name,
         parentId: scopeName || t.namespace,
-        parentLabel: scopeName || t.namespace,
+        parentLabel: parentLabelFromNamespace(t.namespace),
         displayName: t.displayName || t.name,
         description: t.description ?? '',
         createdAt: t.createdAt ?? '',
-        detailHref,
+        detailHref: resolveTemplateRowHref('Template', t.namespace, t.name),
       }
+      return [row]
     })
 
-    if (scopeFilter === 'all') return all
-    return all.filter((r) => scopeLabelFromNamespace(r.namespace) === scopeFilter)
-  }, [templates, orgName, scopeFilter])
+    const policyRows: Row[] = policies.flatMap((p) => {
+      if (!p) return []
+      const scope = scopeLabelFromNamespace(p.namespace)
+      if (scopeFilter !== 'all' && scope !== scopeFilter) return []
+
+      const createdAt = p.createdAt
+        ? new Date(Number(p.createdAt.seconds) * 1000).toISOString()
+        : ''
+
+      const row: Row = {
+        kind: 'TemplatePolicy',
+        name: p.name,
+        namespace: p.namespace,
+        id: `${p.namespace}/${p.name}`,
+        parentId: p.namespace,
+        parentLabel: parentLabelFromNamespace(p.namespace),
+        displayName: p.displayName || p.name,
+        description: p.description ?? '',
+        createdAt,
+        detailHref: resolveTemplateRowHref('TemplatePolicy', p.namespace, p.name),
+      }
+      return [row]
+    })
+
+    const bindingRows: Row[] = bindings.flatMap((b) => {
+      if (!b) return []
+      const scope = scopeLabelFromNamespace(b.namespace)
+      if (scopeFilter !== 'all' && scope !== scopeFilter) return []
+
+      const createdAt = b.createdAt
+        ? new Date(Number(b.createdAt.seconds) * 1000).toISOString()
+        : ''
+
+      const row: Row = {
+        kind: 'TemplatePolicyBinding',
+        name: b.name,
+        namespace: b.namespace,
+        id: `${b.namespace}/${b.name}`,
+        parentId: b.namespace,
+        parentLabel: parentLabelFromNamespace(b.namespace),
+        displayName: b.displayName || b.name,
+        description: b.description ?? '',
+        createdAt,
+        detailHref: resolveTemplateRowHref('TemplatePolicyBinding', b.namespace, b.name),
+      }
+      return [row]
+    })
+
+    return [...templateRows, ...policyRows, ...bindingRows]
+  }, [templates, policies, bindings, scopeFilter])
 
   // ---------------------------------------------------------------------------
-  // Kind definitions
+  // Kind definitions (three kinds for the unified surface)
   // ---------------------------------------------------------------------------
 
   const kinds = useMemo(
@@ -193,6 +254,18 @@ export function OrgTemplatesIndexPage({
         newHref: `/organizations/${orgName}/templates/new`,
         canCreate: canWrite,
       },
+      {
+        id: 'TemplatePolicy',
+        label: 'Template Policy',
+        newHref: `/organizations/${orgName}/template-policies/new`,
+        canCreate: canWrite,
+      },
+      {
+        id: 'TemplatePolicyBinding',
+        label: 'Template Binding',
+        newHref: `/organizations/${orgName}/template-bindings/new`,
+        canCreate: canWrite,
+      },
     ],
     [orgName, canWrite],
   )
@@ -201,13 +274,10 @@ export function OrgTemplatesIndexPage({
   // Handlers
   // ---------------------------------------------------------------------------
 
-  const handleDelete = useCallback(async (_row: Row) => {
-    // Org templates index shows templates from multiple scopes; deletion is
-    // handled from each template's own detail/editor page. This index is
-    // read-only for delete actions — the ResourceGrid delete button is not
-    // rendered when onDelete is undefined, but we provide a no-op so the type
-    // is satisfied. Actual deletion is on the detail page.
-    throw new Error('Delete from the template detail page.')
+  // The unified index spans multiple kinds; deletion is handled from each
+  // resource's own detail page. This index is read-only for delete actions.
+  const handleDelete = useCallback(async () => {
+    throw new Error('Delete from the resource detail page.')
   }, [])
 
   const handleSearchChange = useCallback(
@@ -237,7 +307,7 @@ export function OrgTemplatesIndexPage({
           if (scope === 'all') {
             delete next.scope
           } else {
-            next.scope = scope as 'org' | 'folder' | 'project'
+            next.scope = scope as 'org' | 'folder'
           }
           return next
         },
@@ -248,6 +318,8 @@ export function OrgTemplatesIndexPage({
 
   // ---------------------------------------------------------------------------
   // Scope filter toolbar content (rendered in ResourceGrid headerContent slot)
+  // Note: TemplatePolicies and TemplatePolicyBindings only exist at org and
+  // folder scope — project is intentionally absent from the dropdown.
   // ---------------------------------------------------------------------------
 
   const scopeFilterContent = (
@@ -260,7 +332,6 @@ export function OrgTemplatesIndexPage({
           <SelectItem value="all">All scopes</SelectItem>
           <SelectItem value="org">Organization</SelectItem>
           <SelectItem value="folder">Folder</SelectItem>
-          <SelectItem value="project">Project</SelectItem>
         </SelectContent>
       </Select>
     </div>
@@ -273,7 +344,7 @@ export function OrgTemplatesIndexPage({
       rows={rows}
       onDelete={handleDelete}
       isLoading={isPending || orgName === ''}
-      error={error}
+      error={firstError}
       search={search}
       onSearchChange={handleSearchChange}
       extraColumns={extraColumns}
@@ -282,4 +353,3 @@ export function OrgTemplatesIndexPage({
     />
   )
 }
-


### PR DESCRIPTION
## Summary

- Adds `useAllTemplatePoliciesForOrg` and `useAllTemplatePolicyBindingsForOrg` fan-out hooks that query org + all folder namespaces in parallel (mirrors existing `useAllTemplatesForOrg` pattern)
- Rewrites the org templates index (`/organizations/$orgName/templates`) to show Templates, Template Policies, and Template Bindings in a single ResourceGrid v1 with multi-kind support; scope filter restricted to org/folder only (policies/bindings don't exist at project scope)
- Updates AppSidebar Templates link to resolve to the org-level unified surface when an org is selected; falls back to project scope if only a project is selected
- Adds a Template Policy Bindings section to the folder index page so folder-scoped bindings are discoverable inline
- Updates all affected unit tests (org templates index, app sidebar, folder index)

Fixes HOL-1006

## Test plan

- [ ] All 1357 UI tests pass (`npx vitest run`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] ESLint clean on changed files
- [ ] Navigate to an org in the sidebar → Templates link goes to `/organizations/<org>/templates`
- [ ] The unified grid shows Templates, Template Policies, and Template Bindings rows
- [ ] Scope filter shows only "All scopes", "Organization", "Folder" (no "Project")
- [ ] Each row's detail link resolves correctly for its namespace (org → `/organizations/...`, folder → `/folders/...`)
- [ ] New button dropdown has three entries: Template, Template Policy, Template Binding
- [ ] Folder index page shows a Template Policy Bindings section with "View all" link