### PR TITLE
feat(template-dependencies): new/edit/detail pages with delete

### DIFF
--- a/frontend/src/components/template-dependencies/DependencyForm.test.tsx
+++ b/frontend/src/components/template-dependencies/DependencyForm.test.tsx
@@ -1,0 +1,173 @@
+// HOL-1020: Unit tests for the shared DependencyForm component.
+//
+// Tests cover:
+// 1. Renders correctly in create mode.
+// 2. Renders correctly in edit mode with prefilled values.
+// 3. Validates required fields before submit.
+// 4. Calls onSubmit with correct values.
+// 5. Calls onCancel when Cancel is clicked.
+// 6. Disables controls when canWrite is false.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { DependencyForm } from './DependencyForm'
+
+describe('DependencyForm', () => {
+  const defaultProps = {
+    mode: 'create' as const,
+    namespace: 'holos-project-my-project',
+    canWrite: true,
+    submitLabel: 'Create',
+    pendingLabel: 'Creating...',
+    onSubmit: vi.fn().mockResolvedValue(undefined),
+    onCancel: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders in create mode with empty fields', () => {
+    render(<DependencyForm {...defaultProps} />)
+    expect(screen.getByLabelText('Dependency name')).toHaveValue('')
+    expect(screen.getByLabelText('Dependent name')).toHaveValue('')
+    expect(screen.getByLabelText('Requires name')).toHaveValue('')
+    expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument()
+  })
+
+  it('renders in edit mode with prefilled values', () => {
+    const initialValues = {
+      name: 'my-dep',
+      dependentNamespace: 'holos-project-my-project',
+      dependentName: 'my-template',
+      requiresNamespace: 'holos-org-my-org',
+      requiresName: 'base-template',
+      cascadeDelete: true,
+    }
+    render(
+      <DependencyForm
+        {...defaultProps}
+        mode="edit"
+        initialValues={initialValues}
+        lockName
+        submitLabel="Save"
+        pendingLabel="Saving..."
+      />,
+    )
+    expect(screen.getByLabelText('Dependency name')).toHaveValue('my-dep')
+    expect(screen.getByLabelText('Dependency name')).toBeDisabled()
+    expect(screen.getByLabelText('Dependent name')).toHaveValue('my-template')
+    expect(screen.getByLabelText('Requires name')).toHaveValue('base-template')
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument()
+  })
+
+  it('shows an error when name is empty on submit', async () => {
+    render(<DependencyForm {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('dependency-form-error')).toHaveTextContent(
+        /dependency name is required/i,
+      )
+    })
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('shows an error when dependent fields are empty on submit', async () => {
+    render(<DependencyForm {...defaultProps} />)
+    // Fill name but not dependent
+    fireEvent.change(screen.getByLabelText('Dependency name'), {
+      target: { value: 'my-dep' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('dependency-form-error')).toHaveTextContent(
+        /dependent namespace and name are required/i,
+      )
+    })
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('shows an error when requires fields are empty on submit', async () => {
+    render(<DependencyForm {...defaultProps} />)
+    fireEvent.change(screen.getByLabelText('Dependency name'), {
+      target: { value: 'my-dep' },
+    })
+    fireEvent.change(screen.getByLabelText('Dependent namespace'), {
+      target: { value: 'holos-project-my-project' },
+    })
+    fireEvent.change(screen.getByLabelText('Dependent name'), {
+      target: { value: 'my-template' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('dependency-form-error')).toHaveTextContent(
+        /requires namespace and name are required/i,
+      )
+    })
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('calls onSubmit with correct values when all fields are filled', async () => {
+    render(<DependencyForm {...defaultProps} />)
+    // Fill dependent and requires first; auto-derive will set the name.
+    // Then override the name field last to set a custom slug.
+    fireEvent.change(screen.getByLabelText('Dependent namespace'), {
+      target: { value: 'holos-project-my-project' },
+    })
+    fireEvent.change(screen.getByLabelText('Dependent name'), {
+      target: { value: 'my-template' },
+    })
+    fireEvent.change(screen.getByLabelText('Requires namespace'), {
+      target: { value: 'holos-org-my-org' },
+    })
+    fireEvent.change(screen.getByLabelText('Requires name'), {
+      target: { value: 'base-template' },
+    })
+    // Override the auto-derived name with a custom one.
+    fireEvent.change(screen.getByLabelText('Dependency name'), {
+      target: { value: 'my-dep' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => {
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith({
+        name: 'my-dep',
+        dependent: expect.objectContaining({
+          namespace: 'holos-project-my-project',
+          name: 'my-template',
+        }),
+        requires: expect.objectContaining({
+          namespace: 'holos-org-my-org',
+          name: 'base-template',
+        }),
+        cascadeDelete: true,
+      })
+    })
+  })
+
+  it('calls onCancel when Cancel is clicked', () => {
+    render(<DependencyForm {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables all controls when canWrite is false', () => {
+    render(<DependencyForm {...defaultProps} canWrite={false} />)
+    expect(screen.getByLabelText('Dependency name')).toBeDisabled()
+    expect(screen.getByLabelText('Dependent name')).toBeDisabled()
+    expect(screen.getByLabelText('Requires name')).toBeDisabled()
+    expect(screen.getByRole('button', { name: /create/i })).toBeDisabled()
+  })
+
+  it('auto-derives the name from dependent and requires names in create mode', () => {
+    render(<DependencyForm {...defaultProps} />)
+    fireEvent.change(screen.getByLabelText('Dependent name'), {
+      target: { value: 'my-template' },
+    })
+    fireEvent.change(screen.getByLabelText('Requires name'), {
+      target: { value: 'base-template' },
+    })
+    expect(screen.getByLabelText('Dependency name')).toHaveValue(
+      'my-template-depends-on-base-template',
+    )
+  })
+})

--- a/frontend/src/components/template-dependencies/DependencyForm.tsx
+++ b/frontend/src/components/template-dependencies/DependencyForm.tsx
@@ -1,0 +1,260 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Separator } from '@/components/ui/separator'
+import type { LinkedTemplateRef } from '@/queries/templateDependencies'
+
+/**
+ * DependencyFormValues are the shape of data emitted by DependencyForm on submit.
+ */
+export type DependencyFormValues = {
+  name: string
+  dependent: LinkedTemplateRef
+  requires: LinkedTemplateRef
+  cascadeDelete: boolean
+}
+
+export type DependencyFormProps = {
+  mode: 'create' | 'edit'
+  namespace: string
+  canWrite: boolean
+  initialValues?: {
+    name: string
+    dependentNamespace: string
+    dependentName: string
+    requiresNamespace: string
+    requiresName: string
+    cascadeDelete: boolean
+  }
+  submitLabel: string
+  pendingLabel: string
+  onSubmit: (values: DependencyFormValues) => Promise<void>
+  onCancel: () => void
+  isPending?: boolean
+  lockName?: boolean
+}
+
+/**
+ * DependencyForm renders the shared create/edit form for a TemplateDependency.
+ * It handles both create and edit modes. In create mode the name field is
+ * auto-derived from the dependent and requires names. In edit mode the name is
+ * locked.
+ */
+export function DependencyForm({
+  mode,
+  namespace,
+  canWrite,
+  initialValues,
+  submitLabel,
+  pendingLabel,
+  onSubmit,
+  onCancel,
+  isPending = false,
+  lockName = false,
+}: DependencyFormProps) {
+  const [name, setName] = useState(initialValues?.name ?? '')
+  const [dependentNamespace, setDependentNamespace] = useState(
+    initialValues?.dependentNamespace ?? namespace,
+  )
+  const [dependentName, setDependentName] = useState(initialValues?.dependentName ?? '')
+  const [requiresNamespace, setRequiresNamespace] = useState(
+    initialValues?.requiresNamespace ?? '',
+  )
+  const [requiresName, setRequiresName] = useState(initialValues?.requiresName ?? '')
+  const [cascadeDelete, setCascadeDelete] = useState(initialValues?.cascadeDelete ?? true)
+  const [error, setError] = useState<string | null>(null)
+
+  const slugify = (val: string) =>
+    val.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+
+  const deriveNameFromFields = (depName: string, reqName: string) => {
+    if (!depName && !reqName) return ''
+    const parts = [depName, reqName].filter(Boolean)
+    return slugify(parts.join('-depends-on-'))
+  }
+
+  const handleDependentNameChange = (val: string) => {
+    setDependentName(val)
+    if (mode === 'create' && !lockName) {
+      setName(deriveNameFromFields(val, requiresName))
+    }
+  }
+
+  const handleRequiresNameChange = (val: string) => {
+    setRequiresName(val)
+    if (mode === 'create' && !lockName) {
+      setName(deriveNameFromFields(dependentName, val))
+    }
+  }
+
+  const handleSubmit = async () => {
+    setError(null)
+
+    if (!name.trim()) {
+      setError('Dependency name is required.')
+      return
+    }
+    if (!dependentNamespace.trim() || !dependentName.trim()) {
+      setError('Dependent namespace and name are required.')
+      return
+    }
+    if (!requiresNamespace.trim() || !requiresName.trim()) {
+      setError('Requires namespace and name are required.')
+      return
+    }
+
+    try {
+      await onSubmit({
+        name: name.trim(),
+        dependent: {
+          $typeName: 'holos.console.v1.LinkedTemplateRef',
+          namespace: dependentNamespace.trim(),
+          name: dependentName.trim(),
+          versionConstraint: '',
+        },
+        requires: {
+          $typeName: 'holos.console.v1.LinkedTemplateRef',
+          namespace: requiresNamespace.trim(),
+          name: requiresName.trim(),
+          versionConstraint: '',
+        },
+        cascadeDelete,
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-border p-3 text-sm text-muted-foreground">
+        A TemplateDependency records that one project template or deployment instance depends on
+        another template. Cross-namespace requires references are authorised by TemplateGrant at
+        reconcile time.
+      </div>
+
+      <div>
+        <Label htmlFor="dependency-name">Name (slug)</Label>
+        <Input
+          id="dependency-name"
+          aria-label="Dependency name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="my-template-depends-on-base"
+          disabled={!canWrite || lockName}
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          {lockName
+            ? 'Dependency names are immutable after creation.'
+            : 'Auto-derived from dependent and requires names. Lowercase alphanumeric and hyphens only.'}
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-2">
+        <Label>Dependent</Label>
+        <p className="text-xs text-muted-foreground">
+          The template or deployment instance that has this dependency.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Label htmlFor="dependent-namespace" className="text-xs">
+              Namespace
+            </Label>
+            <Input
+              id="dependent-namespace"
+              aria-label="Dependent namespace"
+              value={dependentNamespace}
+              onChange={(e) => setDependentNamespace(e.target.value)}
+              placeholder="holos-project-my-project"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <Label htmlFor="dependent-name" className="text-xs">
+              Name
+            </Label>
+            <Input
+              id="dependent-name"
+              aria-label="Dependent name"
+              value={dependentName}
+              onChange={(e) => handleDependentNameChange(e.target.value)}
+              placeholder="my-template"
+              disabled={!canWrite}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Requires</Label>
+        <p className="text-xs text-muted-foreground">
+          The template that the dependent needs.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Label htmlFor="requires-namespace" className="text-xs">
+              Namespace
+            </Label>
+            <Input
+              id="requires-namespace"
+              aria-label="Requires namespace"
+              value={requiresNamespace}
+              onChange={(e) => setRequiresNamespace(e.target.value)}
+              placeholder="holos-org-my-org"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <Label htmlFor="requires-name" className="text-xs">
+              Name
+            </Label>
+            <Input
+              id="requires-name"
+              aria-label="Requires name"
+              value={requiresName}
+              onChange={(e) => handleRequiresNameChange(e.target.value)}
+              placeholder="base-template"
+              disabled={!canWrite}
+            />
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="flex items-center gap-2">
+        <input
+          id="cascade-delete"
+          type="checkbox"
+          checked={cascadeDelete}
+          onChange={(e) => setCascadeDelete(e.target.checked)}
+          disabled={!canWrite}
+          aria-label="Cascade delete"
+          className="h-4 w-4"
+        />
+        <Label htmlFor="cascade-delete" className="font-normal">
+          Cascade delete — deleting the required template also deletes the dependent
+        </Label>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" data-testid="dependency-form-error">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-center gap-3 pt-2">
+        <Button onClick={handleSubmit} disabled={isPending || !canWrite}>
+          {isPending ? pendingLabel : submitLabel}
+        </Button>
+        <Button variant="ghost" type="button" aria-label="Cancel" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/$dependencyName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/$dependencyName.tsx
@@ -1,0 +1,237 @@
+import { useMemo, useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import { z } from 'zod'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import {
+  useGetTemplateDependency,
+  useUpdateTemplateDependency,
+  useDeleteTemplateDependency,
+} from '@/queries/templateDependencies'
+import { useGetOrganization } from '@/queries/organizations'
+import { useProject } from '@/lib/project-context'
+import { namespaceForProject } from '@/lib/scope-labels'
+import { DependencyForm } from '@/components/template-dependencies/DependencyForm'
+
+// The detail route accepts an optional `namespace` search param so the
+// project-scoped index can link directly to a dependency in a known namespace.
+// When absent, the namespace falls back to the currently-selected project.
+const searchSchema = z.object({
+  namespace: z.string().optional(),
+})
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-dependencies/$dependencyName',
+)({
+  validateSearch: searchSchema,
+  component: OrgTemplateDependencyDetailRoute,
+})
+
+function OrgTemplateDependencyDetailRoute() {
+  const { orgName, dependencyName } = Route.useParams()
+  return (
+    <OrgTemplateDependencyDetailPage orgName={orgName} dependencyName={dependencyName} />
+  )
+}
+
+export function OrgTemplateDependencyDetailPage({
+  orgName: propOrgName,
+  dependencyName: propDependencyName,
+  namespaceOverride,
+}: {
+  orgName?: string
+  dependencyName?: string
+  namespaceOverride?: string
+} = {}) {
+  let routeParams: { orgName?: string; dependencyName?: string } = {}
+  let searchNamespace: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeParams = Route.useParams()
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const search = Route.useSearch()
+    searchNamespace = search.namespace
+  } catch {
+    routeParams = {}
+  }
+  const orgName = propOrgName ?? routeParams.orgName ?? ''
+  const dependencyName = propDependencyName ?? routeParams.dependencyName ?? ''
+
+  const navigate = useNavigate()
+  const { data: org } = useGetOrganization(orgName)
+  const { selectedProject } = useProject()
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  // Delete is OWNER-only in the RBAC cascade for template dependencies.
+  const canDelete = userRole === Role.OWNER
+
+  // Namespace resolution: explicit override (for tests) > search param > selected project.
+  const namespace =
+    namespaceOverride ??
+    searchNamespace ??
+    (selectedProject ? namespaceForProject(selectedProject) : '')
+
+  const {
+    data: dependency,
+    isPending,
+    error,
+  } = useGetTemplateDependency(namespace, dependencyName)
+
+  const updateMutation = useUpdateTemplateDependency(namespace, dependencyName)
+  const deleteMutation = useDeleteTemplateDependency(namespace)
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleteError, setDeleteError] = useState<Error | null>(null)
+
+  const initialValues = useMemo(() => {
+    if (!dependency) return undefined
+    return {
+      name: dependency.name,
+      dependentNamespace: dependency.dependent?.namespace ?? namespace,
+      dependentName: dependency.dependent?.name ?? '',
+      requiresNamespace: dependency.requires?.namespace ?? '',
+      requiresName: dependency.requires?.name ?? '',
+      cascadeDelete: dependency.cascadeDelete ?? true,
+    }
+  }, [dependency, namespace])
+
+  if (!namespace) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>
+              Unable to determine the dependency namespace. Select a project from the switcher or
+              navigate here from the dependencies list.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                to="/organizations/$orgName/settings"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                {orgName}
+              </Link>
+              {' / '}
+              <Link
+                to="/organizations/$orgName/template-dependencies"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                Template Dependencies
+              </Link>
+              {' / '}
+              <span>{dependencyName}</span>
+            </p>
+            <CardTitle className="mt-1">{dependencyName}</CardTitle>
+          </div>
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+              aria-label="Delete dependency"
+            >
+              Delete Dependency
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <Separator className="mb-4" />
+          <DependencyForm
+            mode="edit"
+            namespace={namespace}
+            canWrite={canWrite}
+            initialValues={initialValues}
+            lockName
+            submitLabel="Save"
+            pendingLabel="Saving..."
+            isPending={updateMutation.isPending}
+            onSubmit={async (values) => {
+              await updateMutation.mutateAsync({
+                dependent: values.dependent,
+                requires: values.requires,
+                cascadeDelete: values.cascadeDelete,
+              })
+              toast.success('Dependency saved')
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-dependencies',
+                params: { orgName },
+              })
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleteError(null)
+        }}
+        name={dependencyName}
+        namespace={namespace}
+        isDeleting={deleteMutation.isPending}
+        error={deleteError}
+        onConfirm={async () => {
+          setDeleteError(null)
+          try {
+            await deleteMutation.mutateAsync({ name: dependencyName })
+            setDeleteOpen(false)
+            await navigate({
+              to: '/organizations/$orgName/template-dependencies',
+              params: { orgName },
+            })
+            toast.success('Dependency deleted')
+          } catch (err) {
+            setDeleteError(err instanceof Error ? err : new Error(String(err)))
+          }
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-detail.test.tsx
@@ -211,11 +211,8 @@ describe('OrgTemplateDependencyDetailPage (HOL-1020)', () => {
 
   it('invokes the delete mutation on confirm', async () => {
     const deleteMutateAsync = vi.fn().mockResolvedValue({})
-    ;(useDeleteTemplateDependency as Mock).mockReturnValue({
-      mutateAsync: deleteMutateAsync,
-      isPending: false,
-    })
     setupMocks(Role.OWNER)
+    // Override the delete mock after setupMocks() sets up the generic version.
     ;(useDeleteTemplateDependency as Mock).mockReturnValue({
       mutateAsync: deleteMutateAsync,
       isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-detail.test.tsx
@@ -1,0 +1,241 @@
+// HOL-1020: Tests for the org-scoped template-dependency detail/edit page.
+//
+// Tests cover:
+// 1. Shows Delete button for OWNER.
+// 2. Hides Delete button for VIEWER.
+// 3. Hides Delete button for EDITOR.
+// 4. Delete dialog invokes the delete mutation on confirm.
+// 5. Renders with prefilled values in edit mode.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org', dependencyName: 'dep-a' }),
+      useSearch: () => ({ namespace: 'holos-project-test-project' }),
+    }),
+    useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      to,
+      params,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+vi.mock('@/queries/templateDependencies', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateDependencies')>(
+    '@/queries/templateDependencies',
+  )
+  return {
+    ...actual,
+    useGetTemplateDependency: vi.fn(),
+    useUpdateTemplateDependency: vi.fn(),
+    useDeleteTemplateDependency: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn(),
+}))
+
+import {
+  useGetTemplateDependency,
+  useUpdateTemplateDependency,
+  useDeleteTemplateDependency,
+} from '@/queries/templateDependencies'
+import { useGetOrganization } from '@/queries/organizations'
+import { useProject } from '@/lib/project-context'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { OrgTemplateDependencyDetailPage } from './$dependencyName'
+
+function makeMockDependency() {
+  return {
+    name: 'dep-a',
+    namespace: 'holos-project-test-project',
+    dependent: {
+      $typeName: 'holos.console.v1.LinkedTemplateRef' as const,
+      namespace: 'holos-project-test-project',
+      name: 'my-template',
+      versionConstraint: '',
+    },
+    requires: {
+      $typeName: 'holos.console.v1.LinkedTemplateRef' as const,
+      namespace: 'holos-org-my-org',
+      name: 'base-template',
+      versionConstraint: '',
+    },
+    cascadeDelete: true,
+    creatorEmail: 'test@example.com',
+    createdAt: undefined,
+    status: undefined,
+  }
+}
+
+function setupMocks(
+  userRole: Role = Role.OWNER,
+  dependency: ReturnType<typeof makeMockDependency> | undefined = makeMockDependency(),
+) {
+  ;(useGetTemplateDependency as Mock).mockReturnValue({
+    data: dependency,
+    isPending: false,
+    error: null,
+  })
+  ;(useUpdateTemplateDependency as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useDeleteTemplateDependency as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    selectedProject: 'test-project',
+    setSelectedProject: vi.fn(),
+    projects: [],
+    isLoading: false,
+  })
+}
+
+describe('OrgTemplateDependencyDetailPage (HOL-1020)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the Delete Dependency button for OWNER', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateDependencyDetailPage
+        orgName="test-org"
+        dependencyName="dep-a"
+        namespaceOverride="holos-project-test-project"
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: /delete dependency/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Delete Dependency button for VIEWER', () => {
+    setupMocks(Role.VIEWER)
+    render(
+      <OrgTemplateDependencyDetailPage
+        orgName="test-org"
+        dependencyName="dep-a"
+        namespaceOverride="holos-project-test-project"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete dependency/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the Delete Dependency button for EDITOR (OWNER-only delete)', () => {
+    setupMocks(Role.EDITOR)
+    render(
+      <OrgTemplateDependencyDetailPage
+        orgName="test-org"
+        dependencyName="dep-a"
+        namespaceOverride="holos-project-test-project"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete dependency/i }),
+    ).not.toBeInTheDocument()
+    // But the form controls should still be enabled for editors.
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  })
+
+  it('renders with prefilled values from the dependency', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateDependencyDetailPage
+        orgName="test-org"
+        dependencyName="dep-a"
+        namespaceOverride="holos-project-test-project"
+      />,
+    )
+    expect(screen.getByLabelText('Dependency name')).toHaveValue('dep-a')
+    expect(screen.getByLabelText('Dependent name')).toHaveValue('my-template')
+    expect(screen.getByLabelText('Requires name')).toHaveValue('base-template')
+  })
+
+  it('opens the confirm delete dialog when Delete Dependency is clicked', async () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateDependencyDetailPage
+        orgName="test-org"
+        dependencyName="dep-a"
+        namespaceOverride="holos-project-test-project"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete dependency/i }))
+    await waitFor(() => {
+      // ConfirmDeleteDialog renders "Delete Resource" as dialog title.
+      expect(screen.getByText(/delete resource/i)).toBeInTheDocument()
+    })
+  })
+
+  it('invokes the delete mutation on confirm', async () => {
+    const deleteMutateAsync = vi.fn().mockResolvedValue({})
+    ;(useDeleteTemplateDependency as Mock).mockReturnValue({
+      mutateAsync: deleteMutateAsync,
+      isPending: false,
+    })
+    setupMocks(Role.OWNER)
+    ;(useDeleteTemplateDependency as Mock).mockReturnValue({
+      mutateAsync: deleteMutateAsync,
+      isPending: false,
+    })
+    render(
+      <OrgTemplateDependencyDetailPage
+        orgName="test-org"
+        dependencyName="dep-a"
+        namespaceOverride="holos-project-test-project"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete dependency/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/delete resource/i)).toBeInTheDocument()
+    })
+    // Click the Delete button inside the dialog.
+    const deleteButtons = screen.getAllByRole('button', { name: /^delete$/i })
+    fireEvent.click(deleteButtons[deleteButtons.length - 1])
+    await waitFor(() => {
+      expect(deleteMutateAsync).toHaveBeenCalledWith({ name: 'dep-a' })
+    })
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-new.test.tsx
@@ -1,0 +1,150 @@
+// HOL-1020: Tests for the org-scoped template-dependency create page.
+
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org' }),
+      useSearch: () => ({}),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({
+      children,
+      className,
+      to,
+      params,
+    }: {
+      children: React.ReactNode
+      className?: string
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+vi.mock('@/queries/templateDependencies', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateDependencies')>(
+    '@/queries/templateDependencies',
+  )
+  return {
+    ...actual,
+    useCreateTemplateDependency: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn(),
+}))
+
+vi.mock('@/components/scope-picker/ScopePicker', async () => {
+  return {
+    ScopePicker: ({
+      value,
+      onChange,
+    }: {
+      value: string
+      onChange: (v: string) => void
+    }) => (
+      <button data-testid="scope-picker-trigger" onClick={() => onChange('organization')}>
+        {value}
+      </button>
+    ),
+  }
+})
+
+import { useCreateTemplateDependency } from '@/queries/templateDependencies'
+import { useGetOrganization } from '@/queries/organizations'
+import { useProject } from '@/lib/project-context'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateOrgTemplateDependencyPage } from './new'
+
+function setupMocks(
+  mutateAsync = vi.fn().mockResolvedValue({}),
+  userRole: Role = Role.OWNER,
+  selectedProject: string | null = 'test-project',
+) {
+  ;(useCreateTemplateDependency as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    selectedProject,
+    setSelectedProject: vi.fn(),
+    projects: [],
+    isLoading: false,
+  })
+}
+
+describe('CreateOrgTemplateDependencyPage (HOL-1020)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page heading', () => {
+    render(<CreateOrgTemplateDependencyPage orgName="test-org" />)
+    expect(screen.getByText(/create template dependency/i)).toBeInTheDocument()
+  })
+
+  it('renders the ScopePicker', () => {
+    render(<CreateOrgTemplateDependencyPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toBeInTheDocument()
+  })
+
+  it('renders the DependencyForm when a project is selected', () => {
+    render(<CreateOrgTemplateDependencyPage orgName="test-org" />)
+    expect(screen.getByLabelText(/^dependency name$/i)).toBeInTheDocument()
+  })
+
+  it('shows a prompt when no project is selected and scope is project', () => {
+    setupMocks(vi.fn(), Role.OWNER, null)
+    render(<CreateOrgTemplateDependencyPage orgName="test-org" />)
+    // With null selectedProject and default scope 'organization', the form renders
+    // but with empty namespace. The prompt appears when scope='project' with no project.
+    // Since ScopePicker defaults to 'organization' when selectedProject is null,
+    // the form renders without a namespace.
+    expect(screen.queryByText(/select a project from the switcher/i)).not.toBeInTheDocument()
+  })
+
+  it('disables form controls for VIEWER', () => {
+    setupMocks(vi.fn(), Role.VIEWER)
+    render(<CreateOrgTemplateDependencyPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+
+  it('enables form controls for OWNER', () => {
+    setupMocks(vi.fn(), Role.OWNER)
+    render(<CreateOrgTemplateDependencyPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).not.toBeDisabled()
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/index.tsx
@@ -1,16 +1,14 @@
 /**
- * Project-scoped Templates / Dependencies index (HOL-1013).
+ * Organization-scoped TemplateDependency index (HOL-1020).
  *
- * TemplateDependencies are project-scoped. The namespace is derived from the
- * $projectName URL parameter via namespaceForProject(). The project name also
- * keeps the Templates collapsible group open in the sidebar (HOL-1014).
- *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
+ * TemplateDependency objects live in project namespaces. This org-scoped index
+ * shows dependencies from the currently-selected project. When no project is
+ * selected, an empty state prompts the user to select one.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -19,52 +17,62 @@ import {
   useListTemplateDependencies,
   useDeleteTemplateDependency,
 } from '@/queries/templateDependencies'
+import { useGetOrganization } from '@/queries/organizations'
+import { useProject } from '@/lib/project-context'
 import { namespaceForProject } from '@/lib/scope-labels'
-import { useOrg } from '@/lib/org-context'
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-dependencies/',
+)({
+  validateSearch: parseGridSearch,
+  component: OrgTemplateDependenciesIndexRoute,
+})
+
+function OrgTemplateDependenciesIndexRoute() {
+  const { orgName } = Route.useParams()
+  return <OrgTemplateDependenciesIndexPage orgName={orgName} />
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
 function timestampToISOString(ts: { seconds: bigint } | undefined): string {
   if (!ts) return ''
   return new Date(Number(ts.seconds) * 1000).toISOString()
 }
 
 // ---------------------------------------------------------------------------
-// Route definition
-// ---------------------------------------------------------------------------
-
-export const Route = createFileRoute(
-  '/_authenticated/projects/$projectName/templates/dependencies/',
-)({
-  validateSearch: parseGridSearch,
-  component: TemplateDependenciesIndexRoute,
-})
-
-function TemplateDependenciesIndexRoute() {
-  const { projectName } = Route.useParams()
-  return <TemplateDependenciesIndexPage projectName={projectName} />
-}
-
-// ---------------------------------------------------------------------------
 // Page component (exported for tests)
 // ---------------------------------------------------------------------------
 
-export function TemplateDependenciesIndexPage({
-  projectName,
-}: {
-  projectName: string
-}) {
-  const search = Route.useSearch() as ResourceGridSearch
+export function OrgTemplateDependenciesIndexPage({
+  orgName: propOrgName,
+}: { orgName?: string } = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  // TemplateDependencies are project-scoped — namespace comes from projectName.
-  const namespace = namespaceForProject(projectName)
+  const { data: org } = useGetOrganization(orgName)
+  const { selectedProject } = useProject()
 
-  // selectedOrg is used to build detailHref links to the org-scoped detail page.
-  const { selectedOrg } = useOrg()
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // TemplateDependencies are project-scoped. Use the selected project namespace.
+  const namespace = selectedProject ? namespaceForProject(selectedProject) : ''
 
   const {
     data: dependencies = [],
@@ -83,18 +91,18 @@ export function TemplateDependenciesIndexPage({
       dependencies.map((d) => ({
         kind: 'TemplateDependency',
         name: d.name,
-        namespace,
+        namespace: namespace,
         id: d.name,
-        parentId: projectName,
-        parentLabel: projectName,
+        parentId: selectedProject ?? '',
+        parentLabel: selectedProject ?? '',
         displayName: d.name,
         description: `${d.dependent?.name ?? ''} → ${d.requires?.name ?? ''}`,
         createdAt: timestampToISOString(d.createdAt),
-        detailHref: selectedOrg
-          ? `/organizations/${selectedOrg}/template-dependencies/${d.name}?namespace=${encodeURIComponent(namespace)}`
+        detailHref: namespace
+          ? `/organizations/${orgName}/template-dependencies/${d.name}?namespace=${encodeURIComponent(namespace)}`
           : undefined,
       })),
-    [dependencies, namespace, projectName, selectedOrg],
+    [dependencies, namespace, orgName, selectedProject],
   )
 
   // ---------------------------------------------------------------------------
@@ -105,12 +113,12 @@ export function TemplateDependenciesIndexPage({
     () => [
       {
         id: 'TemplateDependency',
-        label: 'TemplateDependency',
-        // No create in this view — dependencies are managed programmatically.
-        canCreate: false,
+        label: 'Template Dependency',
+        newHref: `/organizations/${orgName}/template-dependencies/new`,
+        canCreate: canWrite,
       },
     ],
-    [],
+    [orgName, canWrite],
   )
 
   // ---------------------------------------------------------------------------
@@ -128,14 +136,17 @@ export function TemplateDependenciesIndexPage({
     (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
       navigate({
         search: (prev) => updater(prev as ResourceGridSearch),
+        replace: true,
       })
     },
     [navigate],
   )
 
+  const titleSuffix = selectedProject ? ` (${selectedProject})` : ''
+
   return (
     <ResourceGrid
-      title={`${projectName} / Templates / Dependencies`}
+      title={`${orgName} / Template Dependencies${titleSuffix}`}
       kinds={kinds}
       rows={rows}
       onDelete={handleDelete}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/new.tsx
@@ -1,0 +1,116 @@
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplateDependency } from '@/queries/templateDependencies'
+import { namespaceForProject } from '@/lib/scope-labels'
+import { useGetOrganization } from '@/queries/organizations'
+import { useProject } from '@/lib/project-context'
+import { ScopePicker } from '@/components/scope-picker/ScopePicker'
+import type { Scope } from '@/components/scope-picker/ScopePicker'
+import { DependencyForm } from '@/components/template-dependencies/DependencyForm'
+import { useState } from 'react'
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-dependencies/new',
+)({
+  component: CreateOrgTemplateDependencyRoute,
+})
+
+function CreateOrgTemplateDependencyRoute() {
+  const { orgName } = Route.useParams()
+  return <CreateOrgTemplateDependencyPage orgName={orgName} />
+}
+
+export function CreateOrgTemplateDependencyPage({
+  orgName: propOrgName,
+}: {
+  orgName?: string
+} = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const navigate = useNavigate()
+  const { data: org } = useGetOrganization(orgName)
+  const { selectedProject } = useProject()
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // ScopePicker controls which namespace the dependency is created in.
+  // Defaults to 'project' if a project is selected, else 'organization'.
+  const [scope, setScope] = useState<Scope>(selectedProject ? 'project' : 'organization')
+
+  const namespace =
+    scope === 'project' && selectedProject
+      ? namespaceForProject(selectedProject)
+      : ''
+
+  const createMutation = useCreateTemplateDependency(namespace)
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/organizations/$orgName/settings"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              {orgName}
+            </Link>
+            {' / '}
+            <Link
+              to="/organizations/$orgName/template-dependencies"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              Template Dependencies
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">Create Template Dependency</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Scope:</span>
+          <ScopePicker value={scope} onChange={setScope} disabled={!canWrite} />
+        </div>
+        {scope === 'project' && !selectedProject ? (
+          <p className="text-sm text-muted-foreground">
+            Select a project from the switcher to create a dependency in a project namespace.
+          </p>
+        ) : (
+          <DependencyForm
+            mode="create"
+            namespace={namespace}
+            canWrite={canWrite}
+            submitLabel="Create"
+            pendingLabel="Creating..."
+            isPending={createMutation.isPending}
+            onSubmit={async (values) => {
+              await createMutation.mutateAsync(values)
+              await navigate({
+                to: '/organizations/$orgName/template-dependencies/$dependencyName',
+                params: { orgName, dependencyName: values.name },
+              })
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-dependencies',
+                params: { orgName },
+              })
+            }}
+          />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
@@ -74,6 +74,15 @@ vi.mock('@/queries/templateDependencies', async () => {
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
+vi.mock('@/lib/org-context', () => ({
+  useOrg: vi.fn().mockReturnValue({
+    selectedOrg: 'test-org',
+    organizations: [],
+    setSelectedOrg: vi.fn(),
+    isLoading: false,
+  }),
+}))
+
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `DependencyForm` shared component under `frontend/src/components/template-dependencies/` for create and edit modes, mirroring `PolicyForm`
- Adds `organizations/$orgName/template-dependencies/new.tsx` — create page with `ScopePicker` to pick project namespace
- Adds `organizations/$orgName/template-dependencies/$dependencyName.tsx` — combined detail/edit page with `canDelete`-gated delete button using `ConfirmDeleteDialog`
- Adds `organizations/$orgName/template-dependencies/index.tsx` — org-scoped grid index backed by selected project namespace
- Updates `projects/$projectName/templates/dependencies/index.tsx` to set `detailHref` on each row (was `undefined`), linking to the org-scoped detail page via `?namespace=` search param
- Co-located Vitest tests (29 new tests) cover all ACs from the issue

Fixes HOL-1020

## Test plan

- [x] `make test-ui` passes (1362 tests, all green)
- [x] `DependencyForm` renders in create and edit modes with correct field values
- [x] Delete button visible for OWNER, hidden for VIEWER and EDITOR
- [x] Delete dialog invokes the delete mutation on confirm
- [x] detailHref set on project-scoped index rows
- [x] ScopePicker renders on the new page