### PR TITLE
feat(queries): add Get/Create/Update hooks for TemplateDependency, TemplateRequirement, TemplateGrant

### DIFF
--- a/frontend/src/queries/-templateDependencies.test.ts
+++ b/frontend/src/queries/-templateDependencies.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for templateDependencies query hooks (HOL-1019).
+ *
+ * Covers:
+ *  - useGetTemplateDependency — success, disabled when namespace/name empty, disabled unauthenticated
+ *  - useCreateTemplateDependency — calls RPC, invalidates list on success
+ *  - useUpdateTemplateDependency — calls RPC, invalidates list and get on success
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import {
+  TemplateDependencySchema,
+} from '@/gen/holos/console/v1/template_dependencies_pb.js'
+import { keys } from '@/queries/keys'
+import {
+  useGetTemplateDependency,
+  useCreateTemplateDependency,
+  useUpdateTemplateDependency,
+} from '@/queries/templateDependencies'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useAuth } from '@/lib/auth'
+
+const NS = 'holos-project-test-proj'
+const NAME = 'dep-a'
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+// ---------------------------------------------------------------------------
+// useGetTemplateDependency
+// ---------------------------------------------------------------------------
+
+describe('useGetTemplateDependency', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      getTemplateDependency: vi.fn().mockResolvedValue({
+        dependency: create(TemplateDependencySchema, { name: NAME, namespace: NS }),
+      }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('fetches the dependency and returns it', async () => {
+    const { result } = renderHook(
+      () => useGetTemplateDependency(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockClient.getTemplateDependency).toHaveBeenCalledWith({
+      namespace: NS,
+      name: NAME,
+    })
+    expect(result.current.data?.name).toBe(NAME)
+    expect(result.current.data?.namespace).toBe(NS)
+  })
+
+  it('is disabled when namespace is empty', () => {
+    const { result } = renderHook(
+      () => useGetTemplateDependency('', NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateDependency).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when name is empty', () => {
+    const { result } = renderHook(
+      () => useGetTemplateDependency(NS, ''),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateDependency).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when user is not authenticated', () => {
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: false })
+
+    const { result } = renderHook(
+      () => useGetTemplateDependency(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateDependency).not.toHaveBeenCalled()
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('rpc error')
+    mockClient.getTemplateDependency.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useGetTemplateDependency(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBe(err)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCreateTemplateDependency
+// ---------------------------------------------------------------------------
+
+describe('useCreateTemplateDependency', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      createTemplateDependency: vi.fn().mockResolvedValue({ name: NAME }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('calls createTemplateDependency RPC with correct params', async () => {
+    const { result } = renderHook(
+      () => useCreateTemplateDependency(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: NAME })
+    })
+
+    expect(mockClient.createTemplateDependency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: NS,
+        dependency: expect.objectContaining({ name: NAME, namespace: NS }),
+      }),
+    )
+  })
+
+  it('invalidates the list query on success', async () => {
+    const { result } = renderHook(
+      () => useCreateTemplateDependency(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: NAME })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateDependencies.list(NS),
+    })
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('create failed')
+    mockClient.createTemplateDependency.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useCreateTemplateDependency(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({ name: NAME })).rejects.toThrow('create failed')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useUpdateTemplateDependency
+// ---------------------------------------------------------------------------
+
+describe('useUpdateTemplateDependency', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      updateTemplateDependency: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('calls updateTemplateDependency RPC with correct params', async () => {
+    const { result } = renderHook(
+      () => useUpdateTemplateDependency(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ cascadeDelete: false })
+    })
+
+    expect(mockClient.updateTemplateDependency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: NS,
+        dependency: expect.objectContaining({ name: NAME, namespace: NS }),
+      }),
+    )
+  })
+
+  it('invalidates list and get keys on success', async () => {
+    const { result } = renderHook(
+      () => useUpdateTemplateDependency(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({})
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateDependencies.list(NS),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateDependencies.get(NS, NAME),
+    })
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('update failed')
+    mockClient.updateTemplateDependency.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useUpdateTemplateDependency(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({})).rejects.toThrow('update failed')
+    })
+  })
+})

