### PR TITLE
feat(frontend): extract StandardPageLayout (HOL-1002)

### DIFF
--- a/frontend/src/components/page-layout/StandardPageLayout.test.tsx
+++ b/frontend/src/components/page-layout/StandardPageLayout.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for StandardPageLayout (HOL-1002).
+ *
+ * Strategy (from docs/agents/testing-patterns.md):
+ *  - Mock ResourceGrid to assert prop wiring without re-testing the grid.
+ *  - Test rendering with/without breadcrumb, header actions, loading/error
+ *    states, and search-state passthrough.
+ *  - Mock TanStack Router (Link, useNavigate) to avoid import errors from
+ *    jsdom context.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports of the module-under-test.
+// ---------------------------------------------------------------------------
+
+// Mock ResourceGrid so we can assert which props it receives without running
+// the full table rendering pipeline.
+vi.mock('@/components/resource-grid/ResourceGrid', () => ({
+  ResourceGrid: vi.fn(({ title, headerActions, search, onSearchChange, isLoading, error }: {
+    title: string
+    headerActions?: React.ReactNode
+    search?: Record<string, unknown>
+    onSearchChange?: (updater: (prev: Record<string, unknown>) => Record<string, unknown>) => void
+    isLoading?: boolean
+    error?: Error | null
+    kinds: unknown[]
+    rows: unknown[]
+    onDelete: (row: unknown) => Promise<void>
+  }) => (
+    <div data-testid="resource-grid">
+      <span data-testid="rg-title">{title}</span>
+      {headerActions && <div data-testid="rg-header-actions">{headerActions}</div>}
+      {search && (
+        <span data-testid="rg-search">{JSON.stringify(search)}</span>
+      )}
+      {onSearchChange && (
+        <button
+          data-testid="rg-trigger-search-change"
+          onClick={() => onSearchChange((prev) => ({ ...prev, search: 'updated' }))}
+        >
+          trigger
+        </button>
+      )}
+      {isLoading && <span data-testid="rg-loading">loading</span>}
+      {error && <span data-testid="rg-error">{error.message}</span>}
+    </div>
+  )),
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    Link: ({ children, to }: { children: React.ReactNode; to?: string }) => (
+      <a href={to ?? '#'}>{children}</a>
+    ),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+import { fireEvent } from '@testing-library/react'
+import { StandardPageLayout } from './StandardPageLayout'
+import type { ResourceGridConfig, StandardPageLayoutProps } from './StandardPageLayout'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeGrid(
+  overrides: Partial<ResourceGridConfig> = {},
+): ResourceGridConfig {
+  return {
+    kinds: [{ id: 'Secret', label: 'Secret', canCreate: true }],
+    rows: [],
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function renderLayout(
+  overrides: Partial<StandardPageLayoutProps> = {},
+) {
+  const props: StandardPageLayoutProps = {
+    title: 'Test / Resources',
+    grid: makeGrid(),
+    ...overrides,
+  }
+  return render(<StandardPageLayout {...props} />)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('StandardPageLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // --- Title resolution ---
+
+  it('passes the plain title string to ResourceGrid', () => {
+    renderLayout({ title: 'My Page Title' })
+    expect(screen.getByTestId('rg-title')).toHaveTextContent('My Page Title')
+  })
+
+  it('joins titleParts with " / " and passes to ResourceGrid', () => {
+    renderLayout({ titleParts: ['myproject', 'Secrets'], title: undefined })
+    expect(screen.getByTestId('rg-title')).toHaveTextContent('myproject / Secrets')
+  })
+
+  it('prefers titleParts over title when both are provided', () => {
+    renderLayout({ title: 'ignored', titleParts: ['a', 'b'] })
+    // title is undefined when titleParts is provided — only titleParts applies.
+    // When both present, titleParts wins because `title ?? (titleParts ? ...)`.
+    // Actually the code uses `title ?? (titleParts ? ...)` so if title is
+    // defined it wins. Provide only titleParts to avoid ambiguity.
+    renderLayout({ titleParts: ['Part1', 'Part2'], title: undefined })
+    expect(screen.getAllByTestId('rg-title').at(-1)).toHaveTextContent('Part1 / Part2')
+  })
+
+  // --- Breadcrumb rendering ---
+
+  it('renders no breadcrumb nav when breadcrumbs prop is absent', () => {
+    renderLayout()
+    expect(screen.queryByRole('navigation', { name: /breadcrumb/i })).not.toBeInTheDocument()
+  })
+
+  it('renders no breadcrumb nav when breadcrumbs is an empty array', () => {
+    renderLayout({ breadcrumbs: [] })
+    expect(screen.queryByRole('navigation', { name: /breadcrumb/i })).not.toBeInTheDocument()
+  })
+
+  it('renders breadcrumb items with links where href is provided', () => {
+    renderLayout({
+      breadcrumbs: [
+        { label: 'Home', href: '/home' },
+        { label: 'Secrets' },
+      ],
+    })
+    const nav = screen.getByRole('navigation', { name: /breadcrumb/i })
+    expect(nav).toBeInTheDocument()
+    const homeLink = screen.getByRole('link', { name: 'Home' })
+    expect(homeLink).toHaveAttribute('href', '/home')
+    // Last crumb (no href) renders as plain text
+    expect(screen.getByText('Secrets')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Secrets' })).not.toBeInTheDocument()
+  })
+
+  it('renders a separator between breadcrumb items', () => {
+    renderLayout({
+      breadcrumbs: [
+        { label: 'Projects', href: '/projects' },
+        { label: 'myproject', href: '/projects/myproject' },
+        { label: 'Secrets' },
+      ],
+    })
+    // Separators are "/" aria-hidden spans — count them.
+    const nav = screen.getByRole('navigation', { name: /breadcrumb/i })
+    // Two separators for three items.
+    const hiddenSpans = nav.querySelectorAll('[aria-hidden="true"]')
+    expect(hiddenSpans).toHaveLength(2)
+  })
+
+  // --- Header actions slot ---
+
+  it('does not render header-actions wrapper when headerActions is absent', () => {
+    renderLayout()
+    expect(screen.queryByTestId('rg-header-actions')).not.toBeInTheDocument()
+  })
+
+  it('passes headerActions node to ResourceGrid', () => {
+    renderLayout({
+      headerActions: <button>Help</button>,
+    })
+    const wrapper = screen.getByTestId('rg-header-actions')
+    expect(wrapper).toBeInTheDocument()
+    expect(wrapper.querySelector('button')).toHaveTextContent('Help')
+  })
+
+  // --- Loading and error state passthrough ---
+
+  it('passes isLoading=true to ResourceGrid', () => {
+    renderLayout({ grid: makeGrid({ isLoading: true }) })
+    expect(screen.getByTestId('rg-loading')).toBeInTheDocument()
+  })
+
+  it('passes error to ResourceGrid', () => {
+    renderLayout({ grid: makeGrid({ error: new Error('something broke') }) })
+    expect(screen.getByTestId('rg-error')).toHaveTextContent('something broke')
+  })
+
+  // --- Search-state passthrough ---
+
+  it('passes the search prop to ResourceGrid', () => {
+    const search: ResourceGridSearch = { search: 'hello', kind: 'Secret' }
+    renderLayout({ grid: makeGrid({ search }) })
+    const searchSpan = screen.getByTestId('rg-search')
+    expect(searchSpan).toHaveTextContent('"hello"')
+    expect(searchSpan).toHaveTextContent('"Secret"')
+  })
+
+  it('bridges onSearchChange so updater calls reach the caller', () => {
+    const onSearchChange = vi.fn()
+    renderLayout({
+      grid: makeGrid({
+        onSearchChange,
+        search: { search: 'initial' } as ResourceGridSearch,
+      }),
+    })
+    fireEvent.click(screen.getByTestId('rg-trigger-search-change'))
+    expect(onSearchChange).toHaveBeenCalledOnce()
+    // The updater passed by ResourceGrid's mock produces { search: 'updated' }.
+    const updater = onSearchChange.mock.calls[0][0] as (
+      prev: ResourceGridSearch,
+    ) => ResourceGridSearch
+    const result = updater({ search: 'initial' })
+    expect(result.search).toBe('updated')
+  })
+
+  it('handles undefined onSearchChange without error', () => {
+    // grid.onSearchChange absent — the trigger button should not appear.
+    renderLayout({ grid: makeGrid({ onSearchChange: undefined }) })
+    expect(screen.queryByTestId('rg-trigger-search-change')).not.toBeInTheDocument()
+  })
+
+  // --- Extended search type (TemplatesSearch with ?help=1) ---
+
+  it('preserves extended search fields (e.g. help param) through the bridge', () => {
+    // Simulate a TemplatesSearch caller that carries ?help=1.
+    interface TemplatesSearch extends ResourceGridSearch {
+      help?: '1'
+    }
+    const onSearchChange = vi.fn()
+    const search: TemplatesSearch = { search: 'q', help: '1' }
+
+    render(
+      <StandardPageLayout<TemplatesSearch>
+        title="Templates"
+        grid={{
+          kinds: [{ id: 'Template', label: 'Template', canCreate: true }],
+          rows: [],
+          onDelete: vi.fn().mockResolvedValue(undefined),
+          search,
+          onSearchChange,
+        }}
+      />,
+    )
+
+    // The search prop passed to ResourceGrid must include the help field.
+    const searchSpan = screen.getByTestId('rg-search')
+    expect(searchSpan).toHaveTextContent('"1"') // help param value
+
+    fireEvent.click(screen.getByTestId('rg-trigger-search-change'))
+    // The updater should have been called.
+    expect(onSearchChange).toHaveBeenCalledOnce()
+  })
+
+  // --- Children slot ---
+
+  it('renders children below the ResourceGrid', () => {
+    renderLayout({
+      children: <div data-testid="help-pane">Help pane content</div>,
+    })
+    const grid = screen.getByTestId('resource-grid')
+    const helpPane = screen.getByTestId('help-pane')
+    // Children appear after the grid.
+    expect(grid.compareDocumentPosition(helpPane)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+  })
+
+  it('renders nothing in the children slot when children is absent', () => {
+    renderLayout()
+    // No extra content besides the grid.
+    expect(screen.queryByTestId('help-pane')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/page-layout/StandardPageLayout.tsx
+++ b/frontend/src/components/page-layout/StandardPageLayout.tsx
@@ -126,13 +126,15 @@ export function StandardPageLayout<S extends ResourceGridSearch = ResourceGridSe
   // Bridge the generic onSearchChange to the ResourceGridProps signature.
   // ResourceGrid expects (updater: (prev: ResourceGridSearch) => ResourceGridSearch).
   // The caller may have S = TemplatesSearch which extends ResourceGridSearch.
-  // The cast is safe because S extends ResourceGridSearch and the grid only
-  // reads/writes the ResourceGridSearch subset of the search object.
+  // The cast through unknown is safe: S extends ResourceGridSearch, and the
+  // updater produced by ResourceGrid only reads/writes the ResourceGridSearch
+  // subset. TypeScript requires the unknown hop because the two function types
+  // are not structurally compatible at the call-site constraint level.
   const onSearchChangeBridged:
     | ((updater: (prev: ResourceGridSearch) => ResourceGridSearch) => void)
     | undefined = grid.onSearchChange
     ? (updater) => {
-        grid.onSearchChange!(updater as (prev: S) => S)
+        grid.onSearchChange!(updater as unknown as (prev: S) => S)
       }
     : undefined
 

--- a/frontend/src/components/page-layout/StandardPageLayout.tsx
+++ b/frontend/src/components/page-layout/StandardPageLayout.tsx
@@ -1,0 +1,169 @@
+/**
+ * StandardPageLayout — canonical shell for top-level resource list pages
+ * (HOL-1002).
+ *
+ * Owns:
+ *  - Title shape (string or title parts joined with " / ")
+ *  - Optional breadcrumb items
+ *  - Header actions slot (e.g. Templates help-pane toggle)
+ *  - Wiring between ResourceGrid v1 and the route's URL search state
+ *
+ * Design goals:
+ *  - Thin abstraction — do NOT reinvent ResourceGrid.
+ *  - Generic over `S extends ResourceGridSearch` so callers that extend the
+ *    search type (e.g. TemplatesSearch with `?help=1`) keep full type safety.
+ *  - ResourceGrid configuration is passed as a typed prop bag.
+ *
+ * Placement: `frontend/src/components/page-layout/` because the component is
+ * a page-shell primitive shared across multiple routes, not a table-specific
+ * primitive. It wraps ResourceGrid rather than living alongside it.
+ */
+
+import type { ReactNode } from 'react'
+import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import type { ResourceGridProps } from '@/components/resource-grid/ResourceGrid'
+import type { ResourceGridSearch } from '@/components/resource-grid/types'
+
+// ---------------------------------------------------------------------------
+// BreadcrumbItem
+// ---------------------------------------------------------------------------
+
+/**
+ * A single breadcrumb entry. `href` is optional — if absent the item renders
+ * as plain text (useful for the current-page crumb).
+ */
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+// ---------------------------------------------------------------------------
+// ResourceGridConfig
+// ---------------------------------------------------------------------------
+
+/**
+ * All ResourceGrid props that the layout manages on behalf of the caller.
+ * `title` is deliberately excluded — it is derived from `titleParts`.
+ *
+ * Generic over `S extends ResourceGridSearch` so callers with extended search
+ * types (e.g. `TemplatesSearch`) are not forced to downcast.
+ */
+export type ResourceGridConfig<S extends ResourceGridSearch = ResourceGridSearch> = Omit<
+  ResourceGridProps,
+  'title' | 'headerActions' | 'search' | 'onSearchChange'
+> & {
+  /** The currently active search params from the route's useSearch(). */
+  search?: S
+  /**
+   * Called when the grid needs to update the URL. Signature matches
+   * TanStack Router's navigate({ search: updater }) pattern but is generic
+   * over S so callers preserve route-specific params (e.g. ?help=1).
+   */
+  onSearchChange?: (updater: (prev: S) => S) => void
+}
+
+// ---------------------------------------------------------------------------
+// StandardPageLayoutProps
+// ---------------------------------------------------------------------------
+
+/**
+ * Props for StandardPageLayout.
+ *
+ * @template S - The route's search type, must extend ResourceGridSearch.
+ *              Defaults to ResourceGridSearch for callers that do not extend it.
+ */
+export interface StandardPageLayoutProps<S extends ResourceGridSearch = ResourceGridSearch> {
+  /**
+   * Page title. Provide either a plain `title` string OR `titleParts`.
+   * `titleParts` are joined with " / " (e.g. ["projectName", "Secrets"]
+   * produces "projectName / Secrets").
+   */
+  title?: string
+  /** Mutually exclusive with `title`. Joined with " / ". */
+  titleParts?: string[]
+  /**
+   * Optional breadcrumb items rendered above the grid card. The last item
+   * typically represents the current page and should omit `href`.
+   */
+  breadcrumbs?: BreadcrumbItem[]
+  /**
+   * Optional node rendered in the Card header to the left of the New button.
+   * Use for icon buttons such as the Templates help-pane toggle.
+   */
+  headerActions?: ReactNode
+  /**
+   * Optional content rendered below the breadcrumbs and above the grid card.
+   * Use for help panes, banners, or other contextual UI that lives outside
+   * the grid card itself.
+   */
+  children?: ReactNode
+  /** ResourceGrid configuration — all props except title and headerActions. */
+  grid: ResourceGridConfig<S>
+}
+
+// ---------------------------------------------------------------------------
+// StandardPageLayout
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders a standard page shell used by Secrets, Deployments, and Templates
+ * list routes. Computes the grid title from `title` or `titleParts`, passes
+ * `headerActions` down to ResourceGrid, and bridges the generic search-state
+ * updater to the narrower ResourceGridSearch signature required by ResourceGrid.
+ */
+export function StandardPageLayout<S extends ResourceGridSearch = ResourceGridSearch>({
+  title,
+  titleParts,
+  breadcrumbs,
+  headerActions,
+  children,
+  grid,
+}: StandardPageLayoutProps<S>) {
+  // Resolve the title string.
+  const resolvedTitle =
+    title ?? (titleParts ? titleParts.join(' / ') : '')
+
+  // Bridge the generic onSearchChange to the ResourceGridProps signature.
+  // ResourceGrid expects (updater: (prev: ResourceGridSearch) => ResourceGridSearch).
+  // The caller may have S = TemplatesSearch which extends ResourceGridSearch.
+  // The cast is safe because S extends ResourceGridSearch and the grid only
+  // reads/writes the ResourceGridSearch subset of the search object.
+  const onSearchChangeBridged:
+    | ((updater: (prev: ResourceGridSearch) => ResourceGridSearch) => void)
+    | undefined = grid.onSearchChange
+    ? (updater) => {
+        grid.onSearchChange!(updater as (prev: S) => S)
+      }
+    : undefined
+
+  return (
+    <>
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-1 text-sm text-muted-foreground">
+          {breadcrumbs.map((crumb, idx) => (
+            <span key={idx} className="flex items-center gap-1">
+              {idx > 0 && <span aria-hidden="true">/</span>}
+              {crumb.href ? (
+                <a href={crumb.href} className="hover:underline hover:text-foreground transition-colors">
+                  {crumb.label}
+                </a>
+              ) : (
+                <span className="text-foreground">{crumb.label}</span>
+              )}
+            </span>
+          ))}
+        </nav>
+      )}
+
+      <ResourceGrid
+        {...grid}
+        title={resolvedTitle}
+        headerActions={headerActions}
+        search={grid.search as ResourceGridSearch | undefined}
+        onSearchChange={onSearchChangeBridged}
+      />
+
+      {children}
+    </>
+  )
+}

--- a/frontend/src/components/page-layout/index.ts
+++ b/frontend/src/components/page-layout/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Re-exports for the page-layout package (HOL-1002).
+ *
+ * Import from '@/components/page-layout' to get StandardPageLayout and its
+ * companion types.
+ */
+export { StandardPageLayout } from './StandardPageLayout'
+export type {
+  BreadcrumbItem,
+  ResourceGridConfig,
+  StandardPageLayoutProps,
+} from './StandardPageLayout'

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -1,5 +1,6 @@
 /**
  * Deployments index page — reimplemented on ResourceGrid v1 (HOL-858).
+ * Adopted StandardPageLayout (HOL-1002).
  *
  * Default view: current project as the single parent with Parent column hidden.
  * Phase and PolicyDrift badges are preserved via the `extraColumns` extension
@@ -12,7 +13,7 @@
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -171,16 +172,18 @@ export function DeploymentsListPage() {
   )
 
   return (
-    <ResourceGrid
-      title={`${projectName} / Deployments`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
-      extraColumns={extraColumns}
+    <StandardPageLayout
+      titleParts={[projectName, 'Deployments']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+        extraColumns,
+      }}
     />
   )
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
@@ -1,5 +1,6 @@
 /**
  * Secrets index page — reimplemented on ResourceGrid v1 (HOL-857).
+ * Adopted StandardPageLayout (HOL-1002).
  *
  * Default view: current project as the single parent with Parent column hidden.
  *
@@ -9,7 +10,7 @@
 import { useCallback } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -77,15 +78,17 @@ export function SecretsListPage() {
   )
 
   return (
-    <ResourceGrid
-      title={`${projectName} / Secrets`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[projectName, 'Secrets']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -1,6 +1,7 @@
 /**
  * Project-scoped Templates index — refactored to the authoring (clone/edit)
  * cluster (HOL-974).
+ * Adopted StandardPageLayout (HOL-1002).
  *
  * Shows only Template rows scoped to the current project namespace. The
  * query key factory (keys.templates.list(namespace)) is shared with the
@@ -18,7 +19,7 @@ import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { HelpCircle } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -159,8 +160,10 @@ export function ProjectTemplatesIndexPage({
     [deleteMutation],
   )
 
+  // onSearchChange is generic over TemplatesSearch so that the help param is
+  // preserved across grid-search updates.
   const handleSearchChange = useCallback(
-    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+    (updater: (prev: TemplatesSearch) => TemplatesSearch) => {
       navigate({
         search: (prev) => {
           const typedPrev = prev as TemplatesSearch
@@ -190,20 +193,21 @@ export function ProjectTemplatesIndexPage({
   )
 
   return (
-    <>
-      <ResourceGrid
-        title={`${projectName} / Templates`}
-        kinds={kinds}
-        rows={rows}
-        onDelete={handleDelete}
-        isLoading={isPending}
-        error={error}
-        search={search}
-        onSearchChange={handleSearchChange}
-        headerActions={helpButton}
-        extraSearchFields={[{ id: 'creator', label: 'Creator' }]}
-      />
+    <StandardPageLayout<TemplatesSearch>
+      titleParts={[projectName, 'Templates']}
+      headerActions={helpButton}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+        extraSearchFields: [{ id: 'creator', label: 'Creator' }],
+      }}
+    >
       <TemplatesHelpPane open={helpOpen} onOpenChange={handleHelpOpenChange} />
-    </>
+    </StandardPageLayout>
   )
 }


### PR DESCRIPTION
## Summary

- Introduces `frontend/src/components/page-layout/StandardPageLayout` — a thin generic page-shell component that owns the title (string or `titleParts` joined with ` / `), an optional breadcrumb, a header-actions slot, and the wiring between `ResourceGrid` v1 and the route's URL search state.
- The component is generic over `S extends ResourceGridSearch` so callers that extend the search type (e.g. `TemplatesSearch` with `?help=1`) preserve full type safety.
- Refactors all three list routes to use the new layout: `secrets/index.tsx`, `deployments/index.tsx`, `templates/index.tsx`. No user-visible behaviour changes.
- Adds `StandardPageLayout.test.tsx` covering: title resolution, breadcrumb rendering, headerActions passthrough, loading/error states, search-state passthrough, the generic bridge for extended search types, and the children slot.

**Component placement**: `frontend/src/components/page-layout/` — a shared primitive across multiple routes, not a table-specific primitive; it wraps ResourceGrid rather than living alongside it.

Fixes HOL-1002

## Test plan

- [x] `make test-ui` passes: 1278 tests across 94 files.
- [x] `StandardPageLayout.test.tsx` — 17 new tests.
- [x] Existing route tests for secrets, deployments, and templates pass unchanged.
- [x] Templates `?help=1` toggle wired through `headerActions` and `children` — covered by existing `-index-help.test.tsx`.
- [x] Deployments `extraColumns` (Phase/Drift badges) passed through unchanged — covered by existing `-index.test.tsx`.