### PR TITLE
feat(rpc): add OIDC impersonating clients

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -48,9 +48,9 @@ import (
 	"github.com/holos-run/holos-console/console/secrets"
 	"github.com/holos-run/holos-console/console/settings"
 	"github.com/holos-run/holos-console/console/templatedependencies"
+	"github.com/holos-run/holos-console/console/templategrants"
 	"github.com/holos-run/holos-console/console/templatepolicies"
 	"github.com/holos-run/holos-console/console/templatepolicybindings"
-	"github.com/holos-run/holos-console/console/templategrants"
 	"github.com/holos-run/holos-console/console/templaterequirements"
 	"github.com/holos-run/holos-console/console/templates"
 	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
@@ -256,6 +256,15 @@ func (s *Server) Serve(ctx context.Context) error {
 		rpc.LoggingInterceptor(),
 	)
 
+	// Resolve the base Kubernetes REST config once. Startup-scoped clients keep
+	// using service-account credentials in this phase, while the auth
+	// interceptor copies this config per request and fills rest.Config.Impersonate
+	// from the authenticated OIDC claims.
+	restConfig, err := secrets.NewRestConfig()
+	if err != nil {
+		return fmt.Errorf("failed to resolve kubernetes REST config: %w", err)
+	}
+
 	// Configure ConnectRPC interceptors for protected routes (auth required)
 	// Note: The auth interceptor uses lazy verifier initialization since Dex
 	// isn't running yet when we create the interceptor.
@@ -265,7 +274,13 @@ func (s *Server) Serve(ctx context.Context) error {
 		protectedInterceptors = connect.WithInterceptors(
 			rpc.MetricsInterceptor(),
 			rpc.LoggingInterceptor(),
-			rpc.LazyAuthInterceptor(s.cfg.Issuer, s.cfg.ClientID, s.cfg.RolesClaim, internalClient),
+			rpc.LazyAuthInterceptor(
+				s.cfg.Issuer,
+				s.cfg.ClientID,
+				s.cfg.RolesClaim,
+				internalClient,
+				rpc.WithImpersonationConfig(restConfig, controllermgr.Scheme),
+			),
 		)
 	} else {
 		// Fallback to public interceptors if auth not configured
@@ -285,11 +300,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	// Initialize Kubernetes client for secrets (may be nil if no cluster available).
 	// We share the resolved REST config with the controller-runtime manager
 	// below so there is a single loader for the cluster connection.
-	restConfig, err := secrets.NewRestConfig()
-	if err != nil {
-		return fmt.Errorf("failed to resolve kubernetes REST config: %w", err)
-	}
-	k8sClientset, err := secrets.NewClientset()
+	k8sClientset, err := secrets.NewClientsetForConfig(restConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/console/rpc/auth.go
+++ b/console/rpc/auth.go
@@ -2,13 +2,34 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
 
 	"connectrpc.com/connect"
 	"github.com/coreos/go-oidc/v3/oidc"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 )
+
+type authInterceptorConfig struct {
+	impersonationBaseConfig *rest.Config
+	impersonationScheme     *runtime.Scheme
+}
+
+// AuthInterceptorOption configures LazyAuthInterceptor.
+type AuthInterceptorOption func(*authInterceptorConfig)
+
+// WithImpersonationConfig enables per-request Kubernetes impersonating clients
+// in the auth interceptor. The base config is copied for each request before
+// rest.Config.Impersonate is populated.
+func WithImpersonationConfig(base *rest.Config, scheme *runtime.Scheme) AuthInterceptorOption {
+	return func(cfg *authInterceptorConfig) {
+		cfg.impersonationBaseConfig = base
+		cfg.impersonationScheme = scheme
+	}
+}
 
 // LazyAuthInterceptor returns a ConnectRPC interceptor that lazily initializes
 // the OIDC verifier on first use. This is needed because the OIDC provider (Dex)
@@ -17,7 +38,12 @@ import (
 //
 // If OIDC discovery fails, the error is not cached. Subsequent requests retry
 // discovery until it succeeds, at which point the verifier is cached permanently.
-func LazyAuthInterceptor(issuer, clientID, rolesClaim string, client *http.Client) connect.UnaryInterceptorFunc {
+func LazyAuthInterceptor(issuer, clientID, rolesClaim string, client *http.Client, opts ...AuthInterceptorOption) connect.UnaryInterceptorFunc {
+	var cfg authInterceptorConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	var (
 		mu       sync.Mutex
 		verifier *oidc.IDTokenVerifier
@@ -54,6 +80,14 @@ func LazyAuthInterceptor(issuer, clientID, rolesClaim string, client *http.Clien
 			}
 
 			ctx = ContextWithClaims(ctx, claims)
+			impersonatedClients, err := NewImpersonatedClients(claims, cfg.impersonationBaseConfig, cfg.impersonationScheme)
+			if err != nil {
+				if errors.Is(err, ErrUnauthenticatedImpersonation) {
+					return nil, connect.NewError(connect.CodeUnauthenticated, err)
+				}
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
+			ctx = ContextWithImpersonatedClients(ctx, impersonatedClients)
 			return next(ctx, req)
 		}
 	}

--- a/console/rpc/auth_test.go
+++ b/console/rpc/auth_test.go
@@ -15,6 +15,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // fakeOIDCServer creates an httptest server that serves OIDC discovery and JWKS
@@ -80,6 +81,10 @@ func newFakeOIDCServer(t *testing.T) *fakeOIDCServer {
 
 // signToken creates a signed JWT with the given subject and audience.
 func (f *fakeOIDCServer) signToken(t *testing.T, subject, audience string) string {
+	return f.signTokenWithClaims(t, subject, audience, nil)
+}
+
+func (f *fakeOIDCServer) signTokenWithClaims(t *testing.T, subject, audience string, extra map[string]interface{}) string {
 	t.Helper()
 
 	signerOpts := jose.SignerOptions{}
@@ -103,7 +108,11 @@ func (f *fakeOIDCServer) signToken(t *testing.T, subject, audience string) strin
 		NotBefore: jwt.NewNumericDate(now),
 	}
 
-	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	builder := jwt.Signed(signer).Claims(claims)
+	if extra != nil {
+		builder = builder.Claims(extra)
+	}
+	token, err := builder.Serialize()
 	if err != nil {
 		t.Fatalf("signing token: %v", err)
 	}
@@ -196,5 +205,58 @@ func TestLazyAuthInterceptor_CachesAfterSuccess(t *testing.T) {
 	_, err = handler(context.Background(), newTestRequest(token))
 	if err != nil {
 		t.Fatalf("third request failed: %v", err)
+	}
+}
+
+func TestLazyAuthInterceptorAttachesImpersonatedClients(t *testing.T) {
+	fake := newFakeOIDCServer(t)
+	defer fake.Server.Close()
+
+	k8sHeaders := make(chan http.Header, 1)
+	k8sServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		k8sHeaders <- r.Header.Clone()
+		writeNamespaceList(t, w)
+	}))
+	defer k8sServer.Close()
+
+	clientID := "test-client"
+	interceptor := LazyAuthInterceptor(
+		fake.Server.URL,
+		clientID,
+		"groups",
+		fake.Server.Client(),
+		WithImpersonationConfig(testRESTConfig(k8sServer.URL), nil),
+	)
+
+	handler := interceptor(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		if ClaimsFromContext(ctx) == nil {
+			t.Fatal("claims missing from request context")
+		}
+		if ImpersonatedClientsetFromContext(ctx) == nil {
+			t.Fatal("impersonated clientset missing from request context")
+		}
+		if _, err := ImpersonatedClientsetFromContext(ctx).CoreV1().Namespaces().List(ctx, metav1.ListOptions{}); err != nil {
+			t.Fatalf("list namespaces through impersonated clientset: %v", err)
+		}
+		return nil, nil
+	})
+
+	token := fake.signTokenWithClaims(t, "user-1", clientID, map[string]interface{}{
+		"groups": []string{"platform-admins"},
+		"email":  "user-1@example.com",
+	})
+	if _, err := handler(context.Background(), newTestRequest(token)); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	got := <-k8sHeaders
+	if got.Get("Impersonate-User") != "oidc:user-1" {
+		t.Fatalf("Impersonate-User = %q, want oidc:user-1", got.Get("Impersonate-User"))
+	}
+	if got.Get("Impersonate-Group") != "oidc:platform-admins" {
+		t.Fatalf("Impersonate-Group = %q, want oidc:platform-admins", got.Get("Impersonate-Group"))
+	}
+	if got.Get("Impersonate-Extra-Email") != "" {
+		t.Fatalf("Impersonate-Extra-Email = %q, want empty", got.Get("Impersonate-Extra-Email"))
 	}
 }

--- a/console/rpc/impersonation.go
+++ b/console/rpc/impersonation.go
@@ -1,0 +1,165 @@
+package rpc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const oidcImpersonationPrefix = "oidc:"
+
+// ErrUnauthenticatedImpersonation is returned when an impersonating client
+// cannot be built because the request has no authenticated OIDC principal.
+var ErrUnauthenticatedImpersonation = errors.New("authenticated OIDC subject is required for kubernetes impersonation")
+
+// ImpersonatedClients is the per-request Kubernetes client bundle used by RPC
+// handlers as they migrate from the startup-scoped service-account clients.
+type ImpersonatedClients struct {
+	Clientset kubernetes.Interface
+	Dynamic   dynamic.Interface
+	Client    ctrlclient.Client
+}
+
+// NewImpersonatedClients creates Kubernetes clients that impersonate the OIDC
+// subject and groups from claims. The returned clients must be scoped to the
+// current request context; callers must not store them globally.
+func NewImpersonatedClients(claims *Claims, base *rest.Config, scheme *runtime.Scheme) (*ImpersonatedClients, error) {
+	if claims == nil || strings.TrimSpace(claims.Sub) == "" {
+		return nil, ErrUnauthenticatedImpersonation
+	}
+	if base == nil {
+		return newUnauthenticatedClients()
+	}
+
+	config := rest.CopyConfig(base)
+	config.Impersonate = rest.ImpersonationConfig{
+		UserName: oidcImpersonationPrefix + claims.Sub,
+		Groups:   PrefixedOIDCGroups(claims.Roles),
+	}
+	return newClientsForConfig(config, scheme)
+}
+
+// PrefixedOIDCGroups maps OIDC group claims into the Kubernetes principal
+// namespace defined by ADR 036.
+func PrefixedOIDCGroups(groups []string) []string {
+	if len(groups) == 0 {
+		return nil
+	}
+	prefixed := make([]string, 0, len(groups))
+	for _, group := range groups {
+		group = strings.TrimSpace(group)
+		if group == "" || strings.HasPrefix(group, "system:") {
+			continue
+		}
+		prefixed = append(prefixed, oidcImpersonationPrefix+group)
+	}
+	return prefixed
+}
+
+type impersonatedClientsKey struct{}
+
+// ContextWithImpersonatedClients stores the per-request impersonating clients.
+func ContextWithImpersonatedClients(ctx context.Context, clients *ImpersonatedClients) context.Context {
+	return context.WithValue(ctx, impersonatedClientsKey{}, clients)
+}
+
+// ImpersonatedClientsFromContext returns the per-request impersonating clients,
+// or a no-op unauthenticated bundle when the context has no authenticated user.
+func ImpersonatedClientsFromContext(ctx context.Context) *ImpersonatedClients {
+	if clients, _ := ctx.Value(impersonatedClientsKey{}).(*ImpersonatedClients); clients != nil {
+		return clients
+	}
+	return unauthenticatedClients()
+}
+
+// ImpersonatedClientsetFromContext returns the per-request client-go clientset.
+func ImpersonatedClientsetFromContext(ctx context.Context) kubernetes.Interface {
+	return ImpersonatedClientsFromContext(ctx).Clientset
+}
+
+// ImpersonatedDynamicClientFromContext returns the per-request dynamic client.
+func ImpersonatedDynamicClientFromContext(ctx context.Context) dynamic.Interface {
+	return ImpersonatedClientsFromContext(ctx).Dynamic
+}
+
+// ImpersonatedCtrlClientFromContext returns the per-request controller-runtime client.
+func ImpersonatedCtrlClientFromContext(ctx context.Context) ctrlclient.Client {
+	return ImpersonatedClientsFromContext(ctx).Client
+}
+
+func newClientsForConfig(config *rest.Config, scheme *runtime.Scheme) (*ImpersonatedClients, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	if scheme == nil {
+		scheme = clientgoscheme.Scheme
+	}
+	ctrlClient, err := ctrlclient.New(config, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+	return &ImpersonatedClients{
+		Clientset: clientset,
+		Dynamic:   dynamicClient,
+		Client:    ctrlClient,
+	}, nil
+}
+
+var (
+	unauthenticatedOnce sync.Once
+	unauthenticated     *ImpersonatedClients
+)
+
+func unauthenticatedClients() *ImpersonatedClients {
+	unauthenticatedOnce.Do(func() {
+		var err error
+		unauthenticated, err = newUnauthenticatedClients()
+		if err != nil {
+			panic(err)
+		}
+	})
+	return unauthenticated
+}
+
+func newUnauthenticatedClients() (*ImpersonatedClients, error) {
+	return newClientsForConfig(&rest.Config{
+		Host: "https://unauthenticated.invalid",
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			status := apierrors.NewUnauthorized("authentication required").Status()
+			body, err := runtime.Encode(clientgoscheme.Codecs.LegacyCodec(metav1.SchemeGroupVersion), &status)
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Status:     http.StatusText(http.StatusUnauthorized),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(bytes.NewReader(body)),
+			}, nil
+		}),
+	}, clientgoscheme.Scheme)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/console/rpc/impersonation_test.go
+++ b/console/rpc/impersonation_test.go
@@ -1,0 +1,138 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+func TestNewImpersonatedClientsAddsOIDCImpersonationHeaders(t *testing.T) {
+	headers := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers <- r.Header.Clone()
+		writeNamespaceList(t, w)
+	}))
+	defer server.Close()
+
+	clients, err := NewImpersonatedClients(&Claims{
+		Sub:   "user-123",
+		Email: "user@example.com",
+		Roles: []string{"platform-admins", "project-editors", "system:authenticated"},
+	}, testRESTConfig(server.URL), nil)
+	if err != nil {
+		t.Fatalf("NewImpersonatedClients: %v", err)
+	}
+
+	if _, err := clients.Clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{}); err != nil {
+		t.Fatalf("list namespaces: %v", err)
+	}
+
+	got := <-headers
+	if got.Get("Impersonate-User") != "oidc:user-123" {
+		t.Fatalf("Impersonate-User = %q, want oidc:user-123", got.Get("Impersonate-User"))
+	}
+	wantGroups := []string{"oidc:platform-admins", "oidc:project-editors"}
+	if !reflect.DeepEqual(got.Values("Impersonate-Group"), wantGroups) {
+		t.Fatalf("Impersonate-Group = %#v, want %#v", got.Values("Impersonate-Group"), wantGroups)
+	}
+	if got.Get("Impersonate-Extra-Email") != "" {
+		t.Fatalf("Impersonate-Extra-Email = %q, want empty", got.Get("Impersonate-Extra-Email"))
+	}
+}
+
+func TestImpersonatedClientsFromContextCachesWithinRequestOnly(t *testing.T) {
+	users := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		users <- r.Header.Get("Impersonate-User")
+		writeNamespaceList(t, w)
+	}))
+	defer server.Close()
+
+	ctxA := contextWithTestImpersonatedClients(t, "alice", server.URL)
+	ctxB := contextWithTestImpersonatedClients(t, "bob", server.URL)
+
+	clientA := ImpersonatedClientsetFromContext(ctxA)
+	if got := ImpersonatedClientsetFromContext(ctxA); got != clientA {
+		t.Fatal("same request context returned a different impersonated clientset")
+	}
+	clientB := ImpersonatedClientsetFromContext(ctxB)
+	if clientB == clientA {
+		t.Fatal("different request contexts shared the same impersonated clientset")
+	}
+
+	if _, err := clientA.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{}); err != nil {
+		t.Fatalf("list namespaces as alice: %v", err)
+	}
+	if _, err := clientB.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{}); err != nil {
+		t.Fatalf("list namespaces as bob: %v", err)
+	}
+
+	if got := <-users; got != "oidc:alice" {
+		t.Fatalf("first request impersonated %q, want oidc:alice", got)
+	}
+	if got := <-users; got != "oidc:bob" {
+		t.Fatalf("second request impersonated %q, want oidc:bob", got)
+	}
+}
+
+func TestImpersonatedClientsFromContextWithoutAuthReturnsUnauthorizedClient(t *testing.T) {
+	_, err := ImpersonatedClientsetFromContext(context.Background()).
+		CoreV1().
+		Namespaces().
+		List(context.Background(), metav1.ListOptions{})
+	if !apierrors.IsUnauthorized(err) {
+		t.Fatalf("error = %v, want kubernetes unauthorized error", err)
+	}
+}
+
+func TestNewImpersonatedClientsRejectsEmptySubject(t *testing.T) {
+	_, err := NewImpersonatedClients(&Claims{Roles: []string{"platform-admins"}}, testRESTConfig("https://example.test"), nil)
+	if err == nil {
+		t.Fatal("expected error for empty subject, got nil")
+	}
+	if err != ErrUnauthenticatedImpersonation {
+		t.Fatalf("error = %v, want ErrUnauthenticatedImpersonation", err)
+	}
+}
+
+func contextWithTestImpersonatedClients(t *testing.T, sub, host string) context.Context {
+	t.Helper()
+	clients, err := NewImpersonatedClients(&Claims{Sub: sub}, testRESTConfig(host), nil)
+	if err != nil {
+		t.Fatalf("NewImpersonatedClients(%q): %v", sub, err)
+	}
+	return ContextWithImpersonatedClients(context.Background(), clients)
+}
+
+func testRESTConfig(host string) *rest.Config {
+	return &rest.Config{
+		Host:    host,
+		APIPath: "/api",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &schema.GroupVersion{Version: "v1"},
+			NegotiatedSerializer: clientgoscheme.Codecs.WithoutConversion(),
+		},
+	}
+}
+
+func writeNamespaceList(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]interface{}{
+		"kind":       "NamespaceList",
+		"apiVersion": "v1",
+		"metadata":   map[string]interface{}{},
+		"items":      []interface{}{},
+	}); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+}

--- a/console/secrets/client.go
+++ b/console/secrets/client.go
@@ -17,6 +17,13 @@ func NewClientset() (kubernetes.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewClientsetForConfig(config)
+}
+
+// NewClientsetForConfig creates a Kubernetes clientset from an already-resolved
+// REST config. A nil config returns a nil clientset so callers can share the
+// same "cluster unavailable" behavior as NewClientset.
+func NewClientsetForConfig(config *rest.Config) (kubernetes.Interface, error) {
 	if config == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary
- Add a per-request Kubernetes impersonation client bundle for typed, dynamic, and controller-runtime clients.
- Wire LazyAuthInterceptor to attach impersonated clients after OIDC token validation.
- Reuse the resolved base Kubernetes REST config and keep existing handlers on startup-scoped clients.
- Cover OIDC prefixing, groups translation, unauthenticated no-op clients, request-local caching, and interceptor context wiring.

Fixes HOL-1031

## Test plan
- [x] go test ./console/rpc
- [x] make test-go
- [x] make test-ui