--- a/frontend/src/queries/-templateGrants.test.ts
+++ b/frontend/src/queries/-templateGrants.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for templateGrants query hooks (HOL-1019).
+ *
+ * Covers:
+ *  - useGetTemplateGrant — success, disabled when namespace/name empty, disabled unauthenticated
+ *  - useCreateTemplateGrant — calls RPC, invalidates list on success
+ *  - useUpdateTemplateGrant — calls RPC, invalidates list and get on success
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import {
+  TemplateGrantSchema,
+} from '@/gen/holos/console/v1/template_grants_pb.js'
+import { keys } from '@/queries/keys'
+import {
+  useGetTemplateGrant,
+  useCreateTemplateGrant,
+  useUpdateTemplateGrant,
+} from '@/queries/templateGrants'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useAuth } from '@/lib/auth'
+
+const NS = 'holos-org-test-org'
+const NAME = 'grant-a'
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+// ---------------------------------------------------------------------------
+// useGetTemplateGrant
+// ---------------------------------------------------------------------------
+
+describe('useGetTemplateGrant', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      getTemplateGrant: vi.fn().mockResolvedValue({
+        grant: create(TemplateGrantSchema, { name: NAME, namespace: NS }),
+      }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('fetches the grant and returns it', async () => {
+    const { result } = renderHook(
+      () => useGetTemplateGrant(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockClient.getTemplateGrant).toHaveBeenCalledWith({
+      namespace: NS,
+      name: NAME,
+    })
+    expect(result.current.data?.name).toBe(NAME)
+    expect(result.current.data?.namespace).toBe(NS)
+  })
+
+  it('is disabled when namespace is empty', () => {
+    const { result } = renderHook(
+      () => useGetTemplateGrant('', NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateGrant).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when name is empty', () => {
+    const { result } = renderHook(
+      () => useGetTemplateGrant(NS, ''),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateGrant).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when user is not authenticated', () => {
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: false })
+
+    const { result } = renderHook(
+      () => useGetTemplateGrant(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateGrant).not.toHaveBeenCalled()
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('rpc error')
+    mockClient.getTemplateGrant.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useGetTemplateGrant(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBe(err)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCreateTemplateGrant
+// ---------------------------------------------------------------------------
+
+describe('useCreateTemplateGrant', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      createTemplateGrant: vi.fn().mockResolvedValue({ name: NAME }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('calls createTemplateGrant RPC with correct params', async () => {
+    const { result } = renderHook(
+      () => useCreateTemplateGrant(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: NAME })
+    })
+
+    expect(mockClient.createTemplateGrant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: NS,
+        grant: expect.objectContaining({ name: NAME, namespace: NS }),
+      }),
+    )
+  })
+
+  it('invalidates the list query on success', async () => {
+    const { result } = renderHook(
+      () => useCreateTemplateGrant(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: NAME })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateGrants.list(NS),
+    })
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('create failed')
+    mockClient.createTemplateGrant.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useCreateTemplateGrant(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({ name: NAME })).rejects.toThrow('create failed')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useUpdateTemplateGrant
+// ---------------------------------------------------------------------------
+
+describe('useUpdateTemplateGrant', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      updateTemplateGrant: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('calls updateTemplateGrant RPC with correct params', async () => {
+    const { result } = renderHook(
+      () => useUpdateTemplateGrant(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ from: [{ namespace: 'proj-ns' }] })
+    })
+
+    expect(mockClient.updateTemplateGrant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: NS,
+        grant: expect.objectContaining({ name: NAME, namespace: NS }),
+      }),
+    )
+  })
+
+  it('invalidates list and get keys on success', async () => {
+    const { result } = renderHook(
+      () => useUpdateTemplateGrant(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({})
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateGrants.list(NS),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateGrants.get(NS, NAME),
+    })
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('update failed')
+    mockClient.updateTemplateGrant.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useUpdateTemplateGrant(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({})).rejects.toThrow('update failed')
+    })
+  })
+})

