### PR TITLE
refactor(proto): clarify template policy binding semantics

### DIFF
--- a/frontend/src/gen/holos/console/v1/policy_state_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/policy_state_pb.d.ts
@@ -12,17 +12,17 @@ export declare const file_holos_console_v1_policy_state: GenFile;
 
 /**
  * LinkedTemplateRef is a (namespace, name) reference to a template used in
- * the explicit linking list (ADR 021 Decision 5). The resolver classifies
- * the namespace into its hierarchy kind (organization, folder, project) at
- * render time; callers supply the namespace only.
+ * the explicit linking list (ADR 021 Decision 5). The resolver classifies the
+ * namespace as organization, folder, or project at render time; callers supply
+ * the namespace only.
  *
  * @generated from message holos.console.v1.LinkedTemplateRef
  */
 export declare type LinkedTemplateRef = Message<"holos.console.v1.LinkedTemplateRef"> & {
   /**
    * namespace is the Kubernetes namespace that owns the linked template. The
-   * resolver classifies the namespace into its hierarchy kind (organization,
-   * folder, project) at render time — callers supply the namespace only.
+   * resolver classifies the namespace as organization, folder, or project at
+   * render time — callers supply the namespace only.
    *
    * @generated from field: string namespace = 1;
    */

--- a/frontend/src/gen/holos/console/v1/template_policies_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/template_policies_pb.d.ts
@@ -59,9 +59,9 @@ export declare type TemplatePolicyRule = Message<"holos.console.v1.TemplatePolic
   kind: TemplatePolicyKind;
 
   /**
-   * template identifies the template this rule applies to. The referenced
-   * template may live in any namespace the policy's owning namespace can
-   * reach.
+   * template identifies the template this rule requires or excludes. The
+   * referenced template may live in any namespace the policy's owning
+   * namespace can reach.
    *
    * @generated from field: holos.console.v1.LinkedTemplateRef template = 2;
    */
@@ -75,8 +75,9 @@ export declare type TemplatePolicyRule = Message<"holos.console.v1.TemplatePolic
 export declare const TemplatePolicyRuleSchema: GenMessage<TemplatePolicyRule>;
 
 /**
- * TemplatePolicy is a named resource that declares one or more rules
- * attaching templates to projects within its namespace.
+ * TemplatePolicy is a named resource that declares one or more rules. The
+ * rules affect only the explicit render targets named by TemplatePolicyBinding
+ * objects that reference this policy.
  *
  * Storage MUST live in a folder or organization namespace. Project-namespace
  * storage is forbidden and enforced by the HOL-618 admission plugin.
@@ -108,15 +109,17 @@ export declare type TemplatePolicy = Message<"holos.console.v1.TemplatePolicy"> 
   displayName: string;
 
   /**
-   * description explains what the policy enforces.
+   * description explains what the policy is intended to enforce once attached
+   * by a TemplatePolicyBinding.
    *
    * @generated from field: string description = 4;
    */
   description: string;
 
   /**
-   * rules are the REQUIRE/EXCLUDE rules this policy enforces. Rules are
-   * evaluated independently and their effects are combined by the resolver.
+   * rules are the REQUIRE/EXCLUDE rules this policy declares. Rules are
+   * evaluated independently and their effects are combined by the resolver for
+   * render targets selected by matching TemplatePolicyBinding objects.
    *
    * @generated from field: repeated holos.console.v1.TemplatePolicyRule rules = 5;
    */
@@ -435,10 +438,11 @@ export enum TemplatePolicyKind {
 
   /**
    * TEMPLATE_POLICY_KIND_REQUIRE causes the referenced template to be
-   * injected into the effective ref set when a deployment or project template
-   * matching the target is rendered. It does not itself create, apply, or
-   * delete any cluster resources — resources appear only as the output of the
-   * user's deployment or project-template render.
+   * injected into the effective ref set when a TemplatePolicyBinding names
+   * this policy for the deployment or project template being rendered. It does
+   * not itself create, apply, or delete any cluster resources — resources
+   * appear only as the output of the user's deployment or project-template
+   * render.
    *
    * @generated from enum value: TEMPLATE_POLICY_KIND_REQUIRE = 1;
    */
@@ -446,10 +450,11 @@ export enum TemplatePolicyKind {
 
   /**
    * TEMPLATE_POLICY_KIND_EXCLUDE causes the referenced template to be
-   * removed from the effective ref set when a deployment or project template
-   * matching the target is rendered, even if it would otherwise be linked.
-   * Like REQUIRE, it does not itself create, apply, or delete any cluster
-   * resources — it only filters the render-time unification set.
+   * removed from the effective ref set when a TemplatePolicyBinding names this
+   * policy for the deployment or project template being rendered, even if the
+   * template would otherwise be linked. Like REQUIRE, it does not itself
+   * create, apply, or delete any cluster resources — it only filters the
+   * render-time unification set.
    *
    * @generated from enum value: TEMPLATE_POLICY_KIND_EXCLUDE = 2;
    */
@@ -462,12 +467,12 @@ export enum TemplatePolicyKind {
 export declare const TemplatePolicyKindSchema: GenEnum<TemplatePolicyKind>;
 
 /**
- * TemplatePolicyService manages TemplatePolicy resources, which declaratively
- * attach templates to projects through REQUIRE/EXCLUDE rules. Policies replace
- * the legacy `bool mandatory` flag previously carried on Template and
- * LinkableTemplate (removed in HOL-555). The only way to force a template onto
- * every project — or to block one from matching projects — is to author a
- * TemplatePolicy.
+ * TemplatePolicyService manages TemplatePolicy resources, which declare
+ * REQUIRE/EXCLUDE rules that TemplatePolicyBinding objects attach to explicit
+ * render targets. Policies replace the legacy `bool mandatory` flag previously
+ * carried on Template and LinkableTemplate (removed in HOL-555). A policy by
+ * itself does not affect any render target; a TemplatePolicyBinding must name
+ * the policy and the project templates or deployments it applies to.
  *
  * Storage MUST live in a folder or organization namespace (`namespace`).
  * Project-namespace storage is forbidden and is enforced by the HOL-618
@@ -476,9 +481,10 @@ export declare const TemplatePolicyKindSchema: GenEnum<TemplatePolicyKind>;
  * discriminator for that rejection (HOL-619).
  *
  * Backend handler wiring (HOL-556), storage enforcement, and render-time
- * resolver integration (HOL-567) are complete; the resolver consults
- * TemplatePolicy ConfigMaps to pin REQUIRE templates and suppress EXCLUDE
- * templates for every matching project render.
+ * resolver integration (HOL-567) are complete; the resolver consults matching
+ * TemplatePolicyBinding objects, then reads their TemplatePolicy ConfigMaps to
+ * pin REQUIRE templates or suppress EXCLUDE templates for the named render
+ * targets.
  *
  * @generated from service holos.console.v1.TemplatePolicyService
  */

--- a/frontend/src/gen/holos/console/v1/template_policies_pb.js
+++ b/frontend/src/gen/holos/console/v1/template_policies_pb.js
@@ -140,12 +140,12 @@ export const TemplatePolicyKind = /*@__PURE__*/
   tsEnum(TemplatePolicyKindSchema);
 
 /**
- * TemplatePolicyService manages TemplatePolicy resources, which declaratively
- * attach templates to projects through REQUIRE/EXCLUDE rules. Policies replace
- * the legacy `bool mandatory` flag previously carried on Template and
- * LinkableTemplate (removed in HOL-555). The only way to force a template onto
- * every project — or to block one from matching projects — is to author a
- * TemplatePolicy.
+ * TemplatePolicyService manages TemplatePolicy resources, which declare
+ * REQUIRE/EXCLUDE rules that TemplatePolicyBinding objects attach to explicit
+ * render targets. Policies replace the legacy `bool mandatory` flag previously
+ * carried on Template and LinkableTemplate (removed in HOL-555). A policy by
+ * itself does not affect any render target; a TemplatePolicyBinding must name
+ * the policy and the project templates or deployments it applies to.
  *
  * Storage MUST live in a folder or organization namespace (`namespace`).
  * Project-namespace storage is forbidden and is enforced by the HOL-618
@@ -154,9 +154,10 @@ export const TemplatePolicyKind = /*@__PURE__*/
  * discriminator for that rejection (HOL-619).
  *
  * Backend handler wiring (HOL-556), storage enforcement, and render-time
- * resolver integration (HOL-567) are complete; the resolver consults
- * TemplatePolicy ConfigMaps to pin REQUIRE templates and suppress EXCLUDE
- * templates for every matching project render.
+ * resolver integration (HOL-567) are complete; the resolver consults matching
+ * TemplatePolicyBinding objects, then reads their TemplatePolicy ConfigMaps to
+ * pin REQUIRE templates or suppress EXCLUDE templates for the named render
+ * targets.
  *
  * @generated from service holos.console.v1.TemplatePolicyService
  */

--- a/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.d.ts
@@ -475,8 +475,8 @@ export declare const TemplatePolicyBindingTargetKindSchema: GenEnum<TemplatePoli
  * Project-namespace storage is forbidden for the same reason it is forbidden
  * for TemplatePolicy (HOL-554 storage-isolation design note); the policy a
  * binding references is always folder- or org-scoped, so the binding lives
- * in the same hierarchy level. The HOL-618 admission plugin enforces this
- * by rejecting any TemplatePolicyBinding created in a project namespace.
+ * in the same storage scope category. The HOL-618 admission plugin enforces
+ * this by rejecting any TemplatePolicyBinding created in a project namespace.
  *
  * Handler wiring, RBAC enforcement, and ConnectRPC registration shipped in
  * HOL-595. The ancestor-aware policy picker (ListLinkableTemplatePolicies) is

--- a/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.js
+++ b/frontend/src/gen/holos/console/v1/template_policy_bindings_pb.js
@@ -135,8 +135,8 @@ export const TemplatePolicyBindingTargetKind = /*@__PURE__*/
  * Project-namespace storage is forbidden for the same reason it is forbidden
  * for TemplatePolicy (HOL-554 storage-isolation design note); the policy a
  * binding references is always folder- or org-scoped, so the binding lives
- * in the same hierarchy level. The HOL-618 admission plugin enforces this
- * by rejecting any TemplatePolicyBinding created in a project namespace.
+ * in the same storage scope category. The HOL-618 admission plugin enforces
+ * this by rejecting any TemplatePolicyBinding created in a project namespace.
  *
  * Handler wiring, RBAC enforcement, and ConnectRPC registration shipped in
  * HOL-595. The ancestor-aware policy picker (ListLinkableTemplatePolicies) is

--- a/frontend/src/gen/holos/console/v1/templates_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/templates_pb.d.ts
@@ -653,8 +653,8 @@ export declare const CloneTemplateResponseSchema: GenMessage<CloneTemplateRespon
 export declare type ListLinkableTemplatesRequest = Message<"holos.console.v1.ListLinkableTemplatesRequest"> & {
   /**
    * namespace is the starting namespace (e.g. a project namespace for a
-   * project template). The handler walks up the hierarchy and returns enabled
-   * ancestor templates.
+   * project template). The handler walks ancestor scopes and returns enabled
+   * templates from those scopes.
    *
    * @generated from field: string namespace = 1;
    */
@@ -1065,7 +1065,7 @@ export declare type SearchTemplatesRequest = Message<"holos.console.v1.SearchTem
    * organization, when non-empty, restricts results to templates owned by a
    * namespace reachable from the given root organization. Intended for
    * multi-org deployments where the caller wants to scope a search to one
-   * organization without enumerating every descendant namespace.
+   * organization without enumerating every namespace under that root.
    *
    * @generated from field: string organization = 4;
    */
@@ -1425,15 +1425,15 @@ export declare const DependencyScopeSchema: GenEnum<DependencyScope>;
 
 /**
  * TemplateService is the single unified service for managing CUE-based templates
- * at every hierarchy level (organization, folder, project). It replaces the
+ * at every scope level (organization, folder, project). It replaces the
  * separate DeploymentTemplateService and OrgTemplateService from v1alpha1
  * (ADR 021 Decision 1).
  *
  * All CRUD operations carry a `namespace` that owns the template. The
- * backend resolver classifies the namespace into its hierarchy kind
- * (organization, folder, project) — callers do not supply the kind
- * directly. HOL-619 replaced the earlier TemplateScope / TemplateScopeRef
- * discriminator with this namespace-only model.
+ * backend resolver classifies the namespace as organization, folder, or
+ * project — callers do not supply the kind directly. HOL-619 replaced the
+ * earlier TemplateScope / TemplateScopeRef discriminator with this
+ * namespace-only model.
  *
  * @generated from service holos.console.v1.TemplateService
  */

--- a/frontend/src/gen/holos/console/v1/templates_pb.js
+++ b/frontend/src/gen/holos/console/v1/templates_pb.js
@@ -318,15 +318,15 @@ export const DependencyScope = /*@__PURE__*/
 
 /**
  * TemplateService is the single unified service for managing CUE-based templates
- * at every hierarchy level (organization, folder, project). It replaces the
+ * at every scope level (organization, folder, project). It replaces the
  * separate DeploymentTemplateService and OrgTemplateService from v1alpha1
  * (ADR 021 Decision 1).
  *
  * All CRUD operations carry a `namespace` that owns the template. The
- * backend resolver classifies the namespace into its hierarchy kind
- * (organization, folder, project) — callers do not supply the kind
- * directly. HOL-619 replaced the earlier TemplateScope / TemplateScopeRef
- * discriminator with this namespace-only model.
+ * backend resolver classifies the namespace as organization, folder, or
+ * project — callers do not supply the kind directly. HOL-619 replaced the
+ * earlier TemplateScope / TemplateScopeRef discriminator with this
+ * namespace-only model.
  *
  * @generated from service holos.console.v1.TemplateService
  */

--- a/gen/holos/console/v1/policy_state.pb.go
+++ b/gen/holos/console/v1/policy_state.pb.go
@@ -22,14 +22,14 @@ const (
 )
 
 // LinkedTemplateRef is a (namespace, name) reference to a template used in
-// the explicit linking list (ADR 021 Decision 5). The resolver classifies
-// the namespace into its hierarchy kind (organization, folder, project) at
-// render time; callers supply the namespace only.
+// the explicit linking list (ADR 021 Decision 5). The resolver classifies the
+// namespace as organization, folder, or project at render time; callers supply
+// the namespace only.
 type LinkedTemplateRef struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// namespace is the Kubernetes namespace that owns the linked template. The
-	// resolver classifies the namespace into its hierarchy kind (organization,
-	// folder, project) at render time — callers supply the namespace only.
+	// resolver classifies the namespace as organization, folder, or project at
+	// render time — callers supply the namespace only.
 	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// name is the template name.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`

--- a/gen/holos/console/v1/template_policies.pb.go
+++ b/gen/holos/console/v1/template_policies.pb.go
@@ -28,16 +28,18 @@ type TemplatePolicyKind int32
 const (
 	TemplatePolicyKind_TEMPLATE_POLICY_KIND_UNSPECIFIED TemplatePolicyKind = 0
 	// TEMPLATE_POLICY_KIND_REQUIRE causes the referenced template to be
-	// injected into the effective ref set when a deployment or project template
-	// matching the target is rendered. It does not itself create, apply, or
-	// delete any cluster resources — resources appear only as the output of the
-	// user's deployment or project-template render.
+	// injected into the effective ref set when a TemplatePolicyBinding names
+	// this policy for the deployment or project template being rendered. It does
+	// not itself create, apply, or delete any cluster resources — resources
+	// appear only as the output of the user's deployment or project-template
+	// render.
 	TemplatePolicyKind_TEMPLATE_POLICY_KIND_REQUIRE TemplatePolicyKind = 1
 	// TEMPLATE_POLICY_KIND_EXCLUDE causes the referenced template to be
-	// removed from the effective ref set when a deployment or project template
-	// matching the target is rendered, even if it would otherwise be linked.
-	// Like REQUIRE, it does not itself create, apply, or delete any cluster
-	// resources — it only filters the render-time unification set.
+	// removed from the effective ref set when a TemplatePolicyBinding names this
+	// policy for the deployment or project template being rendered, even if the
+	// template would otherwise be linked. Like REQUIRE, it does not itself
+	// create, apply, or delete any cluster resources — it only filters the
+	// render-time unification set.
 	TemplatePolicyKind_TEMPLATE_POLICY_KIND_EXCLUDE TemplatePolicyKind = 2
 )
 
@@ -143,9 +145,9 @@ type TemplatePolicyRule struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// kind is REQUIRE or EXCLUDE.
 	Kind TemplatePolicyKind `protobuf:"varint,1,opt,name=kind,proto3,enum=holos.console.v1.TemplatePolicyKind" json:"kind,omitempty"`
-	// template identifies the template this rule applies to. The referenced
-	// template may live in any namespace the policy's owning namespace can
-	// reach.
+	// template identifies the template this rule requires or excludes. The
+	// referenced template may live in any namespace the policy's owning
+	// namespace can reach.
 	Template      *LinkedTemplateRef `protobuf:"bytes,2,opt,name=template,proto3" json:"template,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -195,8 +197,9 @@ func (x *TemplatePolicyRule) GetTemplate() *LinkedTemplateRef {
 	return nil
 }
 
-// TemplatePolicy is a named resource that declares one or more rules
-// attaching templates to projects within its namespace.
+// TemplatePolicy is a named resource that declares one or more rules. The
+// rules affect only the explicit render targets named by TemplatePolicyBinding
+// objects that reference this policy.
 //
 // Storage MUST live in a folder or organization namespace. Project-namespace
 // storage is forbidden and enforced by the HOL-618 admission plugin.
@@ -210,10 +213,12 @@ type TemplatePolicy struct {
 	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// display_name is a human-readable name for UI presentation.
 	DisplayName string `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	// description explains what the policy enforces.
+	// description explains what the policy is intended to enforce once attached
+	// by a TemplatePolicyBinding.
 	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
-	// rules are the REQUIRE/EXCLUDE rules this policy enforces. Rules are
-	// evaluated independently and their effects are combined by the resolver.
+	// rules are the REQUIRE/EXCLUDE rules this policy declares. Rules are
+	// evaluated independently and their effects are combined by the resolver for
+	// render targets selected by matching TemplatePolicyBinding objects.
 	Rules []*TemplatePolicyRule `protobuf:"bytes,5,rep,name=rules,proto3" json:"rules,omitempty"`
 	// creator_email is the email address of the user who created this policy.
 	CreatorEmail string `protobuf:"bytes,6,opt,name=creator_email,json=creatorEmail,proto3" json:"creator_email,omitempty"`

--- a/gen/holos/console/v1/templates.pb.go
+++ b/gen/holos/console/v1/templates.pb.go
@@ -1270,8 +1270,8 @@ func (x *CloneTemplateResponse) GetName() string {
 type ListLinkableTemplatesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// namespace is the starting namespace (e.g. a project namespace for a
-	// project template). The handler walks up the hierarchy and returns enabled
-	// ancestor templates.
+	// project template). The handler walks ancestor scopes and returns enabled
+	// templates from those scopes.
 	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// include_self_scope, when true, also returns enabled templates at the
 	// request's own namespace in addition to ancestor-namespace templates.
@@ -2018,7 +2018,7 @@ type SearchTemplatesRequest struct {
 	// organization, when non-empty, restricts results to templates owned by a
 	// namespace reachable from the given root organization. Intended for
 	// multi-org deployments where the caller wants to scope a search to one
-	// organization without enumerating every descendant namespace.
+	// organization without enumerating every namespace under that root.
 	Organization  string `protobuf:"bytes,4,opt,name=organization,proto3" json:"organization,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/holos/console/v1/policy_state.proto
+++ b/proto/holos/console/v1/policy_state.proto
@@ -23,13 +23,13 @@ option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;con
 // proto no longer needs a TEMPLATE_SCOPE_PROJECT carve-out.
 
 // LinkedTemplateRef is a (namespace, name) reference to a template used in
-// the explicit linking list (ADR 021 Decision 5). The resolver classifies
-// the namespace into its hierarchy kind (organization, folder, project) at
-// render time; callers supply the namespace only.
+// the explicit linking list (ADR 021 Decision 5). The resolver classifies the
+// namespace as organization, folder, or project at render time; callers supply
+// the namespace only.
 message LinkedTemplateRef {
   // namespace is the Kubernetes namespace that owns the linked template. The
-  // resolver classifies the namespace into its hierarchy kind (organization,
-  // folder, project) at render time — callers supply the namespace only.
+  // resolver classifies the namespace as organization, folder, or project at
+  // render time — callers supply the namespace only.
   string namespace = 1;
   // name is the template name.
   string name = 2;

--- a/proto/holos/console/v1/template_policies.proto
+++ b/proto/holos/console/v1/template_policies.proto
@@ -7,12 +7,12 @@ import "holos/console/v1/policy_state.proto";
 
 option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;consolev1";
 
-// TemplatePolicyService manages TemplatePolicy resources, which declaratively
-// attach templates to projects through REQUIRE/EXCLUDE rules. Policies replace
-// the legacy `bool mandatory` flag previously carried on Template and
-// LinkableTemplate (removed in HOL-555). The only way to force a template onto
-// every project — or to block one from matching projects — is to author a
-// TemplatePolicy.
+// TemplatePolicyService manages TemplatePolicy resources, which declare
+// REQUIRE/EXCLUDE rules that TemplatePolicyBinding objects attach to explicit
+// render targets. Policies replace the legacy `bool mandatory` flag previously
+// carried on Template and LinkableTemplate (removed in HOL-555). A policy by
+// itself does not affect any render target; a TemplatePolicyBinding must name
+// the policy and the project templates or deployments it applies to.
 //
 // Storage MUST live in a folder or organization namespace (`namespace`).
 // Project-namespace storage is forbidden and is enforced by the HOL-618
@@ -21,9 +21,10 @@ option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;con
 // discriminator for that rejection (HOL-619).
 //
 // Backend handler wiring (HOL-556), storage enforcement, and render-time
-// resolver integration (HOL-567) are complete; the resolver consults
-// TemplatePolicy ConfigMaps to pin REQUIRE templates and suppress EXCLUDE
-// templates for every matching project render.
+// resolver integration (HOL-567) are complete; the resolver consults matching
+// TemplatePolicyBinding objects, then reads their TemplatePolicy ConfigMaps to
+// pin REQUIRE templates or suppress EXCLUDE templates for the named render
+// targets.
 service TemplatePolicyService {
   // ListTemplatePolicies returns all TemplatePolicy resources visible in the
   // given namespace. Requires PERMISSION_TEMPLATE_POLICIES_LIST on the
@@ -64,16 +65,18 @@ service TemplatePolicyService {
 enum TemplatePolicyKind {
   TEMPLATE_POLICY_KIND_UNSPECIFIED = 0;
   // TEMPLATE_POLICY_KIND_REQUIRE causes the referenced template to be
-  // injected into the effective ref set when a deployment or project template
-  // matching the target is rendered. It does not itself create, apply, or
-  // delete any cluster resources — resources appear only as the output of the
-  // user's deployment or project-template render.
+  // injected into the effective ref set when a TemplatePolicyBinding names
+  // this policy for the deployment or project template being rendered. It does
+  // not itself create, apply, or delete any cluster resources — resources
+  // appear only as the output of the user's deployment or project-template
+  // render.
   TEMPLATE_POLICY_KIND_REQUIRE = 1;
   // TEMPLATE_POLICY_KIND_EXCLUDE causes the referenced template to be
-  // removed from the effective ref set when a deployment or project template
-  // matching the target is rendered, even if it would otherwise be linked.
-  // Like REQUIRE, it does not itself create, apply, or delete any cluster
-  // resources — it only filters the render-time unification set.
+  // removed from the effective ref set when a TemplatePolicyBinding names this
+  // policy for the deployment or project template being rendered, even if the
+  // template would otherwise be linked. Like REQUIRE, it does not itself
+  // create, apply, or delete any cluster resources — it only filters the
+  // render-time unification set.
   TEMPLATE_POLICY_KIND_EXCLUDE = 2;
 }
 
@@ -106,9 +109,9 @@ message TemplatePolicyTarget {
 message TemplatePolicyRule {
   // kind is REQUIRE or EXCLUDE.
   TemplatePolicyKind kind = 1;
-  // template identifies the template this rule applies to. The referenced
-  // template may live in any namespace the policy's owning namespace can
-  // reach.
+  // template identifies the template this rule requires or excludes. The
+  // referenced template may live in any namespace the policy's owning
+  // namespace can reach.
   LinkedTemplateRef template = 2;
   // Field 3 (target) was the legacy glob-based TemplatePolicyTarget that
   // HOL-600 removed. It is reserved so the number is never reused.
@@ -116,8 +119,9 @@ message TemplatePolicyRule {
   reserved "target";
 }
 
-// TemplatePolicy is a named resource that declares one or more rules
-// attaching templates to projects within its namespace.
+// TemplatePolicy is a named resource that declares one or more rules. The
+// rules affect only the explicit render targets named by TemplatePolicyBinding
+// objects that reference this policy.
 //
 // Storage MUST live in a folder or organization namespace. Project-namespace
 // storage is forbidden and enforced by the HOL-618 admission plugin.
@@ -130,10 +134,12 @@ message TemplatePolicy {
   string namespace = 2;
   // display_name is a human-readable name for UI presentation.
   string display_name = 3;
-  // description explains what the policy enforces.
+  // description explains what the policy is intended to enforce once attached
+  // by a TemplatePolicyBinding.
   string description = 4;
-  // rules are the REQUIRE/EXCLUDE rules this policy enforces. Rules are
-  // evaluated independently and their effects are combined by the resolver.
+  // rules are the REQUIRE/EXCLUDE rules this policy declares. Rules are
+  // evaluated independently and their effects are combined by the resolver for
+  // render targets selected by matching TemplatePolicyBinding objects.
   repeated TemplatePolicyRule rules = 5;
   // creator_email is the email address of the user who created this policy.
   string creator_email = 6;

--- a/proto/holos/console/v1/template_policy_bindings.proto
+++ b/proto/holos/console/v1/template_policy_bindings.proto
@@ -21,8 +21,8 @@ option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;con
 // Project-namespace storage is forbidden for the same reason it is forbidden
 // for TemplatePolicy (HOL-554 storage-isolation design note); the policy a
 // binding references is always folder- or org-scoped, so the binding lives
-// in the same hierarchy level. The HOL-618 admission plugin enforces this
-// by rejecting any TemplatePolicyBinding created in a project namespace.
+// in the same storage scope category. The HOL-618 admission plugin enforces
+// this by rejecting any TemplatePolicyBinding created in a project namespace.
 //
 // Handler wiring, RBAC enforcement, and ConnectRPC registration shipped in
 // HOL-595. The ancestor-aware policy picker (ListLinkableTemplatePolicies) is

--- a/proto/holos/console/v1/templates.proto
+++ b/proto/holos/console/v1/templates.proto
@@ -9,15 +9,15 @@ import "holos/console/v1/policy_state.proto";
 option go_package = "github.com/holos-run/holos-console/gen/holos/console/v1;consolev1";
 
 // TemplateService is the single unified service for managing CUE-based templates
-// at every hierarchy level (organization, folder, project). It replaces the
+// at every scope level (organization, folder, project). It replaces the
 // separate DeploymentTemplateService and OrgTemplateService from v1alpha1
 // (ADR 021 Decision 1).
 //
 // All CRUD operations carry a `namespace` that owns the template. The
-// backend resolver classifies the namespace into its hierarchy kind
-// (organization, folder, project) — callers do not supply the kind
-// directly. HOL-619 replaced the earlier TemplateScope / TemplateScopeRef
-// discriminator with this namespace-only model.
+// backend resolver classifies the namespace as organization, folder, or
+// project — callers do not supply the kind directly. HOL-619 replaced the
+// earlier TemplateScope / TemplateScopeRef discriminator with this
+// namespace-only model.
 service TemplateService {
   // ListTemplates returns all templates the user can see in the given
   // namespace.
@@ -386,8 +386,8 @@ message CloneTemplateResponse {
 // namespaces that the given namespace may explicitly link.
 message ListLinkableTemplatesRequest {
   // namespace is the starting namespace (e.g. a project namespace for a
-  // project template). The handler walks up the hierarchy and returns enabled
-  // ancestor templates.
+  // project template). The handler walks ancestor scopes and returns enabled
+  // templates from those scopes.
   string namespace = 1;
   // include_self_scope, when true, also returns enabled templates at the
   // request's own namespace in addition to ancestor-namespace templates.
@@ -550,7 +550,7 @@ message SearchTemplatesRequest {
   // organization, when non-empty, restricts results to templates owned by a
   // namespace reachable from the given root organization. Intended for
   // multi-org deployments where the caller wants to scope a search to one
-  // organization without enumerating every descendant namespace.
+  // organization without enumerating every namespace under that root.
   string organization = 4;
 }
 


### PR DESCRIPTION
## Summary
- Rewrite TemplatePolicy proto comments to make binding-only enforcement explicit
- Remove cascade/hierarchy wording from the targeted proto comment surfaces
- Regenerate Go and TypeScript bindings from the updated proto comments

Fixes HOL-996

## Test plan
- [x] make generate
- [x] make test-go
- [x] make vet
- [x] cd frontend && npm run build