### PR TITLE
chore(cleanup): docs and consistency pass for new resource flows (HOL-1025)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,10 +125,23 @@ entry and WorkspaceMenu improvements. Key files:
 | `frontend/src/queries/templateDependencies.ts` (CRUD hooks) | HOL-1013 | TanStack Query CRUD hooks for TemplateDependency |
 | `frontend/src/queries/templateRequirements.ts` | HOL-1013 | TanStack Query hooks for TemplateRequirement |
 | `frontend/src/queries/templateGrants.ts` | HOL-1013 | TanStack Query hooks for TemplateGrant |
-| `frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx` | HOL-1013 | Template Dependencies ResourceGrid page |
-| `frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx` | HOL-1013 | Template Requirements ResourceGrid page |
-| `frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx` | HOL-1013 | Template Grants ResourceGrid page |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx` | HOL-1013, HOL-1023 | Template Dependencies ResourceGrid page; New action navigates to org-scoped create route |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx` | HOL-1013, HOL-1023 | Template Requirements ResourceGrid page; New action navigates to org-scoped create route |
+| `frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx` | HOL-1013, HOL-1023 | Template Grants ResourceGrid page; New action navigates to org-scoped create route |
 | `frontend/src/components/app-sidebar.tsx` (nested Templates nav) | HOL-1014 | Collapsible Templates sidebar with Policy / Dependencies / Grants sub-groups |
+| `frontend/src/components/scope-picker/ScopePicker.tsx` | HOL-1018 | Controlled dropdown for Organization / Project scope selection on "new resource" forms |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/index.tsx` | HOL-1020 | Org-scoped TemplateDependency ResourceGrid page |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/new.tsx` | HOL-1020 | Create TemplateDependency form with ScopePicker |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/$dependencyName.tsx` | HOL-1020 | TemplateDependency detail / edit / delete page |
+| `frontend/src/components/template-dependencies/DependencyForm.tsx` | HOL-1020 | Reusable create/edit form for TemplateDependency |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/index.tsx` | HOL-1021 | Org-scoped TemplateRequirement ResourceGrid page |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/new.tsx` | HOL-1021 | Create TemplateRequirement form with ScopePicker |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/$requirementName.tsx` | HOL-1021 | TemplateRequirement detail / edit / delete page |
+| `frontend/src/components/template-requirements/RequirementForm.tsx` | HOL-1021 | Reusable create/edit form for TemplateRequirement |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-grants/index.tsx` | HOL-1022 | Org-scoped TemplateGrant ResourceGrid page |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-grants/new.tsx` | HOL-1022 | Create TemplateGrant form with ScopePicker |
+| `frontend/src/routes/_authenticated/organizations/$orgName/template-grants/$grantName.tsx` | HOL-1022 | TemplateGrant detail / edit / delete page |
+| `frontend/src/components/template-grants/GrantForm.tsx` | HOL-1022 | Reusable create/edit form for TemplateGrant |
 
 **Deleted (HOL-914)**: `frontend/src/components/resource-manager/` and
 `frontend/src/routes/_authenticated/resource-manager/` were removed when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to holos-console are documented here.
 
 ## [Unreleased]
 