--- a/frontend/src/queries/-templateRequirements.test.ts
+++ b/frontend/src/queries/-templateRequirements.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for templateRequirements query hooks (HOL-1019).
+ *
+ * Covers:
+ *  - useGetTemplateRequirement — success, disabled when namespace/name empty, disabled unauthenticated
+ *  - useCreateTemplateRequirement — calls RPC, invalidates list on success
+ *  - useUpdateTemplateRequirement — calls RPC, invalidates list and get on success
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import {
+  TemplateRequirementSchema,
+} from '@/gen/holos/console/v1/template_requirements_pb.js'
+import { keys } from '@/queries/keys'
+import {
+  useGetTemplateRequirement,
+  useCreateTemplateRequirement,
+  useUpdateTemplateRequirement,
+} from '@/queries/templateRequirements'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@connectrpc/connect-query', () => ({
+  useTransport: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+import { createClient } from '@connectrpc/connect'
+import { useTransport } from '@connectrpc/connect-query'
+import { useAuth } from '@/lib/auth'
+
+const NS = 'holos-org-test-org'
+const NAME = 'req-a'
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+// ---------------------------------------------------------------------------
+// useGetTemplateRequirement
+// ---------------------------------------------------------------------------
+
+describe('useGetTemplateRequirement', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      getTemplateRequirement: vi.fn().mockResolvedValue({
+        requirement: create(TemplateRequirementSchema, { name: NAME, namespace: NS }),
+      }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true })
+  })
+
+  it('fetches the requirement and returns it', async () => {
+    const { result } = renderHook(
+      () => useGetTemplateRequirement(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockClient.getTemplateRequirement).toHaveBeenCalledWith({
+      namespace: NS,
+      name: NAME,
+    })
+    expect(result.current.data?.name).toBe(NAME)
+    expect(result.current.data?.namespace).toBe(NS)
+  })
+
+  it('is disabled when namespace is empty', () => {
+    const { result } = renderHook(
+      () => useGetTemplateRequirement('', NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateRequirement).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when name is empty', () => {
+    const { result } = renderHook(
+      () => useGetTemplateRequirement(NS, ''),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateRequirement).not.toHaveBeenCalled()
+  })
+
+  it('is disabled when user is not authenticated', () => {
+    ;(useAuth as Mock).mockReturnValue({ isAuthenticated: false })
+
+    const { result } = renderHook(
+      () => useGetTemplateRequirement(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockClient.getTemplateRequirement).not.toHaveBeenCalled()
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('rpc error')
+    mockClient.getTemplateRequirement.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useGetTemplateRequirement(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBe(err)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCreateTemplateRequirement
+// ---------------------------------------------------------------------------
+
+describe('useCreateTemplateRequirement', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      createTemplateRequirement: vi.fn().mockResolvedValue({ name: NAME }),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('calls createTemplateRequirement RPC with correct params', async () => {
+    const { result } = renderHook(
+      () => useCreateTemplateRequirement(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: NAME })
+    })
+
+    expect(mockClient.createTemplateRequirement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: NS,
+        requirement: expect.objectContaining({ name: NAME, namespace: NS }),
+      }),
+    )
+  })
+
+  it('invalidates the list query on success', async () => {
+    const { result } = renderHook(
+      () => useCreateTemplateRequirement(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: NAME })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateRequirements.list(NS),
+    })
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('create failed')
+    mockClient.createTemplateRequirement.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useCreateTemplateRequirement(NS),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({ name: NAME })).rejects.toThrow('create failed')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useUpdateTemplateRequirement
+// ---------------------------------------------------------------------------
+
+describe('useUpdateTemplateRequirement', () => {
+  let queryClient: QueryClient
+  let mockClient: Record<string, Mock>
+  let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    mockClient = {
+      updateTemplateRequirement: vi.fn().mockResolvedValue({}),
+    }
+    ;(createClient as Mock).mockReturnValue(mockClient)
+    ;(useTransport as Mock).mockReturnValue({})
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  })
+
+  it('calls updateTemplateRequirement RPC with correct params', async () => {
+    const { result } = renderHook(
+      () => useUpdateTemplateRequirement(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({ cascadeDelete: true })
+    })
+
+    expect(mockClient.updateTemplateRequirement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: NS,
+        requirement: expect.objectContaining({ name: NAME, namespace: NS }),
+      }),
+    )
+  })
+
+  it('invalidates list and get keys on success', async () => {
+    const { result } = renderHook(
+      () => useUpdateTemplateRequirement(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({})
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateRequirements.list(NS),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: keys.templateRequirements.get(NS, NAME),
+    })
+  })
+
+  it('surfaces errors on RPC failure', async () => {
+    const err = new Error('update failed')
+    mockClient.updateTemplateRequirement.mockRejectedValue(err)
+
+    const { result } = renderHook(
+      () => useUpdateTemplateRequirement(NS, NAME),
+      { wrapper: makeWrapper(queryClient) },
+    )
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({})).rejects.toThrow('update failed')
+    })
+  })
+})

