### PR TITLE
feat(template-requirements): new/edit/detail pages with delete

### DIFF
--- a/frontend/src/components/template-requirements/RequirementForm.test.tsx
+++ b/frontend/src/components/template-requirements/RequirementForm.test.tsx
@@ -1,0 +1,121 @@
+// HOL-1021: Unit tests for the shared RequirementForm component.
+//
+// Tests cover:
+// 1. Renders correctly in create mode.
+// 2. Renders correctly in edit mode with prefilled values.
+// 3. Validates required fields before submit.
+// 4. Calls onSubmit with correct values.
+// 5. Calls onCancel when Cancel is clicked.
+// 6. Disables controls when canWrite is false.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { RequirementForm } from './RequirementForm'
+
+describe('RequirementForm', () => {
+  const defaultProps = {
+    mode: 'create' as const,
+    namespace: 'holos-org-test-org',
+    canWrite: true,
+    submitLabel: 'Create',
+    pendingLabel: 'Creating...',
+    onSubmit: vi.fn().mockResolvedValue(undefined),
+    onCancel: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders in create mode with empty fields', () => {
+    render(<RequirementForm {...defaultProps} />)
+    expect(screen.getByLabelText('Requirement name')).toHaveValue('')
+    expect(screen.getByLabelText('Requires name')).toHaveValue('')
+    expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument()
+  })
+
+  it('renders in edit mode with prefilled values and locked name', () => {
+    const initialValues = {
+      name: 'my-req',
+      requiresNamespace: 'holos-org-my-org',
+      requiresName: 'base-template',
+      cascadeDelete: true,
+    }
+    render(
+      <RequirementForm
+        {...defaultProps}
+        mode="edit"
+        initialValues={initialValues}
+        lockName
+        submitLabel="Save"
+        pendingLabel="Saving..."
+      />,
+    )
+    expect(screen.getByLabelText('Requirement name')).toHaveValue('my-req')
+    expect(screen.getByLabelText('Requirement name')).toBeDisabled()
+    expect(screen.getByLabelText('Requires name')).toHaveValue('base-template')
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument()
+  })
+
+  it('shows an error when name is empty on submit', async () => {
+    render(<RequirementForm {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('requirement-form-error')).toHaveTextContent(
+        /requirement name is required/i,
+      )
+    })
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('shows an error when requires fields are empty on submit', async () => {
+    render(<RequirementForm {...defaultProps} />)
+    fireEvent.change(screen.getByLabelText('Requirement name'), {
+      target: { value: 'my-req' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('requirement-form-error')).toHaveTextContent(
+        /requires namespace and name are required/i,
+      )
+    })
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('calls onSubmit with correct values when all fields are filled', async () => {
+    render(<RequirementForm {...defaultProps} />)
+    fireEvent.change(screen.getByLabelText('Requirement name'), {
+      target: { value: 'my-req' },
+    })
+    fireEvent.change(screen.getByLabelText('Requires namespace'), {
+      target: { value: 'holos-org-my-org' },
+    })
+    fireEvent.change(screen.getByLabelText('Requires name'), {
+      target: { value: 'base-template' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => {
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith({
+        name: 'my-req',
+        requires: expect.objectContaining({
+          namespace: 'holos-org-my-org',
+          name: 'base-template',
+        }),
+        cascadeDelete: true,
+      })
+    })
+  })
+
+  it('calls onCancel when Cancel is clicked', () => {
+    render(<RequirementForm {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables all controls when canWrite is false', () => {
+    render(<RequirementForm {...defaultProps} canWrite={false} />)
+    expect(screen.getByLabelText('Requirement name')).toBeDisabled()
+    expect(screen.getByLabelText('Requires name')).toBeDisabled()
+    expect(screen.getByRole('button', { name: /create/i })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/template-requirements/RequirementForm.tsx
+++ b/frontend/src/components/template-requirements/RequirementForm.tsx
@@ -39,7 +39,7 @@ export type RequirementFormProps = {
  * editable. In edit mode the name is locked.
  */
 export function RequirementForm({
-  mode,
+  mode: _mode,
   namespace: _namespace,
   canWrite,
   initialValues,

--- a/frontend/src/components/template-requirements/RequirementForm.tsx
+++ b/frontend/src/components/template-requirements/RequirementForm.tsx
@@ -1,0 +1,184 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Separator } from '@/components/ui/separator'
+import type { LinkedTemplateRef } from '@/queries/templateRequirements'
+
+/**
+ * RequirementFormValues are the shape of data emitted by RequirementForm on submit.
+ */
+export type RequirementFormValues = {
+  name: string
+  requires: LinkedTemplateRef
+  cascadeDelete: boolean
+}
+
+export type RequirementFormProps = {
+  mode: 'create' | 'edit'
+  namespace: string
+  canWrite: boolean
+  initialValues?: {
+    name: string
+    requiresNamespace: string
+    requiresName: string
+    cascadeDelete: boolean
+  }
+  submitLabel: string
+  pendingLabel: string
+  onSubmit: (values: RequirementFormValues) => Promise<void>
+  onCancel: () => void
+  isPending?: boolean
+  lockName?: boolean
+}
+
+/**
+ * RequirementForm renders the shared create/edit form for a TemplateRequirement.
+ * It handles both create and edit modes. In create mode the name field is
+ * editable. In edit mode the name is locked.
+ */
+export function RequirementForm({
+  mode,
+  namespace: _namespace,
+  canWrite,
+  initialValues,
+  submitLabel,
+  pendingLabel,
+  onSubmit,
+  onCancel,
+  isPending = false,
+  lockName = false,
+}: RequirementFormProps) {
+  const [name, setName] = useState(initialValues?.name ?? '')
+  const [requiresNamespace, setRequiresNamespace] = useState(
+    initialValues?.requiresNamespace ?? '',
+  )
+  const [requiresName, setRequiresName] = useState(initialValues?.requiresName ?? '')
+  const [cascadeDelete, setCascadeDelete] = useState(initialValues?.cascadeDelete ?? true)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    setError(null)
+
+    if (!name.trim()) {
+      setError('Requirement name is required.')
+      return
+    }
+    if (!requiresNamespace.trim() || !requiresName.trim()) {
+      setError('Requires namespace and name are required.')
+      return
+    }
+
+    try {
+      await onSubmit({
+        name: name.trim(),
+        requires: {
+          $typeName: 'holos.console.v1.LinkedTemplateRef',
+          namespace: requiresNamespace.trim(),
+          name: requiresName.trim(),
+          versionConstraint: '',
+        },
+        cascadeDelete,
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-border p-3 text-sm text-muted-foreground">
+        A TemplateRequirement records that project templates or deployment instances in this
+        organization require another template. Cross-namespace requires references are authorised
+        by TemplateGrant at reconcile time.
+      </div>
+
+      <div>
+        <Label htmlFor="requirement-name">Name (slug)</Label>
+        <Input
+          id="requirement-name"
+          aria-label="Requirement name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="my-requirement"
+          disabled={!canWrite || lockName || mode === 'edit'}
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          {lockName || mode === 'edit'
+            ? 'Requirement names are immutable after creation.'
+            : 'Lowercase alphanumeric and hyphens only.'}
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-2">
+        <Label>Requires</Label>
+        <p className="text-xs text-muted-foreground">
+          The template that matching targets must have applied.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Label htmlFor="requires-namespace" className="text-xs">
+              Namespace
+            </Label>
+            <Input
+              id="requires-namespace"
+              aria-label="Requires namespace"
+              value={requiresNamespace}
+              onChange={(e) => setRequiresNamespace(e.target.value)}
+              placeholder="holos-org-my-org"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <Label htmlFor="requires-name" className="text-xs">
+              Name
+            </Label>
+            <Input
+              id="requires-name"
+              aria-label="Requires name"
+              value={requiresName}
+              onChange={(e) => setRequiresName(e.target.value)}
+              placeholder="base-template"
+              disabled={!canWrite}
+            />
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="flex items-center gap-2">
+        <input
+          id="cascade-delete"
+          type="checkbox"
+          checked={cascadeDelete}
+          onChange={(e) => setCascadeDelete(e.target.checked)}
+          disabled={!canWrite}
+          aria-label="Cascade delete"
+          className="h-4 w-4"
+        />
+        <Label htmlFor="cascade-delete" className="font-normal">
+          Cascade delete — deleting the required template also removes matching targets
+        </Label>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" data-testid="requirement-form-error">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-center gap-3 pt-2">
+        <Button onClick={handleSubmit} disabled={isPending || !canWrite}>
+          {isPending ? pendingLabel : submitLabel}
+        </Button>
+        <Button variant="ghost" type="button" aria-label="Cancel" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/template-requirements/RequirementForm.tsx
+++ b/frontend/src/components/template-requirements/RequirementForm.tsx
@@ -102,10 +102,10 @@ export function RequirementForm({
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="my-requirement"
-          disabled={!canWrite || lockName || mode === 'edit'}
+          disabled={!canWrite || lockName}
         />
         <p className="text-xs text-muted-foreground mt-1">
-          {lockName || mode === 'edit'
+          {lockName
             ? 'Requirement names are immutable after creation.'
             : 'Lowercase alphanumeric and hyphens only.'}
         </p>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/$requirementName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/$requirementName.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import {
+  useGetTemplateRequirement,
+  useUpdateTemplateRequirement,
+  useDeleteTemplateRequirement,
+} from '@/queries/templateRequirements'
+import { useGetOrganization } from '@/queries/organizations'
+import { namespaceForOrg } from '@/lib/scope-labels'
+import { RequirementForm } from '@/components/template-requirements/RequirementForm'
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-requirements/$requirementName',
+)({
+  component: OrgTemplateRequirementDetailRoute,
+})
+
+function OrgTemplateRequirementDetailRoute() {
+  const { orgName, requirementName } = Route.useParams()
+  return (
+    <OrgTemplateRequirementDetailPage orgName={orgName} requirementName={requirementName} />
+  )
+}
+
+export function OrgTemplateRequirementDetailPage({
+  orgName: propOrgName,
+  requirementName: propRequirementName,
+  namespaceOverride,
+}: {
+  orgName?: string
+  requirementName?: string
+  namespaceOverride?: string
+} = {}) {
+  let routeParams: { orgName?: string; requirementName?: string } = {}
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeParams = Route.useParams()
+  } catch {
+    routeParams = {}
+  }
+  const orgName = propOrgName ?? routeParams.orgName ?? ''
+  const requirementName = propRequirementName ?? routeParams.requirementName ?? ''
+
+  const navigate = useNavigate()
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  // Delete is OWNER-only.
+  const canDelete = userRole === Role.OWNER
+
+  // Namespace resolution: explicit override (for tests) > org namespace.
+  const namespace = namespaceOverride ?? namespaceForOrg(orgName)
+
+  const {
+    data: requirement,
+    isPending,
+    error,
+  } = useGetTemplateRequirement(namespace, requirementName)
+
+  const updateMutation = useUpdateTemplateRequirement(namespace, requirementName)
+  const deleteMutation = useDeleteTemplateRequirement(namespace)
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleteError, setDeleteError] = useState<Error | null>(null)
+
+  const initialValues = useMemo(() => {
+    if (!requirement) return undefined
+    return {
+      name: requirement.name,
+      requiresNamespace: requirement.requires?.namespace ?? '',
+      requiresName: requirement.requires?.name ?? '',
+      cascadeDelete: requirement.cascadeDelete ?? true,
+    }
+  }, [requirement])
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                to="/organizations/$orgName/settings"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                {orgName}
+              </Link>
+              {' / '}
+              <Link
+                to="/organizations/$orgName/template-requirements"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                Template Requirements
+              </Link>
+              {' / '}
+              <span>{requirementName}</span>
+            </p>
+            <CardTitle className="mt-1">{requirementName}</CardTitle>
+          </div>
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+              aria-label="Delete requirement"
+            >
+              Delete Requirement
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <Separator className="mb-4" />
+          <RequirementForm
+            mode="edit"
+            namespace={namespace}
+            canWrite={canWrite}
+            initialValues={initialValues}
+            lockName
+            submitLabel="Save"
+            pendingLabel="Saving..."
+            isPending={updateMutation.isPending}
+            onSubmit={async (values) => {
+              await updateMutation.mutateAsync({
+                requires: values.requires,
+                cascadeDelete: values.cascadeDelete,
+              })
+              toast.success('Requirement saved')
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-requirements',
+                params: { orgName },
+              })
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleteError(null)
+        }}
+        name={requirementName}
+        namespace={namespace}
+        isDeleting={deleteMutation.isPending}
+        error={deleteError}
+        onConfirm={async () => {
+          setDeleteError(null)
+          try {
+            await deleteMutation.mutateAsync({ name: requirementName })
+            setDeleteOpen(false)
+            await navigate({
+              to: '/organizations/$orgName/template-requirements',
+              params: { orgName },
+            })
+            toast.success('Requirement deleted')
+          } catch (err) {
+            setDeleteError(err instanceof Error ? err : new Error(String(err)))
+          }
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-detail.test.tsx
@@ -1,0 +1,218 @@
+// HOL-1021: Tests for the org-scoped template-requirement detail/edit page.
+//
+// Tests cover:
+// 1. Shows Delete button for OWNER.
+// 2. Hides Delete button for VIEWER.
+// 3. Hides Delete button for EDITOR.
+// 4. Delete dialog invokes the delete mutation on confirm.
+// 5. Renders with prefilled values in edit mode.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org', requirementName: 'req-a' }),
+      useSearch: () => ({}),
+    }),
+    useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      to,
+      params,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+vi.mock('@/queries/templateRequirements', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateRequirements')>(
+    '@/queries/templateRequirements',
+  )
+  return {
+    ...actual,
+    useGetTemplateRequirement: vi.fn(),
+    useUpdateTemplateRequirement: vi.fn(),
+    useDeleteTemplateRequirement: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+import {
+  useGetTemplateRequirement,
+  useUpdateTemplateRequirement,
+  useDeleteTemplateRequirement,
+} from '@/queries/templateRequirements'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { OrgTemplateRequirementDetailPage } from './$requirementName'
+
+function makeMockRequirement() {
+  return {
+    name: 'req-a',
+    namespace: 'holos-org-test-org',
+    requires: {
+      $typeName: 'holos.console.v1.LinkedTemplateRef' as const,
+      namespace: 'holos-org-my-org',
+      name: 'base-template',
+      versionConstraint: '',
+    },
+    targetRefs: [],
+    cascadeDelete: true,
+    creatorEmail: 'test@example.com',
+    createdAt: undefined,
+    status: undefined,
+  }
+}
+
+function setupMocks(
+  userRole: Role = Role.OWNER,
+  requirement: ReturnType<typeof makeMockRequirement> | undefined = makeMockRequirement(),
+) {
+  ;(useGetTemplateRequirement as Mock).mockReturnValue({
+    data: requirement,
+    isPending: false,
+    error: null,
+  })
+  ;(useUpdateTemplateRequirement as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useDeleteTemplateRequirement as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('OrgTemplateRequirementDetailPage (HOL-1021)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the Delete Requirement button for OWNER', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateRequirementDetailPage
+        orgName="test-org"
+        requirementName="req-a"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: /delete requirement/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Delete Requirement button for VIEWER', () => {
+    setupMocks(Role.VIEWER)
+    render(
+      <OrgTemplateRequirementDetailPage
+        orgName="test-org"
+        requirementName="req-a"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete requirement/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the Delete Requirement button for EDITOR (OWNER-only delete)', () => {
+    setupMocks(Role.EDITOR)
+    render(
+      <OrgTemplateRequirementDetailPage
+        orgName="test-org"
+        requirementName="req-a"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /delete requirement/i }),
+    ).not.toBeInTheDocument()
+    // But the form controls should still be enabled for editors.
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  })
+
+  it('renders with prefilled values from the requirement', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateRequirementDetailPage
+        orgName="test-org"
+        requirementName="req-a"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(screen.getByLabelText('Requirement name')).toHaveValue('req-a')
+    expect(screen.getByLabelText('Requires name')).toHaveValue('base-template')
+  })
+
+  it('opens the confirm delete dialog when Delete Requirement is clicked', async () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateRequirementDetailPage
+        orgName="test-org"
+        requirementName="req-a"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete requirement/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/delete resource/i)).toBeInTheDocument()
+    })
+  })
+
+  it('invokes the delete mutation on confirm', async () => {
+    const deleteMutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(Role.OWNER)
+    ;(useDeleteTemplateRequirement as Mock).mockReturnValue({
+      mutateAsync: deleteMutateAsync,
+      isPending: false,
+    })
+    render(
+      <OrgTemplateRequirementDetailPage
+        orgName="test-org"
+        requirementName="req-a"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete requirement/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/delete resource/i)).toBeInTheDocument()
+    })
+    const deleteButtons = screen.getAllByRole('button', { name: /^delete$/i })
+    fireEvent.click(deleteButtons[deleteButtons.length - 1])
+    await waitFor(() => {
+      expect(deleteMutateAsync).toHaveBeenCalledWith({ name: 'req-a' })
+    })
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-new.test.tsx
@@ -1,0 +1,139 @@
+// HOL-1021: Tests for the org-scoped template-requirement create page.
+
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org' }),
+      useSearch: () => ({}),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({
+      children,
+      className,
+      to,
+      params,
+    }: {
+      children: React.ReactNode
+      className?: string
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+vi.mock('@/queries/templateRequirements', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateRequirements')>(
+    '@/queries/templateRequirements',
+  )
+  return {
+    ...actual,
+    useCreateTemplateRequirement: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn(),
+}))
+
+vi.mock('@/components/scope-picker/ScopePicker', async () => {
+  return {
+    ScopePicker: ({
+      value,
+      onChange,
+    }: {
+      value: string
+      onChange: (v: string) => void
+    }) => (
+      <button data-testid="scope-picker-trigger" onClick={() => onChange('organization')}>
+        {value}
+      </button>
+    ),
+  }
+})
+
+import { useCreateTemplateRequirement } from '@/queries/templateRequirements'
+import { useGetOrganization } from '@/queries/organizations'
+import { useProject } from '@/lib/project-context'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateOrgTemplateRequirementPage } from './new'
+
+function setupMocks(
+  mutateAsync = vi.fn().mockResolvedValue({}),
+  userRole: Role = Role.OWNER,
+) {
+  ;(useCreateTemplateRequirement as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    selectedProject: null,
+    setSelectedProject: vi.fn(),
+    projects: [],
+    isLoading: false,
+  })
+}
+
+describe('CreateOrgTemplateRequirementPage (HOL-1021)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page heading', () => {
+    render(<CreateOrgTemplateRequirementPage orgName="test-org" />)
+    expect(screen.getByText(/create template requirement/i)).toBeInTheDocument()
+  })
+
+  it('renders the ScopePicker', () => {
+    render(<CreateOrgTemplateRequirementPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toBeInTheDocument()
+  })
+
+  it('renders the RequirementForm', () => {
+    render(<CreateOrgTemplateRequirementPage orgName="test-org" />)
+    expect(screen.getByLabelText(/^requirement name$/i)).toBeInTheDocument()
+  })
+
+  it('disables form controls for VIEWER', () => {
+    setupMocks(vi.fn(), Role.VIEWER)
+    render(<CreateOrgTemplateRequirementPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+
+  it('enables form controls for OWNER', () => {
+    setupMocks(vi.fn(), Role.OWNER)
+    render(<CreateOrgTemplateRequirementPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).not.toBeDisabled()
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/index.tsx
@@ -1,17 +1,13 @@
 /**
- * Project-scoped Templates / Requirements index (HOL-1013).
+ * Organization-scoped TemplateRequirement index (HOL-1021).
  *
- * TemplateRequirements are org/folder-scoped, not project-scoped. The namespace
- * is derived from the selected organization via useOrg().selectedOrg. The
- * project name still appears in the URL so the Templates collapsible group
- * can stay open in a later sidebar phase (HOL-1014).
- *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
+ * TemplateRequirement objects live in organization or folder namespaces. This
+ * org-scoped index shows requirements in the current org namespace.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -20,52 +16,60 @@ import {
   useListTemplateRequirements,
   useDeleteTemplateRequirement,
 } from '@/queries/templateRequirements'
-import { useOrg } from '@/lib/org-context'
+import { useGetOrganization } from '@/queries/organizations'
 import { namespaceForOrg } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-requirements/',
+)({
+  validateSearch: parseGridSearch,
+  component: OrgTemplateRequirementsIndexRoute,
+})
+
+function OrgTemplateRequirementsIndexRoute() {
+  const { orgName } = Route.useParams()
+  return <OrgTemplateRequirementsIndexPage orgName={orgName} />
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
 function timestampToISOString(ts: { seconds: bigint } | undefined): string {
   if (!ts) return ''
   return new Date(Number(ts.seconds) * 1000).toISOString()
 }
 
 // ---------------------------------------------------------------------------
-// Route definition
-// ---------------------------------------------------------------------------
-
-export const Route = createFileRoute(
-  '/_authenticated/projects/$projectName/templates/requirements/',
-)({
-  validateSearch: parseGridSearch,
-  component: TemplateRequirementsIndexRoute,
-})
-
-function TemplateRequirementsIndexRoute() {
-  const { projectName } = Route.useParams()
-  return <TemplateRequirementsIndexPage projectName={projectName} />
-}
-
-// ---------------------------------------------------------------------------
 // Page component (exported for tests)
 // ---------------------------------------------------------------------------
 
-export function TemplateRequirementsIndexPage({
-  projectName,
-}: {
-  projectName: string
-}) {
-  const search = Route.useSearch() as ResourceGridSearch
+export function OrgTemplateRequirementsIndexPage({
+  orgName: propOrgName,
+}: { orgName?: string } = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  // TemplateRequirements are org/folder-scoped — namespace comes from the
-  // selected org, not the project. The project param keeps Templates sidebar
-  // active in a later phase.
-  const { selectedOrg } = useOrg()
-  const namespace = namespaceForOrg(selectedOrg ?? '')
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // TemplateRequirements are org-scoped.
+  const namespace = namespaceForOrg(orgName)
 
   const {
     data: requirements = [],
@@ -84,18 +88,16 @@ export function TemplateRequirementsIndexPage({
       requirements.map((r) => ({
         kind: 'TemplateRequirement',
         name: r.name,
-        namespace,
+        namespace: namespace,
         id: r.name,
-        parentId: selectedOrg ?? '',
-        parentLabel: selectedOrg ?? '',
+        parentId: orgName,
+        parentLabel: orgName,
         displayName: r.name,
         description: r.requires?.name ?? '',
         createdAt: timestampToISOString(r.createdAt),
-        detailHref: namespace
-          ? `/organizations/${selectedOrg}/template-requirements/${r.name}`
-          : undefined,
+        detailHref: `/organizations/${orgName}/template-requirements/${r.name}`,
       })),
-    [requirements, namespace, selectedOrg],
+    [requirements, namespace, orgName],
   )
 
   // ---------------------------------------------------------------------------
@@ -106,12 +108,12 @@ export function TemplateRequirementsIndexPage({
     () => [
       {
         id: 'TemplateRequirement',
-        label: 'TemplateRequirement',
-        // No create in this view — requirements are created from org-level pages.
-        canCreate: false,
+        label: 'Template Requirement',
+        newHref: `/organizations/${orgName}/template-requirements/new`,
+        canCreate: canWrite,
       },
     ],
-    [],
+    [orgName, canWrite],
   )
 
   // ---------------------------------------------------------------------------
@@ -129,6 +131,7 @@ export function TemplateRequirementsIndexPage({
     (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
       navigate({
         search: (prev) => updater(prev as ResourceGridSearch),
+        replace: true,
       })
     },
     [navigate],
@@ -136,7 +139,7 @@ export function TemplateRequirementsIndexPage({
 
   return (
     <ResourceGrid
-      title={`${projectName} / Templates / Requirements`}
+      title={`${orgName} / Template Requirements`}
       kinds={kinds}
       rows={rows}
       onDelete={handleDelete}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/new.tsx
@@ -1,0 +1,105 @@
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplateRequirement } from '@/queries/templateRequirements'
+import { namespaceForOrg } from '@/lib/scope-labels'
+import { useGetOrganization } from '@/queries/organizations'
+import { ScopePicker } from '@/components/scope-picker/ScopePicker'
+import type { Scope } from '@/components/scope-picker/ScopePicker'
+import { RequirementForm } from '@/components/template-requirements/RequirementForm'
+import { useState } from 'react'
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-requirements/new',
+)({
+  component: CreateOrgTemplateRequirementRoute,
+})
+
+function CreateOrgTemplateRequirementRoute() {
+  const { orgName } = Route.useParams()
+  return <CreateOrgTemplateRequirementPage orgName={orgName} />
+}
+
+export function CreateOrgTemplateRequirementPage({
+  orgName: propOrgName,
+}: {
+  orgName?: string
+} = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const navigate = useNavigate()
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // ScopePicker controls org vs folder scope. Defaults to 'organization'.
+  const [scope, setScope] = useState<Scope>('organization')
+
+  // TemplateRequirements are org/folder-scoped.
+  const namespace = scope === 'organization' ? namespaceForOrg(orgName) : ''
+
+  const createMutation = useCreateTemplateRequirement(namespace)
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/organizations/$orgName/settings"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              {orgName}
+            </Link>
+            {' / '}
+            <Link
+              to="/organizations/$orgName/template-requirements"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              Template Requirements
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">Create Template Requirement</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Scope:</span>
+          <ScopePicker value={scope} onChange={setScope} disabled={!canWrite} />
+        </div>
+        <RequirementForm
+          mode="create"
+          namespace={namespace}
+          canWrite={canWrite}
+          submitLabel="Create"
+          pendingLabel="Creating..."
+          isPending={createMutation.isPending}
+          onSubmit={async (values) => {
+            await createMutation.mutateAsync(values)
+            await navigate({
+              to: '/organizations/$orgName/template-requirements/$requirementName',
+              params: { orgName, requirementName: values.name },
+            })
+          }}
+          onCancel={() => {
+            void navigate({
+              to: '/organizations/$orgName/template-requirements',
+              params: { orgName },
+            })
+          }}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/new.tsx
@@ -78,27 +78,33 @@ export function CreateOrgTemplateRequirementPage({
           <span className="text-sm text-muted-foreground">Scope:</span>
           <ScopePicker value={scope} onChange={setScope} disabled={!canWrite} />
         </div>
-        <RequirementForm
-          mode="create"
-          namespace={namespace}
-          canWrite={canWrite}
-          submitLabel="Create"
-          pendingLabel="Creating..."
-          isPending={createMutation.isPending}
-          onSubmit={async (values) => {
-            await createMutation.mutateAsync(values)
-            await navigate({
-              to: '/organizations/$orgName/template-requirements/$requirementName',
-              params: { orgName, requirementName: values.name },
-            })
-          }}
-          onCancel={() => {
-            void navigate({
-              to: '/organizations/$orgName/template-requirements',
-              params: { orgName },
-            })
-          }}
-        />
+        {scope === 'project' ? (
+          <p className="text-sm text-muted-foreground">
+            TemplateRequirements are organization-scoped. Select Organization scope to create one.
+          </p>
+        ) : (
+          <RequirementForm
+            mode="create"
+            namespace={namespace}
+            canWrite={canWrite}
+            submitLabel="Create"
+            pendingLabel="Creating..."
+            isPending={createMutation.isPending}
+            onSubmit={async (values) => {
+              await createMutation.mutateAsync(values)
+              await navigate({
+                to: '/organizations/$orgName/template-requirements/$requirementName',
+                params: { orgName, requirementName: values.name },
+              })
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-requirements',
+                params: { orgName },
+              })
+            }}
+          />
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
@@ -91,9 +91,10 @@ export function TemplateRequirementsIndexPage({
         displayName: r.name,
         description: r.requires?.name ?? '',
         createdAt: timestampToISOString(r.createdAt),
-        detailHref: namespace
-          ? `/organizations/${selectedOrg}/template-requirements/${r.name}`
-          : undefined,
+        detailHref:
+          namespace && selectedOrg
+            ? `/organizations/${selectedOrg}/template-requirements/${r.name}`
+            : undefined,
       })),
     [requirements, namespace, selectedOrg],
   )


### PR DESCRIPTION
## Summary

- Adds org-scoped `index.tsx`, `new.tsx`, and `$requirementName.tsx` routes for `TemplateRequirement` under `organizations/$orgName/template-requirements/`
- `RequirementForm` component handles both create and edit modes with `requires` ref and cascade-delete toggle
- `new.tsx` uses `ScopePicker` (defaults to organization scope)
- `$requirementName.tsx` is the combined detail/edit page with an OWNER-only delete button backed by `ConfirmDeleteDialog`
- Project-scoped requirements index now sets `detailHref` on every row pointing to the org-scoped detail page
- Co-located Vitest tests for `RequirementForm`, create page, and detail page (1380 total, all passing)

Fixes HOL-1021

## Test plan

- [x] `make test-ui` passes (104 test files, 1380 tests)
- [ ] Navigate to `/organizations/<org>/template-requirements` — index loads
- [ ] Click "New" — form renders with ScopePicker, submission creates and redirects to detail
- [ ] Edit fields on detail page, Save — updates persisted
- [ ] OWNER sees Delete Requirement button; VIEWER/EDITOR do not
- [ ] Delete dialog confirmation triggers delete mutation and redirects to index
- [ ] Project-scoped requirements index rows link to org-scoped detail page