### PR TITLE
chore(hol-999): final cascade purge sweep, regression test, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to holos-console are documented here.
 
 ## [Unreleased]
 
+### Chore — Purge cascade/hierarchical-apply TemplatePolicy terminology (HOL-992 / HOL-993)
+
+TemplatePolicy enforcement is now binding-only: a policy in an ancestor namespace
+has no effect unless a `TemplatePolicyBinding` explicitly selects the render target.
+The cascade/hierarchical-apply model and all associated terminology have been removed.
+
+- Renamed wildcard cascade tests to clarify binding-based scope semantics (HOL-995).
+- Purged cascade and hierarchical-policy prose from proto comments (HOL-996).
+- Rewrote `TemplatesHelpPane` to explain binding-only enforcement (HOL-997).
+- Updated ADR 034 and ADR 035 to reflect binding-only enforcement (HOL-998).
+- Added `TestFolderResolver_PolicyWithoutBindingDoesNotApply` regression test as a
+  permanent guardrail: asserts that a `TemplatePolicy` in an org namespace with no
+  matching `TemplatePolicyBinding` contributes zero rules to `Resolve()` for any
+  descendant project (HOL-999).
+
 ### Added — Deployment Dependencies: TemplateGrant, TemplateDependency, TemplateRequirement, Deployment CRD (HOL-954)
 
 Implements [ADR 035](docs/adrs/035-deployment-dependencies.md): three new tightly-scoped

--- a/console/policyresolver/folder_resolver_bindings_test.go
+++ b/console/policyresolver/folder_resolver_bindings_test.go
@@ -593,3 +593,58 @@ func TestFolderResolver_WildcardBindingFolderFanout(t *testing.T) {
 		t.Errorf("roses/project-template: DEPLOYMENT {*,*} must not match PROJECT_TEMPLATE; got %v", names)
 	}
 }
+
+// TestFolderResolver_PolicyWithoutBindingDoesNotApply is a permanent
+// guardrail (HOL-999) asserting that a TemplatePolicy stored in an org
+// namespace contributes zero rules to Resolve() for any descendant project
+// when no matching TemplatePolicyBinding exists.
+//
+// Rationale: TemplatePolicy enforcement is binding-only. A policy sitting in
+// the ancestor chain is inert until a TemplatePolicyBinding explicitly
+// selects a render target. This test exists so that any future change that
+// reintroduces ancestor-walk-as-cascade behavior fails loudly.
+func TestFolderResolver_PolicyWithoutBindingDoesNotApply(t *testing.T) {
+	client, r, ns := buildFixture()
+	walker := &resolver.Walker{Client: client, Resolver: r}
+
+	// Seed a policy with a REQUIRE rule in the org namespace.
+	// No TemplatePolicyBinding is created — the policy is intentionally
+	// unbound.
+	policies := map[string][]templatesv1alpha1.TemplatePolicy{
+		ns["org"]: {
+			policyCRD(ns["org"], "unbound-audit", []templatesv1alpha1.TemplatePolicyRule{
+				requireRuleCRD(v1alpha2.TemplateScopeOrganization, "acme", "audit-policy"),
+			}),
+		},
+	}
+
+	// Empty binding lister — no bindings exist anywhere.
+	bl := &bindingListerFromMap{items: nil}
+	pl := &policyListerFromClient{items: policies}
+	fr := newFolderResolverWithBindingsForTest(pl, bl, walker, r)
+
+	ctx := context.Background()
+
+	// Verify all three descendant project namespaces contribute zero rules.
+	descendants := []struct {
+		label string
+		ns    string
+	}{
+		{"projectOrchids (direct child of org)", ns["projectOrchids"]},
+		{"projectLilies (grandchild of org via eng)", ns["projectLilies"]},
+		{"projectRoses (great-grandchild of org via eng/team-a)", ns["projectRoses"]},
+	}
+	for _, d := range descendants {
+		d := d
+		t.Run(d.label, func(t *testing.T) {
+			got, err := fr.Resolve(ctx, d.ns, TargetKindDeployment, "api")
+			if err != nil {
+				t.Fatalf("Resolve returned unexpected error: %v", err)
+			}
+			if len(got) != 0 {
+				t.Errorf("unbound policy contributed rules to %s: got %v, want empty",
+					d.label, refNames(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Added `TestFolderResolver_PolicyWithoutBindingDoesNotApply` regression test to `console/policyresolver/folder_resolver_bindings_test.go` as a permanent guardrail asserting that a `TemplatePolicy` in an org namespace with no matching `TemplatePolicyBinding` contributes zero rules to `Resolve()` for any descendant project.
- Added CHANGELOG entry under `## [Unreleased]` documenting that `TemplatePolicy` enforcement is binding-only and that cascade/hierarchical terminology has been removed (HOL-992 / HOL-993).

Fixes HOL-999

## Test plan

- [x] `TestFolderResolver_PolicyWithoutBindingDoesNotApply` passes (verified locally)
- [x] Full Go test suite passes (`make test-go`)
- [x] Frontend unit tests pass (`npm run test -- --run`: 1219 tests)
- [x] `make fmt` and `make vet` pass
- [x] Pre-existing lint issues (42) confirmed unchanged — none introduced by this PR