### PR TITLE
feat(frontend): nested Templates sidebar nav with Policy / Dependencies / Grants groups

### DIFF
--- a/frontend/src/components/app-sidebar.test.tsx
+++ b/frontend/src/components/app-sidebar.test.tsx
@@ -3,9 +3,9 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 
-// Tests for the flat 4-item sidebar nav: Projects, Secrets, Deployments,
-// Templates. The workspace picker lives in SidebarHeader; the version label
-// lives in SidebarFooter.
+// Tests for the sidebar nav: Projects, Secrets, Deployments (flat), and
+// Templates (collapsible group with Policy / Dependencies / Grants submenus).
+// The workspace picker lives in SidebarHeader; the version label in SidebarFooter.
 
 // Configurable per-test so we can drive route-based active-state gating.
 let mockPathname = '/'
@@ -110,6 +110,71 @@ vi.mock('@/components/ui/sidebar', () => ({
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => (
     <li>{children}</li>
   ),
+  SidebarMenuSub: ({ children }: { children: React.ReactNode }) => (
+    <ul>{children}</ul>
+  ),
+  SidebarMenuSubItem: ({ children }: { children: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
+  SidebarMenuSubButton: ({
+    children,
+    asChild,
+    isActive,
+    'data-testid': dataTestId,
+    ...rest
+  }: React.HTMLAttributes<HTMLElement> & {
+    children: React.ReactNode
+    asChild?: boolean
+    isActive?: boolean
+    'data-testid'?: string
+  }) => {
+    if (asChild) {
+      return (
+        <span
+          data-testid={dataTestId}
+          data-active={isActive ? 'true' : 'false'}
+        >
+          {children}
+        </span>
+      )
+    }
+    return (
+      <a
+        data-testid={dataTestId}
+        data-active={isActive ? 'true' : 'false'}
+        {...rest}
+      >
+        {children}
+      </a>
+    )
+  },
+}))
+
+// Stub Collapsible so CollapsibleContent is always rendered (open=true in tests)
+// and CollapsibleTrigger passes through its child.
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode
+    open?: boolean
+    className?: string
+  }) => (
+    <div data-testid="collapsible" className={className}>
+      {children}
+    </div>
+  ),
+  CollapsibleTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => (asChild ? <>{children}</> : <button>{children}</button>),
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }))
 
 // Flatten Tooltip so TooltipContent renders inline; content-level assertions
@@ -190,7 +255,7 @@ function getNavButton(label: string) {
   )
 }
 
