### PR TITLE
feat(grids): add New header action on dep/req/grant index pages

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
@@ -1,18 +1,21 @@
 /**
- * Tests for the project-scoped Templates / Dependencies index (HOL-1013).
+ * Tests for the project-scoped Templates / Dependencies index (HOL-1013, HOL-1023).
  *
  * TemplateDependencies are project-scoped. Namespace comes from $projectName
  * via namespaceForProject(). The project param also keeps the Templates
  * sidebar active in a later phase.
  *
  * Covers: happy path, empty state, loading, error, delete flow, page title,
- * undefined createdAt renders em-dash.
+ * undefined createdAt renders em-dash, New button renders for OWNER/EDITOR,
+ * New button hidden for VIEWER, New button links to the correct org route,
+ * canCreate propagates to ResourceGrid.
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 
 // ---------------------------------------------------------------------------
 // Router mock
@@ -72,6 +75,10 @@ vi.mock('@/queries/templateDependencies', async () => {
   }
 })
 
+vi.mock('@/queries/projects', () => ({
+  useGetProject: vi.fn(),
+}))
+
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 vi.mock('@/lib/org-context', () => ({
@@ -91,6 +98,7 @@ import {
   useListTemplateDependencies,
   useDeleteTemplateDependency,
 } from '@/queries/templateDependencies'
+import { useGetProject } from '@/queries/projects'
 import { TemplateDependenciesIndexPage } from './dependencies/index'
 
 // ---------------------------------------------------------------------------
@@ -117,7 +125,12 @@ function setupMocks({
   dependencies = [makeDependency('my-dep')],
   isPending = false,
   error = null as Error | null,
+  userRole = Role.OWNER,
 } = {}) {
+  ;(useGetProject as Mock).mockReturnValue({
+    data: { name: 'test-project', userRole },
+    isPending: false,
+  })
   ;(useListTemplateDependencies as Mock).mockReturnValue({
     data: dependencies,
     isPending,
@@ -226,5 +239,51 @@ describe('TemplateDependenciesIndexPage (HOL-1013)', () => {
     })
     render(<TemplateDependenciesIndexPage projectName="test-project" />)
     expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // New button — HOL-1023
+  // -------------------------------------------------------------------------
+
+  it('renders "New Template Dependency" button for OWNER', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template dependency/i })).toBeInTheDocument()
+  })
+
+  it('renders "New Template Dependency" button for EDITOR', () => {
+    setupMocks({ userRole: Role.EDITOR })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template dependency/i })).toBeInTheDocument()
+  })
+
+  it('does not render "New" button for VIEWER', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    expect(screen.queryByRole('link', { name: /new template dependency/i })).not.toBeInTheDocument()
+  })
+
+  it('"New" button href navigates to the org-scoped new route', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    const link = screen.getByRole('link', { name: /new template dependency/i })
+    expect(link).toHaveAttribute(
+      'href',
+      '/organizations/test-org/template-dependencies/new',
+    )
+  })
+
+  it('passes canCreate=true to ResourceGrid when OWNER', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    // When canCreate is true, the New button link is rendered
+    expect(screen.getByRole('link', { name: /new template dependency/i })).toBeInTheDocument()
+  })
+
+  it('passes canCreate=false to ResourceGrid when VIEWER', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<TemplateDependenciesIndexPage projectName="test-project" />)
+    // When canCreate is false, no New button link is rendered
+    expect(screen.queryByRole('link', { name: /new template dependency/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-grants-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-grants-index.test.tsx
@@ -1,18 +1,21 @@
 /**
- * Tests for the project-scoped Templates / Grants index (HOL-1013).
+ * Tests for the project-scoped Templates / Grants index (HOL-1013, HOL-1023).
  *
  * TemplateGrants are org/folder-scoped. Namespace comes from
  * useOrg().selectedOrg via namespaceForOrg(). The project param keeps the
  * Templates sidebar active in a later phase.
  *
  * Covers: happy path, empty state, loading, error, delete flow, page title,
- * undefined createdAt renders em-dash.
+ * undefined createdAt renders em-dash, New button renders for OWNER/EDITOR,
+ * New button hidden for VIEWER, New button links to the correct org route,
+ * canCreate propagates to ResourceGrid.
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 
 // ---------------------------------------------------------------------------
 // Router mock
@@ -80,6 +83,10 @@ vi.mock('@/queries/templateGrants', async () => {
   }
 })
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 // ---------------------------------------------------------------------------
@@ -90,6 +97,7 @@ import {
   useListTemplateGrants,
   useDeleteTemplateGrant,
 } from '@/queries/templateGrants'
+import { useGetOrganization } from '@/queries/organizations'
 import { useOrg } from '@/lib/org-context'
 import { TemplateGrantsIndexPage } from './grants/index'
 
@@ -118,8 +126,13 @@ function setupMocks({
   isPending = false,
   error = null as Error | null,
   selectedOrg = 'test-org',
+  userRole = Role.OWNER,
 } = {}) {
   ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: selectedOrg ?? '', userRole },
+    isPending: false,
+  })
   ;(useListTemplateGrants as Mock).mockReturnValue({
     data: grants,
     isPending,
@@ -228,5 +241,49 @@ describe('TemplateGrantsIndexPage (HOL-1013)', () => {
     })
     render(<TemplateGrantsIndexPage projectName="test-project" />)
     expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // New button — HOL-1023
+  // -------------------------------------------------------------------------
+
+  it('renders "New Template Grant" button for OWNER', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template grant/i })).toBeInTheDocument()
+  })
+
+  it('renders "New Template Grant" button for EDITOR', () => {
+    setupMocks({ userRole: Role.EDITOR })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template grant/i })).toBeInTheDocument()
+  })
+
+  it('does not render "New" button for VIEWER', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.queryByRole('link', { name: /new template grant/i })).not.toBeInTheDocument()
+  })
+
+  it('"New" button href navigates to the org-scoped new route', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    const link = screen.getByRole('link', { name: /new template grant/i })
+    expect(link).toHaveAttribute(
+      'href',
+      '/organizations/test-org/template-grants/new',
+    )
+  })
+
+  it('passes canCreate=true to ResourceGrid when OWNER', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template grant/i })).toBeInTheDocument()
+  })
+
+  it('passes canCreate=false to ResourceGrid when VIEWER', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<TemplateGrantsIndexPage projectName="test-project" />)
+    expect(screen.queryByRole('link', { name: /new template grant/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-requirements-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-requirements-index.test.tsx
@@ -1,18 +1,21 @@
 /**
- * Tests for the project-scoped Templates / Requirements index (HOL-1013).
+ * Tests for the project-scoped Templates / Requirements index (HOL-1013, HOL-1023).
  *
  * TemplateRequirements are org/folder-scoped. Namespace comes from
  * useOrg().selectedOrg via namespaceForOrg(). The project param keeps the
  * Templates sidebar active in a later phase.
  *
  * Covers: happy path, empty state, loading, error, delete flow, page title,
- * undefined createdAt renders em-dash.
+ * undefined createdAt renders em-dash, New button renders for OWNER/EDITOR,
+ * New button hidden for VIEWER, New button links to the correct org route,
+ * canCreate propagates to ResourceGrid.
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
 
 // ---------------------------------------------------------------------------
 // Router mock
@@ -80,6 +83,10 @@ vi.mock('@/queries/templateRequirements', async () => {
   }
 })
 
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 // ---------------------------------------------------------------------------
@@ -90,6 +97,7 @@ import {
   useListTemplateRequirements,
   useDeleteTemplateRequirement,
 } from '@/queries/templateRequirements'
+import { useGetOrganization } from '@/queries/organizations'
 import { useOrg } from '@/lib/org-context'
 import { TemplateRequirementsIndexPage } from './requirements/index'
 
@@ -118,8 +126,13 @@ function setupMocks({
   isPending = false,
   error = null as Error | null,
   selectedOrg = 'test-org',
+  userRole = Role.OWNER,
 } = {}) {
   ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: selectedOrg ?? '', userRole },
+    isPending: false,
+  })
   ;(useListTemplateRequirements as Mock).mockReturnValue({
     data: requirements,
     isPending,
@@ -228,5 +241,53 @@ describe('TemplateRequirementsIndexPage (HOL-1013)', () => {
     })
     render(<TemplateRequirementsIndexPage projectName="test-project" />)
     expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // New button — HOL-1023
+  // -------------------------------------------------------------------------
+
+  it('renders "New Template Requirement" button for OWNER', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template requirement/i })).toBeInTheDocument()
+  })
+
+  it('renders "New Template Requirement" button for EDITOR', () => {
+    setupMocks({ userRole: Role.EDITOR })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template requirement/i })).toBeInTheDocument()
+  })
+
+  it('does not render "New" button for VIEWER', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(
+      screen.queryByRole('link', { name: /new template requirement/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('"New" button href navigates to the org-scoped new route', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    const link = screen.getByRole('link', { name: /new template requirement/i })
+    expect(link).toHaveAttribute(
+      'href',
+      '/organizations/test-org/template-requirements/new',
+    )
+  })
+
+  it('passes canCreate=true to ResourceGrid when OWNER', () => {
+    setupMocks({ userRole: Role.OWNER })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(screen.getByRole('link', { name: /new template requirement/i })).toBeInTheDocument()
+  })
+
+  it('passes canCreate=false to ResourceGrid when VIEWER', () => {
+    setupMocks({ userRole: Role.VIEWER })
+    render(<TemplateRequirementsIndexPage projectName="test-project" />)
+    expect(
+      screen.queryByRole('link', { name: /new template requirement/i }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
@@ -1,9 +1,12 @@
 /**
- * Project-scoped Templates / Dependencies index (HOL-1013).
+ * Project-scoped Templates / Dependencies index (HOL-1013, HOL-1023).
  *
  * TemplateDependencies are project-scoped. The namespace is derived from the
  * $projectName URL parameter via namespaceForProject(). The project name also
  * keeps the Templates collapsible group open in the sidebar (HOL-1014).
+ *
+ * HOL-1023: added "New" header action gated on project OWNER/EDITOR role,
+ * navigating to the org-scoped /template-dependencies/new route.
  *
  * Sidebar nesting is handled in HOL-1014; for now the route exists and is
  * reachable by URL.
@@ -11,7 +14,8 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -19,6 +23,7 @@ import {
   useListTemplateDependencies,
   useDeleteTemplateDependency,
 } from '@/queries/templateDependencies'
+import { useGetProject } from '@/queries/projects'
 import { namespaceForProject } from '@/lib/scope-labels'
 import { useOrg } from '@/lib/org-context'
 
@@ -63,8 +68,13 @@ export function TemplateDependenciesIndexPage({
   // TemplateDependencies are project-scoped — namespace comes from projectName.
   const namespace = namespaceForProject(projectName)
 
-  // selectedOrg is used to build detailHref links to the org-scoped detail page.
+  // selectedOrg is used to build detailHref links and the New route URL.
   const { selectedOrg } = useOrg()
+
+  // Project role — used to gate the "New" button (OWNER or EDITOR can create).
+  const { data: project } = useGetProject(projectName)
+  const userRole = project?.userRole ?? Role.VIEWER
+  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
 
   const {
     data: dependencies = [],
@@ -105,12 +115,14 @@ export function TemplateDependenciesIndexPage({
     () => [
       {
         id: 'TemplateDependency',
-        label: 'TemplateDependency',
-        // No create in this view — dependencies are managed programmatically.
-        canCreate: false,
+        label: 'Template Dependency',
+        newHref: selectedOrg
+          ? `/organizations/${selectedOrg}/template-dependencies/new`
+          : undefined,
+        canCreate: !!selectedOrg && canCreate,
       },
     ],
-    [],
+    [selectedOrg, canCreate],
   )
 
   // ---------------------------------------------------------------------------
@@ -134,15 +146,17 @@ export function TemplateDependenciesIndexPage({
   )
 
   return (
-    <ResourceGrid
-      title={`${projectName} / Templates / Dependencies`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[projectName, 'Templates', 'Dependencies']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
@@ -1,10 +1,13 @@
 /**
- * Project-scoped Templates / Grants index (HOL-1013).
+ * Project-scoped Templates / Grants index (HOL-1013, HOL-1023).
  *
  * TemplateGrants are org/folder-scoped, not project-scoped. The namespace is
  * derived from the selected organization via useOrg().selectedOrg. The project
  * name still appears in the URL so the Templates collapsible group can stay
  * open in a later sidebar phase (HOL-1014).
+ *
+ * HOL-1023: added "New" header action gated on org OWNER/EDITOR role,
+ * navigating to the org-scoped /template-grants/new route.
  *
  * Sidebar nesting is handled in HOL-1014; for now the route exists and is
  * reachable by URL.
@@ -12,7 +15,8 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -20,6 +24,7 @@ import {
   useListTemplateGrants,
   useDeleteTemplateGrant,
 } from '@/queries/templateGrants'
+import { useGetOrganization } from '@/queries/organizations'
 import { useOrg } from '@/lib/org-context'
 import { namespaceForOrg } from '@/lib/scope-labels'
 
@@ -67,6 +72,11 @@ export function TemplateGrantsIndexPage({
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 
+  // Org role — used to gate the "New" button (OWNER or EDITOR can create).
+  const { data: org } = useGetOrganization(selectedOrg ?? '')
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+
   const {
     data: grants = [],
     isPending,
@@ -107,12 +117,14 @@ export function TemplateGrantsIndexPage({
     () => [
       {
         id: 'TemplateGrant',
-        label: 'TemplateGrant',
-        // No create in this view — grants are created from org-level pages.
-        canCreate: false,
+        label: 'Template Grant',
+        newHref: selectedOrg
+          ? `/organizations/${selectedOrg}/template-grants/new`
+          : undefined,
+        canCreate: !!selectedOrg && canCreate,
       },
     ],
-    [],
+    [selectedOrg, canCreate],
   )
 
   // ---------------------------------------------------------------------------
@@ -136,15 +148,17 @@ export function TemplateGrantsIndexPage({
   )
 
   return (
-    <ResourceGrid
-      title={`${projectName} / Templates / Grants`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[projectName, 'Templates', 'Grants']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
@@ -1,10 +1,13 @@
 /**
- * Project-scoped Templates / Requirements index (HOL-1013).
+ * Project-scoped Templates / Requirements index (HOL-1013, HOL-1023).
  *
  * TemplateRequirements are org/folder-scoped, not project-scoped. The namespace
  * is derived from the selected organization via useOrg().selectedOrg. The
  * project name still appears in the URL so the Templates collapsible group
  * can stay open in a later sidebar phase (HOL-1014).
+ *
+ * HOL-1023: added "New" header action gated on org OWNER/EDITOR role,
+ * navigating to the org-scoped /template-requirements/new route.
  *
  * Sidebar nesting is handled in HOL-1014; for now the route exists and is
  * reachable by URL.
@@ -12,7 +15,8 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -20,6 +24,7 @@ import {
   useListTemplateRequirements,
   useDeleteTemplateRequirement,
 } from '@/queries/templateRequirements'
+import { useGetOrganization } from '@/queries/organizations'
 import { useOrg } from '@/lib/org-context'
 import { namespaceForOrg } from '@/lib/scope-labels'
 
@@ -67,6 +72,11 @@ export function TemplateRequirementsIndexPage({
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 
+  // Org role — used to gate the "New" button (OWNER or EDITOR can create).
+  const { data: org } = useGetOrganization(selectedOrg ?? '')
+  const userRole = org?.userRole ?? Role.VIEWER
+  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+
   const {
     data: requirements = [],
     isPending,
@@ -107,12 +117,14 @@ export function TemplateRequirementsIndexPage({
     () => [
       {
         id: 'TemplateRequirement',
-        label: 'TemplateRequirement',
-        // No create in this view — requirements are created from org-level pages.
-        canCreate: false,
+        label: 'Template Requirement',
+        newHref: selectedOrg
+          ? `/organizations/${selectedOrg}/template-requirements/new`
+          : undefined,
+        canCreate: !!selectedOrg && canCreate,
       },
     ],
-    [],
+    [selectedOrg, canCreate],
   )
 
   // ---------------------------------------------------------------------------
@@ -136,15 +148,17 @@ export function TemplateRequirementsIndexPage({
   )
 
   return (
-    <ResourceGrid
-      title={`${projectName} / Templates / Requirements`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[projectName, 'Templates', 'Requirements']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }


### PR DESCRIPTION
## Summary

- Upgrades the three project-scoped index pages for `TemplateDependency`, `TemplateRequirement`, and `TemplateGrant` from bare `ResourceGrid` to `StandardPageLayout` for title/header-action slot consistency.
- Sets `canCreate: true` and `newHref` on each page, gated on the user's OWNER/EDITOR role (project role for dependencies, org role for requirements and grants).
- New button routes to the org-scoped `/new` routes created in HOL-1020/1021/1022.
- Preserves existing delete action and `detailHref` row behavior on all three pages.
- Co-located Vitest tests assert: New button renders for OWNER/EDITOR, hidden for VIEWER, href targets the correct org route, `canCreate` propagates correctly to `ResourceGrid`.

Fixes HOL-1023

## Test plan

- [x] `make test-ui` passes (1417 tests across 107 files)
- [x] New button appears for OWNER and EDITOR roles on all three index pages
- [x] New button is absent for VIEWER role on all three pages
- [x] Clicking New navigates to the correct org-scoped `/template-dependencies/new`, `/template-requirements/new`, or `/template-grants/new` route
- [x] Existing delete action and detailHref row links are preserved