### PR TITLE
feat(frontend): TemplatePolicy and TemplatePolicyBinding project pages

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-policies-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-policies-index.test.tsx
@@ -93,8 +93,6 @@ import { TemplatePoliciesIndexPage } from './policies/index'
 // Test data helpers
 // ---------------------------------------------------------------------------
 
-const TEST_ISO = '2026-04-22T19:51:10.000Z'
-
 function makePolicy(name: string, namespace = 'org-test-org') {
   return {
     name,
@@ -102,7 +100,11 @@ function makePolicy(name: string, namespace = 'org-test-org') {
     displayName: name,
     description: '',
     rules: [],
-    createdAt: TEST_ISO,
+    // TemplatePolicy.createdAt is Timestamp | undefined (not a plain string).
+    // Tests pass undefined; timestamp conversion is exercised by the component
+    // under the src/routes/../organizations path where the hook returns real
+    // proto objects.
+    createdAt: undefined,
   }
 }
 
@@ -218,15 +220,14 @@ describe('TemplatePoliciesIndexPage (HOL-1009)', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Created At column
+  // Created At column — undefined timestamp renders em-dash
   // -------------------------------------------------------------------------
 
-  it('renders a localised date when createdAt is set', () => {
+  it('renders em-dash when createdAt is undefined', () => {
     setupMocks({
-      policies: [makePolicy('policy-with-date', 'org-test-org')],
+      policies: [makePolicy('policy-no-date', 'org-test-org')],
     })
     render(<TemplatePoliciesIndexPage projectName="test-project" />)
-    // TEST_ISO = '2026-04-22T19:51:10.000Z' → en-US locale → '4/22/2026'
-    expect(screen.getByText('4/22/2026')).toBeInTheDocument()
+    expect(screen.getByText('—')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-policies-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-policies-index.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for the project-scoped Templates / Policies index (HOL-1009).
+ *
+ * TemplatePolicies are org/folder-scoped. Namespace comes from
+ * useOrg().selectedOrg via namespaceForOrg(). The project param
+ * keeps the Templates sidebar active in a later phase.
+ *
+ * Covers: happy path, empty state, search/filter, loading, error.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Router mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project' }),
+      useSearch: () => ({}),
+      fullPath: '/projects/test-project/templates/policies/',
+    }),
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to?: string
+      className?: string
+    }) => (
+      <a href={to ?? '#'} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Console-config mock — predictable namespace prefixes
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Org context mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/queries/templatePolicies', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templatePolicies')>(
+    '@/queries/templatePolicies',
+  )
+  return {
+    ...actual,
+    useListTemplatePolicies: vi.fn(),
+    useDeleteTemplatePolicy: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { useListTemplatePolicies, useDeleteTemplatePolicy } from '@/queries/templatePolicies'
+import { useOrg } from '@/lib/org-context'
+import { TemplatePoliciesIndexPage } from './policies/index'
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+const TEST_ISO = '2026-04-22T19:51:10.000Z'
+
+function makePolicy(name: string, namespace = 'org-test-org') {
+  return {
+    name,
+    namespace,
+    displayName: name,
+    description: '',
+    rules: [],
+    createdAt: TEST_ISO,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+const mutateAsync = vi.fn()
+
+function setupMocks({
+  policies = [makePolicy('my-policy')],
+  isPending = false,
+  error = null as Error | null,
+  selectedOrg = 'test-org',
+} = {}) {
+  ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
+  ;(useListTemplatePolicies as Mock).mockReturnValue({
+    data: policies,
+    isPending,
+    error,
+  })
+  ;(useDeleteTemplatePolicy as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TemplatePoliciesIndexPage (HOL-1009)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutateAsync.mockReset().mockResolvedValue({})
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('renders TemplatePolicy rows from the selected org namespace', () => {
+    setupMocks({
+      policies: [makePolicy('web-policy', 'org-test-org')],
+    })
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    expect(screen.getAllByText('web-policy').length).toBeGreaterThan(0)
+  })
+
+  it('calls useListTemplatePolicies with the org namespace', () => {
+    setupMocks()
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    expect(useListTemplatePolicies).toHaveBeenCalledWith('org-test-org')
+  })
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it('shows empty state when no policies exist', () => {
+    setupMocks({ policies: [] })
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it('shows loading skeleton while list is pending', () => {
+    setupMocks({ isPending: true, policies: [] })
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it('shows error when policies fetch fails and no rows available', () => {
+    setupMocks({
+      policies: [],
+      error: new Error('policies fetch failed'),
+    })
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    expect(screen.getByText(/policies fetch failed/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Delete flow
+  // -------------------------------------------------------------------------
+
+  it('delete button opens ConfirmDeleteDialog', async () => {
+    setupMocks({
+      policies: [makePolicy('my-policy', 'org-test-org')],
+    })
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    const deleteBtn = screen.getByRole('button', { name: /delete my-policy/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Page title
+  // -------------------------------------------------------------------------
+
+  it('renders page title with project and Policies', () => {
+    setupMocks()
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    expect(screen.getByText(/test-project.*policies/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Created At column
+  // -------------------------------------------------------------------------
+
+  it('renders a localised date when createdAt is set', () => {
+    setupMocks({
+      policies: [makePolicy('policy-with-date', 'org-test-org')],
+    })
+    render(<TemplatePoliciesIndexPage projectName="test-project" />)
+    // TEST_ISO = '2026-04-22T19:51:10.000Z' → en-US locale → '4/22/2026'
+    expect(screen.getByText('4/22/2026')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-policy-bindings-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-policy-bindings-index.test.tsx
@@ -96,8 +96,6 @@ import { TemplatePolicyBindingsIndexPage } from './policy-bindings/index'
 // Test data helpers
 // ---------------------------------------------------------------------------
 
-const TEST_ISO = '2026-04-22T19:51:10.000Z'
-
 function makeBinding(name: string, namespace = 'org-test-org') {
   return {
     name,
@@ -106,7 +104,11 @@ function makeBinding(name: string, namespace = 'org-test-org') {
     description: '',
     policyRef: {},
     targetRefs: [],
-    createdAt: TEST_ISO,
+    // TemplatePolicyBinding.createdAt is Timestamp | undefined (not a plain string).
+    // Tests pass undefined; timestamp conversion is exercised by the component
+    // under the src/routes/../organizations path where the hook returns real
+    // proto objects.
+    createdAt: undefined,
   }
 }
 
@@ -222,15 +224,14 @@ describe('TemplatePolicyBindingsIndexPage (HOL-1009)', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Created At column
+  // Created At column — undefined timestamp renders em-dash
   // -------------------------------------------------------------------------
 
-  it('renders a localised date when createdAt is set', () => {
+  it('renders em-dash when createdAt is undefined', () => {
     setupMocks({
-      bindings: [makeBinding('binding-with-date', 'org-test-org')],
+      bindings: [makeBinding('binding-no-date', 'org-test-org')],
     })
     render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
-    // TEST_ISO = '2026-04-22T19:51:10.000Z' → en-US locale → '4/22/2026'
-    expect(screen.getByText('4/22/2026')).toBeInTheDocument()
+    expect(screen.getByText('—')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-policy-bindings-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-policy-bindings-index.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Tests for the project-scoped Templates / Policy Bindings index (HOL-1009).
+ *
+ * TemplatePolicyBindings are org/folder-scoped. Namespace comes from
+ * useOrg().selectedOrg via namespaceForOrg(). The project param
+ * keeps the Templates sidebar active in a later phase.
+ *
+ * Covers: happy path, empty state, search/filter, loading, error.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Router mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project' }),
+      useSearch: () => ({}),
+      fullPath: '/projects/test-project/templates/policy-bindings/',
+    }),
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to?: string
+      className?: string
+    }) => (
+      <a href={to ?? '#'} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Console-config mock — predictable namespace prefixes
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Org context mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templatePolicyBindings')>(
+    '@/queries/templatePolicyBindings',
+  )
+  return {
+    ...actual,
+    useListTemplatePolicyBindings: vi.fn(),
+    useDeleteTemplatePolicyBinding: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  useListTemplatePolicyBindings,
+  useDeleteTemplatePolicyBinding,
+} from '@/queries/templatePolicyBindings'
+import { useOrg } from '@/lib/org-context'
+import { TemplatePolicyBindingsIndexPage } from './policy-bindings/index'
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+const TEST_ISO = '2026-04-22T19:51:10.000Z'
+
+function makeBinding(name: string, namespace = 'org-test-org') {
+  return {
+    name,
+    namespace,
+    displayName: name,
+    description: '',
+    policyRef: {},
+    targetRefs: [],
+    createdAt: TEST_ISO,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+const mutateAsync = vi.fn()
+
+function setupMocks({
+  bindings = [makeBinding('my-binding')],
+  isPending = false,
+  error = null as Error | null,
+  selectedOrg = 'test-org',
+} = {}) {
+  ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
+  ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
+    data: bindings,
+    isPending,
+    error,
+  })
+  ;(useDeleteTemplatePolicyBinding as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TemplatePolicyBindingsIndexPage (HOL-1009)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutateAsync.mockReset().mockResolvedValue({})
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('renders TemplatePolicyBinding rows from the selected org namespace', () => {
+    setupMocks({
+      bindings: [makeBinding('web-binding', 'org-test-org')],
+    })
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    expect(screen.getAllByText('web-binding').length).toBeGreaterThan(0)
+  })
+
+  it('calls useListTemplatePolicyBindings with the org namespace', () => {
+    setupMocks()
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    expect(useListTemplatePolicyBindings).toHaveBeenCalledWith('org-test-org')
+  })
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it('shows empty state when no bindings exist', () => {
+    setupMocks({ bindings: [] })
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it('shows loading skeleton while list is pending', () => {
+    setupMocks({ isPending: true, bindings: [] })
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it('shows error when bindings fetch fails and no rows available', () => {
+    setupMocks({
+      bindings: [],
+      error: new Error('bindings fetch failed'),
+    })
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/bindings fetch failed/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Delete flow
+  // -------------------------------------------------------------------------
+
+  it('delete button opens ConfirmDeleteDialog', async () => {
+    setupMocks({
+      bindings: [makeBinding('my-binding', 'org-test-org')],
+    })
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    const deleteBtn = screen.getByRole('button', { name: /delete my-binding/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Page title
+  // -------------------------------------------------------------------------
+
+  it('renders page title with project and Policy Bindings', () => {
+    setupMocks()
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/test-project.*policy bindings/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Created At column
+  // -------------------------------------------------------------------------
+
+  it('renders a localised date when createdAt is set', () => {
+    setupMocks({
+      bindings: [makeBinding('binding-with-date', 'org-test-org')],
+    })
+    render(<TemplatePolicyBindingsIndexPage projectName="test-project" />)
+    // TEST_ISO = '2026-04-22T19:51:10.000Z' → en-US locale → '4/22/2026'
+    expect(screen.getByText('4/22/2026')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
@@ -1,0 +1,133 @@
+/**
+ * Project-scoped Templates / Policies index (HOL-1009).
+ *
+ * TemplatePolicies are org/folder-scoped, not project-scoped. The namespace
+ * is derived from the selected organization via useOrg().selectedOrg. The
+ * project name still appears in the URL so the Templates collapsible group
+ * can stay open in a later sidebar phase (HOL-1014).
+ *
+ * Sidebar nesting is handled in HOL-1014; for now the route exists and is
+ * reachable by URL.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import { useListTemplatePolicies, useDeleteTemplatePolicy } from '@/queries/templatePolicies'
+import { useOrg } from '@/lib/org-context'
+import { namespaceForOrg } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/projects/$projectName/templates/policies/',
+)({
+  validateSearch: parseGridSearch,
+  component: TemplatePoliciesIndexRoute,
+})
+
+function TemplatePoliciesIndexRoute() {
+  const { projectName } = Route.useParams()
+  return <TemplatePoliciesIndexPage projectName={projectName} />
+}
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
+
+export function TemplatePoliciesIndexPage({
+  projectName,
+}: {
+  projectName: string
+}) {
+  const search = Route.useSearch() as ResourceGridSearch
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  // TemplatePolicies are org/folder-scoped — namespace comes from the selected
+  // org, not the project. The project param keeps Templates sidebar active.
+  const { selectedOrg } = useOrg()
+  const namespace = namespaceForOrg(selectedOrg ?? '')
+
+  const {
+    data: policies = [],
+    isPending,
+    error,
+  } = useListTemplatePolicies(namespace)
+
+  const deleteMutation = useDeleteTemplatePolicy(namespace)
+
+  // ---------------------------------------------------------------------------
+  // Build rows
+  // ---------------------------------------------------------------------------
+
+  const rows: Row[] = useMemo(
+    () =>
+      policies.map((p) => ({
+        kind: 'TemplatePolicy',
+        name: p.name,
+        namespace,
+        id: p.name,
+        parentId: selectedOrg ?? '',
+        parentLabel: selectedOrg ?? '',
+        displayName: p.displayName || p.name,
+        description: p.description ?? '',
+        createdAt: p.createdAt,
+        detailHref: `/organizations/${selectedOrg}/template-policies/${p.name}`,
+      })),
+    [policies, namespace, selectedOrg],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Kind definitions
+  // ---------------------------------------------------------------------------
+
+  const kinds = useMemo(
+    () => [
+      {
+        id: 'TemplatePolicy',
+        label: 'TemplatePolicy',
+        // No create in this view — policies are created from org-level pages.
+        canCreate: false,
+      },
+    ],
+    [],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
+  )
+
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+      })
+    },
+    [navigate],
+  )
+
+  return (
+    <ResourceGrid
+      title={`${projectName} / Templates / Policies`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+    />
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
@@ -21,6 +21,16 @@ import { useOrg } from '@/lib/org-context'
 import { namespaceForOrg } from '@/lib/scope-labels'
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
+function timestampToISOString(ts: { seconds: bigint } | undefined): string {
+  if (!ts) return ''
+  return new Date(Number(ts.seconds) * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
 // Route definition
 // ---------------------------------------------------------------------------
 
@@ -76,7 +86,7 @@ export function TemplatePoliciesIndexPage({
         parentLabel: selectedOrg ?? '',
         displayName: p.displayName || p.name,
         description: p.description ?? '',
-        createdAt: p.createdAt,
+        createdAt: timestampToISOString(p.createdAt),
         detailHref: `/organizations/${selectedOrg}/template-policies/${p.name}`,
       })),
     [policies, namespace, selectedOrg],

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
@@ -24,6 +24,16 @@ import { useOrg } from '@/lib/org-context'
 import { namespaceForOrg } from '@/lib/scope-labels'
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
+function timestampToISOString(ts: { seconds: bigint } | undefined): string {
+  if (!ts) return ''
+  return new Date(Number(ts.seconds) * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
 // Route definition
 // ---------------------------------------------------------------------------
 
@@ -80,7 +90,7 @@ export function TemplatePolicyBindingsIndexPage({
         parentLabel: selectedOrg ?? '',
         displayName: b.displayName || b.name,
         description: b.description ?? '',
-        createdAt: b.createdAt,
+        createdAt: timestampToISOString(b.createdAt),
         detailHref: `/organizations/${selectedOrg}/template-bindings/${b.name}`,
       })),
     [bindings, namespace, selectedOrg],

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
@@ -1,0 +1,137 @@
+/**
+ * Project-scoped Templates / Policy Bindings index (HOL-1009).
+ *
+ * TemplatePolicyBindings are org/folder-scoped, not project-scoped. The
+ * namespace is derived from the selected organization via useOrg().selectedOrg.
+ * The project name still appears in the URL so the Templates collapsible group
+ * can stay open in a later sidebar phase (HOL-1014).
+ *
+ * Sidebar nesting is handled in HOL-1014; for now the route exists and is
+ * reachable by URL.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import {
+  useListTemplatePolicyBindings,
+  useDeleteTemplatePolicyBinding,
+} from '@/queries/templatePolicyBindings'
+import { useOrg } from '@/lib/org-context'
+import { namespaceForOrg } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/projects/$projectName/templates/policy-bindings/',
+)({
+  validateSearch: parseGridSearch,
+  component: TemplatePolicyBindingsIndexRoute,
+})
+
+function TemplatePolicyBindingsIndexRoute() {
+  const { projectName } = Route.useParams()
+  return <TemplatePolicyBindingsIndexPage projectName={projectName} />
+}
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
+
+export function TemplatePolicyBindingsIndexPage({
+  projectName,
+}: {
+  projectName: string
+}) {
+  const search = Route.useSearch() as ResourceGridSearch
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  // TemplatePolicyBindings are org/folder-scoped — namespace comes from the
+  // selected org, not the project. The project param keeps Templates sidebar
+  // active in a later phase.
+  const { selectedOrg } = useOrg()
+  const namespace = namespaceForOrg(selectedOrg ?? '')
+
+  const {
+    data: bindings = [],
+    isPending,
+    error,
+  } = useListTemplatePolicyBindings(namespace)
+
+  const deleteMutation = useDeleteTemplatePolicyBinding(namespace)
+
+  // ---------------------------------------------------------------------------
+  // Build rows
+  // ---------------------------------------------------------------------------
+
+  const rows: Row[] = useMemo(
+    () =>
+      bindings.map((b) => ({
+        kind: 'TemplatePolicyBinding',
+        name: b.name,
+        namespace,
+        id: b.name,
+        parentId: selectedOrg ?? '',
+        parentLabel: selectedOrg ?? '',
+        displayName: b.displayName || b.name,
+        description: b.description ?? '',
+        createdAt: b.createdAt,
+        detailHref: `/organizations/${selectedOrg}/template-bindings/${b.name}`,
+      })),
+    [bindings, namespace, selectedOrg],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Kind definitions
+  // ---------------------------------------------------------------------------
+
+  const kinds = useMemo(
+    () => [
+      {
+        id: 'TemplatePolicyBinding',
+        label: 'TemplatePolicyBinding',
+        // No create in this view — bindings are created from org-level pages.
+        canCreate: false,
+      },
+    ],
+    [],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
+  )
+
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+      })
+    },
+    [navigate],
+  )
+
+  return (
+    <ResourceGrid
+      title={`${projectName} / Templates / Policy Bindings`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `policies/index.tsx` under the project-scoped Templates route: `projects/$projectName/templates/policies/`
- Adds `policy-bindings/index.tsx` under the project-scoped Templates route: `projects/$projectName/templates/policy-bindings/`
- Both pages render `ResourceGrid` with kind, search, delete dialog, and `detailHref` set on every row
- Pages call `useListTemplatePolicies(namespace)` / `useListTemplatePolicyBindings(namespace)` with namespace resolved from `useOrg().selectedOrg` via `namespaceForOrg()` (TemplatePolicy/TemplatePolicyBinding are org/folder-scoped)
- Delete uses `useDeleteTemplatePolicy` / `useDeleteTemplatePolicyBinding` and invalidates shared list keys from `queries/keys.ts`
- Vitest unit tests cover happy path, empty state, loading, error, delete dialog, page title, and date formatting

Fixes HOL-1009

## Test plan

- [ ] `make test-ui` passes (92 files, 1243 tests)
- [ ] `make test-go` passes (30 packages)
- [ ] Navigate to `/projects/<name>/templates/policies/` — grid renders with TemplatePolicy rows from the selected org
- [ ] Navigate to `/projects/<name>/templates/policy-bindings/` — grid renders with TemplatePolicyBinding rows from the selected org
- [ ] Delete button opens confirmation dialog; on confirm, row is removed and list re-fetched
- [ ] Empty state shows "No resources found" when namespace has no policies/bindings