### PR TITLE
refactor(frontend): migrate policies/policy-bindings index pages to StandardPageLayout

### DIFF
--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policies/index.tsx
@@ -10,7 +10,7 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -127,15 +127,17 @@ export function TemplatePoliciesIndexPage({
   )
 
   return (
-    <ResourceGrid
-      title={`${projectName} / Templates / Policies`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[projectName, 'Templates', 'Policies']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/policy-bindings/index.tsx
@@ -10,7 +10,7 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -131,15 +131,17 @@ export function TemplatePolicyBindingsIndexPage({
   )
 
   return (
-    <ResourceGrid
-      title={`${projectName} / Templates / Policy Bindings`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[projectName, 'Templates', 'Policy Bindings']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }


### PR DESCRIPTION
## Summary

- Replace `ResourceGrid` direct usage with `StandardPageLayout` in `templates/policies/index.tsx`
- Replace `ResourceGrid` direct usage with `StandardPageLayout` in `templates/policy-bindings/index.tsx`
- Convert `title` string prop to `titleParts={[projectName, 'Templates', 'Policies']}` and `titleParts={[projectName, 'Templates', 'Policy Bindings']}` respectively
- Aligns both pages with every other project-scoped template family index page (dependencies, requirements, grants, templates index)

Fixes HOL-1037

## Test plan

- [x] `make test-ui` passes (1433 tests, 108 test files)
- [x] Both files use `StandardPageLayout` instead of `ResourceGrid` directly
- [x] `titleParts` array follows the `[projectName, 'Templates', '<resource>']` pattern
- [x] No behaviour change — pure component composition refactor