+### Added — TemplateDependency, TemplateRequirement, TemplateGrant new/edit/detail pages and ScopePicker (HOL-1017)
+
+Full CRUD UI for the three template-dependency resource families introduced in HOL-954.
+All creation forms use the new `ScopePicker` component so users can choose between
+organization and project scope without leaving the page.
+
+#### ScopePicker component (HOL-1018)
+
+`frontend/src/components/scope-picker/ScopePicker.tsx` — a controlled dropdown that
+lets "new resource" forms toggle between Organization and Project scope. Disables the
+Project option (with tooltip) when no project is selected. Used on all five creation
+forms below.
+
+#### Query hooks (HOL-1019)
+
+Added `useGetTemplateDependency`, `useCreateTemplateDependency`,
+`useUpdateTemplateDependency`, `useGetTemplateRequirement`,
+`useCreateTemplateRequirement`, `useUpdateTemplateRequirement`,
+`useGetTemplateGrant`, `useCreateTemplateGrant`, and `useUpdateTemplateGrant`
+hooks to the existing query modules in `frontend/src/queries/`.
+
+#### TemplateDependency pages (HOL-1020)
+
+- `/organizations/$orgName/template-dependencies/` — ResourceGrid index
+- `/organizations/$orgName/template-dependencies/new` — create form with ScopePicker
+- `/organizations/$orgName/template-dependencies/$dependencyName` — detail / edit / delete
+- `frontend/src/components/template-dependencies/DependencyForm.tsx` — shared form component
+
+#### TemplateRequirement pages (HOL-1021)
+
+- `/organizations/$orgName/template-requirements/` — ResourceGrid index
+- `/organizations/$orgName/template-requirements/new` — create form with ScopePicker
+- `/organizations/$orgName/template-requirements/$requirementName` — detail / edit / delete
+- `frontend/src/components/template-requirements/RequirementForm.tsx` — shared form component
+
+#### TemplateGrant pages (HOL-1022)
+
+- `/organizations/$orgName/template-grants/` — ResourceGrid index
+- `/organizations/$orgName/template-grants/new` — create form with ScopePicker
+- `/organizations/$orgName/template-grants/$grantName` — detail / edit / delete
+- `frontend/src/components/template-grants/GrantForm.tsx` — shared form component
+
+#### New header actions on project-scoped grid pages (HOL-1023)
+
+Added canCreate-gated "New" header actions to the three project-scoped template
+index pages (`/projects/$projectName/templates/dependencies/`,
+`/projects/$projectName/templates/requirements/`,
+`/projects/$projectName/templates/grants/`). The New button navigates to the
+corresponding org-scoped creation route above.
+
+#### ScopePicker adopted on existing new-resource pages (HOL-1024)
+
+`TemplatePolicy`, `TemplatePolicyBinding`, and Template creation pages now render
+`ScopePicker` so the namespace is always visible and selectable at creation time.
+
 ### Chore — Purge cascade/hierarchical-apply TemplatePolicy terminology (HOL-992 / HOL-993)
 
 TemplatePolicy enforcement is now binding-only: a policy in an ancestor namespace

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -41,6 +41,12 @@
 // a prerequisite template.
 #ResourceTypeTemplateRequirement: "template-requirement"
 
+// ResourceTypeTemplateGrant is the resource type label value for
+// TemplateGrant CRDs. Grants live only in organization or folder
+// namespaces and authorize cross-namespace template references, mirroring
+// the Gateway API ReferenceGrant pattern.
+#ResourceTypeTemplateGrant: "template-grant"
+
 // Annotations.
 #AnnotationDisplayName:  "console.holos.run/display-name"
 #AnnotationDescription:  "console.holos.run/description"

--- a/docs/agents/frontend-architecture.md
+++ b/docs/agents/frontend-architecture.md
@@ -111,6 +111,39 @@ rather than mocking ConnectRPC clients directly. See
 [docs/agents/testing-patterns.md](testing-patterns.md) for the worked testing
 patterns.
 
+## ScopePicker (HOL-1018)
+
+All "new resource" forms for org-or-project-scoped resources use `ScopePicker`
+from `frontend/src/components/scope-picker/ScopePicker.tsx`. It renders a
+controlled dropdown (Organization / Project) that lets the user choose which
+namespace a resource is created in.
+
+```tsx
+import { ScopePicker } from '@/components/scope-picker/ScopePicker'
+import type { Scope } from '@/components/scope-picker/ScopePicker'
+
+const [scope, setScope] = useState<Scope>('organization')
+<ScopePicker value={scope} onChange={setScope} disabled={!canWrite} />
+```
+
+**Convention**: every new-resource form for `TemplatePolicy`,
+`TemplatePolicyBinding`, `TemplateDependency`, `TemplateRequirement`, and
+`TemplateGrant` must include a `ScopePicker` so the user can choose between org
+and project scope. The picker reads `useProject().selectedProject` to disable
+the Project option when no project is selected; it never writes to the
+selected-entity stores.
+
+The creation pages that use `ScopePicker`:
+
+| Route | Resource | Scope options |
+|-------|----------|---------------|
+| `/organizations/$orgName/template-policies/new` | TemplatePolicy | org / project |
+| `/organizations/$orgName/template-bindings/new` | TemplatePolicyBinding | org / project |
+| `/organizations/$orgName/template-dependencies/new` | TemplateDependency | project (org disabled per admission rules) |
+| `/organizations/$orgName/template-requirements/new` | TemplateRequirement | org |
+| `/organizations/$orgName/template-grants/new` | TemplateGrant | org |
+| `/projects/$projectName/templates/new` | Template | project (fixed, disabled) |
+
 ## Nested Templates Sidebar Nav (HOL-1014)
 
 The Templates sidebar entry is a collapsible group implemented in

