### PR TITLE
refactor: migrate org-scoped template resource index pages to StandardPageLayout

### DIFF
--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/index.tsx
@@ -1,15 +1,18 @@
 /**
- * Organization-scoped TemplateDependency index (HOL-1020).
+ * Organization-scoped TemplateDependency index (HOL-1020, HOL-1038).
  *
  * TemplateDependency objects live in project namespaces. This org-scoped index
  * shows dependencies from the currently-selected project. When no project is
  * selected, an empty state prompts the user to select one.
+ *
+ * HOL-1038: migrated from ResourceGrid directly to StandardPageLayout for
+ * consistency with the project-scoped equivalents.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -142,18 +145,22 @@ export function OrgTemplateDependenciesIndexPage({
     [navigate],
   )
 
-  const titleSuffix = selectedProject ? ` (${selectedProject})` : ''
+  const titleParts = selectedProject
+    ? [orgName, 'Template Dependencies', selectedProject]
+    : [orgName, 'Template Dependencies']
 
   return (
-    <ResourceGrid
-      title={`${orgName} / Template Dependencies${titleSuffix}`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={titleParts}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/index.tsx
@@ -1,14 +1,17 @@
 /**
- * Organization-scoped TemplateGrant index (HOL-1022).
+ * Organization-scoped TemplateGrant index (HOL-1022, HOL-1038).
  *
  * TemplateGrant objects live in organization or folder namespaces. This
  * org-scoped index shows grants in the current org namespace.
+ *
+ * HOL-1038: migrated from ResourceGrid directly to StandardPageLayout for
+ * consistency with the project-scoped equivalents.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -138,15 +141,17 @@ export function OrgTemplateGrantsIndexPage({
   )
 
   return (
-    <ResourceGrid
-      title={`${orgName} / Template Grants`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[orgName, 'Template Grants']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/index.tsx
@@ -1,14 +1,17 @@
 /**
- * Organization-scoped TemplateRequirement index (HOL-1021).
+ * Organization-scoped TemplateRequirement index (HOL-1021, HOL-1038).
  *
  * TemplateRequirement objects live in organization or folder namespaces. This
  * org-scoped index shows requirements in the current org namespace.
+ *
+ * HOL-1038: migrated from ResourceGrid directly to StandardPageLayout for
+ * consistency with the project-scoped equivalents.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
-import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
+import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
@@ -138,15 +141,17 @@ export function OrgTemplateRequirementsIndexPage({
   )
 
   return (
-    <ResourceGrid
-      title={`${orgName} / Template Requirements`}
-      kinds={kinds}
-      rows={rows}
-      onDelete={handleDelete}
-      isLoading={isPending}
-      error={error}
-      search={search}
-      onSearchChange={handleSearchChange}
+    <StandardPageLayout
+      titleParts={[orgName, 'Template Requirements']}
+      grid={{
+        kinds,
+        rows,
+        onDelete: handleDelete,
+        isLoading: isPending,
+        error,
+        search,
+        onSearchChange: handleSearchChange,
+      }}
     />
   )
 }


### PR DESCRIPTION
## Summary

- Replaces `<ResourceGrid title={...} />` with `<StandardPageLayout titleParts={[...]} grid={{...}} />` in three org-scoped index pages: `template-dependencies/index.tsx`, `template-requirements/index.tsx`, and `template-grants/index.tsx`
- The template-dependencies page gains a richer title — when a project is selected the title parts become `[orgName, 'Template Dependencies', selectedProject]` instead of appending a suffix string
- Project-scoped equivalents already used `StandardPageLayout`; this brings the org-scoped pages into alignment
- The org-level `templates/index.tsx` is intentionally left unchanged per the issue spec (it uses custom `extraColumns` and `headerContent` not exposed by `StandardPageLayout`)

Fixes HOL-1038

## Test plan

- [ ] `make test-ui` passes (108 test files, 1433 tests)
- [ ] Org-scoped template-dependencies page renders `orgName / Template Dependencies` title (or `orgName / Template Dependencies / projectName` when a project is selected)
- [ ] Org-scoped template-requirements page renders `orgName / Template Requirements` title
- [ ] Org-scoped template-grants page renders `orgName / Template Grants` title
- [ ] No behaviour regressions: rows, delete, search, and New button all work as before