### PR TITLE
feat(frontend): TanStack Query hooks and ResourceGrid pages for TemplateDependency, TemplateRequirement, TemplateGrant

### DIFF
--- a/frontend/src/queries/keys.ts
+++ b/frontend/src/queries/keys.ts
@@ -81,6 +81,22 @@ export const keys = {
       ['templateDependencies', 'templateDependents', namespace, name] as const,
     deploymentDependents: (namespace: string, name: string) =>
       ['templateDependencies', 'deploymentDependents', namespace, name] as const,
+    list: (namespace: string) =>
+      ['templateDependencies', 'list', namespace] as const,
+    get: (namespace: string, name: string) =>
+      ['templateDependencies', 'get', namespace, name] as const,
+  },
+  templateRequirements: {
+    list: (namespace: string) =>
+      ['templateRequirements', 'list', namespace] as const,
+    get: (namespace: string, name: string) =>
+      ['templateRequirements', 'get', namespace, name] as const,
+  },
+  templateGrants: {
+    list: (namespace: string) =>
+      ['templateGrants', 'list', namespace] as const,
+    get: (namespace: string, name: string) =>
+      ['templateGrants', 'get', namespace, name] as const,
   },
   templates: {
     list: (namespace: string) => ['templates', 'list', namespace] as const,

--- a/frontend/src/queries/templateDependencies.ts
+++ b/frontend/src/queries/templateDependencies.ts
@@ -1,24 +1,44 @@
-// templateDependencies.ts — query hooks for the reverse-dependency RPCs
-// introduced in HOL-986 (ListTemplateDependents, ListDeploymentDependents).
+// templateDependencies.ts — query hooks for TemplateDependency resources.
 //
-// These hooks back the <ReverseDependents> component and the Dependencies
-// facet on the unified Templates surface (HOL-987).
+// This file has two sections:
+//   1. Reverse-dependency read hooks (HOL-986): useListTemplateDependents,
+//      useListDeploymentDependents — back the <ReverseDependents> component
+//      and the Dependencies facet on the unified Templates surface (HOL-987).
+//   2. CRUD hooks for TemplateDependencyService (HOL-1013):
+//      useListTemplateDependencies, useDeleteTemplateDependency — back the
+//      project-scoped Dependencies ResourceGrid page.
 
 import { useMemo } from 'react'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
-import { useQuery } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { TemplateService, DependencyScope } from '@/gen/holos/console/v1/templates_pb.js'
 import type {
   TemplateDependentRecord,
   DeploymentDependentRecord,
 } from '@/gen/holos/console/v1/templates_pb.js'
+import {
+  TemplateDependencyService,
+} from '@/gen/holos/console/v1/template_dependencies_pb.js'
+import type { TemplateDependency } from '@/gen/holos/console/v1/template_dependencies_pb.js'
 import { useAuth } from '@/lib/auth'
 import { keys } from '@/queries/keys'
 
 // Re-export proto types and enum so consumers import from one place.
 export type { TemplateDependentRecord, DeploymentDependentRecord }
 export { DependencyScope }
+
+// Re-export TemplateDependency so consumers import from one place.
+export type { TemplateDependency }
+
+// ---------------------------------------------------------------------------
+// Reverse-dependency read hooks (HOL-986)
+// ---------------------------------------------------------------------------
 
 // useListTemplateDependents fetches all dependents of a given template
 // identified by (namespace, name). Returns the array of TemplateDependentRecord
@@ -58,5 +78,51 @@ export function useListDeploymentDependents(namespace: string, name: string) {
       return response.dependents
     },
     enabled: isAuthenticated && !!namespace && !!name,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// CRUD hooks for TemplateDependencyService (HOL-1013)
+//
+// TemplateDependency lives in a project namespace. The hooks below back the
+// project-scoped Dependencies ResourceGrid page.
+// ---------------------------------------------------------------------------
+
+// useListTemplateDependencies lists all TemplateDependency resources in a
+// project namespace. Backed by TemplateDependencyService.ListTemplateDependencies.
+export function useListTemplateDependencies(namespace: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateDependencyService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: keys.templateDependencies.list(namespace),
+    queryFn: async () => {
+      const response = await client.listTemplateDependencies({ namespace })
+      return response.dependencies
+    },
+    enabled: isAuthenticated && !!namespace,
+    placeholderData: keepPreviousData,
+  })
+}
+
+// useDeleteTemplateDependency deletes a TemplateDependency by name.
+export function useDeleteTemplateDependency(namespace: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateDependencyService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { name: string }) =>
+      client.deleteTemplateDependency({ namespace, ...params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateDependencies.list(namespace),
+      })
+    },
   })
 }