--- a/docs/ui/resource-routing.md
+++ b/docs/ui/resource-routing.md
@@ -156,3 +156,28 @@ navigate({ to: target })
 | `frontend/src/routes/_authenticated/folders/$folderName/settings/index.tsx` | Folder settings (plural + identifier) |
 | `frontend/src/routes/_authenticated/projects/$projectName/settings/index.tsx` | Project settings (plural + identifier) |
 | `frontend/src/lib/return-to.ts` | `buildReturnTo` / `resolveReturnTo` / `isValidReturnTo` |
+
+## Template Resource URL Patterns (HOL-1017)
+
+The following URL patterns were introduced for TemplateDependency, TemplateRequirement,
+and TemplateGrant CRUD pages. They follow the standard plural-identifier convention.
+
+| Pattern | Purpose |
+|---------|---------|
+| `/organizations/$orgName/template-dependencies/` | List org-scoped TemplateDependency resources |
+| `/organizations/$orgName/template-dependencies/new` | Create TemplateDependency (with ScopePicker) |
+| `/organizations/$orgName/template-dependencies/$dependencyName` | Detail / edit / delete TemplateDependency |
+| `/organizations/$orgName/template-requirements/` | List org-scoped TemplateRequirement resources |
+| `/organizations/$orgName/template-requirements/new` | Create TemplateRequirement (with ScopePicker) |
+| `/organizations/$orgName/template-requirements/$requirementName` | Detail / edit / delete TemplateRequirement |
+| `/organizations/$orgName/template-grants/` | List org-scoped TemplateGrant resources |
+| `/organizations/$orgName/template-grants/new` | Create TemplateGrant (with ScopePicker) |
+| `/organizations/$orgName/template-grants/$grantName` | Detail / edit / delete TemplateGrant |
+| `/projects/$projectName/templates/dependencies/` | Project-scoped TemplateDependency index (New navigates to org route above) |
+| `/projects/$projectName/templates/requirements/` | Project-scoped TemplateRequirement index (New navigates to org route above) |
+| `/projects/$projectName/templates/grants/` | Project-scoped TemplateGrant index (New navigates to org route above) |
+
+TemplateDependency objects are stored in **project** namespaces; TemplateRequirement
+and TemplateGrant objects are stored in **org or folder** namespaces. The `ScopePicker`
+on the create pages lets users choose the target namespace at creation time.
+Admission policies enforce the namespace constraint server-side.

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
@@ -8,8 +8,7 @@
  * HOL-1023: added "New" header action gated on project OWNER/EDITOR role,
  * navigating to the org-scoped /template-dependencies/new route.
  *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
