### PR TITLE
refactor(frontend): remove cascade/hierarchy language from TemplatesHelpPane

### DIFF
--- a/frontend/src/components/platform-template-copy.ts
+++ b/frontend/src/components/platform-template-copy.ts
@@ -23,7 +23,7 @@ export const ORG_SCOPE_INDEX_DESCRIPTION =
   'Platform templates authored at organization scope are available for inclusion by project templates and deployments throughout the organization.'
 
 export const FOLDER_SCOPE_INDEX_DESCRIPTION =
-  'Platform templates authored at this folder scope are available for inclusion by project templates and deployments in this folder and its descendants.'
+  'Platform templates authored at this folder scope are available for inclusion by project templates and deployments within this folder.'
 
 export const REQUIRE_RULE_DESCRIPTION =
   'REQUIRE — when a project template or deployment matching the target is rendered, include this platform template in the effective ref set. The rule affects render-time ref selection only; it does not itself create, apply, or delete resources.'

--- a/frontend/src/components/templates/-templates-help-pane.test.tsx
+++ b/frontend/src/components/templates/-templates-help-pane.test.tsx
@@ -66,7 +66,7 @@ describe('TemplatesHelpPane', () => {
 
     const section = screen.getByTestId('help-section-template-policy')
     expect(section).toBeInTheDocument()
-    expect(section.textContent).toMatch(/constraint authored at organization/i)
+    expect(section.textContent).toMatch(/constraint defined at organization/i)
   })
 
   it('renders the TemplatePolicyBinding section copy block', () => {

--- a/frontend/src/components/templates/TemplatesHelpPane.tsx
+++ b/frontend/src/components/templates/TemplatesHelpPane.tsx
@@ -51,12 +51,11 @@ export function TemplatesHelpPane({ open, onOpenChange }: TemplatesHelpPaneProps
           <section data-testid="help-section-template-policy">
             <h3 className="font-semibold text-base mb-1">Template Policy</h3>
             <p className="text-muted-foreground leading-relaxed">
-              A <strong>Template Policy</strong> is a constraint authored at organization
-              or folder scope. It expresses what is allowed or required in descendant
-              templates — for example, mandating a minimum replica count or prohibiting
-              certain image registries. Policies propagate down the namespace hierarchy
-              so platform and security teams can apply guardrails without touching each
-              project.
+              A <strong>Template Policy</strong> is a constraint defined at organization
+              or folder scope — for example, mandating a minimum replica count or
+              prohibiting certain image registries. A Template Policy has no effect on
+              its own; it must be referenced by a Template Policy Binding before any
+              enforcement takes place.
             </p>
           </section>
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-index-help.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-index-help.test.tsx
@@ -220,7 +220,7 @@ describe('ProjectTemplatesIndexPage — help pane', () => {
     expect(templateSection.textContent).toMatch(/reusable CUE configuration/i)
 
     const policySection = screen.getByTestId('help-section-template-policy')
-    expect(policySection.textContent).toMatch(/constraint authored at organization/i)
+    expect(policySection.textContent).toMatch(/constraint defined at organization/i)
 
     const bindingSection = screen.getByTestId('help-section-template-policy-binding')
     expect(bindingSection.textContent).toMatch(/enforcement point/i)


### PR DESCRIPTION
## Summary

- Rewrites the `TemplatesHelpPane` Template Policy section to remove "propagate down the namespace hierarchy" and "descendant templates" — replacing it with binding-only enforcement copy: a TemplatePolicy has no effect on its own; it must be referenced by a TemplatePolicyBinding.
- Removes "and its descendants" from `FOLDER_SCOPE_INDEX_DESCRIPTION` in `platform-template-copy.ts`.
- Updates two test assertions (`-templates-help-pane.test.tsx`, `-index-help.test.tsx`) from "authored at organization" → "defined at organization" to match the rewritten copy.
- Folder-scoped template-policy route files listed in the AC were already removed by HOL-978 (MVP folder-routes cut). Code-level "RBAC cascade" comments and generated proto files are explicitly out of scope.

Fixes HOL-997

## Test plan

- [x] `cd frontend && npm run test -- --run` → 1227 tests pass, 0 failures
- [x] Lint error count unchanged from main (55 pre-existing errors in unrelated files)
- [x] TypeScript error count unchanged from main (2 pre-existing errors in ResourceGrid.tsx)
- [x] `CascadeDeleteToggle` and its test are untouched (out of scope per AC)