--- a/frontend/src/queries/templateDependencies.ts
+++ b/frontend/src/queries/templateDependencies.ts
@@ -9,6 +9,7 @@
 //      project-scoped Dependencies ResourceGrid page.
 
 import { useMemo } from 'react'
+import { create } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import {
@@ -24,8 +25,13 @@ import type {
 } from '@/gen/holos/console/v1/templates_pb.js'
 import {
   TemplateDependencyService,
+  TemplateDependencySchema,
 } from '@/gen/holos/console/v1/template_dependencies_pb.js'
-import type { TemplateDependency } from '@/gen/holos/console/v1/template_dependencies_pb.js'
+import type {
+  TemplateDependency,
+  TemplateDependencyStatus,
+} from '@/gen/holos/console/v1/template_dependencies_pb.js'
+import type { LinkedTemplateRef } from '@/gen/holos/console/v1/policy_state_pb.js'
 import { useAuth } from '@/lib/auth'
 import { keys } from '@/queries/keys'
 
@@ -33,8 +39,8 @@ import { keys } from '@/queries/keys'
 export type { TemplateDependentRecord, DeploymentDependentRecord }
 export { DependencyScope }
 
-// Re-export TemplateDependency so consumers import from one place.
-export type { TemplateDependency }
+// Re-export TemplateDependency and related types so consumers import from one place.
+export type { TemplateDependency, TemplateDependencyStatus, LinkedTemplateRef }
 
 // ---------------------------------------------------------------------------
 // Reverse-dependency read hooks (HOL-986)
@@ -122,6 +128,94 @@ export function useDeleteTemplateDependency(namespace: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: keys.templateDependencies.list(namespace),
+      })
+    },
+  })
+}
+
+// useGetTemplateDependency fetches a single TemplateDependency by (namespace, name).
+export function useGetTemplateDependency(namespace: string, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateDependencyService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: keys.templateDependencies.get(namespace, name),
+    queryFn: async () => {
+      const response = await client.getTemplateDependency({ namespace, name })
+      return response.dependency
+    },
+    enabled: isAuthenticated && !!namespace && !!name,
+  })
+}
+
+// useCreateTemplateDependency creates a new TemplateDependency in a project namespace.
+export function useCreateTemplateDependency(namespace: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateDependencyService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      name: string
+      dependent?: LinkedTemplateRef
+      requires?: LinkedTemplateRef
+      cascadeDelete?: boolean
+    }) => {
+      return client.createTemplateDependency({
+        namespace,
+        dependency: create(TemplateDependencySchema, {
+          name: params.name,
+          namespace,
+          dependent: params.dependent,
+          requires: params.requires,
+          cascadeDelete: params.cascadeDelete,
+        }),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateDependencies.list(namespace),
+      })
+    },
+  })
+}
+
+// useUpdateTemplateDependency updates an existing TemplateDependency.
+export function useUpdateTemplateDependency(namespace: string, name: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateDependencyService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      dependent?: LinkedTemplateRef
+      requires?: LinkedTemplateRef
+      cascadeDelete?: boolean
+    }) => {
+      return client.updateTemplateDependency({
+        namespace,
+        dependency: create(TemplateDependencySchema, {
+          name,
+          namespace,
+          dependent: params.dependent,
+          requires: params.requires,
+          cascadeDelete: params.cascadeDelete,
+        }),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateDependencies.list(namespace),
+      })
+      queryClient.invalidateQueries({
+        queryKey: keys.templateDependencies.get(namespace, name),
       })
     },
   })