+ * The sidebar nesting was implemented in HOL-1014.
  */
 
 import { useCallback, useMemo } from 'react'

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
@@ -65,7 +65,7 @@ export function TemplateGrantsIndexPage({
 
   // TemplateGrants are org/folder-scoped — namespace comes from the selected
   // org, not the project. The project param keeps Templates sidebar active
-  // The project param keeps Templates sidebar active (HOL-1014).
+  // in the sidebar (HOL-1014).
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
@@ -3,14 +3,11 @@
  *
  * TemplateGrants are org/folder-scoped, not project-scoped. The namespace is
  * derived from the selected organization via useOrg().selectedOrg. The project
- * name still appears in the URL so the Templates collapsible group can stay
- * open in a later sidebar phase (HOL-1014).
+ * name still appears in the URL so the Templates collapsible group stays open
+ * in the sidebar (HOL-1014).
  *
  * HOL-1023: added "New" header action gated on org OWNER/EDITOR role,
  * navigating to the org-scoped /template-grants/new route.
- *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
  */
 
 import { useCallback, useMemo } from 'react'
@@ -68,7 +65,7 @@ export function TemplateGrantsIndexPage({
 
   // TemplateGrants are org/folder-scoped — namespace comes from the selected
   // org, not the project. The project param keeps Templates sidebar active
-  // in a later phase.
+  // The project param keeps Templates sidebar active (HOL-1014).
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
@@ -4,10 +4,8 @@
  * TemplatePolicies are org/folder-scoped, not project-scoped. The namespace
  * is derived from the selected organization via useOrg().selectedOrg. The
  * project name still appears in the URL so the Templates collapsible group
- * can stay open in a later sidebar phase (HOL-1014).
- *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
+ * can stay open in the sidebar. The collapsible Templates sidebar was
+ * implemented in HOL-1014.
  */
 
 import { useCallback, useMemo } from 'react'

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
@@ -4,10 +4,8 @@
  * TemplatePolicyBindings are org/folder-scoped, not project-scoped. The
  * namespace is derived from the selected organization via useOrg().selectedOrg.
  * The project name still appears in the URL so the Templates collapsible group
- * can stay open in a later sidebar phase (HOL-1014).
- *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
+ * can stay open in the sidebar. The collapsible Templates sidebar was
+ * implemented in HOL-1014.
  */
 
 import { useCallback, useMemo } from 'react'
@@ -63,7 +61,7 @@ export function TemplatePolicyBindingsIndexPage({
 
   // TemplatePolicyBindings are org/folder-scoped — namespace comes from the
   // selected org, not the project. The project param keeps Templates sidebar
-  // active in a later phase.
+  // The project param keeps Templates sidebar active (HOL-1014).
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
@@ -61,7 +61,7 @@ export function TemplatePolicyBindingsIndexPage({
 
   // TemplatePolicyBindings are org/folder-scoped — namespace comes from the
   // selected org, not the project. The project param keeps Templates sidebar
-  // The project param keeps Templates sidebar active (HOL-1014).
+  // active in the sidebar (HOL-1014).
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
@@ -4,13 +4,10 @@
  * TemplateRequirements are org/folder-scoped, not project-scoped. The namespace
  * is derived from the selected organization via useOrg().selectedOrg. The
  * project name still appears in the URL so the Templates collapsible group
- * can stay open in a later sidebar phase (HOL-1014).
+ * stays open in the sidebar (HOL-1014).
  *
  * HOL-1023: added "New" header action gated on org OWNER/EDITOR role,
  * navigating to the org-scoped /template-requirements/new route.
- *
- * Sidebar nesting is handled in HOL-1014; for now the route exists and is
- * reachable by URL.
  */
 
 import { useCallback, useMemo } from 'react'
@@ -68,7 +65,7 @@ export function TemplateRequirementsIndexPage({
 
   // TemplateRequirements are org/folder-scoped — namespace comes from the
   // selected org, not the project. The project param keeps Templates sidebar
-  // active in a later phase.
+  // The project param keeps Templates sidebar active (HOL-1014).
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
@@ -65,7 +65,7 @@ export function TemplateRequirementsIndexPage({
 
   // TemplateRequirements are org/folder-scoped — namespace comes from the
   // selected org, not the project. The project param keeps Templates sidebar
-  // The project param keeps Templates sidebar active (HOL-1014).
+  // active in the sidebar (HOL-1014).
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 


### PR DESCRIPTION
## Summary

- Updated `AGENTS.md` route table with entries for `ScopePicker`, the three new resource families (TemplateDependency, TemplateRequirement, TemplateGrant), their `new.tsx` / `$name.tsx` detail routes, and their form components (HOL-1018–1024).
- Added a `ScopePicker` section to `docs/agents/frontend-architecture.md` documenting the component contract, the convention that all "new resource" forms for org/project-scoped resources use it, and a table of creation pages.
- Extended `docs/ui/resource-routing.md` with a "Template Resource URL Patterns" section covering the six new URL patterns (org-scoped and project-scoped indexes, new, and detail routes).
- Added a `CHANGELOG.md` entry for the full HOL-1017 series (HOL-1018 through HOL-1024).
- Removed stale `"later sidebar phase (HOL-1014)"` comments from five project-scoped template index files; HOL-1014 shipped in PR #1224.
- Synced `api/v1alpha2/schema_gen.cue` with the `#ResourceTypeTemplateGrant` constant already present in `api/v1alpha2/annotations.go` (leftover from implementation phases).

Fixes HOL-1025

## Follow-up issues filed

- **HOL-1037**: `policies/index.tsx` and `policy-bindings/index.tsx` (project-scoped) still use `ResourceGrid` directly; all other project-scoped template family index pages use `StandardPageLayout`.
- **HOL-1038**: `organizations/$orgName/template-dependencies/`, `template-requirements/`, and `template-grants/` index pages still use `ResourceGrid` directly; their project-scoped equivalents use `StandardPageLayout`.

These are not fixed here per the issue scope: "Anything that would be a behaviour change goes into a follow-up issue."

## Test plan

- [x] `make test-ui` — 108 test files, 1433 tests pass
- [x] `make test-go` — all Go packages pass
- [ ] Manual smoke: `make run` + `make dev`, navigate to a project → Templates → Dependencies / Requirements / Grants, click New, confirm ScopePicker is present