### PR TITLE
feat(scope-picker): shared ScopePicker component for Org/Project selection

### DIFF
--- a/frontend/src/components/scope-picker/ScopePicker.test.tsx
+++ b/frontend/src/components/scope-picker/ScopePicker.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+// ---------------------------------------------------------------------------
+// Mock context hooks BEFORE importing the component under test.
+// vi.mock calls are hoisted to the top of the file by Vitest.
+// ---------------------------------------------------------------------------
+vi.mock('@/lib/org-context', () => ({ useOrg: vi.fn() }))
+vi.mock('@/lib/project-context', () => ({ useProject: vi.fn() }))
+
+// Flatten the shadcn DropdownMenu so menu items are immediately queryable
+// without simulating an open click (the portal + animation make it opaque
+// to jsdom without this flatten).
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="scope-picker-menu-content">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...rest
+  }: {
+    children: React.ReactNode
+    disabled?: boolean
+    onSelect?: () => void
+  } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+      role="menuitem"
+      aria-disabled={disabled ? 'true' : undefined}
+      onClick={!disabled ? onSelect : undefined}
+      {...rest}
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+    disabled?: boolean
+  }) => (asChild ? <>{children}</> : <div>{children}</div>),
+}))
+
+// Flatten tooltip so the tooltip content is visible in the DOM tree
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => (asChild ? <>{children}</> : <span>{children}</span>),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="scope-picker-tooltip">{children}</div>
+  ),
+}))
+
+import { useOrg } from '@/lib/org-context'
+import { useProject } from '@/lib/project-context'
+import { ScopePicker } from './ScopePicker'
+
+// ---------------------------------------------------------------------------
+// Default mock values
+// ---------------------------------------------------------------------------
+function setupMocks({
+  selectedProject = 'my-project',
+}: { selectedProject?: string | null } = {}) {
+  ;(useOrg as Mock).mockReturnValue({
+    organizations: [],
+    selectedOrg: 'my-org',
+    setSelectedOrg: vi.fn(),
+    isLoading: false,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    projects: [],
+    selectedProject,
+    setSelectedProject: vi.fn(),
+    isLoading: false,
+  })
+}
+
+describe('ScopePicker — renders both menu items', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders an Organization menu item', () => {
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    expect(
+      screen.getByTestId('scope-picker-item-organization'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('scope-picker-item-organization'),
+    ).toHaveTextContent('Organization')
+  })
+
+  it('renders a Project menu item', () => {
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    expect(
+      screen.getByTestId('scope-picker-item-project'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('scope-picker-item-project'),
+    ).toHaveTextContent('Project')
+  })
+
+  it('renders exactly two menu items', () => {
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    const items = screen.getAllByRole('menuitem')
+    expect(items).toHaveLength(2)
+  })
+})
+
+describe('ScopePicker — fires onChange when an item is clicked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('calls onChange with "project" when the Project item is clicked', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<ScopePicker value="organization" onChange={onChange} />)
+    await user.click(screen.getByTestId('scope-picker-item-project'))
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith('project')
+  })
+
+  it('calls onChange with "organization" when the Organization item is clicked', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<ScopePicker value="project" onChange={onChange} />)
+    await user.click(screen.getByTestId('scope-picker-item-organization'))
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith('organization')
+  })
+
+  it('does not call onChange when a disabled item is clicked', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    // No project selected — Project item is disabled
+    setupMocks({ selectedProject: null })
+    render(<ScopePicker value="organization" onChange={onChange} />)
+    await user.click(screen.getByTestId('scope-picker-item-project'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('ScopePicker — disables Project when no project is selected', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('disables the Project item when selectedProject is null', () => {
+    setupMocks({ selectedProject: null })
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    const projectItem = screen.getByTestId('scope-picker-item-project')
+    expect(projectItem).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('enables the Project item when selectedProject is non-null', () => {
+    setupMocks({ selectedProject: 'my-project' })
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    const projectItem = screen.getByTestId('scope-picker-item-project')
+    expect(projectItem).not.toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('shows a tooltip hint when Project is disabled', () => {
+    setupMocks({ selectedProject: null })
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    // Tooltip content is rendered in the flattened mock
+    expect(screen.getByTestId('scope-picker-tooltip')).toHaveTextContent(
+      'Select a project first',
+    )
+  })
+
+  it('does not show a tooltip when Project is enabled', () => {
+    setupMocks({ selectedProject: 'my-project' })
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    expect(screen.queryByTestId('scope-picker-tooltip')).not.toBeInTheDocument()
+  })
+})
+
+describe('ScopePicker — trigger label reflects current value', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('shows "Organization" in the trigger when value is organization', () => {
+    render(<ScopePicker value="organization" onChange={vi.fn()} />)
+    expect(
+      screen.getByTestId('scope-picker-trigger'),
+    ).toHaveTextContent('Organization')
+  })
+
+  it('shows "Project" in the trigger when value is project', () => {
+    render(<ScopePicker value="project" onChange={vi.fn()} />)
+    expect(
+      screen.getByTestId('scope-picker-trigger'),
+    ).toHaveTextContent('Project')
+  })
+})

--- a/frontend/src/components/scope-picker/ScopePicker.tsx
+++ b/frontend/src/components/scope-picker/ScopePicker.tsx
@@ -1,0 +1,109 @@
+import { ChevronDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useProject } from '@/lib/project-context'
+import { cn } from '@/lib/utils'
+
+/** The two scope options — organization or project. No folder option. */
+export type Scope = 'organization' | 'project'
+
+export interface ScopePickerProps {
+  /** Currently selected scope. */
+  value: Scope
+  /** Called when the user selects a different scope. */
+  onChange: (next: Scope) => void
+  /** When true the entire picker is non-interactive. */
+  disabled?: boolean
+  /** Additional class names forwarded to the trigger button. */
+  className?: string
+}
+
+const SCOPE_LABELS: Record<Scope, string> = {
+  organization: 'Organization',
+  project: 'Project',
+}
+
+/**
+ * ScopePicker renders a controlled dropdown button that lets a "new resource"
+ * form choose between Organization and Project scope. It reads the currently-
+ * selected project from `useProject()` to determine whether the Project item
+ * should be enabled, but it never writes to either context store.
+ *
+ * Usage:
+ * ```tsx
+ * <ScopePicker value={scope} onChange={setScope} />
+ * ```
+ */
+export function ScopePicker({ value, onChange, disabled, className }: ScopePickerProps) {
+  const { selectedProject } = useProject()
+  const projectDisabled = selectedProject === null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild disabled={disabled}>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn('flex items-center gap-1', className)}
+          data-testid="scope-picker-trigger"
+        >
+          {SCOPE_LABELS[value]}
+          <ChevronDown className="h-4 w-4 opacity-60" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuItem
+          data-testid="scope-picker-item-organization"
+          onSelect={() => onChange('organization')}
+        >
+          Organization
+        </DropdownMenuItem>
+        {projectDisabled ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/*
+                  Radix DropdownMenuItem with `disabled` does not forward the
+                  mouse-enter event needed for the tooltip, so we wrap with a
+                  span that serves as the tooltip anchor.
+                */}
+                <span
+                  className="block"
+                  data-testid="scope-picker-item-project-wrapper"
+                >
+                  <DropdownMenuItem
+                    data-testid="scope-picker-item-project"
+                    disabled
+                  >
+                    Project
+                  </DropdownMenuItem>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                Select a project first
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <DropdownMenuItem
+            data-testid="scope-picker-item-project"
+            onSelect={() => onChange('project')}
+          >
+            Project
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `frontend/src/components/scope-picker/ScopePicker.tsx` — a fully controlled dropdown that lets a "new resource" form choose between Organization and Project scope
- Exports `Scope = 'organization' | 'project'` type plus `ScopePickerProps` interface with `value`, `onChange`, optional `disabled`, and optional `className`
- Renders exactly two `DropdownMenuItem` entries ("Organization" and "Project") using existing shadcn primitives — no new libraries introduced
- Disables the "Project" item when `useProject().selectedProject` is null and shows a tooltip: "Select a project first"
- Reads from `useProject()` (never writes), per the selected-entity-state contract

Co-located `ScopePicker.test.tsx` covers all required scenarios: renders both items, fires `onChange` on click, disables Project when no project is selected, and shows/hides the tooltip. All 12 new tests pass; full Vitest suite (1308 tests, 95 files) is green.

Fixes HOL-1018

## Test plan

- [x] `make test-ui` passes (1308 tests, 95 files)
- [x] ScopePicker-specific tests: 12 / 12 pass
- [ ] Visual spot-check: render `<ScopePicker value="organization" onChange={…} />` in a "new" form page and confirm dropdown shows two items
- [ ] Confirm "Project" item is disabled with tooltip when no project is selected in the sidebar picker