### PR TITLE
docs(frontend): document StandardPageLayout usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,23 @@ Agent-facing frontend docs:
   source of record for `ResourceGrid` architecture conventions.
 - [Data Grid Conventions](docs/agents/data-grid-conventions.md) — quick
   pointer for the clickable resource ID and fully-clickable row rule.
+- [Standard Page Layout](docs/agents/standard-page-layout.md) — when to use
+  `StandardPageLayout`, its slots, prop contract, and canonical examples.
 - [Frontend Audit Baseline](docs/agents/frontend-audit-2026-04.md) — Phase 1
   inventory and target conventions.
+
+### StandardPageLayout
+
+Use `StandardPageLayout` from `@/components/page-layout` for top-level
+resource list pages that render a `ResourceGrid` and need the standard title,
+breadcrumb, header action, URL-search, and contextual-content slots. It exposes
+`title` or `titleParts`, `breadcrumbs`, `headerActions`, `children`, and a
+typed `grid` prop bag. Canonical examples are the project-scoped
+[Secrets](frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx),
+[Deployments](frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx),
+and [Templates](frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx)
+routes; see [Standard Page Layout](docs/agents/standard-page-layout.md) for
+the prop table and minimal usage example.
 
 ### Security: secrets in the UI
 

--- a/docs/agents/standard-page-layout.md
+++ b/docs/agents/standard-page-layout.md
@@ -1,0 +1,97 @@
+# Standard Page Layout
+
+`StandardPageLayout` is the shared page shell for top-level resource list
+routes that are backed by `ResourceGrid` v1. Import it from
+`@/components/page-layout`.
+
+Use it when a route needs the standard resource-list structure:
+
+- Optional breadcrumbs above the grid.
+- A title rendered by `ResourceGrid`, either as a plain string or as scoped
+  title parts joined with ` / `.
+- Optional header actions next to the grid's New button.
+- Optional contextual content outside the grid card.
+- URL search state wired through `ResourceGrid`'s `search` and
+  `onSearchChange` props.
+
+Keep detail pages, form pages, settings pages, and custom non-grid workflows
+outside this layout unless they adopt `ResourceGrid` as their primary surface.
+
+Canonical examples:
+
+- `frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx`
+- `frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx`
+- `frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx`
+- `frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx`
+
+## Props
+
+| Prop | Type | Required | Purpose |
+|---|---|---:|---|
+| `title` | `string` | No | Plain grid title. Use this when the page title is not scope-derived. |
+| `titleParts` | `string[]` | No | Scope-aware title parts joined with ` / `, such as `[projectName, 'Secrets']`. Mutually exclusive with `title`. |
+| `breadcrumbs` | `BreadcrumbItem[]` | No | Breadcrumb links rendered above the grid. Omit `href` for the current page crumb. |
+| `headerActions` | `ReactNode` | No | Header action slot passed to `ResourceGrid`, typically icon buttons or a custom create button. |
+| `children` | `ReactNode` | No | Contextual content rendered below the grid, such as a help pane or banner. |
+| `grid` | `ResourceGridConfig<S>` | Yes | Typed `ResourceGrid` prop bag. It excludes `title`, `headerActions`, `search`, and `onSearchChange` from the base grid props, then adds generic `search` and `onSearchChange` fields for route search state. |
+
+`StandardPageLayout` is generic over `S extends ResourceGridSearch`. Use the
+generic form when a route extends grid search state with its own params, such
+as the Templates `help` query parameter.
+
+## Minimal Usage
+
+```tsx
+import { useCallback } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { StandardPageLayout } from '@/components/page-layout'
+import type { Row, ResourceGridSearch } from '@/components/resource-grid/types'
+import { parseGridSearch } from '@/components/resource-grid/url-state'
+
+export const Route = createFileRoute('/_authenticated/projects/$projectName/secrets/')({
+  validateSearch: parseGridSearch,
+  component: SecretsListPage,
+})
+
+function SecretsListPage() {
+  const { projectName } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  const rows: Row[] = []
+  const kinds = [{ id: 'Secret', label: 'Secret', newHref: `/projects/${projectName}/secrets/new` }]
+
+  const handleSearchChange = useCallback(
+    (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
+      navigate({ search: (prev) => updater(prev as ResourceGridSearch) })
+    },
+    [navigate],
+  )
+
+  return (
+    <StandardPageLayout
+      titleParts={[projectName, 'Secrets']}
+      grid={{
+        kinds,
+        rows,
+        isLoading: false,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
+    />
+  )
+}
+```
+
+For pages with route-specific search params, preserve those params in the route
+handler and instantiate the layout with the extended search type:
+
+```tsx
+<StandardPageLayout<TemplatesSearch>
+  titleParts={[projectName, 'Templates']}
+  headerActions={helpButton}
+  grid={{ kinds, rows, search, onSearchChange: handleSearchChange }}
+>
+  <TemplatesHelpPane open={helpOpen} onOpenChange={handleHelpOpenChange} />
+</StandardPageLayout>
+```

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -102,7 +102,6 @@ export function AppSidebar() {
     },
   ]
 
-  // Templates root link resolves the same way as the old flat entry.
   const templatesRootHref = hasOrg
     ? `/organizations/${selectedOrg}/templates`
     : hasProject
@@ -190,7 +189,7 @@ export function AppSidebar() {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {/* Flat nav items: Projects, Secrets, Deployments */}
+              {/* Flat nav items: Project, Secrets, Deployments */}
               {navItems.map((item) => {
                 const resolvedPath = item.href
                 const isActive =

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -1,6 +1,5 @@
 /**
  * Deployments index page — reimplemented on ResourceGrid v1 (HOL-858).
- * Adopted StandardPageLayout (HOL-1002).
  *
  * Default view: current project as the single parent with Parent column hidden.
  * Phase and PolicyDrift badges are preserved via the `extraColumns` extension

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
@@ -1,6 +1,5 @@
 /**
  * Secrets index page — reimplemented on ResourceGrid v1 (HOL-857).
- * Adopted StandardPageLayout (HOL-1002).
  *
  * Default view: current project as the single parent with Parent column hidden.
  *

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -1,7 +1,6 @@
 /**
  * Project-scoped Templates index — refactored to the authoring (clone/edit)
  * cluster (HOL-974).
- * Adopted StandardPageLayout (HOL-1002).
  *
  * Shows only Template rows scoped to the current project namespace. The
  * query key factory (keys.templates.list(namespace)) is shared with the


### PR DESCRIPTION
## Summary
- add a StandardPageLayout reference doc with prop table and examples
- link the layout guidance from AGENTS.md for future frontend work
- remove stale StandardPageLayout migration comments from migrated routes and sidebar nav comments

Fixes HOL-1005

## Test plan
- [x] make test-go
- [x] make test-ui
- [x] npm run build
- [x] npx eslint changed frontend files
- [x] GitHub CI: Lint, Unit Tests, E2E Tests

## Notes
- Local repo-wide `make lint` and `npm run lint` still report pre-existing findings outside this PR's changed files; GitHub CI lint passed for this PR.