### PR TITLE
refactor frontend org projects layout

### DIFF
--- a/frontend/src/components/page-layout/StandardPageLayout.tsx
+++ b/frontend/src/components/page-layout/StandardPageLayout.tsx
@@ -20,6 +20,7 @@
  */
 
 import type { ReactNode } from 'react'
+import { Link } from '@tanstack/react-router'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { ResourceGridProps } from '@/components/resource-grid/ResourceGrid'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -146,9 +147,9 @@ export function StandardPageLayout<S extends ResourceGridSearch = ResourceGridSe
             <span key={idx} className="flex items-center gap-1">
               {idx > 0 && <span aria-hidden="true">/</span>}
               {crumb.href ? (
-                <a href={crumb.href} className="hover:underline hover:text-foreground transition-colors">
+                <Link to={crumb.href} className="hover:underline hover:text-foreground transition-colors">
                   {crumb.label}
-                </a>
+                </Link>
               ) : (
                 <span className="text-foreground">{crumb.label}</span>
               )}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { vi, beforeEach, afterEach } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
@@ -175,11 +175,28 @@ describe('OrgProjectsIndexPage', () => {
     expect(screen.getByText(/failed to load projects/i)).toBeInTheDocument()
   })
 
-  it('renders breadcrumb linking back to /organizations', () => {
+  it('renders breadcrumb and Create Project button through layout slots', () => {
     setupMocks([])
     render(<OrgProjectsIndexPage orgName="my-org" />)
+    const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i })
+    expect(within(breadcrumb).getByText('Organizations')).toBeInTheDocument()
+    expect(within(breadcrumb).getByText('my-org')).toBeInTheDocument()
+    expect(within(breadcrumb).getByText('Projects')).toBeInTheDocument()
+
     const orgLink = screen.getByRole('link', { name: 'Organizations' })
     expect(orgLink).toHaveAttribute('href', '/organizations')
+
+    const createLinks = screen.getAllByRole('link', { name: /create project/i })
+    expect(createLinks.length).toBeGreaterThanOrEqual(1)
+    expect(createLinks[0]).toHaveAttribute('href', '/project/new')
+  })
+
+  it('does not render row-level delete actions for project rows', () => {
+    setupMocks([makeProject('alpha', 'Alpha Project')])
+    render(<OrgProjectsIndexPage orgName="my-org" />)
+    expect(
+      screen.queryByRole('button', { name: /delete alpha project/i }),
+    ).not.toBeInTheDocument()
   })
 
   // ── Create Project link regression (HOL-929) ────────────────────────────────

--- a/frontend/src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx
@@ -176,7 +176,7 @@ describe('OrgProjectsIndexPage', () => {
   })
 
   it('renders breadcrumb and Create Project button through layout slots', () => {
-    setupMocks([])
+    setupMocks([makeProject('alpha', 'Alpha Project')])
     render(<OrgProjectsIndexPage orgName="my-org" />)
     const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i })
     expect(within(breadcrumb).getByText('Organizations')).toBeInTheDocument()

--- a/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
@@ -15,8 +15,8 @@
 import { useCallback } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 
+import { StandardPageLayout } from '@/components/page-layout'
 import { Button } from '@/components/ui/button'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -108,17 +108,6 @@ export function OrgProjectsIndexPage({
   // trash column entirely.
   const handleDelete = async () => undefined
 
-  const breadcrumb = (
-    <p className="text-sm text-muted-foreground mb-2">
-      <Link to="/organizations" className="hover:underline">
-        Organizations
-      </Link>
-      {' / '}
-      {orgName}
-      {' / Projects'}
-    </p>
-  )
-
   const emptyState = (
     <div className="flex flex-col items-center gap-3 py-8 text-center">
       <p className="text-muted-foreground">
@@ -134,22 +123,26 @@ export function OrgProjectsIndexPage({
   )
 
   return (
-    <>
-      {breadcrumb}
-      <ResourceGrid
-        title="Projects"
-        kinds={kinds}
-        rows={rows}
-        onDelete={handleDelete}
-        isLoading={isLoading}
-        error={error}
-        search={search}
-        onSearchChange={handleSearchChange}
-        extraSearchFields={[{ id: 'creator', label: 'Creator' }]}
-        emptyStateContent={emptyState}
-        headerActions={createProjectButton}
-        showDeleteAction={false}
-      />
-    </>
+    <StandardPageLayout
+      title="Projects"
+      breadcrumbs={[
+        { label: 'Organizations', href: '/organizations' },
+        { label: orgName },
+        { label: 'Projects' },
+      ]}
+      headerActions={createProjectButton}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+        extraSearchFields: [{ id: 'creator', label: 'Creator' }],
+        emptyStateContent: emptyState,
+        showDeleteAction: false,
+      }}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- refactor the organization-scoped projects index to render through `StandardPageLayout`
- pass the preserved breadcrumb and `Create Project` action through the layout slots
- keep breadcrumb links on TanStack Router navigation and add regression coverage for the slot wiring and hidden row delete action

Fixes HOL-1003

## Test plan
- [x] `cd frontend && npm test -- --run 'src/components/page-layout/StandardPageLayout.test.tsx' 'src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx'`
- [x] `make test-ui`
- [x] `cd frontend && npx eslint 'src/components/page-layout/StandardPageLayout.tsx' 'src/routes/_authenticated/organizations/$orgName/projects/index.tsx' 'src/routes/_authenticated/organizations/$orgName/projects/-index.test.tsx'`
- [x] `cd frontend && npm run build`

## Notes
- `cd frontend && npm run lint` still fails on pre-existing repo-wide lint errors outside this change.
