### PR TITLE
feat(template-grants): new/edit/detail pages with delete

### DIFF
--- a/frontend/src/components/template-grants/GrantForm.test.tsx
+++ b/frontend/src/components/template-grants/GrantForm.test.tsx
@@ -1,0 +1,159 @@
+// HOL-1022: Tests for the GrantForm component.
+//
+// Covers:
+// 1. Create-mode render — name, from, to fields present.
+// 2. Edit-mode prefill — initial values populate the fields.
+// 3. Validation — missing name shows error.
+// 4. Validation — missing from namespace shows error.
+// 5. Submits with correct values.
+// 6. OWNER can submit; VIEWER cannot.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+import { GrantForm } from './GrantForm'
+
+describe('GrantForm (HOL-1022)', () => {
+  const baseProps = {
+    mode: 'create' as const,
+    namespace: 'holos-org-test-org',
+    canWrite: true,
+    submitLabel: 'Create',
+    pendingLabel: 'Creating...',
+    onSubmit: vi.fn().mockResolvedValue(undefined),
+    onCancel: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders in create mode with all fields', () => {
+    render(<GrantForm {...baseProps} />)
+    expect(screen.getByLabelText('Grant name')).toBeInTheDocument()
+    expect(screen.getByLabelText('From namespace')).toBeInTheDocument()
+    expect(screen.getByLabelText('To namespace')).toBeInTheDocument()
+    expect(screen.getByLabelText('To name')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeInTheDocument()
+  })
+
+  it('prefills fields in edit mode', () => {
+    render(
+      <GrantForm
+        {...baseProps}
+        mode="edit"
+        lockName
+        initialValues={{
+          name: 'allow-project-foo',
+          fromNamespace: 'holos-project-foo',
+          toNamespace: 'holos-org-test-org',
+          toName: 'base-template',
+        }}
+        submitLabel="Save"
+        pendingLabel="Saving..."
+      />,
+    )
+    expect(screen.getByLabelText('Grant name')).toHaveValue('allow-project-foo')
+    expect(screen.getByLabelText('From namespace')).toHaveValue('holos-project-foo')
+    expect(screen.getByLabelText('To namespace')).toHaveValue('holos-org-test-org')
+    expect(screen.getByLabelText('To name')).toHaveValue('base-template')
+  })
+
+  it('shows an error when name is empty on submit', async () => {
+    render(<GrantForm {...baseProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('grant-form-error')).toHaveTextContent(
+        'Grant name is required.',
+      )
+    })
+    expect(baseProps.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('shows an error when from namespace is empty on submit', async () => {
+    render(<GrantForm {...baseProps} />)
+    fireEvent.change(screen.getByLabelText('Grant name'), {
+      target: { value: 'allow-project-foo' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('grant-form-error')).toHaveTextContent(
+        'From namespace is required.',
+      )
+    })
+    expect(baseProps.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits with correct from/to values', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<GrantForm {...baseProps} onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByLabelText('Grant name'), {
+      target: { value: 'allow-project-foo' },
+    })
+    fireEvent.change(screen.getByLabelText('From namespace'), {
+      target: { value: 'holos-project-foo' },
+    })
+    fireEvent.change(screen.getByLabelText('To namespace'), {
+      target: { value: 'holos-org-test-org' },
+    })
+    fireEvent.change(screen.getByLabelText('To name'), {
+      target: { value: 'base-template' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: 'allow-project-foo',
+        from: [
+          {
+            $typeName: 'holos.console.v1.TemplateGrantFromRef',
+            namespace: 'holos-project-foo',
+          },
+        ],
+        to: [
+          {
+            $typeName: 'holos.console.v1.TemplateGrantToRef',
+            namespace: 'holos-org-test-org',
+            name: 'base-template',
+          },
+        ],
+      })
+    })
+  })
+
+  it('submits with empty to array when to fields are blank', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<GrantForm {...baseProps} onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByLabelText('Grant name'), {
+      target: { value: 'allow-all' },
+    })
+    fireEvent.change(screen.getByLabelText('From namespace'), {
+      target: { value: '*' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [],
+        }),
+      )
+    })
+  })
+
+  it('disables submit button when canWrite is false', () => {
+    render(<GrantForm {...baseProps} canWrite={false} />)
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+
+  it('calls onCancel when Cancel is clicked', () => {
+    const onCancel = vi.fn()
+    render(<GrantForm {...baseProps} onCancel={onCancel} />)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/template-grants/GrantForm.tsx
+++ b/frontend/src/components/template-grants/GrantForm.tsx
@@ -1,0 +1,204 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Separator } from '@/components/ui/separator'
+import type { TemplateGrantFromRef, TemplateGrantToRef } from '@/queries/templateGrants'
+
+/**
+ * GrantFormValues are the shape of data emitted by GrantForm on submit.
+ */
+export type GrantFormValues = {
+  name: string
+  from: TemplateGrantFromRef[]
+  to: TemplateGrantToRef[]
+}
+
+export type GrantFormProps = {
+  mode: 'create' | 'edit'
+  namespace: string
+  canWrite: boolean
+  initialValues?: {
+    name: string
+    fromNamespace: string
+    toNamespace: string
+    toName: string
+  }
+  submitLabel: string
+  pendingLabel: string
+  onSubmit: (values: GrantFormValues) => Promise<void>
+  onCancel: () => void
+  isPending?: boolean
+  lockName?: boolean
+}
+
+/**
+ * GrantForm renders the shared create/edit form for a TemplateGrant.
+ * It handles both create and edit modes. In create mode the name field is
+ * editable. In edit mode the name is locked.
+ *
+ * A TemplateGrant authorizes cross-namespace template references by specifying
+ * which namespaces (from) are permitted to reference templates in the grant's
+ * namespace, optionally narrowed to specific templates (to).
+ */
+export function GrantForm({
+  mode: _mode,
+  namespace: _namespace,
+  canWrite,
+  initialValues,
+  submitLabel,
+  pendingLabel,
+  onSubmit,
+  onCancel,
+  isPending = false,
+  lockName = false,
+}: GrantFormProps) {
+  const [name, setName] = useState(initialValues?.name ?? '')
+  const [fromNamespace, setFromNamespace] = useState(initialValues?.fromNamespace ?? '')
+  const [toNamespace, setToNamespace] = useState(initialValues?.toNamespace ?? '')
+  const [toName, setToName] = useState(initialValues?.toName ?? '')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    setError(null)
+
+    if (!name.trim()) {
+      setError('Grant name is required.')
+      return
+    }
+    if (!fromNamespace.trim()) {
+      setError('From namespace is required.')
+      return
+    }
+
+    const fromRef: TemplateGrantFromRef = {
+      $typeName: 'holos.console.v1.TemplateGrantFromRef',
+      namespace: fromNamespace.trim(),
+    }
+
+    const toRefs: TemplateGrantToRef[] =
+      toNamespace.trim() && toName.trim()
+        ? [
+            {
+              $typeName: 'holos.console.v1.TemplateGrantToRef',
+              namespace: toNamespace.trim(),
+              name: toName.trim(),
+            },
+          ]
+        : []
+
+    try {
+      await onSubmit({
+        name: name.trim(),
+        from: [fromRef],
+        to: toRefs,
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-border p-3 text-sm text-muted-foreground">
+        A TemplateGrant authorizes cross-namespace template references. It lives in the namespace
+        that owns the templates being shared and permits specified namespaces to reference them,
+        mirroring the Gateway API ReferenceGrant pattern.
+      </div>
+
+      <div>
+        <Label htmlFor="grant-name">Name (slug)</Label>
+        <Input
+          id="grant-name"
+          aria-label="Grant name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="allow-project-foo"
+          disabled={!canWrite || lockName}
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          {lockName
+            ? 'Grant names are immutable after creation.'
+            : 'Lowercase alphanumeric and hyphens only.'}
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-2">
+        <Label>From</Label>
+        <p className="text-xs text-muted-foreground">
+          The namespace permitted to reference templates in this grant&apos;s namespace. Use{' '}
+          <code className="font-mono">*</code> to permit all namespaces.
+        </p>
+        <div>
+          <Label htmlFor="from-namespace" className="text-xs">
+            Namespace
+          </Label>
+          <Input
+            id="from-namespace"
+            aria-label="From namespace"
+            value={fromNamespace}
+            onChange={(e) => setFromNamespace(e.target.value)}
+            placeholder="holos-project-my-project"
+            disabled={!canWrite}
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-2">
+        <Label>To (optional)</Label>
+        <p className="text-xs text-muted-foreground">
+          Optionally narrow which template may be referenced. Leave both fields empty to permit all
+          templates in this namespace.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Label htmlFor="to-namespace" className="text-xs">
+              Namespace
+            </Label>
+            <Input
+              id="to-namespace"
+              aria-label="To namespace"
+              value={toNamespace}
+              onChange={(e) => setToNamespace(e.target.value)}
+              placeholder="holos-org-my-org"
+              disabled={!canWrite}
+            />
+          </div>
+          <div>
+            <Label htmlFor="to-name" className="text-xs">
+              Name
+            </Label>
+            <Input
+              id="to-name"
+              aria-label="To name"
+              value={toName}
+              onChange={(e) => setToName(e.target.value)}
+              placeholder="base-template"
+              disabled={!canWrite}
+            />
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" data-testid="grant-form-error">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-center gap-3 pt-2">
+        <Button onClick={handleSubmit} disabled={isPending || !canWrite}>
+          {isPending ? pendingLabel : submitLabel}
+        </Button>
+        <Button variant="ghost" type="button" aria-label="Cancel" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/$grantName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/$grantName.tsx
@@ -1,0 +1,199 @@
+import { useMemo, useState } from 'react'
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Separator } from '@/components/ui/separator'
+import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import {
+  useGetTemplateGrant,
+  useUpdateTemplateGrant,
+  useDeleteTemplateGrant,
+} from '@/queries/templateGrants'
+import { useGetOrganization } from '@/queries/organizations'
+import { namespaceForOrg } from '@/lib/scope-labels'
+import { GrantForm } from '@/components/template-grants/GrantForm'
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-grants/$grantName',
+)({
+  component: OrgTemplateGrantDetailRoute,
+})
+
+function OrgTemplateGrantDetailRoute() {
+  const { orgName, grantName } = Route.useParams()
+  return <OrgTemplateGrantDetailPage orgName={orgName} grantName={grantName} />
+}
+
+export function OrgTemplateGrantDetailPage({
+  orgName: propOrgName,
+  grantName: propGrantName,
+  namespaceOverride,
+}: {
+  orgName?: string
+  grantName?: string
+  namespaceOverride?: string
+} = {}) {
+  let routeParams: { orgName?: string; grantName?: string } = {}
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeParams = Route.useParams()
+  } catch {
+    routeParams = {}
+  }
+  const orgName = propOrgName ?? routeParams.orgName ?? ''
+  const grantName = propGrantName ?? routeParams.grantName ?? ''
+
+  const navigate = useNavigate()
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  // Delete is OWNER-only.
+  const canDelete = userRole === Role.OWNER
+
+  // Namespace resolution: explicit override (for tests) > org namespace.
+  const namespace = namespaceOverride ?? namespaceForOrg(orgName)
+
+  const {
+    data: grant,
+    isPending,
+    error,
+  } = useGetTemplateGrant(namespace, grantName)
+
+  const updateMutation = useUpdateTemplateGrant(namespace, grantName)
+  const deleteMutation = useDeleteTemplateGrant(namespace)
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleteError, setDeleteError] = useState<Error | null>(null)
+
+  const initialValues = useMemo(() => {
+    if (!grant) return undefined
+    return {
+      name: grant.name,
+      fromNamespace: grant.from[0]?.namespace ?? '',
+      toNamespace: grant.to[0]?.namespace ?? '',
+      toName: grant.to[0]?.name ?? '',
+    }
+  }, [grant])
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Alert variant="destructive">
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              <Link
+                to="/organizations/$orgName/settings"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                {orgName}
+              </Link>
+              {' / '}
+              <Link
+                to="/organizations/$orgName/template-grants"
+                params={{ orgName }}
+                className="hover:underline"
+              >
+                Template Grants
+              </Link>
+              {' / '}
+              <span>{grantName}</span>
+            </p>
+            <CardTitle className="mt-1">{grantName}</CardTitle>
+          </div>
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+              aria-label="Delete grant"
+            >
+              Delete Grant
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <Separator className="mb-4" />
+          <GrantForm
+            mode="edit"
+            namespace={namespace}
+            canWrite={canWrite}
+            initialValues={initialValues}
+            lockName
+            submitLabel="Save"
+            pendingLabel="Saving..."
+            isPending={updateMutation.isPending}
+            onSubmit={async (values) => {
+              await updateMutation.mutateAsync({
+                from: values.from,
+                to: values.to,
+              })
+              toast.success('Grant saved')
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-grants',
+                params: { orgName },
+              })
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) setDeleteError(null)
+        }}
+        name={grantName}
+        namespace={namespace}
+        isDeleting={deleteMutation.isPending}
+        error={deleteError}
+        onConfirm={async () => {
+          setDeleteError(null)
+          try {
+            await deleteMutation.mutateAsync({ name: grantName })
+            setDeleteOpen(false)
+            await navigate({
+              to: '/organizations/$orgName/template-grants',
+              params: { orgName },
+            })
+            toast.success('Grant deleted')
+          } catch (err) {
+            setDeleteError(err instanceof Error ? err : new Error(String(err)))
+          }
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-detail.test.tsx
@@ -1,0 +1,220 @@
+// HOL-1022: Tests for the org-scoped template-grant detail/edit page.
+//
+// Tests cover:
+// 1. Shows Delete button for OWNER.
+// 2. Hides Delete button for VIEWER.
+// 3. Hides Delete button for EDITOR (OWNER-only delete).
+// 4. Delete dialog invokes the delete mutation on confirm.
+// 5. Renders with prefilled values in edit mode.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org', grantName: 'allow-project-foo' }),
+      useSearch: () => ({}),
+    }),
+    useNavigate: () => vi.fn(),
+    Link: ({
+      children,
+      to,
+      params,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: React.ReactNode
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+vi.mock('@/queries/templateGrants', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateGrants')>(
+    '@/queries/templateGrants',
+  )
+  return {
+    ...actual,
+    useGetTemplateGrant: vi.fn(),
+    useUpdateTemplateGrant: vi.fn(),
+    useDeleteTemplateGrant: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+import {
+  useGetTemplateGrant,
+  useUpdateTemplateGrant,
+  useDeleteTemplateGrant,
+} from '@/queries/templateGrants'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { OrgTemplateGrantDetailPage } from './$grantName'
+
+function makeMockGrant() {
+  return {
+    name: 'allow-project-foo',
+    namespace: 'holos-org-test-org',
+    from: [
+      {
+        $typeName: 'holos.console.v1.TemplateGrantFromRef' as const,
+        namespace: 'holos-project-foo',
+      },
+    ],
+    to: [
+      {
+        $typeName: 'holos.console.v1.TemplateGrantToRef' as const,
+        namespace: 'holos-org-test-org',
+        name: 'base-template',
+      },
+    ],
+    creatorEmail: 'test@example.com',
+    createdAt: undefined,
+    status: undefined,
+  }
+}
+
+function setupMocks(
+  userRole: Role = Role.OWNER,
+  grant: ReturnType<typeof makeMockGrant> | undefined = makeMockGrant(),
+) {
+  ;(useGetTemplateGrant as Mock).mockReturnValue({
+    data: grant,
+    isPending: false,
+    error: null,
+  })
+  ;(useUpdateTemplateGrant as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useDeleteTemplateGrant as Mock).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('OrgTemplateGrantDetailPage (HOL-1022)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the Delete Grant button for OWNER', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateGrantDetailPage
+        orgName="test-org"
+        grantName="allow-project-foo"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(screen.getByRole('button', { name: /delete grant/i })).toBeInTheDocument()
+  })
+
+  it('hides the Delete Grant button for VIEWER', () => {
+    setupMocks(Role.VIEWER)
+    render(
+      <OrgTemplateGrantDetailPage
+        orgName="test-org"
+        grantName="allow-project-foo"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /delete grant/i })).not.toBeInTheDocument()
+  })
+
+  it('hides the Delete Grant button for EDITOR (OWNER-only delete)', () => {
+    setupMocks(Role.EDITOR)
+    render(
+      <OrgTemplateGrantDetailPage
+        orgName="test-org"
+        grantName="allow-project-foo"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /delete grant/i })).not.toBeInTheDocument()
+    // But form controls should still be enabled for editors.
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  })
+
+  it('renders with prefilled values from the grant', () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateGrantDetailPage
+        orgName="test-org"
+        grantName="allow-project-foo"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    expect(screen.getByLabelText('Grant name')).toHaveValue('allow-project-foo')
+    expect(screen.getByLabelText('From namespace')).toHaveValue('holos-project-foo')
+    expect(screen.getByLabelText('To namespace')).toHaveValue('holos-org-test-org')
+    expect(screen.getByLabelText('To name')).toHaveValue('base-template')
+  })
+
+  it('opens the confirm delete dialog when Delete Grant is clicked', async () => {
+    setupMocks(Role.OWNER)
+    render(
+      <OrgTemplateGrantDetailPage
+        orgName="test-org"
+        grantName="allow-project-foo"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete grant/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/delete resource/i)).toBeInTheDocument()
+    })
+  })
+
+  it('invokes the delete mutation on confirm', async () => {
+    const deleteMutateAsync = vi.fn().mockResolvedValue({})
+    setupMocks(Role.OWNER)
+    ;(useDeleteTemplateGrant as Mock).mockReturnValue({
+      mutateAsync: deleteMutateAsync,
+      isPending: false,
+    })
+    render(
+      <OrgTemplateGrantDetailPage
+        orgName="test-org"
+        grantName="allow-project-foo"
+        namespaceOverride="holos-org-test-org"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /delete grant/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/delete resource/i)).toBeInTheDocument()
+    })
+    // Click the Delete button inside the dialog.
+    const deleteButtons = screen.getAllByRole('button', { name: /^delete$/i })
+    fireEvent.click(deleteButtons[deleteButtons.length - 1])
+    await waitFor(() => {
+      expect(deleteMutateAsync).toHaveBeenCalledWith({ name: 'allow-project-foo' })
+    })
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-new.test.tsx
@@ -1,0 +1,128 @@
+// HOL-1022: Tests for the org-scoped template-grant create page.
+
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org' }),
+      useSearch: () => ({}),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({
+      children,
+      className,
+      to,
+      params,
+    }: {
+      children: React.ReactNode
+      className?: string
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'org-',
+    folderPrefix: 'folder-',
+    projectPrefix: 'project-',
+  }),
+}))
+
+vi.mock('@/queries/templateGrants', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templateGrants')>(
+    '@/queries/templateGrants',
+  )
+  return {
+    ...actual,
+    useCreateTemplateGrant: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('@/components/scope-picker/ScopePicker', async () => {
+  return {
+    ScopePicker: ({
+      value,
+      onChange,
+    }: {
+      value: string
+      onChange: (v: string) => void
+    }) => (
+      <button data-testid="scope-picker-trigger" onClick={() => onChange('organization')}>
+        {value}
+      </button>
+    ),
+  }
+})
+
+import { useCreateTemplateGrant } from '@/queries/templateGrants'
+import { useGetOrganization } from '@/queries/organizations'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateOrgTemplateGrantPage } from './new'
+
+function setupMocks(
+  mutateAsync = vi.fn().mockResolvedValue({}),
+  userRole: Role = Role.OWNER,
+) {
+  ;(useCreateTemplateGrant as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+}
+
+describe('CreateOrgTemplateGrantPage (HOL-1022)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page heading', () => {
+    render(<CreateOrgTemplateGrantPage orgName="test-org" />)
+    expect(screen.getByText(/create template grant/i)).toBeInTheDocument()
+  })
+
+  it('renders the ScopePicker', () => {
+    render(<CreateOrgTemplateGrantPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toBeInTheDocument()
+  })
+
+  it('renders the GrantForm in organization scope', () => {
+    render(<CreateOrgTemplateGrantPage orgName="test-org" />)
+    expect(screen.getByLabelText(/^grant name$/i)).toBeInTheDocument()
+  })
+
+  it('disables form controls for VIEWER', () => {
+    setupMocks(vi.fn(), Role.VIEWER)
+    render(<CreateOrgTemplateGrantPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+
+  it('enables form controls for OWNER', () => {
+    setupMocks(vi.fn(), Role.OWNER)
+    render(<CreateOrgTemplateGrantPage orgName="test-org" />)
+    expect(screen.getByRole('button', { name: /^create$/i })).not.toBeDisabled()
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/index.tsx
@@ -1,17 +1,13 @@
 /**
- * Project-scoped Templates / Grants index (HOL-1013).
+ * Organization-scoped TemplateGrant index (HOL-1022).
  *
- * TemplateGrants are org/folder-scoped, not project-scoped. The namespace is
- * derived from the selected organization via useOrg().selectedOrg. The project
- * name still appears in the URL so the Templates collapsible group can stay
- * open in a later sidebar phase (HOL-1014).
- *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
+ * TemplateGrant objects live in organization or folder namespaces. This
+ * org-scoped index shows grants in the current org namespace.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -20,52 +16,60 @@ import {
   useListTemplateGrants,
   useDeleteTemplateGrant,
 } from '@/queries/templateGrants'
-import { useOrg } from '@/lib/org-context'
+import { useGetOrganization } from '@/queries/organizations'
 import { namespaceForOrg } from '@/lib/scope-labels'
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-grants/',
+)({
+  validateSearch: parseGridSearch,
+  component: OrgTemplateGrantsIndexRoute,
+})
+
+function OrgTemplateGrantsIndexRoute() {
+  const { orgName } = Route.useParams()
+  return <OrgTemplateGrantsIndexPage orgName={orgName} />
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Convert a proto Timestamp to an ISO-8601 string for ResourceGrid createdAt. */
 function timestampToISOString(ts: { seconds: bigint } | undefined): string {
   if (!ts) return ''
   return new Date(Number(ts.seconds) * 1000).toISOString()
 }
 
 // ---------------------------------------------------------------------------
-// Route definition
-// ---------------------------------------------------------------------------
-
-export const Route = createFileRoute(
-  '/_authenticated/projects/$projectName/templates/grants/',
-)({
-  validateSearch: parseGridSearch,
-  component: TemplateGrantsIndexRoute,
-})
-
-function TemplateGrantsIndexRoute() {
-  const { projectName } = Route.useParams()
-  return <TemplateGrantsIndexPage projectName={projectName} />
-}
-
-// ---------------------------------------------------------------------------
 // Page component (exported for tests)
 // ---------------------------------------------------------------------------
 
-export function TemplateGrantsIndexPage({
-  projectName,
-}: {
-  projectName: string
-}) {
-  const search = Route.useSearch() as ResourceGridSearch
+export function OrgTemplateGrantsIndexPage({
+  orgName: propOrgName,
+}: { orgName?: string } = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  // TemplateGrants are org/folder-scoped — namespace comes from the selected
-  // org, not the project. The project param keeps Templates sidebar active
-  // in a later phase.
-  const { selectedOrg } = useOrg()
-  const namespace = namespaceForOrg(selectedOrg ?? '')
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // TemplateGrants are org-scoped.
+  const namespace = namespaceForOrg(orgName)
 
   const {
     data: grants = [],
@@ -84,19 +88,16 @@ export function TemplateGrantsIndexPage({
       grants.map((g) => ({
         kind: 'TemplateGrant',
         name: g.name,
-        namespace,
+        namespace: namespace,
         id: g.name,
-        parentId: selectedOrg ?? '',
-        parentLabel: selectedOrg ?? '',
+        parentId: orgName,
+        parentLabel: orgName,
         displayName: g.name,
-        description:
-          g.from.map((f) => f.namespace).join(', ') || '',
+        description: g.from.map((f) => f.namespace).join(', ') || '',
         createdAt: timestampToISOString(g.createdAt),
-        detailHref: selectedOrg
-          ? `/organizations/${selectedOrg}/template-grants/${g.name}`
-          : undefined,
+        detailHref: `/organizations/${orgName}/template-grants/${g.name}`,
       })),
-    [grants, namespace, selectedOrg],
+    [grants, namespace, orgName],
   )
 
   // ---------------------------------------------------------------------------
@@ -107,12 +108,12 @@ export function TemplateGrantsIndexPage({
     () => [
       {
         id: 'TemplateGrant',
-        label: 'TemplateGrant',
-        // No create in this view — grants are created from org-level pages.
-        canCreate: false,
+        label: 'Template Grant',
+        newHref: `/organizations/${orgName}/template-grants/new`,
+        canCreate: canWrite,
       },
     ],
-    [],
+    [orgName, canWrite],
   )
 
   // ---------------------------------------------------------------------------
@@ -130,6 +131,7 @@ export function TemplateGrantsIndexPage({
     (updater: (prev: ResourceGridSearch) => ResourceGridSearch) => {
       navigate({
         search: (prev) => updater(prev as ResourceGridSearch),
+        replace: true,
       })
     },
     [navigate],
@@ -137,7 +139,7 @@ export function TemplateGrantsIndexPage({
 
   return (
     <ResourceGrid
-      title={`${projectName} / Templates / Grants`}
+      title={`${orgName} / Template Grants`}
       kinds={kinds}
       rows={rows}
       onDelete={handleDelete}

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/new.tsx
@@ -1,0 +1,111 @@
+import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { useCreateTemplateGrant } from '@/queries/templateGrants'
+import { namespaceForOrg } from '@/lib/scope-labels'
+import { useGetOrganization } from '@/queries/organizations'
+import { ScopePicker } from '@/components/scope-picker/ScopePicker'
+import type { Scope } from '@/components/scope-picker/ScopePicker'
+import { GrantForm } from '@/components/template-grants/GrantForm'
+import { useState } from 'react'
+
+export const Route = createFileRoute(
+  '/_authenticated/organizations/$orgName/template-grants/new',
+)({
+  component: CreateOrgTemplateGrantRoute,
+})
+
+function CreateOrgTemplateGrantRoute() {
+  const { orgName } = Route.useParams()
+  return <CreateOrgTemplateGrantPage orgName={orgName} />
+}
+
+export function CreateOrgTemplateGrantPage({
+  orgName: propOrgName,
+}: {
+  orgName?: string
+} = {}) {
+  let routeOrgName: string | undefined
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    routeOrgName = Route.useParams().orgName
+  } catch {
+    routeOrgName = undefined
+  }
+  const orgName = propOrgName ?? routeOrgName ?? ''
+
+  const navigate = useNavigate()
+  const { data: org } = useGetOrganization(orgName)
+
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+
+  // ScopePicker controls org vs folder scope. Defaults to 'organization'.
+  const [scope, setScope] = useState<Scope>('organization')
+
+  // TemplateGrants are org/folder-scoped.
+  const namespace = scope === 'organization' ? namespaceForOrg(orgName) : ''
+
+  const createMutation = useCreateTemplateGrant(namespace)
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/organizations/$orgName/settings"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              {orgName}
+            </Link>
+            {' / '}
+            <Link
+              to="/organizations/$orgName/template-grants"
+              params={{ orgName }}
+              className="hover:underline"
+            >
+              Template Grants
+            </Link>
+            {' / New'}
+          </p>
+          <CardTitle className="mt-1">Create Template Grant</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Scope:</span>
+          <ScopePicker value={scope} onChange={setScope} disabled={!canWrite} />
+        </div>
+        {scope === 'project' ? (
+          <p className="text-sm text-muted-foreground">
+            TemplateGrants are organization-scoped. Select Organization scope to create one.
+          </p>
+        ) : (
+          <GrantForm
+            mode="create"
+            namespace={namespace}
+            canWrite={canWrite}
+            submitLabel="Create"
+            pendingLabel="Creating..."
+            isPending={createMutation.isPending}
+            onSubmit={async (values) => {
+              await createMutation.mutateAsync(values)
+              await navigate({
+                to: '/organizations/$orgName/template-grants/$grantName',
+                params: { orgName, grantName: values.name },
+              })
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-grants',
+                params: { orgName },
+              })
+            }}
+          />
+        )}
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `GrantForm` component under `frontend/src/components/template-grants/` supporting create and edit modes with from/to ref fields
- Adds org-scoped `index.tsx`, `new.tsx`, and `$grantName.tsx` (detail/edit) routes under `organizations/$orgName/template-grants/`
- `$grantName.tsx` includes `canDelete`-gated delete button backed by `ConfirmDeleteDialog`
- Updates `projects/$projectName/templates/grants/index.tsx` to set `detailHref` on each row pointing to the org-scoped detail page
- Co-located Vitest tests: `GrantForm.test.tsx`, `-new.test.tsx`, `-detail.test.tsx`
- Mirrors TemplateDependency (HOL-1020) and TemplateRequirement (HOL-1021) conventions exactly

Fixes HOL-1022

## Test plan

- [x] `make test-ui` passes (107 test files, 1399 tests)
- [x] `GrantForm.test.tsx` — create-mode render, edit-mode prefill, validation, submit values, canWrite gating
- [x] `-new.test.tsx` — page heading, ScopePicker, form render, VIEWER disabled, OWNER enabled
- [x] `-detail.test.tsx` — OWNER sees Delete, VIEWER/EDITOR do not, prefill values, delete dialog, delete mutation invoked