### PR TITLE
refactor(new-pages): adopt ScopePicker on TemplatePolicy, Binding, Template new pages

### DIFF
--- a/frontend/src/components/template-policies/PolicyForm.tsx
+++ b/frontend/src/components/template-policies/PolicyForm.tsx
@@ -95,14 +95,17 @@ export function PolicyForm({
   const handleSubmit = async () => {
     setError(null)
 
-    // Scope guard: policies can only be authored at folder or organization
-    // scope. Anything else is a programmer error or a contrived URL; the form
-    // refuses to dispatch the mutation and surfaces the constraint to the
-    // user. The backend performs the authoritative check, but the UI must
+    // Scope guard: policies can only be authored at folder, organization, or
+    // project scope. Anything else is a programmer error or a contrived URL;
+    // the form refuses to dispatch the mutation and surfaces the constraint to
+    // the user. The backend performs the authoritative check, but the UI must
     // make it clear before round-tripping.
-    if (scopeType !== 'organization' && scopeType !== 'folder') {
+    //
+    // HOL-1024: 'project' is now a valid scope (ScopePicker on the new page
+    // routes the create mutation to the project namespace when selected).
+    if (scopeType !== 'organization' && scopeType !== 'folder' && scopeType !== 'project') {
       setError(
-        'Template policies can only be created at folder or organization scope. Navigate to a folder or organization to manage policies.',
+        'Template policies can only be created at folder, organization, or project scope. Navigate to a valid scope to manage policies.',
       )
       return
     }
@@ -192,7 +195,7 @@ export function PolicyForm({
         <div className="flex items-center justify-between">
           <Label>Rules</Label>
           <p className="text-xs text-muted-foreground">
-            Scope: {scopeType === 'folder' ? 'Folder' : scopeType === 'organization' ? 'Organization' : 'Invalid'}
+            Scope: {scopeType === 'folder' ? 'Folder' : scopeType === 'organization' ? 'Organization' : scopeType === 'project' ? 'Project' : 'Invalid'}
           </p>
         </div>
         <RuleEditor

--- a/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.test.tsx
@@ -367,12 +367,15 @@ describe('BindingForm', () => {
     })
   })
 
-  it('blocks submission when the resolved scope is project (contrived URL)', async () => {
+  // HOL-1024: 'project' is now a valid scope for bindings (ScopePicker routes
+  // the create mutation to the project namespace). Test that 'unknown' scope
+  // (a contrived or unsupported value) still blocks submission.
+  it('blocks submission when the resolved scope is unknown (contrived URL)', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined)
     render(
       <BindingForm
         mode="create"
-        scopeType="project"
+        scopeType="unknown"
         namespace={ORG_NAMESPACE}
         organization="test-org"
         canWrite
@@ -390,7 +393,7 @@ describe('BindingForm', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('binding-form-error')).toHaveTextContent(
-        /only be created at folder or organization scope/i,
+        /only be created at folder, organization, or project scope/i,
       )
     })
     expect(onSubmit).not.toHaveBeenCalled()

--- a/frontend/src/components/template-policy-bindings/BindingForm.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.tsx
@@ -123,11 +123,14 @@ export function BindingForm({
   const handleSubmit = async () => {
     setError(null)
 
-    // Scope guard: bindings can only be authored at folder or organization
-    // scope. Matches PolicyForm's guard.
-    if (scopeType !== 'organization' && scopeType !== 'folder') {
+    // Scope guard: bindings can only be authored at folder, organization, or
+    // project scope. Matches PolicyForm's guard.
+    //
+    // HOL-1024: 'project' is now a valid scope (ScopePicker on the new page
+    // routes the create mutation to the project namespace when selected).
+    if (scopeType !== 'organization' && scopeType !== 'folder' && scopeType !== 'project') {
       setError(
-        'Template policy bindings can only be created at folder or organization scope. Navigate to a folder or organization to manage bindings.',
+        'Template policy bindings can only be created at folder, organization, or project scope. Navigate to a valid scope to manage bindings.',
       )
       return
     }
@@ -248,7 +251,9 @@ export function BindingForm({
               ? 'Folder'
               : scopeType === 'organization'
                 ? 'Organization'
-                : 'Invalid'}
+                : scopeType === 'project'
+                  ? 'Project'
+                  : 'Invalid'}
           </p>
         </div>
         <TargetRefEditor

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-new.test.tsx
@@ -1,0 +1,207 @@
+// HOL-1024: Tests for the org-scope TemplatePolicyBinding create page.
+//
+// Covers:
+// 1. Page heading renders.
+// 2. ScopePicker is rendered; defaults to 'organization' scope.
+// 3. Switching to project scope with a project selected shows the form.
+// 4. Switching to project scope with no project selected shows a prompt.
+// 5. VIEWER role disables controls.
+// 6. OWNER/EDITOR roles enable controls.
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import React from 'react'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ orgName: 'test-org' }),
+    }),
+    useNavigate: () => mockNavigate,
+    Link: ({
+      children,
+      className,
+      to,
+      params,
+    }: {
+      children: React.ReactNode
+      className?: string
+      to?: string
+      params?: Record<string, string>
+    }) => (
+      <a href={to} data-params={JSON.stringify(params)} className={className}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'holos-org-',
+    folderPrefix: 'holos-folder-',
+    projectPrefix: 'holos-project-',
+  }),
+}))
+
+vi.mock('@/queries/templatePolicyBindings', async () => {
+  const actual = await vi.importActual<typeof import('@/queries/templatePolicyBindings')>(
+    '@/queries/templatePolicyBindings',
+  )
+  return {
+    ...actual,
+    useCreateTemplatePolicyBinding: vi.fn(),
+  }
+})
+
+vi.mock('@/queries/organizations', () => ({
+  useGetOrganization: vi.fn(),
+}))
+
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn(),
+}))
+
+vi.mock('@/components/scope-picker/ScopePicker', async () => {
+  return {
+    ScopePicker: ({
+      value,
+      onChange,
+      disabled,
+    }: {
+      value: string
+      onChange: (v: string) => void
+      disabled?: boolean
+    }) => (
+      <button
+        data-testid="scope-picker-trigger"
+        disabled={disabled}
+        onClick={() => onChange(value === 'organization' ? 'project' : 'organization')}
+      >
+        {value}
+      </button>
+    ),
+  }
+})
+
+// BindingForm has deep dependencies; mock it to keep tests focused on the page.
+vi.mock('@/components/template-policy-bindings/BindingForm', () => ({
+  BindingForm: ({ scopeType }: { scopeType: string }) => (
+    <div data-testid="binding-form" data-scope={scopeType}>
+      <input aria-label="Display Name" />
+      <button>Create</button>
+    </div>
+  ),
+}))
+
+import { useCreateTemplatePolicyBinding } from '@/queries/templatePolicyBindings'
+import { useGetOrganization } from '@/queries/organizations'
+import { useProject } from '@/lib/project-context'
+import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { CreateOrgTemplateBindingPage } from './new'
+
+function setupMocks(
+  mutateAsync = vi.fn().mockResolvedValue({}),
+  userRole: Role = Role.OWNER,
+  selectedProject: string | null = 'test-project',
+) {
+  ;(useCreateTemplatePolicyBinding as Mock).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+  })
+  ;(useGetOrganization as Mock).mockReturnValue({
+    data: { name: 'test-org', userRole },
+    isPending: false,
+    error: null,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    selectedProject,
+    setSelectedProject: vi.fn(),
+    projects: [],
+    isLoading: false,
+  })
+}
+
+describe('CreateOrgTemplateBindingPage (HOL-1024)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page heading', () => {
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(screen.getByText(/create template binding/i)).toBeInTheDocument()
+  })
+
+  it('renders the ScopePicker', () => {
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toBeInTheDocument()
+  })
+
+  it('defaults to organization scope', () => {
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toHaveTextContent('organization')
+  })
+
+  it('shows the form with organization scopeType by default', () => {
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(screen.getByTestId('binding-form')).toHaveAttribute('data-scope', 'organization')
+  })
+
+  it('shows the form with project scopeType after switching to project scope', () => {
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    // Switch to project scope.
+    fireEvent.click(screen.getByTestId('scope-picker-trigger'))
+    expect(screen.getByTestId('binding-form')).toHaveAttribute('data-scope', 'project')
+  })
+
+  it('shows a prompt when scope=project and no project is selected', () => {
+    setupMocks(vi.fn(), Role.OWNER, null)
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    // Switch to project scope via the mock picker.
+    fireEvent.click(screen.getByTestId('scope-picker-trigger'))
+    expect(
+      screen.getByText(/select a project from the switcher/i),
+    ).toBeInTheDocument()
+  })
+
+  it('disables the scope picker for VIEWER', () => {
+    setupMocks(vi.fn(), Role.VIEWER)
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toBeDisabled()
+  })
+
+  it('enables the scope picker for OWNER', () => {
+    setupMocks(vi.fn(), Role.OWNER)
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).not.toBeDisabled()
+  })
+
+  it('enables the scope picker for EDITOR', () => {
+    setupMocks(vi.fn(), Role.EDITOR)
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).not.toBeDisabled()
+  })
+
+  // HOL-1024: When scope=project and a project is selected, the mutation is
+  // called with the project namespace.
+  it('calls useCreateTemplatePolicyBinding with project namespace when scope=project', () => {
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    // Switch to project scope.
+    fireEvent.click(screen.getByTestId('scope-picker-trigger'))
+    // The mutation hook should have been called with the project namespace.
+    expect(useCreateTemplatePolicyBinding).toHaveBeenCalledWith('holos-project-test-project')
+  })
+
+  // HOL-1024: Default org scope routes mutation to org namespace.
+  it('calls useCreateTemplatePolicyBinding with org namespace by default', () => {
+    render(<CreateOrgTemplateBindingPage orgName="test-org" />)
+    expect(useCreateTemplatePolicyBinding).toHaveBeenCalledWith('holos-org-test-org')
+  })
+})

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/new.tsx
@@ -1,13 +1,14 @@
+import { useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplatePolicyBinding } from '@/queries/templatePolicyBindings'
-import { namespaceForOrg } from '@/lib/scope-labels'
+import { namespaceForOrg, namespaceForProject } from '@/lib/scope-labels'
 import { useGetOrganization } from '@/queries/organizations'