--- a/frontend/src/queries/templateGrants.ts
+++ b/frontend/src/queries/templateGrants.ts
@@ -1,0 +1,63 @@
+// templateGrants.ts — TanStack Query hooks for TemplateGrantService (HOL-1013).
+//
+// TemplateGrant lives in an organization or folder namespace. The hooks below
+// back the org-scoped Grants ResourceGrid page that appears under the
+// Templates sidebar collapsible.
+
+import { useMemo } from 'react'
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import {
+  keepPreviousData,
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
+import {
+  TemplateGrantService,
+} from '@/gen/holos/console/v1/template_grants_pb.js'
+import type { TemplateGrant } from '@/gen/holos/console/v1/template_grants_pb.js'
+import { useAuth } from '@/lib/auth'
+import { keys } from '@/queries/keys'
+
+// Re-export proto types so consumers import from one place.
+export type { TemplateGrant }
+
+// useListTemplateGrants lists all TemplateGrant resources in an organization
+// or folder namespace. Backed by TemplateGrantService.ListTemplateGrants.
+export function useListTemplateGrants(namespace: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateGrantService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: keys.templateGrants.list(namespace),
+    queryFn: async () => {
+      const response = await client.listTemplateGrants({ namespace })
+      return response.grants
+    },
+    enabled: isAuthenticated && !!namespace,
+    placeholderData: keepPreviousData,
+  })
+}
+
+// useDeleteTemplateGrant deletes a TemplateGrant by name.
+export function useDeleteTemplateGrant(namespace: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateGrantService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { name: string }) =>
+      client.deleteTemplateGrant({ namespace, ...params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateGrants.list(namespace),
+      })
+    },
+  })
+}

