### PR TITLE
chore(docs): refresh AGENTS.md, frontend docs, and TemplatesHelpPane for new pages (HOL-1015)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,27 @@ entry and WorkspaceMenu improvements. Key files:
 | `docs/agents/frontend-audit-2026-04.md` | HOL-943 | Phase 2 audit baseline — current frontend architecture, gaps, and target conventions |
 | `frontend/src/queries/templateDependencies.ts` | HOL-986 | `useListTemplateDependents` / `useListDeploymentDependents` reverse-dep query hooks |
 | `frontend/src/components/templates/ReverseDependents.tsx` | HOL-987 | "Who depends on me" section with ADR-032 scope badges (instance / project / remote-project) |
+| `console/templatepolicies/` | HOL-1009 | ConnectRPC handler + K8s adapter for TemplatePolicy CRUD |
+| `console/templatepolicybindings/` | HOL-1009 | ConnectRPC handler + K8s adapter for TemplatePolicyBinding CRUD |
+| `proto/holos/console/v1/template_policies.proto` | HOL-1009 | TemplatePolicy service proto (List, Get, Create, Update, Delete) |
+| `proto/holos/console/v1/template_policy_bindings.proto` | HOL-1009 | TemplatePolicyBinding service proto |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx` | HOL-1009 | Template Policies ResourceGrid page |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx` | HOL-1009 | Template Policy Bindings ResourceGrid page |
+| `console/templatedependencies/` | HOL-1010 | ConnectRPC handler for TemplateDependency CRUD |
+| `proto/holos/console/v1/template_dependencies.proto` | HOL-1010 | TemplateDependency service proto |
+| `console/templaterequirements/` | HOL-1011 | ConnectRPC handler for TemplateRequirement CRUD |
+| `proto/holos/console/v1/template_requirements.proto` | HOL-1011 | TemplateRequirement service proto |
+| `console/templategrants/` | HOL-1012 | ConnectRPC handler for TemplateGrant CRUD |
+| `proto/holos/console/v1/template_grants.proto` | HOL-1012 | TemplateGrant service proto |
+| `frontend/src/queries/templatePolicies.ts` | HOL-1013 | TanStack Query hooks for TemplatePolicy (list/get/create/update/delete) |
+| `frontend/src/queries/templatePolicyBindings.ts` | HOL-1013 | TanStack Query hooks for TemplatePolicyBinding |
+| `frontend/src/queries/templateDependencies.ts` (CRUD hooks) | HOL-1013 | TanStack Query CRUD hooks for TemplateDependency |
+| `frontend/src/queries/templateRequirements.ts` | HOL-1013 | TanStack Query hooks for TemplateRequirement |
+| `frontend/src/queries/templateGrants.ts` | HOL-1013 | TanStack Query hooks for TemplateGrant |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx` | HOL-1013 | Template Dependencies ResourceGrid page |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx` | HOL-1013 | Template Requirements ResourceGrid page |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx` | HOL-1013 | Template Grants ResourceGrid page |
+| `frontend/src/components/app-sidebar.tsx` (nested Templates nav) | HOL-1014 | Collapsible Templates sidebar with Policy / Dependencies / Grants sub-groups |
 
 **Deleted (HOL-914)**: `frontend/src/components/resource-manager/` and
 `frontend/src/routes/_authenticated/resource-manager/` were removed when the

--- a/docs/agents/frontend-architecture.md
+++ b/docs/agents/frontend-architecture.md
@@ -111,6 +111,28 @@ rather than mocking ConnectRPC clients directly. See
 [docs/agents/testing-patterns.md](testing-patterns.md) for the worked testing
 patterns.
 
+## Nested Templates Sidebar Nav (HOL-1014)
+
+The Templates sidebar entry is a collapsible group implemented in
+`frontend/src/components/app-sidebar.tsx`. When a project is selected it
+expands to show three sub-groups:
+
+| Sidebar group | Pages |
+|---|---|
+| **Policy** | Template Policies (`templates/policies/`), Policy Bindings (`templates/policy-bindings/`) |
+| **Dependencies** | Template Dependencies (`templates/dependencies/`), Requirements (`templates/requirements/`) |
+| **Grants** | Template Grants (`templates/grants/`) |
+
+Each sub-link is a `SidebarMenuSubButton` backed by a `Link` from TanStack
+Router. The group auto-expands (`open={isTemplatesActive}`) when any descendant
+route is active. The relevant route files are:
+
+- `frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx` (HOL-1009)
+- `frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx` (HOL-1009)
+- `frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx` (HOL-1013)
+- `frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx` (HOL-1013)
+- `frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx` (HOL-1013)
+
 ## Tables and Data Grids
 
 New flat resource list pages should use `ResourceGrid` when the page is a named

--- a/frontend/src/components/templates/TemplatesHelpPane.tsx
+++ b/frontend/src/components/templates/TemplatesHelpPane.tsx
@@ -1,9 +1,15 @@
 /**
  * TemplatesHelpPane — static help content for the Templates index page.
  *
- * Explains the three template-family resource kinds and how they relate.
+ * Explains all template-family resource kinds and how they relate.
  * Rendered inside a shadcn Sheet (side="right") toggled by the ? icon
  * in the Templates Card header.
+ *
+ * The Templates section of the sidebar is a collapsible group with three
+ * sub-groups (HOL-1014):
+ *   - Policy: Template Policies and Policy Bindings (HOL-1009)
+ *   - Dependencies: Template Dependencies and Requirements (HOL-1013)
+ *   - Grants: Template Grants (HOL-1013)
  *
  * Keep copy in TSX (not MDX) to avoid any build-system changes (HOL-860).
  */
@@ -28,7 +34,7 @@ export function TemplatesHelpPane({ open, onOpenChange }: TemplatesHelpPaneProps
         <SheetHeader>
           <SheetTitle>Templates — how it works</SheetTitle>
           <SheetDescription>
-            Three resource kinds work together to let platform teams govern
+            Seven resource kinds work together to let platform teams govern
             configuration templates across projects.
           </SheetDescription>
         </SheetHeader>
@@ -71,11 +77,44 @@ export function TemplatesHelpPane({ open, onOpenChange }: TemplatesHelpPaneProps
             </p>
           </section>
 
+          {/* TemplateDependency */}
+          <section data-testid="help-section-template-dependency">
+            <h3 className="font-semibold text-base mb-1">Template Dependency</h3>
+            <p className="text-muted-foreground leading-relaxed">
+              A <strong>Template Dependency</strong> declares that one template requires
+              another template to be deployed first. Dependencies are project-scoped and
+              express ordering constraints so the platform can resolve a correct deployment
+              sequence.
+            </p>
+          </section>
+
+          {/* TemplateRequirement */}
+          <section data-testid="help-section-template-requirement">
+            <h3 className="font-semibold text-base mb-1">Template Requirement</h3>
+            <p className="text-muted-foreground leading-relaxed">
+              A <strong>Template Requirement</strong> records that a template requires a
+              specific capability or resource to be present before it can render correctly.
+              Requirements are checked at preview and deployment time to surface missing
+              prerequisites early.
+            </p>
+          </section>
+
+          {/* TemplateGrant */}
+          <section data-testid="help-section-template-grant">
+            <h3 className="font-semibold text-base mb-1">Template Grant</h3>
+            <p className="text-muted-foreground leading-relaxed">
+              A <strong>Template Grant</strong> gives a project permission to consume a
+              template that is owned by a different organization or folder. Without a grant,
+              cross-scope template references are denied by the policy resolver.
+            </p>
+          </section>
+
           {/* Summary */}
           <section data-testid="help-section-summary">
             <p className="text-muted-foreground leading-relaxed border-t pt-4">
-              Authors write templates; platform, SM, and ISRM teams attach policy via
-              bindings; product teams deploy.
+              Authors write templates; platform, SM, and ISRM teams attach policies via
+              bindings; dependency and requirement records express ordering and capability
+              constraints; grants enable cross-scope sharing; product teams deploy.
             </p>
           </section>
         </div>


### PR DESCRIPTION
## Summary

- **AGENTS.md**: added 15 new rows to the "MVP UI — ResourceGrid v1 and sidebar nav" table covering every artifact shipped in HOL-1009 through HOL-1014 (Go handler packages, proto files, query hook modules, route pages, and the nested sidebar nav component).
- **docs/agents/frontend-architecture.md**: added a "Nested Templates Sidebar Nav (HOL-1014)" section documenting the three sub-groups (Policy, Dependencies, Grants), the `isTemplatesActive` auto-expand behaviour, and direct links to each route file.
- **TemplatesHelpPane.tsx**: updated the description from "Three resource kinds" to "Seven resource kinds"; added sections for TemplateDependency, TemplateRequirement, and TemplateGrant; refreshed the summary sentence to cover the full lifecycle.

Fixes HOL-1015

## Test plan

- [x] `make test-ui` — 93 test files, 1261 tests, all pass
- [x] Existing help-pane tests (`-index-help.test.tsx`) still pass — the new `data-testid` sections are additive; the summary `data-testid` and text match (`Authors write templates`) are preserved.