### PR TITLE
docs(adr-034): rephrase binding-scope prose to avoid cascade implication

### DIFF
--- a/docs/adrs/034-namespace-template-policy-binding-for-new-projects.md
+++ b/docs/adrs/034-namespace-template-policy-binding-for-new-projects.md
@@ -52,12 +52,21 @@ Three design choices needed explicit decisions before implementation:
 
 ### Option A: Scope = Project, Folder, and Organization namespaces
 
-Extend the mechanism at once to cover every hierarchy level that
-provisions a namespace on creation.
+Allow `TemplatePolicyBinding` objects to be placed in organization, folder,
+and project namespaces — covering every object type that provisions a
+namespace on creation. TemplatePolicy enforcement remains binding-only at
+each level; no cross-level propagation occurs.
+
+_Update (HOL-993): The original prose used "extend the mechanism to every
+hierarchy level" which could be read as implying TemplatePolicy cascades
+across levels. Clarified to binding-placement scope: a binding applies only
+where it is explicitly created. No ancestor-based propagation of policy
+enforcement was ever part of this design option._
 
 Pros:
 - Single feature request; no need for a follow-up.
-- Uniform semantics for all hierarchy-object creation events.
+- Uniform binding semantics for all object-creation events that provision a
+  namespace.
 
 Cons:
 - `CreateFolder` and `CreateOrganization` have different RBAC callers,


### PR DESCRIPTION
## Summary

- Revises ADR 034 Option A prose to replace "Extend the mechanism at once to cover every hierarchy level" with language that makes binding-only enforcement explicit: TemplatePolicyBinding objects are placed at specific namespace levels; no cross-level propagation occurs
- Adds an inline Update (HOL-993) note per the ADR historical-record convention
- ADR 035 audited: all `cascadeDelete` mentions refer to Kubernetes owner-ref GC (not TemplatePolicy cascade); no changes needed
- All other docs files audited: `docs/agents/`, `docs/ui/`, `docs/secret-injector/lifecycle.md`, `docs/api/secrets.holos.run.md` — cascade/hierarchy mentions are in SecretInjectionPolicy context (excluded per implementation notes) or K8s RBAC/folder context (not TemplatePolicy)

Fixes HOL-998

## Test plan

- [x] `make test-go` passes (all packages, 132s)
- [x] grep for `cascade|hierarch|propagate|descendant` in `docs/` confirms no remaining text claims TemplatePolicy applies to descendants without a binding
- [x] ADR 035 `cascadeDelete` terminology confirmed to be Kubernetes owner-ref GC only