-import {
-  BindingForm,
-  type BindingScope,
-} from '@/components/template-policy-bindings/BindingForm'
+import { useProject } from '@/lib/project-context'
+import { ScopePicker } from '@/components/scope-picker/ScopePicker'
+import type { Scope } from '@/components/scope-picker/ScopePicker'
+import { BindingForm } from '@/components/template-policy-bindings/BindingForm'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-bindings/new',
@@ -22,10 +23,8 @@ function CreateOrgTemplateBindingRoute() {
 
 export function CreateOrgTemplateBindingPage({
   orgName: propOrgName,
-  forcedScopeType,
 }: {
   orgName?: string
-  forcedScopeType?: BindingScope
 } = {}) {
   let routeOrgName: string | undefined
   try {
@@ -37,14 +36,22 @@ export function CreateOrgTemplateBindingPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const navigate = useNavigate()
-  const namespace = namespaceForOrg(orgName)
-  const createMutation = useCreateTemplatePolicyBinding(namespace)
   const { data: org } = useGetOrganization(orgName)
+  const { selectedProject } = useProject()
 
   const userRole = org?.userRole ?? Role.VIEWER
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
-  const scopeType: BindingScope = forcedScopeType ?? 'organization'
+  // ScopePicker controls which namespace the binding is created in.
+  // Defaults to 'organization' so the existing behaviour is preserved.
+  const [scope, setScope] = useState<Scope>('organization')
+
+  const namespace =
+    scope === 'project' && selectedProject
+      ? namespaceForProject(selectedProject)
+      : namespaceForOrg(orgName)
+
+  const createMutation = useCreateTemplatePolicyBinding(namespace)
 
   return (
     <Card>
@@ -74,29 +81,39 @@ export function CreateOrgTemplateBindingPage({
         </div>
       </CardHeader>
       <CardContent>
-        <BindingForm
-          mode="create"
-          scopeType={scopeType}
-          namespace={namespace}
-          organization={orgName}
-          canWrite={canWrite}
-          submitLabel="Create"
-          pendingLabel="Creating..."
-          isPending={createMutation.isPending}
-          onSubmit={async (values) => {
-            await createMutation.mutateAsync(values)
-            await navigate({
-              to: '/organizations/$orgName/template-bindings/$bindingName',
-              params: { orgName, bindingName: values.name },
-            })
-          }}
-          onCancel={() => {
-            void navigate({
-              to: '/organizations/$orgName/template-bindings',
-              params: { orgName },
-            })
-          }}
-        />
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Scope:</span>
+          <ScopePicker value={scope} onChange={setScope} disabled={!canWrite} />
+        </div>
+        {scope === 'project' && !selectedProject ? (
+          <p className="text-sm text-muted-foreground">
+            Select a project from the switcher to create a binding in a project namespace.
+          </p>
+        ) : (
+          <BindingForm
+            mode="create"
+            scopeType={scope === 'project' ? 'project' : 'organization'}
+            namespace={namespace}
+            organization={orgName}
+            canWrite={canWrite}
+            submitLabel="Create"
+            pendingLabel="Creating..."
+            isPending={createMutation.isPending}
+            onSubmit={async (values) => {
+              await createMutation.mutateAsync(values)
+              await navigate({
+                to: '/organizations/$orgName/template-bindings/$bindingName',
+                params: { orgName, bindingName: values.name },
+              })
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-bindings',
+                params: { orgName },
+              })
+            }}
+          />
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-new.test.tsx
@@ -1,5 +1,8 @@
 // HOL-836: Audit + test coverage for the org-scope TemplatePolicy create form.
 //
+// HOL-1024: updated to add ScopePicker mock and extend tests to cover both
+// org-scope (default) and project-scope branches.
+//
 // Audit findings (no production changes needed):
 // - PolicyForm.tsx calls useListLinkableTemplates(namespace, { includeSelfScope: true })
 //   which invokes the ancestor-walking ListLinkableTemplates RPC.
@@ -12,6 +15,8 @@
 // 1. The form calls useListLinkableTemplates with includeSelfScope: true.
 // 2. Org-owned templates appear in the rule's template picker with a scope label.
 // 3. The form correctly renders and submits for OWNER/EDITOR roles.
+// 4. ScopePicker is rendered; switching to Project scope routes mutation to project namespace.
+// 5. When no project is selected and scope=project, a prompt is shown instead of the form.
 
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
@@ -46,6 +51,15 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     ),
   }
 })
+
+vi.mock('@/lib/console-config', () => ({
+  getConsoleConfig: vi.fn().mockReturnValue({
+    namespacePrefix: '',
+    organizationPrefix: 'holos-org-',
+    folderPrefix: 'holos-folder-',
+    projectPrefix: 'holos-project-',
+  }),
+}))
 
 vi.mock('@/queries/templatePolicies', async () => {
   const actual = await vi.importActual<typeof import('@/queries/templatePolicies')>(
@@ -87,15 +101,43 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
+vi.mock('@/lib/project-context', () => ({
+  useProject: vi.fn(),
+}))
+
+vi.mock('@/components/scope-picker/ScopePicker', async () => {
+  return {
+    ScopePicker: ({
+      value,
+      onChange,
+      disabled,
+    }: {
+      value: string
+      onChange: (v: string) => void
+      disabled?: boolean
+    }) => (
+      <button
+        data-testid="scope-picker-trigger"
+        disabled={disabled}
+        onClick={() => onChange(value === 'organization' ? 'project' : 'organization')}
+      >
+        {value}
+      </button>
+    ),
+  }
+})
+
 import { useCreateTemplatePolicy } from '@/queries/templatePolicies'
 import { useGetOrganization } from '@/queries/organizations'
 import { useListLinkableTemplates } from '@/queries/templates'
+import { useProject } from '@/lib/project-context'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { CreateOrgTemplatePolicyPage } from './new'
 
 function setupMocks(
   mutateAsync = vi.fn().mockResolvedValue({}),
   userRole: Role = Role.OWNER,
+  selectedProject: string | null = 'test-project',
 ) {
   ;(useCreateTemplatePolicy as Mock).mockReturnValue({
     mutateAsync,
@@ -106,6 +148,12 @@ function setupMocks(
     data: { name: 'test-org', userRole },
     isPending: false,
     error: null,
+  })
+  ;(useProject as Mock).mockReturnValue({
+    selectedProject,
+    setSelectedProject: vi.fn(),
+    projects: [],
+    isLoading: false,
   })
 }
 
@@ -120,7 +168,7 @@ if (!Element.prototype.releasePointerCapture) {
   Element.prototype.releasePointerCapture = () => {}
 }
 
-describe('CreateOrgTemplatePolicyPage (HOL-836)', () => {
+describe('CreateOrgTemplatePolicyPage (HOL-836 + HOL-1024)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     setupMocks()
@@ -129,6 +177,38 @@ describe('CreateOrgTemplatePolicyPage (HOL-836)', () => {
   it('renders the page heading', () => {
     render(<CreateOrgTemplatePolicyPage orgName="test-org" />)
     expect(screen.getByText(/create template policy/i)).toBeInTheDocument()
+  })
+
+  // HOL-1024: ScopePicker must be rendered on the page.
+  it('renders the ScopePicker', () => {
+    render(<CreateOrgTemplatePolicyPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toBeInTheDocument()
+  })
+
+  // HOL-1024: By default scope is 'organization' so the picker shows 'organization'.
+  it('defaults to organization scope', () => {
+    render(<CreateOrgTemplatePolicyPage orgName="test-org" />)
+    expect(screen.getByTestId('scope-picker-trigger')).toHaveTextContent('organization')
+  })
+
+  // HOL-1024: When scope is 'project' and no project is selected, show a prompt.
+  it('shows a prompt when scope=project and no project is selected', () => {
+    setupMocks(vi.fn(), Role.OWNER, null)
+    render(<CreateOrgTemplatePolicyPage orgName="test-org" />)
+    // Switch to project scope via the mock picker (click toggles to 'project').
+    fireEvent.click(screen.getByTestId('scope-picker-trigger'))
+    expect(
+      screen.getByText(/select a project from the switcher/i),
+    ).toBeInTheDocument()
+  })
+
+  // HOL-1024: When scope=project and a project IS selected, the form renders.
+  it('shows the form when scope=project and a project is selected', () => {
+    render(<CreateOrgTemplatePolicyPage orgName="test-org" />)
+    // Click the picker to switch to 'project'.
+    fireEvent.click(screen.getByTestId('scope-picker-trigger'))
+    // Form should be visible.
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
   })
 
   // HOL-836 AC: the org-scope form must call useListLinkableTemplates with

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/new.tsx
@@ -1,10 +1,14 @@
+import { useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplatePolicy } from '@/queries/templatePolicies'
-import { namespaceForOrg } from '@/lib/scope-labels'
+import { namespaceForOrg, namespaceForProject } from '@/lib/scope-labels'
 import { useGetOrganization } from '@/queries/organizations'
-import { PolicyForm, type PolicyScope } from '@/components/template-policies/PolicyForm'
+import { useProject } from '@/lib/project-context'
+import { ScopePicker } from '@/components/scope-picker/ScopePicker'
+import type { Scope } from '@/components/scope-picker/ScopePicker'
+import { PolicyForm } from '@/components/template-policies/PolicyForm'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-policies/new',
@@ -19,10 +23,8 @@ function CreateOrgTemplatePolicyRoute() {
 
 export function CreateOrgTemplatePolicyPage({
   orgName: propOrgName,
-  forcedScopeType,
 }: {
   orgName?: string
-  forcedScopeType?: PolicyScope
 } = {}) {
   let routeOrgName: string | undefined
   try {
@@ -34,15 +36,23 @@ export function CreateOrgTemplatePolicyPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const navigate = useNavigate()
-  const namespace = namespaceForOrg(orgName)
-  const createMutation = useCreateTemplatePolicy(namespace)
   const { data: org } = useGetOrganization(orgName)
+  const { selectedProject } = useProject()
 
   const userRole = org?.userRole ?? Role.VIEWER
   // PERMISSION_TEMPLATE_POLICIES_WRITE cascades to editors too.
   const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
-  const scopeType: PolicyScope = forcedScopeType ?? 'organization'
+  // ScopePicker controls which namespace the policy is created in.
+  // Defaults to 'organization' so the existing behaviour is preserved.
+  const [scope, setScope] = useState<Scope>('organization')
+
+  const namespace =
+    scope === 'project' && selectedProject
+      ? namespaceForProject(selectedProject)
+      : namespaceForOrg(orgName)
+
+  const createMutation = useCreateTemplatePolicy(namespace)
 
   return (
     <Card>
@@ -66,28 +76,38 @@ export function CreateOrgTemplatePolicyPage({
         </div>
       </CardHeader>
       <CardContent>
-        <PolicyForm
-          mode="create"
-          scopeType={scopeType}
-          namespace={namespace}
-          canWrite={canWrite}
-          submitLabel="Create"
-          pendingLabel="Creating..."
-          isPending={createMutation.isPending}
-          onSubmit={async (values) => {
-            await createMutation.mutateAsync(values)
-            await navigate({
-              to: '/organizations/$orgName/template-policies/$policyName',
-              params: { orgName, policyName: values.name },
-            })
-          }}
-          onCancel={() => {
-            void navigate({
-              to: '/organizations/$orgName/template-policies',
-              params: { orgName },
-            })
-          }}
-        />
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Scope:</span>
+          <ScopePicker value={scope} onChange={setScope} disabled={!canWrite} />
+        </div>
+        {scope === 'project' && !selectedProject ? (
+          <p className="text-sm text-muted-foreground">
+            Select a project from the switcher to create a policy in a project namespace.
+          </p>
+        ) : (
+          <PolicyForm
+            mode="create"
+            scopeType={scope === 'project' ? 'project' : 'organization'}
+            namespace={namespace}
+            canWrite={canWrite}
+            submitLabel="Create"
+            pendingLabel="Creating..."
+            isPending={createMutation.isPending}
+            onSubmit={async (values) => {
+              await createMutation.mutateAsync(values)
+              await navigate({
+                to: '/organizations/$orgName/template-policies/$policyName',
+                params: { orgName, policyName: values.name },
+              })
+            }}
+            onCancel={() => {
+              void navigate({
+                to: '/organizations/$orgName/template-policies',
+                params: { orgName },
+              })
+            }}
+          />
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-new-wrapper.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-new-wrapper.test.tsx
@@ -1,6 +1,10 @@
 /**
  * Tests for the project-scoped template clone page (HOL-974).
  *
+ * HOL-1024: updated to add ScopePicker mock. The clone page always shows
+ * scope=project (fixed/disabled) per the integration decision documented in the
+ * PR and in docs/agents/frontend-architecture.md.
+ *
  * Covers: source picker rendering, display name → slug auto-derive,
  * clone mutation call, navigation to the new template's detail on success,
  * and validation errors.
@@ -46,6 +50,25 @@ vi.mock('@/queries/templates', () => ({
   useListLinkableTemplates: vi.fn(),
 }))
 
+// HOL-1024: mock ScopePicker — the clone page renders it with value='project'
+// and disabled=true (scope is fixed by the route URL).
+vi.mock('@/components/scope-picker/ScopePicker', async () => {
+  return {
+    ScopePicker: ({
+      value,
+      disabled,
+    }: {
+      value: string
+      onChange: (v: string) => void
+      disabled?: boolean
+    }) => (
+      <button data-testid="scope-picker-trigger" disabled={disabled}>
+        {value}
+      </button>
+    ),
+  }
+})
+
 import { useCloneTemplate, useListLinkableTemplates } from '@/queries/templates'
 import { CloneTemplatePage } from './new'
 
@@ -69,7 +92,19 @@ beforeEach(() => {
   })
 })
 
-describe('CloneTemplatePage (HOL-974)', () => {
+describe('CloneTemplatePage (HOL-974 + HOL-1024)', () => {
+  // -------------------------------------------------------------------------
+  // HOL-1024: ScopePicker integration
+  // -------------------------------------------------------------------------
+
+  it('renders the ScopePicker with value=project and disabled', () => {
+    render(<CloneTemplatePage projectName="my-proj" />)
+    const picker = screen.getByTestId('scope-picker-trigger')
+    expect(picker).toBeInTheDocument()
+    expect(picker).toHaveTextContent('project')
+    expect(picker).toBeDisabled()
+  })
+
   // -------------------------------------------------------------------------
   // Source picker
   // -------------------------------------------------------------------------

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -14,6 +14,11 @@
  * HOL-975: accepts an optional `cloneSource` search param encoding
  * "namespace/name" to pre-select a platform template when navigating from
  * the org-scope template detail page via the "Clone to project" CTA.
+ *
+ * HOL-1024: ScopePicker is rendered with value fixed to 'project' (disabled)
+ * because the clone destination is always the project namespace encoded in
+ * the route URL. The picker communicates the scope visually, aligning this
+ * page with all other "new" pages in the HOL-1016 wave.
  */
 
 import { useState, useEffect } from 'react'
@@ -24,6 +29,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Combobox } from '@/components/ui/combobox'
+import { ScopePicker } from '@/components/scope-picker/ScopePicker'
 import {
   useCloneTemplate,
   useListLinkableTemplates,
@@ -175,6 +181,14 @@ export function CloneTemplatePage({
         <CardTitle>Clone Platform Template</CardTitle>
       </CardHeader>
       <CardContent>
+        {/* HOL-1024: scope is always 'project' for this clone-only route. The
+            picker is disabled because the destination namespace is fixed by the
+            $projectName URL segment. It communicates the scope visually and
+            aligns this page with the other HOL-1016 "new" pages. */}
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Scope:</span>
+          <ScopePicker value="project" onChange={() => {}} disabled />
+        </div>
         <div className="space-y-4">
           <div>
             <Label>Source Platform Template</Label>


### PR DESCRIPTION
## Summary

- Replace hard-pinned `scopeType` constants on the TemplatePolicy and TemplatePolicyBinding new pages with a live `ScopePicker` component (from HOL-1018). Selecting Project scope routes the create mutation to the project namespace; Organization scope (the default) preserves existing behaviour.
- The CloneTemplate page under `projects/$projectName/templates/new.tsx` is a clone-only flow: the destination namespace is always the project encoded in the URL segment. A `ScopePicker` is rendered with `value="project"` and `disabled` to communicate the fixed scope visually and align this page with the other HOL-1016 new pages. This choice is documented in the PR description and in the component comment.
- `PolicyForm` and `BindingForm` scope guards are expanded to accept `'project'` as a valid scope. The `BindingForm` test that previously expected project scope to be blocked is updated to use `'unknown'` instead.
- New test file for the template-bindings new page (`-new.test.tsx`); existing policy and clone template tests extended to cover ScopePicker integration and both scope branches.

Fixes HOL-1024

## Test plan

- [x] `make test-ui` passes (1433 tests, 108 files)
- [x] TemplatePolicy new page: renders ScopePicker, defaults to org scope, switches to project scope with project selected, shows prompt when no project selected
- [x] TemplatePolicyBinding new page: same scope-switching behaviour; mutation called with project namespace when scope=project
- [x] CloneTemplate new page: ScopePicker renders with value=project and disabled
- [x] BindingForm scope guard test updated to use 'unknown' scope

## Integration choice — CloneTemplate page

The `projects/$projectName/templates/new.tsx` route is a clone-only flow (HOL-974). The clone mutation always writes to the project namespace derived from `$projectName`. There is no separate org-vs-project destination choice here; the org namespace is always the *source* (linkable templates) and the project namespace is always the *destination*. Adding a functional picker that could target an org namespace would require a separate mutation (`useCreateTemplate`) and its own form — that is out of scope for this issue. Instead, the ScopePicker is rendered disabled at `'project'` to satisfy the visual consistency AC while accurately reflecting the fixed destination scope.