--- a/frontend/src/queries/templateRequirements.ts
+++ b/frontend/src/queries/templateRequirements.ts
@@ -1,0 +1,65 @@
+// templateRequirements.ts — TanStack Query hooks for TemplateRequirementService
+// (HOL-1013).
+//
+// TemplateRequirement lives in an organization or folder namespace. The hooks
+// below back the org-scoped Requirements ResourceGrid page that appears under
+// the Templates sidebar collapsible.
+
+import { useMemo } from 'react'
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import {
+  keepPreviousData,
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
+import {
+  TemplateRequirementService,
+} from '@/gen/holos/console/v1/template_requirements_pb.js'
+import type { TemplateRequirement } from '@/gen/holos/console/v1/template_requirements_pb.js'
+import { useAuth } from '@/lib/auth'
+import { keys } from '@/queries/keys'
+
+// Re-export proto types so consumers import from one place.
+export type { TemplateRequirement }
+
+// useListTemplateRequirements lists all TemplateRequirement resources in an
+// organization or folder namespace. Backed by
+// TemplateRequirementService.ListTemplateRequirements.
+export function useListTemplateRequirements(namespace: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateRequirementService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: keys.templateRequirements.list(namespace),
+    queryFn: async () => {
+      const response = await client.listTemplateRequirements({ namespace })
+      return response.requirements
+    },
+    enabled: isAuthenticated && !!namespace,
+    placeholderData: keepPreviousData,
+  })
+}
+
+// useDeleteTemplateRequirement deletes a TemplateRequirement by name.
+export function useDeleteTemplateRequirement(namespace: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateRequirementService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { name: string }) =>
+      client.deleteTemplateRequirement({ namespace, ...params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateRequirements.list(namespace),
+      })
+    },
+  })
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Tests for the project-scoped Templates / Dependencies index (HOL-1013).
+ *
+ * TemplateDependencies are project-scoped. Namespace comes from $projectName
+ * via namespaceForProject(). The project param also keeps the Templates
+ * sidebar active in a later phase.
+ *
+ * Covers: happy path, empty state, loading, error, delete flow, page title,
+ * undefined createdAt renders em-dash.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Router mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project' }),
+      useSearch: () => ({}),
+      fullPath: '/projects/test-project/templates/dependencies/',
+    }),
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to?: string
+      className?: string
+    }) => (
+      <a href={to ?? '#'} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Console-config mock — predictable namespace prefixes
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/queries/templateDependencies', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateDependencies')>(
+    '@/queries/templateDependencies',
+  )
+  return {
+    ...actual,
+    useListTemplateDependencies: vi.fn(),
+    useDeleteTemplateDependency: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  useListTemplateDependencies,
+  useDeleteTemplateDependency,
+} from '@/queries/templateDependencies'
+import { TemplateDependenciesIndexPage } from './dependencies/index'
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+function makeDependency(name: string, namespace = 'project-test-project') {
+  return {
+    name,
+    namespace,
+    dependent: { name: 'dep-template', namespace },
+    requires: { name: 'req-template', namespace: 'org-test-org' },
+    createdAt: undefined,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+const mutateAsync = vi.fn()
+
+function setupMocks({
+  dependencies = [makeDependency('my-dep')],
+  isPending = false,
+  error = null as Error | null,
+} = {}) {
+  ;(useListTemplateDependencies as Mock).mockReturnValue({
+    data: dependencies,
+    isPending,
+    error,
+  })
+  ;(useDeleteTemplateDependency as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TemplateDependenciesIndexPage (HOL-1013)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutateAsync.mockReset().mockResolvedValue({})
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('renders TemplateDependency rows from the project namespace', () => {
+    setupMocks({
+      dependencies: [makeDependency('web-dep', 'project-test-project')],
+    })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getAllByText('web-dep').length).toBeGreaterThan(0)
+  })
+
+  it('calls useListTemplateDependencies with the project namespace', () => {
+    setupMocks()
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(useListTemplateDependencies).toHaveBeenCalledWith('project-test-project')
+  })
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it('shows empty state when no dependencies exist', () => {
+    setupMocks({ dependencies: [] })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it('shows loading skeleton while list is pending', () => {
+    setupMocks({ isPending: true, dependencies: [] })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it('shows error when dependencies fetch fails and no rows available', () => {
+    setupMocks({
+      dependencies: [],
+      error: new Error('dependencies fetch failed'),
+    })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getByText(/dependencies fetch failed/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Delete flow
+  // -------------------------------------------------------------------------
+
+  it('delete button opens ConfirmDeleteDialog', async () => {
+    setupMocks({
+      dependencies: [makeDependency('my-dep', 'project-test-project')],
+    })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    const deleteBtn = screen.getByRole('button', { name: /delete my-dep/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Page title
+  // -------------------------------------------------------------------------
+
+  it('renders page title with project and Dependencies', () => {
+    setupMocks()
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getByText(/test-project.*dependencies/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Created At column — undefined timestamp renders em-dash
+  // -------------------------------------------------------------------------
+
+  it('renders em-dash when createdAt is undefined', () => {
+    setupMocks({
+      dependencies: [makeDependency('dep-no-date', 'project-test-project')],
+    })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-grants-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-grants-index.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for the project-scoped Templates / Grants index (HOL-1013).
+ *
+ * TemplateGrants are org/folder-scoped. Namespace comes from
+ * useOrg().selectedOrg via namespaceForOrg(). The project param keeps the
+ * Templates sidebar active in a later phase.
+ *
+ * Covers: happy path, empty state, loading, error, delete flow, page title,
+ * undefined createdAt renders em-dash.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Router mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project' }),
+      useSearch: () => ({}),
+      fullPath: '/projects/test-project/templates/grants/',
+    }),
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to?: string
+      className?: string
+    }) => (
+      <a href={to ?? '#'} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Console-config mock — predictable namespace prefixes
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Org context mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/queries/templateGrants', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateGrants')>(
+    '@/queries/templateGrants',
+  )
+  return {
+    ...actual,
+    useListTemplateGrants: vi.fn(),
+    useDeleteTemplateGrant: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  useListTemplateGrants,
+  useDeleteTemplateGrant,
+} from '@/queries/templateGrants'
+import { useOrg } from '@/lib/org-context'
+import { TemplateGrantsIndexPage } from './grants/index'
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+function makeGrant(name: string, namespace = 'org-test-org') {
+  return {
+    name,
+    namespace,
+    from: [{ namespace: 'project-my-project' }],
+    to: [],
+    createdAt: undefined,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+const mutateAsync = vi.fn()
+
+function setupMocks({
+  grants = [makeGrant('my-grant')],
+  isPending = false,
+  error = null as Error | null,
+  selectedOrg = 'test-org',
+} = {}) {
+  ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
+  ;(useListTemplateGrants as Mock).mockReturnValue({
+    data: grants,
+    isPending,
+    error,
+  })
+  ;(useDeleteTemplateGrant as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TemplateGrantsIndexPage (HOL-1013)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutateAsync.mockReset().mockResolvedValue({})
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('renders TemplateGrant rows from the selected org namespace', () => {
+    setupMocks({
+      grants: [makeGrant('web-grant', 'org-test-org')],
+    })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getAllByText('web-grant').length).toBeGreaterThan(0)
+  })
+
+  it('calls useListTemplateGrants with the org namespace', () => {
+    setupMocks()
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(useListTemplateGrants).toHaveBeenCalledWith('org-test-org')
+  })
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it('shows empty state when no grants exist', () => {
+    setupMocks({ grants: [] })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it('shows loading skeleton while list is pending', () => {
+    setupMocks({ isPending: true, grants: [] })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it('shows error when grants fetch fails and no rows available', () => {
+    setupMocks({
+      grants: [],
+      error: new Error('grants fetch failed'),
+    })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/grants fetch failed/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Delete flow
+  // -------------------------------------------------------------------------
+
+  it('delete button opens ConfirmDeleteDialog', async () => {
+    setupMocks({
+      grants: [makeGrant('my-grant', 'org-test-org')],
+    })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    const deleteBtn = screen.getByRole('button', { name: /delete my-grant/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Page title
+  // -------------------------------------------------------------------------
+
+  it('renders page title with project and Grants', () => {
+    setupMocks()
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/test-project.*grants/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Created At column — undefined timestamp renders em-dash
+  // -------------------------------------------------------------------------
+
+  it('renders em-dash when createdAt is undefined', () => {
+    setupMocks({
+      grants: [makeGrant('grant-no-date', 'org-test-org')],
+    })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-requirements-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-requirements-index.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for the project-scoped Templates / Requirements index (HOL-1013).
+ *
+ * TemplateRequirements are org/folder-scoped. Namespace comes from
+ * useOrg().selectedOrg via namespaceForOrg(). The project param keeps the
+ * Templates sidebar active in a later phase.
+ *
+ * Covers: happy path, empty state, loading, error, delete flow, page title,
+ * undefined createdAt renders em-dash.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Router mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ projectName: 'test-project' }),
+      useSearch: () => ({}),
+      fullPath: '/projects/test-project/templates/requirements/',
+    }),
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to?: string
+      className?: string
+    }) => (
+      <a href={to ?? '#'} className={className}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Console-config mock — predictable namespace prefixes
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Org context mock
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Query mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/queries/templateRequirements', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateRequirements')>(
+    '@/queries/templateRequirements',
+  )
+  return {
+    ...actual,
+    useListTemplateRequirements: vi.fn(),
+    useDeleteTemplateRequirement: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  useListTemplateRequirements,
+  useDeleteTemplateRequirement,
+} from '@/queries/templateRequirements'
+import { useOrg } from '@/lib/org-context'
+import { TemplateRequirementsIndexPage } from './requirements/index'
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+function makeRequirement(name: string, namespace = 'org-test-org') {
+  return {
+    name,
+    namespace,
+    requires: { name: 'req-template', namespace },
+    targetRefs: [],
+    createdAt: undefined,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+const mutateAsync = vi.fn()
+
+function setupMocks({
+  requirements = [makeRequirement('my-req')],
+  isPending = false,
+  error = null as Error | null,
+  selectedOrg = 'test-org',
+} = {}) {
+  ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
+  ;(useListTemplateRequirements as Mock).mockReturnValue({
+    data: requirements,
+    isPending,
+    error,
+  })
+  ;(useDeleteTemplateRequirement as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TemplateRequirementsIndexPage (HOL-1013)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutateAsync.mockReset().mockResolvedValue({})
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('renders TemplateRequirement rows from the selected org namespace', () => {
+    setupMocks({
+      requirements: [makeRequirement('web-req', 'org-test-org')],
+    })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getAllByText('web-req').length).toBeGreaterThan(0)
+  })
+
+  it('calls useListTemplateRequirements with the org namespace', () => {
+    setupMocks()
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(useListTemplateRequirements).toHaveBeenCalledWith('org-test-org')
+  })
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it('shows empty state when no requirements exist', () => {
+    setupMocks({ requirements: [] })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/no resources found/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it('shows loading skeleton while list is pending', () => {
+    setupMocks({ isPending: true, requirements: [] })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByTestId('resource-grid-loading')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it('shows error when requirements fetch fails and no rows available', () => {
+    setupMocks({
+      requirements: [],
+      error: new Error('requirements fetch failed'),
+    })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/requirements fetch failed/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Delete flow
+  // -------------------------------------------------------------------------
+
+  it('delete button opens ConfirmDeleteDialog', async () => {
+    setupMocks({
+      requirements: [makeRequirement('my-req', 'org-test-org')],
+    })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    const deleteBtn = screen.getByRole('button', { name: /delete my-req/i })
+    fireEvent.click(deleteBtn)
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Page title
+  // -------------------------------------------------------------------------
+
+  it('renders page title with project and Requirements', () => {
+    setupMocks()
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByText(/test-project.*requirements/i)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Created At column — undefined timestamp renders em-dash
+  // -------------------------------------------------------------------------
+
+  it('renders em-dash when createdAt is undefined', () => {
+    setupMocks({
+      requirements: [makeRequirement('req-no-date', 'org-test-org')],
+    })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
@@ -1,0 +1,142 @@
+/**
+ * Project-scoped Templates / Dependencies index (HOL-1013).
+ *
+ * TemplateDependencies are project-scoped. The namespace is derived from the
+ * $projectName URL parameter via namespaceForProject(). The project name also
+ * keeps the Templates collapsible group open in the sidebar (HOL-1014).
+ *
+ * Sidebar nesting is handled in HOL-1014; for now the route exists and is
+ * reachable by URL.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import {
+  useListTemplateDependencies,
+  useDeleteTemplateDependency,
+} from '@/queries/templateDependencies'
+import { namespaceForProject } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
+function timestampToISOString(ts: { seconds: bigint } | undefined): string {
+  if (!ts) return ''
+  return new Date(Number(ts.seconds) * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/projects/$projectName/templates/dependencies/',
+)({
+  validateSearch: parseGridSearch,
+  component: TemplateDependenciesIndexRoute,
+})
+
+function TemplateDependenciesIndexRoute() {
+  const { projectName } = Route.useParams()
+  return <TemplateDependenciesIndexPage projectName={projectName} />
+}
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
+
+export function TemplateDependenciesIndexPage({
+  projectName,
+}: {
+  projectName: string
+}) {
+  const search = Route.useSearch() as ResourceGridSearch
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  // TemplateDependencies are project-scoped — namespace comes from projectName.
+  const namespace = namespaceForProject(projectName)
+
+  const {
+    data: dependencies = [],
+    isPending,
+    error,
+  } = useListTemplateDependencies(namespace)
+
+  const deleteMutation = useDeleteTemplateDependency(namespace)
+
+  // ---------------------------------------------------------------------------
+  // Build rows
+  // ---------------------------------------------------------------------------
+
+  const rows: Row[] = useMemo(
+    () =>
+      dependencies.map((d) => ({
+        kind: 'TemplateDependency',
+        name: d.name,
+        namespace,
+        id: d.name,
+        parentId: projectName,
+        parentLabel: projectName,
+        displayName: d.name,
+        description: `${d.dependent?.name ?? ''} → ${d.requires?.name ?? ''}`,
+        createdAt: timestampToISOString(d.createdAt),
+        detailHref: undefined,
+      })),
+    [dependencies, namespace, projectName],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Kind definitions
+  // ---------------------------------------------------------------------------
+
+  const kinds = useMemo(
+    () => [
+      {
+        id: 'TemplateDependency',
+        label: 'TemplateDependency',
+        // No create in this view — dependencies are managed programmatically.
+        canCreate: false,
+      },
+    ],
+    [],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
+  )
+
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+      })
+    },
+    [navigate],
+  )
+
+  return (
+    <ResourceGrid
+      title={`${projectName} / Templates / Dependencies`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+    />
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
@@ -1,0 +1,148 @@
+/**
+ * Project-scoped Templates / Grants index (HOL-1013).
+ *
+ * TemplateGrants are org/folder-scoped, not project-scoped. The namespace is
+ * derived from the selected organization via useOrg().selectedOrg. The project
+ * name still appears in the URL so the Templates collapsible group can stay
+ * open in a later sidebar phase (HOL-1014).
+ *
+ * Sidebar nesting is handled in HOL-1014; for now the route exists and is
+ * reachable by URL.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import {
+  useListTemplateGrants,
+  useDeleteTemplateGrant,
+} from '@/queries/templateGrants'
+import { useOrg } from '@/lib/org-context'
+import { namespaceForOrg } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
+function timestampToISOString(ts: { seconds: bigint } | undefined): string {
+  if (!ts) return ''
+  return new Date(Number(ts.seconds) * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/projects/$projectName/templates/grants/',
+)({
+  validateSearch: parseGridSearch,
+  component: TemplateGrantsIndexRoute,
+})
+
+function TemplateGrantsIndexRoute() {
+  const { projectName } = Route.useParams()
+  return <TemplateGrantsIndexPage projectName={projectName} />
+}
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
+
+export function TemplateGrantsIndexPage({
+  projectName,
+}: {
+  projectName: string
+}) {
+  const search = Route.useSearch() as ResourceGridSearch
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  // TemplateGrants are org/folder-scoped — namespace comes from the selected
+  // org, not the project. The project param keeps Templates sidebar active
+  // in a later phase.
+  const { selectedOrg } = useOrg()
+  const namespace = namespaceForOrg(selectedOrg ?? '')
+
+  const {
+    data: grants = [],
+    isPending,
+    error,
+  } = useListTemplateGrants(namespace)
+
+  const deleteMutation = useDeleteTemplateGrant(namespace)
+
+  // ---------------------------------------------------------------------------
+  // Build rows
+  // ---------------------------------------------------------------------------
+
+  const rows: Row[] = useMemo(
+    () =>
+      grants.map((g) => ({
+        kind: 'TemplateGrant',
+        name: g.name,
+        namespace,
+        id: g.name,
+        parentId: selectedOrg ?? '',
+        parentLabel: selectedOrg ?? '',
+        displayName: g.name,
+        description:
+          g.from.map((f) => f.namespace).join(', ') || '',
+        createdAt: timestampToISOString(g.createdAt),
+        detailHref: undefined,
+      })),
+    [grants, namespace, selectedOrg],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Kind definitions
+  // ---------------------------------------------------------------------------
+
+  const kinds = useMemo(
+    () => [
+      {
+        id: 'TemplateGrant',
+        label: 'TemplateGrant',
+        // No create in this view — grants are created from org-level pages.
+        canCreate: false,
+      },
+    ],
+    [],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
+  )
+
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+      })
+    },
+    [navigate],
+  )
+
+  return (
+    <ResourceGrid
+      title={`${projectName} / Templates / Grants`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+    />
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
@@ -1,0 +1,147 @@
+/**
+ * Project-scoped Templates / Requirements index (HOL-1013).
+ *
+ * TemplateRequirements are org/folder-scoped, not project-scoped. The namespace
+ * is derived from the selected organization via useOrg().selectedOrg. The
+ * project name still appears in the URL so the Templates collapsible group
+ * can stay open in a later sidebar phase (HOL-1014).
+ *
+ * Sidebar nesting is handled in HOL-1014; for now the route exists and is
+ * reachable by URL.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { Row } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+import {
+  useListTemplateRequirements,
+  useDeleteTemplateRequirement,
+} from '@/queries/templateRequirements'
+import { useOrg } from '@/lib/org-context'
+import { namespaceForOrg } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
+function timestampToISOString(ts: { seconds: bigint } | undefined): string {
+  if (!ts) return ''
+  return new Date(Number(ts.seconds) * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/projects/$projectName/templates/requirements/',
+)({
+  validateSearch: parseGridSearch,
+  component: TemplateRequirementsIndexRoute,
+})
+
+function TemplateRequirementsIndexRoute() {
+  const { projectName } = Route.useParams()
+  return <TemplateRequirementsIndexPage projectName={projectName} />
+}
+
+// ---------------------------------------------------------------------------
+// Page component (exported for tests)
+// ---------------------------------------------------------------------------
+
+export function TemplateRequirementsIndexPage({
+  projectName,
+}: {
+  projectName: string
+}) {
+  const search = Route.useSearch() as ResourceGridSearch
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  // TemplateRequirements are org/folder-scoped — namespace comes from the
+  // selected org, not the project. The project param keeps Templates sidebar
+  // active in a later phase.
+  const { selectedOrg } = useOrg()
+  const namespace = namespaceForOrg(selectedOrg ?? '')
+
+  const {
+    data: requirements = [],
+    isPending,
+    error,
+  } = useListTemplateRequirements(namespace)
+
+  const deleteMutation = useDeleteTemplateRequirement(namespace)
+
+  // ---------------------------------------------------------------------------
+  // Build rows
+  // ---------------------------------------------------------------------------
+
+  const rows: Row[] = useMemo(
+    () =>
+      requirements.map((r) => ({
+        kind: 'TemplateRequirement',
+        name: r.name,
+        namespace,
+        id: r.name,
+        parentId: selectedOrg ?? '',
+        parentLabel: selectedOrg ?? '',
+        displayName: r.name,
+        description: r.requires?.name ?? '',
+        createdAt: timestampToISOString(r.createdAt),
+        detailHref: undefined,
+      })),
+    [requirements, namespace, selectedOrg],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Kind definitions
+  // ---------------------------------------------------------------------------
+
+  const kinds = useMemo(
+    () => [
+      {
+        id: 'TemplateRequirement',
+        label: 'TemplateRequirement',
+        // No create in this view — requirements are created from org-level pages.
+        canCreate: false,
+      },
+    ],
+    [],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleDelete = useCallback(
+    async (row: Row) => {
+      await deleteMutation.mutateAsync({ name: row.name })
+    },
+    [deleteMutation],
+  )
+
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({
+        search: (prev) => updater(prev as ResourceGridSearch),
+      })
+    },
+    [navigate],
+  )
+
+  return (
+    <ResourceGrid
+      title={`${projectName} / Templates / Requirements`}
+      kinds={kinds}
+      rows={rows}
+      onDelete={handleDelete}
+      isLoading={isPending}
+      error={error}
+      search={search}
+      onSearchChange={handleSearchChange}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- Adds query key factories for `templateDependencies` (list/get), `templateRequirements` (list/get), and `templateGrants` (list/get) to `keys.ts`.
- Extends `templateDependencies.ts` with `useListTemplateDependencies` and `useDeleteTemplateDependency` backed by `TemplateDependencyService` (project-scoped, from HOL-1010).
- Adds `templateRequirements.ts` with `useListTemplateRequirements` and `useDeleteTemplateRequirement` backed by `TemplateRequirementService` (org/folder-scoped, from HOL-1011).
- Adds `templateGrants.ts` with `useListTemplateGrants` and `useDeleteTemplateGrant` backed by `TemplateGrantService` (org/folder-scoped, from HOL-1012).
- Adds project-scoped ResourceGrid index pages for Dependencies (project namespace), Requirements (org namespace via `useOrg()`), and Grants (org namespace via `useOrg()`), following the HOL-1009 pattern.
- Adds 24 Vitest unit tests across 3 test files covering: happy path, empty state, loading, error, delete flow, page title, and undefined `createdAt` renders em-dash.

Fixes HOL-1013

## Test plan

- [x] `make test-ui` — 93 test files, 1243 tests all pass
- [ ] Verify `/projects/$projectName/templates/dependencies/` renders dependency rows from the project namespace
- [ ] Verify `/projects/$projectName/templates/requirements/` renders requirement rows from the selected org namespace
- [ ] Verify `/projects/$projectName/templates/grants/` renders grant rows from the selected org namespace
- [ ] Verify delete button opens ConfirmDeleteDialog and calls the correct mutation