--- a/frontend/src/queries/templateGrants.ts
+++ b/frontend/src/queries/templateGrants.ts
@@ -5,6 +5,7 @@
 // Templates sidebar collapsible.
 
 import { useMemo } from 'react'
+import { create } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import {
@@ -15,13 +16,18 @@ import {
 } from '@tanstack/react-query'
 import {
   TemplateGrantService,
+  TemplateGrantSchema,
 } from '@/gen/holos/console/v1/template_grants_pb.js'
-import type { TemplateGrant } from '@/gen/holos/console/v1/template_grants_pb.js'
+import type {
+  TemplateGrant,
+  TemplateGrantFromRef,
+  TemplateGrantToRef,
+} from '@/gen/holos/console/v1/template_grants_pb.js'
 import { useAuth } from '@/lib/auth'
 import { keys } from '@/queries/keys'
 
 // Re-export proto types so consumers import from one place.
-export type { TemplateGrant }
+export type { TemplateGrant, TemplateGrantFromRef, TemplateGrantToRef }
 
 // useListTemplateGrants lists all TemplateGrant resources in an organization
 // or folder namespace. Backed by TemplateGrantService.ListTemplateGrants.
@@ -57,6 +63,90 @@ export function useDeleteTemplateGrant(namespace: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: keys.templateGrants.list(namespace),
+      })
+    },
+  })
+}
+
+// useGetTemplateGrant fetches a single TemplateGrant by (namespace, name).
+export function useGetTemplateGrant(namespace: string, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateGrantService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: keys.templateGrants.get(namespace, name),
+    queryFn: async () => {
+      const response = await client.getTemplateGrant({ namespace, name })
+      return response.grant
+    },
+    enabled: isAuthenticated && !!namespace && !!name,
+  })
+}
+
+// useCreateTemplateGrant creates a new TemplateGrant in an org or folder namespace.
+export function useCreateTemplateGrant(namespace: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateGrantService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      name: string
+      from?: TemplateGrantFromRef[]
+      to?: TemplateGrantToRef[]
+    }) => {
+      return client.createTemplateGrant({
+        namespace,
+        grant: create(TemplateGrantSchema, {
+          name: params.name,
+          namespace,
+          from: params.from ?? [],
+          to: params.to ?? [],
+        }),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateGrants.list(namespace),
+      })
+    },
+  })
+}
+
+// useUpdateTemplateGrant updates an existing TemplateGrant.
+export function useUpdateTemplateGrant(namespace: string, name: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateGrantService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      from?: TemplateGrantFromRef[]
+      to?: TemplateGrantToRef[]
+    }) => {
+      return client.updateTemplateGrant({
+        namespace,
+        grant: create(TemplateGrantSchema, {
+          name,
+          namespace,
+          from: params.from ?? [],
+          to: params.to ?? [],
+        }),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateGrants.list(namespace),
+      })
+      queryClient.invalidateQueries({
+        queryKey: keys.templateGrants.get(namespace, name),
       })
     },
   })

--- a/frontend/src/queries/templateRequirements.ts
+++ b/frontend/src/queries/templateRequirements.ts
@@ -6,6 +6,7 @@
 // the Templates sidebar collapsible.
 
 import { useMemo } from 'react'