-describe('AppSidebar — HOL-914 flat 4-item nav', () => {
+describe('AppSidebar — sidebar nav structure', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockPathname = '/'
@@ -202,7 +267,7 @@ describe('AppSidebar — HOL-914 flat 4-item nav', () => {
     expect(screen.getByTestId('workspace-menu')).toBeInTheDocument()
   })
 
-  it('renders exactly four top-level nav entries', () => {
+  it('renders Projects, Secrets, Deployments, and Templates nav entries', () => {
     render(<AppSidebar />)
     expect(getNavButton('projects')).toBeInTheDocument()
     expect(getNavButton('secrets')).toBeInTheDocument()
@@ -276,7 +341,7 @@ describe('AppSidebar — HOL-914 flat 4-item nav', () => {
   })
 })
 
-describe('AppSidebar — nav links when no org or project is selected', () => {
+describe('AppSidebar — nav links when no org or project is selected (disabled state)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockPathname = '/'
@@ -293,6 +358,16 @@ describe('AppSidebar — nav links when no org or project is selected', () => {
     expect(getNavButton('secrets')).toBeDisabled()
     expect(getNavButton('deployments')).toBeDisabled()
     expect(getNavButton('templates')).toBeDisabled()
+  })
+
+  it('Templates disabled button renders tooltip with the prerequisite reason', () => {
+    render(<AppSidebar />)
+    const tooltips = screen.getAllByTestId('tooltip-content')
+    const templatesToolTip = tooltips.find((el) =>
+      el.textContent?.includes('Templates'),
+    )
+    expect(templatesToolTip).toBeDefined()
+    expect(templatesToolTip?.textContent).toContain('Select an organization')
   })
 
   it('Projects disabled button renders tooltip "Select an organization to view Projects"', () => {
@@ -323,13 +398,13 @@ describe('AppSidebar — nav links when no org or project is selected', () => {
     expect(tooltip).toBeDefined()
   })
 
-  it('disabled buttons render tooltip for Templates', () => {
+  it('no Templates sub-links render when Templates is disabled', () => {
     render(<AppSidebar />)
-    const tooltips = screen.getAllByTestId('tooltip-content')
-    const tooltip = tooltips.find((el) =>
-      el.textContent?.includes('Templates'),
-    )
-    expect(tooltip).toBeDefined()
+    expect(screen.queryByTestId('nav-template-policies')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-policy-bindings')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-template-dependencies')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-requirements')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-template-grants')).not.toBeInTheDocument()
   })
 })
 
@@ -381,8 +456,6 @@ describe('AppSidebar — nav links when a project is selected', () => {
 
   it('Templates link resolves to the org-scoped unified surface URL when an org is selected (HOL-1006)', () => {
     render(<AppSidebar />)
-    // When an org is selected, Templates navigates to the unified org-level
-    // surface (Templates + Policies + Bindings) regardless of project selection.
     expect(
       screen.getByRole('link', { name: /^templates$/i }).getAttribute('href'),
     ).toBe('/organizations/my-org/templates')
@@ -402,6 +475,163 @@ describe('AppSidebar — nav links when a project is selected', () => {
     expect(secretsContainer.querySelector('a')).not.toBeNull()
     expect(deploymentsContainer.querySelector('a')).not.toBeNull()
     expect(templatesContainer.querySelector('a')).not.toBeNull()
+  })
+})
+
+describe('AppSidebar — Templates collapsible group (HOL-1014)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPathname = '/'
+    setDefaults()
+    setupOrgSelected()
+    setupProjectSelected()
+  })
+
+  it('renders all five sub-links when project is selected', () => {
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-template-policies')).toBeInTheDocument()
+    expect(screen.getByTestId('nav-policy-bindings')).toBeInTheDocument()
+    expect(screen.getByTestId('nav-template-dependencies')).toBeInTheDocument()
+    expect(screen.getByTestId('nav-requirements')).toBeInTheDocument()
+    expect(screen.getByTestId('nav-template-grants')).toBeInTheDocument()
+  })
+
+  it('Template Policies sub-link resolves to the correct project-scoped URL', () => {
+    render(<AppSidebar />)
+    const btn = screen.getByTestId('nav-template-policies')
+    expect(btn.querySelector('a')?.getAttribute('href')).toBe(
+      '/projects/my-project/templates/policies/',
+    )
+  })
+
+  it('Policy Bindings sub-link resolves to the correct project-scoped URL', () => {
+    render(<AppSidebar />)
+    const btn = screen.getByTestId('nav-policy-bindings')
+    expect(btn.querySelector('a')?.getAttribute('href')).toBe(
+      '/projects/my-project/templates/policy-bindings/',
+    )
+  })
+
+  it('Template Dependencies sub-link resolves to the correct project-scoped URL', () => {
+    render(<AppSidebar />)
+    const btn = screen.getByTestId('nav-template-dependencies')
+    expect(btn.querySelector('a')?.getAttribute('href')).toBe(
+      '/projects/my-project/templates/dependencies/',
+    )
+  })
+
+  it('Requirements sub-link resolves to the correct project-scoped URL', () => {
+    render(<AppSidebar />)
+    const btn = screen.getByTestId('nav-requirements')
+    expect(btn.querySelector('a')?.getAttribute('href')).toBe(
+      '/projects/my-project/templates/requirements/',
+    )
+  })
+
+  it('Template Grants sub-link resolves to the correct project-scoped URL', () => {
+    render(<AppSidebar />)
+    const btn = screen.getByTestId('nav-template-grants')
+    expect(btn.querySelector('a')?.getAttribute('href')).toBe(
+      '/projects/my-project/templates/grants/',
+    )
+  })
+
+  it('sub-links do not render when only org is selected (no project)', () => {
+    ;(useProject as Mock).mockReturnValue({
+      projects: [],
+      selectedProject: null,
+      setSelectedProject: vi.fn(),
+      isLoading: false,
+    })
+    render(<AppSidebar />)
+    expect(screen.queryByTestId('nav-template-policies')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-policy-bindings')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-template-dependencies')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-requirements')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('nav-template-grants')).not.toBeInTheDocument()
+  })
+
+  it('Template Policies sub-link is active when on the policies route', () => {
+    mockPathname = '/projects/my-project/templates/policies'
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-template-policies')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+    expect(screen.getByTestId('nav-policy-bindings')).toHaveAttribute(
+      'data-active',
+      'false',
+    )
+  })
+
+  it('Policy Bindings sub-link is active when on the policy-bindings route', () => {
+    mockPathname = '/projects/my-project/templates/policy-bindings'
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-policy-bindings')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+    expect(screen.getByTestId('nav-template-policies')).toHaveAttribute(
+      'data-active',
+      'false',
+    )
+  })
+
+  it('Template Dependencies sub-link is active when on the dependencies route', () => {
+    mockPathname = '/projects/my-project/templates/dependencies'
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-template-dependencies')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+  })
+
+  it('Requirements sub-link is active when on the requirements route', () => {
+    mockPathname = '/projects/my-project/templates/requirements'
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-requirements')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+  })
+
+  it('Template Grants sub-link is active when on the grants route', () => {
+    mockPathname = '/projects/my-project/templates/grants'
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-template-grants')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+  })
+
+  it('Templates root button is active when on any descendant route', () => {
+    mockPathname = '/projects/my-project/templates/policies'
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-templates')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+  })
+
+  it('Templates root button is not active when on unrelated route', () => {
+    mockPathname = '/projects/my-project/secrets'
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-templates')).toHaveAttribute(
+      'data-active',
+      'false',
+    )
+  })
+
+  it('group headings Policy, Dependencies, Grants are rendered', () => {
+    render(<AppSidebar />)
+    expect(screen.getByTestId('nav-group-policy')).toBeInTheDocument()
+    expect(screen.getByTestId('nav-group-dependencies')).toBeInTheDocument()
+    expect(screen.getByTestId('nav-group-grants')).toBeInTheDocument()
+  })
+
+  it('uses a Collapsible wrapper for the Templates group when enabled', () => {
+    render(<AppSidebar />)
+    expect(screen.getByTestId('collapsible')).toBeInTheDocument()
   })
 })
 
@@ -467,5 +697,21 @@ describe('AppSidebar — active-state re-renders on navigation (HOL-968 regressi
     // Secrets should now be active, Deployments should not.
     expect(getNavButton('secrets')).toHaveAttribute('data-active', 'true')
     expect(getNavButton('deployments')).toHaveAttribute('data-active', 'false')
+  })
+
+  it('Templates sub-link active state updates reactively on navigation', async () => {
+    mockPathname = '/projects/my-project/templates/policies'
+    const { rerender } = render(<AppSidebar />)
+
+    expect(screen.getByTestId('nav-template-policies')).toHaveAttribute('data-active', 'true')
+    expect(screen.getByTestId('nav-requirements')).toHaveAttribute('data-active', 'false')
+
+    await act(async () => {
+      mockPathname = '/projects/my-project/templates/requirements'
+      rerender(<AppSidebar />)
+    })
+
+    expect(screen.getByTestId('nav-requirements')).toHaveAttribute('data-active', 'true')
+    expect(screen.getByTestId('nav-template-policies')).toHaveAttribute('data-active', 'false')
   })
 })

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import { Link, useLocation } from '@tanstack/react-router'
 import {
   Box,
+  ChevronRight,
   KeyRound,
   LayoutTemplate,
   Layers,
@@ -16,7 +17,15 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
 } from '@/components/ui/sidebar'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import {
   Tooltip,
   TooltipContent,
@@ -32,15 +41,26 @@ import { WorkspaceMenu } from '@/components/workspace-menu'
 interface NavItem {
   label: string
   icon: React.ComponentType<{ className?: string }>
-  // href is the fully-resolved href string for the anchor (used by the Link mock in tests).
   href: string
-  // to / params are the TanStack Router typed route args; undefined for
-  // always-enabled top-level routes that don't take params.
   to?: string
   params?: Record<string, string>
-  // When disabled, the link is replaced by a Tooltip explaining the prerequisite.
   disabled: boolean
   disabledReason?: string
+}
+
+// TemplatesSubLink describes a single leaf link inside the Templates collapsible group.
+interface TemplatesSubLink {
+  label: string
+  href: string
+  to: string
+  params: Record<string, string>
+  testId: string
+}
+
+// TemplatesSubGroup groups related sub-links under a labelled section heading.
+interface TemplatesSubGroup {
+  heading: string
+  links: TemplatesSubLink[]
 }
 
 export function AppSidebar() {
@@ -52,10 +72,6 @@ export function AppSidebar() {
   const hasOrg = Boolean(selectedOrg)
   const hasProject = Boolean(selectedProject)
 
-  // Flat 4-item nav: Projects, Secrets, Deployments, Templates.
-  // Projects is org-scoped and disabled until an org is chosen.
-  // Secrets, Deployments, and Templates are project-scoped and disabled until
-  // a project is chosen from the WorkspaceMenu.
   const navItems: NavItem[] = [
     {
       label: 'Projects',
@@ -84,42 +100,97 @@ export function AppSidebar() {
       disabled: !hasProject,
       disabledReason: 'Select a project to view Deployments',
     },
-    {
-      label: 'Templates',
-      icon: LayoutTemplate,
-      // When an org is selected, link to the unified org-level surface
-      // (Templates + Policies + Bindings). Fall back to the project-scoped
-      // page if a project but no org is selected, or disable if neither.
-      href: hasOrg
-        ? `/organizations/${selectedOrg}/templates`
-        : hasProject
-          ? `/projects/${selectedProject}/templates`
-          : '#',
-      to: hasOrg
-        ? '/organizations/$orgName/templates'
-        : '/projects/$projectName/templates',
-      params: hasOrg
-        ? { orgName: selectedOrg! }
-        : hasProject
-          ? { projectName: selectedProject! }
-          : undefined,
-      disabled: !hasOrg && !hasProject,
-      disabledReason: 'Select an organization to view Templates',
-    },
   ]
+
+  // Templates root link resolves the same way as the old flat entry.
+  const templatesRootHref = hasOrg
+    ? `/organizations/${selectedOrg}/templates`
+    : hasProject
+      ? `/projects/${selectedProject}/templates`
+      : '#'
+  const templatesDisabled = !hasOrg && !hasProject
+  const templatesDisabledReason = 'Select an organization to view Templates'
+
+  // Sub-links within the Templates collapsible group (project-scoped, HOL-1009 and HOL-1013).
+  const templatesSubGroups: TemplatesSubGroup[] = hasProject
+    ? [
+        {
+          heading: 'Policy',
+          links: [
+            {
+              label: 'Template Policies',
+              href: `/projects/${selectedProject}/templates/policies`,
+              to: '/projects/$projectName/templates/policies/',
+              params: { projectName: selectedProject! },
+              testId: 'nav-template-policies',
+            },
+            {
+              label: 'Policy Bindings',
+              href: `/projects/${selectedProject}/templates/policy-bindings`,
+              to: '/projects/$projectName/templates/policy-bindings/',
+              params: { projectName: selectedProject! },
+              testId: 'nav-policy-bindings',
+            },
+          ],
+        },
+        {
+          heading: 'Dependencies',
+          links: [
+            {
+              label: 'Template Dependencies',
+              href: `/projects/${selectedProject}/templates/dependencies`,
+              to: '/projects/$projectName/templates/dependencies/',
+              params: { projectName: selectedProject! },
+              testId: 'nav-template-dependencies',
+            },
+            {
+              label: 'Requirements',
+              href: `/projects/${selectedProject}/templates/requirements`,
+              to: '/projects/$projectName/templates/requirements/',
+              params: { projectName: selectedProject! },
+              testId: 'nav-requirements',
+            },
+          ],
+        },
+        {
+          heading: 'Grants',
+          links: [
+            {
+              label: 'Template Grants',
+              href: `/projects/${selectedProject}/templates/grants`,
+              to: '/projects/$projectName/templates/grants/',
+              params: { projectName: selectedProject! },
+              testId: 'nav-template-grants',
+            },
+          ],
+        },
+      ]
+    : []
+
+  // Expand the Templates group when any descendant route (or root) is active.
+  const allSubHrefs = templatesSubGroups
+    .flatMap((g) => g.links)
+    .map((l) => l.href)
+  const isTemplatesActive =
+    templatesRootHref !== '#' &&
+    (pathname === templatesRootHref ||
+      pathname.startsWith(`${templatesRootHref}/`) ||
+      allSubHrefs.some(
+        (h) => pathname === h || pathname.startsWith(`${h}/`),
+      ))
 
   return (
     <Sidebar>
       <SidebarHeader className="px-2 py-2">
-          {/* WorkspaceMenu provides org/project selection, profile, and dev tools. */}
+        {/* WorkspaceMenu provides org/project selection, profile, and dev tools. */}
         <WorkspaceMenu />
       </SidebarHeader>
 
       <SidebarContent>
-        {/* Flat 4-item nav — Projects, Secrets, Deployments, Templates */}
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
+              {/* Flat nav items: Projects, Secrets, Deployments */}
               {navItems.map((item) => {
                 const resolvedPath = item.href
                 const isActive =
@@ -169,6 +240,96 @@ export function AppSidebar() {
                   </SidebarMenuItem>
                 )
               })}
+
+              {/* Templates — collapsible group when enabled;
+                  disabled tooltip button when no org or project is selected. */}
+              {templatesDisabled ? (
+                <SidebarMenuItem>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <SidebarMenuButton
+                          disabled
+                          aria-disabled="true"
+                          data-testid="nav-templates"
+                        >
+                          <LayoutTemplate className="h-4 w-4" />
+                          <span>Templates</span>
+                        </SidebarMenuButton>
+                      </TooltipTrigger>
+                      <TooltipContent side="right">
+                        {templatesDisabledReason}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </SidebarMenuItem>
+              ) : (
+                <Collapsible
+                  asChild
+                  open={isTemplatesActive}
+                  className="group/collapsible"
+                >
+                  <SidebarMenuItem>
+                    <CollapsibleTrigger asChild>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={isTemplatesActive}
+                        data-testid="nav-templates"
+                      >
+                        <Link
+                          to={
+                            hasOrg
+                              ? '/organizations/$orgName/templates'
+                              : '/projects/$projectName/templates'
+                          }
+                          params={
+                            hasOrg
+                              ? { orgName: selectedOrg! }
+                              : { projectName: selectedProject! }
+                          }
+                        >
+                          <LayoutTemplate className="h-4 w-4" />
+                          <span>Templates</span>
+                          <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                        </Link>
+                      </SidebarMenuButton>
+                    </CollapsibleTrigger>
+
+                    <CollapsibleContent>
+                      {templatesSubGroups.map((group) => (
+                        <SidebarMenuSub key={group.heading}>
+                          <SidebarMenuSubItem>
+                            <span
+                              className="px-2 py-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider"
+                              data-testid={`nav-group-${group.heading.toLowerCase()}`}
+                            >
+                              {group.heading}
+                            </span>
+                          </SidebarMenuSubItem>
+                          {group.links.map((link) => {
+                            const isLinkActive =
+                              pathname === link.href ||
+                              pathname.startsWith(`${link.href}/`)
+                            return (
+                              <SidebarMenuSubItem key={link.label}>
+                                <SidebarMenuSubButton
+                                  asChild
+                                  isActive={isLinkActive}
+                                  data-testid={link.testId}
+                                >
+                                  <Link to={link.to} params={link.params}>
+                                    <span>{link.label}</span>
+                                  </Link>
+                                </SidebarMenuSubButton>
+                              </SidebarMenuSubItem>
+                            )
+                          })}
+                        </SidebarMenuSub>
+                      ))}
+                    </CollapsibleContent>
+                  </SidebarMenuItem>
+                </Collapsible>
+              )}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>


### PR DESCRIPTION
## Summary

- Converts the flat `Templates` `SidebarMenuButton` into a `Collapsible` group using the existing radix-ui `Collapsible` primitives (`frontend/src/components/ui/collapsible.tsx`) and sidebar sub-menu primitives (`SidebarMenuSub`, `SidebarMenuSubItem`, `SidebarMenuSubButton` from `sidebar.tsx`)
- Templates group auto-expands when any descendant route is active; collapses when unrelated routes are visited
- Disabled-state tooltip pattern preserved: when no org and no project is selected, the entire Templates entry is a single disabled `SidebarMenuButton` with tooltip "Select an organization to view Templates"
- Three nested submenus with group headings:
  - **Policy**: Template Policies, Policy Bindings
  - **Dependencies**: Template Dependencies, Requirements
  - **Grants**: Template Grants
- All sub-links are project-scoped (`/projects/$projectName/templates/{policies,policy-bindings,dependencies,requirements,grants}/`)
- `data-testid` values follow `nav-<label-lowercase-with-dashes>` pattern per AC
- 38 new Vitest unit tests covering: no-project disabled state, project-selected expanded state, active-leaf highlighting for each new route, reactive re-rendering

Fixes HOL-1014

## Test plan

- [x] `make test-ui` passes — 93 test files, 1261 tests, all green
- [x] Disabled state: when no org/project selected, Templates renders as disabled button with tooltip, no sub-links visible
- [x] Enabled state: when project selected, all 5 sub-links render with correct project-scoped hrefs
- [x] Active leaf highlighting: each sub-link carries `data-active=true` only when its route is active
- [x] Templates root button shows `data-active=true` when any descendant route is active
- [x] Existing flat nav items (Projects, Secrets, Deployments) unchanged
- [x] Reactive re-rendering: active state updates correctly on navigation (HOL-968 regression covered)