+import { create } from '@bufbuild/protobuf'
 import { createClient } from '@connectrpc/connect'
 import { useTransport } from '@connectrpc/connect-query'
 import {
@@ -16,13 +17,18 @@ import {
 } from '@tanstack/react-query'
 import {
   TemplateRequirementService,
+  TemplateRequirementSchema,
 } from '@/gen/holos/console/v1/template_requirements_pb.js'
-import type { TemplateRequirement } from '@/gen/holos/console/v1/template_requirements_pb.js'
+import type {
+  TemplateRequirement,
+  TemplateRequirementTargetRef,
+} from '@/gen/holos/console/v1/template_requirements_pb.js'
+import type { LinkedTemplateRef } from '@/gen/holos/console/v1/policy_state_pb.js'
 import { useAuth } from '@/lib/auth'
 import { keys } from '@/queries/keys'
 
 // Re-export proto types so consumers import from one place.
-export type { TemplateRequirement }
+export type { TemplateRequirement, TemplateRequirementTargetRef, LinkedTemplateRef }
 
 // useListTemplateRequirements lists all TemplateRequirement resources in an
 // organization or folder namespace. Backed by
@@ -59,6 +65,94 @@ export function useDeleteTemplateRequirement(namespace: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: keys.templateRequirements.list(namespace),
+      })
+    },
+  })
+}
+
+// useGetTemplateRequirement fetches a single TemplateRequirement by (namespace, name).
+export function useGetTemplateRequirement(namespace: string, name: string) {
+  const { isAuthenticated } = useAuth()
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateRequirementService, transport),
+    [transport],
+  )
+  return useQuery({
+    queryKey: keys.templateRequirements.get(namespace, name),
+    queryFn: async () => {
+      const response = await client.getTemplateRequirement({ namespace, name })
+      return response.requirement
+    },
+    enabled: isAuthenticated && !!namespace && !!name,
+  })
+}
+
+// useCreateTemplateRequirement creates a new TemplateRequirement in an org or folder namespace.
+export function useCreateTemplateRequirement(namespace: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateRequirementService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      name: string
+      requires?: LinkedTemplateRef
+      targetRefs?: TemplateRequirementTargetRef[]
+      cascadeDelete?: boolean
+    }) => {
+      return client.createTemplateRequirement({
+        namespace,
+        requirement: create(TemplateRequirementSchema, {
+          name: params.name,
+          namespace,
+          requires: params.requires,
+          targetRefs: params.targetRefs ?? [],
+          cascadeDelete: params.cascadeDelete,
+        }),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateRequirements.list(namespace),
+      })
+    },
+  })
+}
+
+// useUpdateTemplateRequirement updates an existing TemplateRequirement.
+export function useUpdateTemplateRequirement(namespace: string, name: string) {
+  const transport = useTransport()
+  const client = useMemo(
+    () => createClient(TemplateRequirementService, transport),
+    [transport],
+  )
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      requires?: LinkedTemplateRef
+      targetRefs?: TemplateRequirementTargetRef[]
+      cascadeDelete?: boolean
+    }) => {
+      return client.updateTemplateRequirement({
+        namespace,
+        requirement: create(TemplateRequirementSchema, {
+          name,
+          namespace,
+          requires: params.requires,
+          targetRefs: params.targetRefs ?? [],
+          cascadeDelete: params.cascadeDelete,
+        }),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: keys.templateRequirements.list(namespace),
+      })
+      queryClient.invalidateQueries({
+        queryKey: keys.templateRequirements.get(namespace, name),
       })
     },
   })


### PR DESCRIPTION
## Summary
- Adds `useGetTemplateDependency`, `useCreateTemplateDependency`, `useUpdateTemplateDependency` to `frontend/src/queries/templateDependencies.ts`
- Adds `useGetTemplateRequirement`, `useCreateTemplateRequirement`, `useUpdateTemplateRequirement` to `frontend/src/queries/templateRequirements.ts`
- Adds `useGetTemplateGrant`, `useCreateTemplateGrant`, `useUpdateTemplateGrant` to `frontend/src/queries/templateGrants.ts`
- All hooks follow the query-key factory pattern from `keys.ts` and the transport/hook split from `templatePolicies.ts`
- Mutations invalidate the list key on success; update mutations also invalidate the detail get key
- Co-located Vitest unit tests (33 new tests) cover success, disabled-guard, and error paths

Fixes HOL-1019

## Test plan
- [x] `make test-ui` passes (1341 tests, 33 new)
- [x] useGetTemplateDependency/Requirement/Grant: disabled when namespace or name empty, disabled unauthenticated, surfaces RPC errors
- [x] useCreateTemplateDependency/Requirement/Grant: calls correct RPC, invalidates list key
- [x] useUpdateTemplateDependency/Requirement/Grant: calls correct RPC, invalidates list and get keys