### PR TITLE
feat(secrets): use Kubernetes RBAC for project secret sharing

### DIFF
--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -326,8 +326,13 @@ func (h *Handler) CreateProject(
 		}
 	}
 
-	// Ensure creator is included as owner
+	// Keep the legacy project metadata grant email-shaped for UI display, but
+	// bind the RBAC owner to the stable OIDC subject per ADR 036.
 	shareUsers = ensureCreatorOwner(shareUsers, claims.Email)
+	rbacShareUsers := removeGrantPrincipal(shareUsers, claims.Email)
+	if claims.Sub != "" {
+		rbacShareUsers = ensureCreatorOwner(rbacShareUsers, claims.Sub)
+	}
 
 	// Create the project namespace, retrying on AlreadyExists when the name was
 	// auto-generated (race between GenerateIdentifier check and K8s create).
@@ -337,7 +342,7 @@ func (h *Handler) CreateProject(
 	// single branch.
 	const maxCreateRetries = 3
 	for attempt := range maxCreateRetries + 1 {
-		err = h.createProjectOnce(ctx, name, req.Msg, parentNs, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+		err = h.createProjectOnce(ctx, name, req.Msg, parentNs, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles, rbacShareUsers)
 		if err == nil {
 			break
 		}
@@ -390,6 +395,7 @@ func (h *Handler) createProjectOnce(
 	parentNs string,
 	creatorEmail string,
 	shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant,
+	rbacShareUsers []secrets.AnnotationGrant,
 ) error {
 	// Always build the base Namespace object up front — both paths need
 	// it (the typed Create call still uses it, and the pipeline needs
@@ -416,17 +422,23 @@ func (h *Handler) createProjectOnce(
 		}
 		if outcome == ProjectNamespacePipelineBindingsApplied {
 			// The applier already SSA'd the Namespace and every
-			// associated resource; there is nothing else to write.
+			// associated resource. The RBAC objects below are a
+			// console-owned elevation path from ADR 036 Decision 5,
+			// so they are reconciled explicitly after the namespace
+			// exists rather than rendered as the impersonated user.
 			// Note this path does not surface AlreadyExists (SSA is
 			// idempotent), so the auto-generated-name retry is a
 			// no-op when the pipeline handles the create.
-			return nil
+			return h.k8s.EnsureProjectSecretRBACForNamespace(ctx, baseNs.Name, namespaceOwnerRefs(baseNs), rbacShareUsers, shareRoles)
 		}
 	}
 
 	// Existing path: typed Create. Unchanged from pre-HOL-812 behavior.
 	_, err = h.k8s.client.CoreV1().Namespaces().Create(ctx, baseNs, metav1.CreateOptions{})
-	return err
+	if err != nil {
+		return err
+	}
+	return h.k8s.EnsureProjectSecretRBAC(ctx, name, rbacShareUsers, shareRoles)
 }
 
 // parentAncestorNamespace returns the namespace the ProjectNamespace
@@ -1175,15 +1187,33 @@ func protoRoleFromString(s string) consolev1.Role {
 	}
 }
 
-// ensureCreatorOwner ensures the creator email is in the share-users list as owner.
-func ensureCreatorOwner(shareUsers []secrets.AnnotationGrant, email string) []secrets.AnnotationGrant {
-	emailLower := strings.ToLower(email)
+// ensureCreatorOwner ensures the creator principal is in the share-users list as owner.
+func ensureCreatorOwner(shareUsers []secrets.AnnotationGrant, principal string) []secrets.AnnotationGrant {
+	if principal == "" {
+		return shareUsers
+	}
+	principalLower := strings.ToLower(principal)
 	for _, g := range shareUsers {
-		if strings.ToLower(g.Principal) == emailLower && strings.ToLower(g.Role) == "owner" {
+		if strings.ToLower(g.Principal) == principalLower && strings.ToLower(g.Role) == "owner" {
 			return shareUsers
 		}
 	}
-	return append(shareUsers, secrets.AnnotationGrant{Principal: email, Role: "owner"})
+	return append(shareUsers, secrets.AnnotationGrant{Principal: principal, Role: "owner"})
+}
+
+func removeGrantPrincipal(grants []secrets.AnnotationGrant, principal string) []secrets.AnnotationGrant {
+	if principal == "" {
+		return append([]secrets.AnnotationGrant(nil), grants...)
+	}
+	principalLower := strings.ToLower(principal)
+	filtered := make([]secrets.AnnotationGrant, 0, len(grants))
+	for _, grant := range grants {
+		if strings.ToLower(grant.Principal) == principalLower {
+			continue
+		}
+		filtered = append(filtered, grant)
+	}
+	return filtered
 }
 
 // mapK8sError converts Kubernetes API errors to ConnectRPC errors.

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -9,8 +9,10 @@ import (
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/secretrbac"
 	"github.com/holos-run/holos-console/console/secrets"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -169,6 +171,120 @@ func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, descri
 		return nil, err
 	}
 	return c.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+}
+
+// EnsureProjectSecretRBAC materializes the project-scoped Secret Roles and the
+// RoleBindings implied by the project's resolved share grants. This runs as the
+// console service account per ADR 036 Decision 5 because it reconciles RBAC for
+// humans rather than acting as the requesting human.
+func (c *K8sClient) EnsureProjectSecretRBAC(ctx context.Context, project string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
+	ns, err := c.GetProject(ctx, project)
+	if err != nil {
+		return err
+	}
+	return c.EnsureProjectSecretRBACForNamespace(ctx, ns.Name, namespaceOwnerRefs(ns), shareUsers, shareRoles)
+}
+
+func (c *K8sClient) EnsureProjectSecretRBACForNamespace(ctx context.Context, namespace string, ownerRefs []metav1.OwnerReference, shareUsers, shareRoles []secrets.AnnotationGrant) error {
+	roleOwners := make(map[string][]metav1.OwnerReference)
+	for _, role := range secretrbac.ProjectSecretRoles(namespace, ownerRefs) {
+		if err := c.applyRole(ctx, role); err != nil {
+			return fmt.Errorf("applying project secret role %q: %w", role.Name, err)
+		}
+		roleOwners[role.Name] = []metav1.OwnerReference{{
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+			Kind:       "Role",
+			Name:       role.Name,
+			UID:        role.UID,
+		}}
+	}
+	for _, grant := range secrets.DeduplicateGrants(shareUsers) {
+		if grant.Principal == "" {
+			continue
+		}
+		binding := secretrbac.RoleBinding(namespace, secretrbac.ShareTargetUser, grant.Principal, grant.Role, roleOwners[secretrbac.RoleName(grant.Role)])
+		if err := c.applyRoleBinding(ctx, binding); err != nil {
+			return fmt.Errorf("applying project secret user binding %q: %w", binding.Name, err)
+		}
+	}
+	for _, grant := range secrets.DeduplicateGrants(shareRoles) {
+		if grant.Principal == "" {
+			continue
+		}
+		binding := secretrbac.RoleBinding(namespace, secretrbac.ShareTargetGroup, grant.Principal, grant.Role, roleOwners[secretrbac.RoleName(grant.Role)])
+		if err := c.applyRoleBinding(ctx, binding); err != nil {
+			return fmt.Errorf("applying project secret group binding %q: %w", binding.Name, err)
+		}
+	}
+	return nil
+}
+
+func namespaceOwnerRefs(ns *corev1.Namespace) []metav1.OwnerReference {
+	if ns == nil {
+		return nil
+	}
+	return []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+		Name:       ns.Name,
+		UID:        ns.UID,
+	}}
+}
+
+func (c *K8sClient) applyRole(ctx context.Context, role *rbacv1.Role) error {
+	created, err := c.client.RbacV1().Roles(role.Namespace).Create(ctx, role, metav1.CreateOptions{})
+	if err == nil {
+		*role = *created
+		return nil
+	}
+	if !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := c.client.RbacV1().Roles(role.Namespace).Get(ctx, role.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	existing.Labels = role.Labels
+	existing.OwnerReferences = role.OwnerReferences
+	existing.Rules = role.Rules
+	updated, err := c.client.RbacV1().Roles(role.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err == nil {
+		*role = *updated
+	}
+	return err
+}
+
+func (c *K8sClient) applyRoleBinding(ctx context.Context, binding *rbacv1.RoleBinding) error {
+	created, err := c.client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+	if err == nil {
+		*binding = *created
+		return nil
+	}
+	if !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := c.client.RbacV1().RoleBindings(binding.Namespace).Get(ctx, binding.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if existing.RoleRef != binding.RoleRef {
+		if err := c.client.RbacV1().RoleBindings(binding.Namespace).Delete(ctx, binding.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+		created, err := c.client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+		if err == nil {
+			*binding = *created
+		}
+		return err
+	}
+	existing.Labels = binding.Labels
+	existing.OwnerReferences = binding.OwnerReferences
+	existing.Subjects = binding.Subjects
+	updated, err := c.client.RbacV1().RoleBindings(binding.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err == nil {
+		*binding = *updated
+	}
+	return err
 }
 
 // UpdateProject updates the description and display name annotations on a managed namespace.

--- a/console/rbacname/rbacname.go
+++ b/console/rbacname/rbacname.go
@@ -1,0 +1,56 @@
+package rbacname
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"strings"
+)
+
+const maxDNS1123LabelLength = 63
+
+// RoleBindingName returns the deterministic RoleBinding name specified by ADR
+// 036. rolePurpose is truncated as needed, preserving the subject hash suffix.
+func RoleBindingName(rolePurpose, kind, name string) string {
+	kindPrefix := "x"
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "user":
+		kindPrefix = "u"
+	case "group":
+		kindPrefix = "g"
+	}
+
+	sum := sha256.Sum256([]byte(name))
+	encoded := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(sum[:]))
+	suffix := kindPrefix + "-" + encoded[:10]
+
+	prefix := dns1123(strings.ToLower(strings.TrimSpace(rolePurpose)))
+	if prefix == "" {
+		prefix = "role"
+	}
+	maxPrefix := maxDNS1123LabelLength - len(suffix) - 1
+	if len(prefix) > maxPrefix {
+		prefix = strings.Trim(prefix[:maxPrefix], "-")
+	}
+	if prefix == "" {
+		prefix = "role"
+	}
+	return prefix + "-" + suffix
+}
+
+func dns1123(s string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/console/rbacname/rbacname_test.go
+++ b/console/rbacname/rbacname_test.go
@@ -1,0 +1,21 @@
+package rbacname
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestRoleBindingNameIsDeterministicAndDNS1123(t *testing.T) {
+	name := RoleBindingName("project-secrets-owner", "user", "oidc:admin@localhost")
+
+	if got, wantPrefix := name, "project-secrets-owner-u-"; !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("RoleBindingName() = %q, want prefix %q", got, wantPrefix)
+	}
+	if !regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`).MatchString(name) {
+		t.Fatalf("RoleBindingName() = %q, want DNS-1123 label", name)
+	}
+	if again := RoleBindingName("project-secrets-owner", "user", "oidc:admin@localhost"); again != name {
+		t.Fatalf("RoleBindingName() is not deterministic: %q then %q", name, again)
+	}
+}

--- a/console/rpc/impersonation.go
+++ b/console/rpc/impersonation.go
@@ -85,6 +85,13 @@ func ImpersonatedClientsFromContext(ctx context.Context) *ImpersonatedClients {
 	return unauthenticatedClients()
 }
 
+// HasImpersonatedClients reports whether the auth interceptor stored a
+// per-request impersonating client bundle on this context.
+func HasImpersonatedClients(ctx context.Context) bool {
+	clients, _ := ctx.Value(impersonatedClientsKey{}).(*ImpersonatedClients)
+	return clients != nil
+}
+
 // ImpersonatedClientsetFromContext returns the per-request client-go clientset.
 func ImpersonatedClientsetFromContext(ctx context.Context) kubernetes.Interface {
 	return ImpersonatedClientsFromContext(ctx).Clientset

--- a/console/secretrbac/secretrbac.go
+++ b/console/secretrbac/secretrbac.go
@@ -1,0 +1,199 @@
+package secretrbac
+
+import (
+	"strings"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rbacname"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	RolePurposeProjectSecrets = "project-secrets"
+
+	LabelRolePurpose     = "console.holos.run/role-purpose"
+	LabelShareTarget     = "console.holos.run/share-target"
+	LabelShareTargetName = "console.holos.run/share-target-name"
+	LabelSecretRole      = "holos.run/role"
+
+	AnnotationShareTargetName = LabelShareTargetName
+
+	RoleViewer = "viewer"
+	RoleEditor = "editor"
+	RoleOwner  = "owner"
+
+	ShareTargetUser  = "user"
+	ShareTargetGroup = "group"
+
+	OIDCPrefix = "oidc:"
+)
+
+var roleNames = map[string]string{
+	RoleViewer: "holos-project-secrets-viewer",
+	RoleEditor: "holos-project-secrets-editor",
+	RoleOwner:  "holos-project-secrets-owner",
+}
+
+// ProjectSecretRoles returns the managed Roles for project-scoped Secret RBAC.
+func ProjectSecretRoles(namespace string, ownerRefs []metav1.OwnerReference) []*rbacv1.Role {
+	roles := []*rbacv1.Role{
+		projectSecretRole(namespace, RoleViewer, []string{"get", "list", "watch"}, nil, ownerRefs),
+		projectSecretRole(namespace, RoleEditor, []string{"get", "list", "watch", "create", "update", "patch"}, nil, ownerRefs),
+		projectSecretRole(namespace, RoleOwner, []string{"*"}, ownerRules(), ownerRefs),
+	}
+	return roles
+}
+
+func projectSecretRole(namespace, role string, secretVerbs []string, extraRules []rbacv1.PolicyRule, ownerRefs []metav1.OwnerReference) *rbacv1.Role {
+	rules := []rbacv1.PolicyRule{{
+		APIGroups: []string{""},
+		Resources: []string{"secrets"},
+		Verbs:     secretVerbs,
+	}}
+	rules = append(rules, extraRules...)
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleName(role),
+			Namespace:       namespace,
+			Labels:          RoleLabels(role),
+			OwnerReferences: ownerRefs,
+		},
+		Rules: rules,
+	}
+}
+
+func ownerRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"rolebindings"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups:     []string{"rbac.authorization.k8s.io"},
+			Resources:     []string{"roles"},
+			ResourceNames: []string{RoleName(RoleViewer), RoleName(RoleEditor), RoleName(RoleOwner)},
+			Verbs:         []string{"get", "list", "watch", "bind"},
+		},
+	}
+}
+
+func RoleName(role string) string {
+	if name, ok := roleNames[NormalizeRole(role)]; ok {
+		return name
+	}
+	return roleNames[RoleViewer]
+}
+
+func RoleLabels(role string) map[string]string {
+	role = NormalizeRole(role)
+	return map[string]string{
+		v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+		LabelRolePurpose:        RolePurposeProjectSecrets,
+		LabelSecretRole:         "secrets-" + role,
+	}
+}
+
+func RoleBindingLabels(target, principal, role string) map[string]string {
+	labels := RoleLabels(role)
+	labels[LabelShareTarget] = target
+	labels[LabelShareTargetName] = labelValue(principal)
+	return labels
+}
+
+func RoleBinding(namespace, target, principal, role string, ownerRefs []metav1.OwnerReference) *rbacv1.RoleBinding {
+	target = NormalizeTarget(target)
+	role = NormalizeRole(role)
+	subjectKind := rbacv1.UserKind
+	if target == ShareTargetGroup {
+		subjectKind = rbacv1.GroupKind
+	}
+	roleName := RoleName(role)
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleBindingName(role, target, principal),
+			Namespace:       namespace,
+			Labels:          RoleBindingLabels(target, principal, role),
+			Annotations:     map[string]string{AnnotationShareTargetName: OIDCPrincipal(principal)},
+			OwnerReferences: ownerRefs,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:     subjectKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     OIDCPrincipal(principal),
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     roleName,
+		},
+	}
+}
+
+func RoleBindingName(role, target, principal string) string {
+	rolePurpose := RolePurposeProjectSecrets + "-" + NormalizeRole(role)
+	return rbacname.RoleBindingName(rolePurpose, target, OIDCPrincipal(principal))
+}
+
+func OIDCPrincipal(principal string) string {
+	principal = strings.TrimSpace(principal)
+	if principal == "" || strings.HasPrefix(principal, OIDCPrefix) {
+		return principal
+	}
+	return OIDCPrefix + principal
+}
+
+func UnprefixedPrincipal(principal string) string {
+	return strings.TrimPrefix(principal, OIDCPrefix)
+}
+
+func NormalizeRole(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case RoleOwner:
+		return RoleOwner
+	case RoleEditor:
+		return RoleEditor
+	default:
+		return RoleViewer
+	}
+}
+
+func NormalizeTarget(target string) string {
+	if strings.EqualFold(strings.TrimSpace(target), ShareTargetGroup) {
+		return ShareTargetGroup
+	}
+	return ShareTargetUser
+}
+
+func RoleFromLabels(labels map[string]string, roleRefName string) string {
+	if labels != nil {
+		if value := strings.TrimPrefix(labels[LabelSecretRole], "secrets-"); value != "" {
+			return NormalizeRole(value)
+		}
+	}
+	for role, name := range roleNames {
+		if name == roleRefName {
+			return role
+		}
+	}
+	return RoleViewer
+}
+
+func labelValue(value string) string {
+	var b strings.Builder
+	lastSep := false
+	for _, r := range value {
+		ok := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.'
+		if ok {
+			b.WriteRune(r)
+			lastSep = false
+			continue
+		}
+		if !lastSep {
+			b.WriteByte('_')
+			lastSep = true
+		}
+	}
+	return strings.Trim(b.String(), "-_.")
+}

--- a/console/secretrbac/secretrbac_test.go
+++ b/console/secretrbac/secretrbac_test.go
@@ -1,0 +1,38 @@
+package secretrbac
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestRoleBindingUsesOIDCSubjectAndSafeLabels(t *testing.T) {
+	rb := RoleBinding("holos-prj-demo", ShareTargetUser, "admin@localhost", RoleOwner, nil)
+
+	if got, want := rb.Subjects[0].Kind, rbacv1.UserKind; got != want {
+		t.Fatalf("subject kind = %q, want %q", got, want)
+	}
+	if got, want := rb.Subjects[0].Name, "oidc:admin@localhost"; got != want {
+		t.Fatalf("subject name = %q, want %q", got, want)
+	}
+	if got := rb.Labels[LabelShareTargetName]; got != "admin_localhost" {
+		t.Fatalf("share target label = %q, want sanitized label", got)
+	}
+	if got, want := rb.Annotations[AnnotationShareTargetName], "oidc:admin@localhost"; got != want {
+		t.Fatalf("share target annotation = %q, want %q", got, want)
+	}
+	if got, want := rb.RoleRef.Name, RoleName(RoleOwner); got != want {
+		t.Fatalf("role ref = %q, want %q", got, want)
+	}
+}
+
+func TestRoleBindingUsesOIDCGroups(t *testing.T) {
+	rb := RoleBinding("holos-prj-demo", ShareTargetGroup, "platform", RoleViewer, nil)
+
+	if got, want := rb.Subjects[0].Kind, rbacv1.GroupKind; got != want {
+		t.Fatalf("subject kind = %q, want %q", got, want)
+	}
+	if got, want := rb.Subjects[0].Name, "oidc:platform"; got != want {
+		t.Fatalf("subject name = %q, want %q", got, want)
+	}
+}

--- a/console/secrets/handler.go
+++ b/console/secrets/handler.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
@@ -61,29 +60,19 @@ func (h *Handler) ListSecrets(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("project is required"))
 	}
 
-	// Resolve project grants for fallback access checks
-	projUsers, projRoles := h.resolveProjectGrants(ctx, project)
-
-	// List secrets from Kubernetes with console label
-	secretList, err := h.k8s.ListSecrets(ctx, project)
+	k8s := h.requestK8s(ctx)
+	secretList, err := k8s.ListSecrets(ctx, project)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+	shareUsers, shareRoles, err := k8s.ListSharing(ctx, project)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
 
-	// Build list with accessibility info for each secret
-	now := time.Now()
 	var secrets []*consolev1.SecretMetadata
-	var accessibleCount int
 	for _, secret := range secretList.Items {
-		shareUsers, _ := GetShareUsers(&secret)
-		shareRoles, _ := GetShareRoles(&secret)
-		activeUsers := ActiveGrantsMap(shareUsers, now)
-		activeRoles := ActiveGrantsMap(shareRoles, now)
-		accessible := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsList) == nil
-		if accessible {
-			accessibleCount++
-		}
-		metadata := h.buildSecretMetadata(&secret, shareUsers, shareRoles, activeUsers, activeRoles, projUsers, projRoles, claims)
+		metadata := h.buildSecretMetadata(&secret, displayUserGrants(shareUsers, claims), shareRoles, true)
 		secrets = append(secrets, metadata)
 	}
 
@@ -94,7 +83,7 @@ func (h *Handler) ListSecrets(
 		slog.String("sub", claims.Sub),
 		slog.String("email", claims.Email),
 		slog.Int("total", len(secrets)),
-		slog.Int("accessible", accessibleCount),
+		slog.Int("accessible", len(secrets)),
 	)
 
 	return connect.NewResponse(&consolev1.ListSecretsResponse{
@@ -124,7 +113,7 @@ func (h *Handler) GetSecret(
 	}
 
 	// Get secret from Kubernetes
-	secret, err := h.k8s.GetSecret(ctx, project, req.Msg.Name)
+	secret, err := h.requestK8s(ctx).GetSecret(ctx, project, req.Msg.Name)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -153,35 +142,7 @@ func (h *Handler) DeleteSecret(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	// Get existing secret to check RBAC
-	secret, err := h.k8s.GetSecret(ctx, project, req.Msg.Name)
-	if err != nil {
-		return nil, mapK8sError(err)
-	}
-
-	// Check RBAC for delete access (per-secret grants, then project grants)
-	shareUsers, _ := GetShareUsers(secret)
-	shareRoles, _ := GetShareRoles(secret)
-	now := time.Now()
-	activeUsers := ActiveGrantsMap(shareUsers, now)
-	activeRoles := ActiveGrantsMap(shareRoles, now)
-	projUsers, projRoles := h.resolveProjectGrants(ctx, project)
-
-	if err := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsDelete); err != nil {
-		slog.WarnContext(ctx, "secret delete denied",
-			slog.String("action", "secret_delete_denied"),
-			slog.String("resource_type", auditResourceType),
-			slog.String("secret", req.Msg.Name),
-			slog.String("project", project),
-			slog.String("sub", claims.Sub),
-			slog.String("email", claims.Email),
-			slog.Any("roles", claims.Roles),
-		)
-		return nil, err
-	}
-
-	// Perform the delete
-	if err := h.k8s.DeleteSecret(ctx, project, req.Msg.Name); err != nil {
+	if err := h.requestK8s(ctx).DeleteSecret(ctx, project, req.Msg.Name); err != nil {
 		return nil, mapK8sError(err)
 	}
 
@@ -220,49 +181,8 @@ func (h *Handler) CreateSecret(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	// Convert proto ShareGrant slices to annotation grants
 	shareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
 	shareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
-
-	// Merge project-level default sharing grants (if the resolver supports it).
-	// Request-supplied grants override defaults for the same principal via DeduplicateGrants
-	// (highest role wins, so explicit grants at a higher role shadow lower defaults).
-	if ds, ok := h.projectResolver.(DefaultShareResolver); ok {
-		defaultUsers, defaultRoles, err := ds.GetDefaultGrants(ctx, project)
-		if err != nil {
-			slog.WarnContext(ctx, "failed to resolve default grants, proceeding without them",
-				slog.String("project", project),
-				slog.Any("error", err),
-			)
-		} else {
-			// Concatenate: request grants first so they win over defaults for the same principal.
-			shareUsers = DeduplicateGrants(append(shareUsers, defaultUsers...))
-			shareRoles = DeduplicateGrants(append(shareRoles, defaultRoles...))
-		}
-	}
-
-	// Check that the user has write permission based on the requested sharing grants
-	// and project grants. Access check happens before adding creator-as-owner so that
-	// viewers cannot bypass the check by being elevated via ensureCreatorOwner.
-	now := time.Now()
-	activeUsers := ActiveGrantsMap(shareUsers, now)
-	activeRoles := ActiveGrantsMap(shareRoles, now)
-	projUsers, projRoles := h.resolveProjectGrants(ctx, project)
-
-	if err := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsWrite); err != nil {
-		slog.WarnContext(ctx, "secret create denied",
-			slog.String("action", "secret_create_denied"),
-			slog.String("resource_type", auditResourceType),
-			slog.String("secret", req.Msg.Name),
-			slog.String("project", project),
-			slog.String("sub", claims.Sub),
-			slog.String("email", claims.Email),
-		)
-		return nil, err
-	}
-
-	// Ensure creator is always an owner after access check passes.
-	shareUsers = ensureCreatorOwner(shareUsers, claims.Email)
 
 	// Merge string_data into data (string_data takes precedence)
 	data := mergeStringData(req.Msg.Data, req.Msg.StringData)
@@ -277,9 +197,16 @@ func (h *Handler) CreateSecret(
 	}
 
 	// Create the secret
-	_, err := h.k8s.CreateSecret(ctx, project, req.Msg.Name, data, shareUsers, shareRoles, description, url)
+	k8s := h.requestK8s(ctx)
+	_, err := k8s.CreateSecret(ctx, project, req.Msg.Name, data, nil, nil, description, url)
 	if err != nil {
 		return nil, mapK8sError(err)
+	}
+	if len(shareUsers) > 0 || len(shareRoles) > 0 {
+		shareUsers = rbacUserGrantsForClaims(shareUsers, claims)
+		if _, err := k8s.UpdateSharing(ctx, project, req.Msg.Name, shareUsers, shareRoles); err != nil {
+			return nil, mapK8sError(err)
+		}
 	}
 
 	slog.InfoContext(ctx, "secret created",
@@ -320,37 +247,10 @@ func (h *Handler) UpdateSecret(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	// Get existing secret to check RBAC
-	secret, err := h.k8s.GetSecret(ctx, project, req.Msg.Name)
-	if err != nil {
-		return nil, mapK8sError(err)
-	}
-
-	// Check RBAC for write access (per-secret grants, then project grants)
-	shareUsers, _ := GetShareUsers(secret)
-	shareRoles, _ := GetShareRoles(secret)
-	now := time.Now()
-	activeUsers := ActiveGrantsMap(shareUsers, now)
-	activeRoles := ActiveGrantsMap(shareRoles, now)
-	projUsers, projRoles := h.resolveProjectGrants(ctx, project)
-	if err := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsWrite); err != nil {
-		logAuditDenied(ctx, claims, secret.Name, project)
-		slog.WarnContext(ctx, "secret update denied",
-			slog.String("action", "secret_update_denied"),
-			slog.String("resource_type", auditResourceType),
-			slog.String("secret", req.Msg.Name),
-			slog.String("project", project),
-			slog.String("sub", claims.Sub),
-			slog.String("email", claims.Email),
-		)
-		return nil, err
-	}
-
 	// Merge string_data into data (string_data takes precedence)
 	data := mergeStringData(req.Msg.Data, req.Msg.StringData)
 
-	// Perform the update
-	if _, err := h.k8s.UpdateSecret(ctx, project, req.Msg.Name, data, req.Msg.Description, req.Msg.Url); err != nil {
+	if _, err := h.requestK8s(ctx).UpdateSecret(ctx, project, req.Msg.Name, data, req.Msg.Description, req.Msg.Url); err != nil {
 		return nil, mapK8sError(err)
 	}
 
@@ -388,38 +288,14 @@ func (h *Handler) UpdateSharing(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	// Get existing secret to check RBAC
-	secret, err := h.k8s.GetSecret(ctx, project, req.Msg.Name)
-	if err != nil {
-		return nil, mapK8sError(err)
-	}
-
-	// Check RBAC for admin access (per-secret grants, then project grants)
-	shareUsers, _ := GetShareUsers(secret)
-	shareRoles, _ := GetShareRoles(secret)
-	now := time.Now()
-	activeUsers := ActiveGrantsMap(shareUsers, now)
-	activeRoles := ActiveGrantsMap(shareRoles, now)
-	projUsers, projRoles := h.resolveProjectGrants(ctx, project)
-
-	if err := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsAdmin); err != nil {
-		slog.WarnContext(ctx, "sharing update denied",
-			slog.String("action", "sharing_update_denied"),
-			slog.String("resource_type", auditResourceType),
-			slog.String("secret", req.Msg.Name),
-			slog.String("project", project),
-			slog.String("sub", claims.Sub),
-			slog.String("email", claims.Email),
-		)
-		return nil, err
-	}
+	k8s := h.requestK8s(ctx)
 
 	// Convert proto ShareGrant slices to annotation grants
 	newShareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
 	newShareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
+	newShareUsers = rbacUserGrantsForClaims(newShareUsers, claims)
 
-	// Persist the sharing annotations
-	updated, err := h.k8s.UpdateSharing(ctx, project, req.Msg.Name, newShareUsers, newShareRoles)
+	updated, err := k8s.UpdateSharing(ctx, project, req.Msg.Name, newShareUsers, newShareRoles)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -433,12 +309,11 @@ func (h *Handler) UpdateSharing(
 		slog.String("email", claims.Email),
 	)
 
-	// Build response metadata
-	updatedUsers, _ := GetShareUsers(updated)
-	updatedRoles, _ := GetShareRoles(updated)
-	updatedActiveUsers := ActiveGrantsMap(updatedUsers, now)
-	updatedActiveGroups := ActiveGrantsMap(updatedRoles, now)
-	metadata := h.buildSecretMetadata(updated, updatedUsers, updatedRoles, updatedActiveUsers, updatedActiveGroups, projUsers, projRoles, claims)
+	updatedUsers, updatedRoles, err := k8s.ListSharing(ctx, project)
+	if err != nil {
+		return nil, mapK8sError(err)
+	}
+	metadata := h.buildSecretMetadata(updated, displayUserGrants(updatedUsers, claims), updatedRoles, true)
 
 	return connect.NewResponse(&consolev1.UpdateSharingResponse{
 		Metadata: metadata,
@@ -467,21 +342,9 @@ func (h *Handler) GetSecretRaw(
 	}
 
 	// Get secret from Kubernetes
-	secret, err := h.k8s.GetSecret(ctx, project, req.Msg.Name)
+	secret, err := h.requestK8s(ctx).GetSecret(ctx, project, req.Msg.Name)
 	if err != nil {
 		return nil, mapK8sError(err)
-	}
-
-	// Check RBAC (per-secret grants, then project grants)
-	shareUsers, _ := GetShareUsers(secret)
-	shareRoles, _ := GetShareRoles(secret)
-	now := time.Now()
-	activeUsers := ActiveGrantsMap(shareUsers, now)
-	activeRoles := ActiveGrantsMap(shareRoles, now)
-	projUsers, projRoles := h.resolveProjectGrants(ctx, project)
-	if err := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsRead); err != nil {
-		logAuditDenied(ctx, claims, secret.Name, project)
-		return nil, err
 	}
 
 	logAuditAllowed(ctx, claims, secret.Name, project)
@@ -516,15 +379,54 @@ func mergeStringData(data map[string][]byte, stringData map[string]string) map[s
 	return data
 }
 
-// ensureCreatorOwner ensures the creator email is in the share-users list as owner.
-func ensureCreatorOwner(shareUsers []AnnotationGrant, email string) []AnnotationGrant {
-	emailLower := strings.ToLower(email)
+// ensureCreatorOwner ensures the caller principal is in the share-users list as owner.
+func ensureCreatorOwner(shareUsers []AnnotationGrant, principal string) []AnnotationGrant {
+	if principal == "" {
+		return shareUsers
+	}
+	principalLower := strings.ToLower(principal)
 	for _, g := range shareUsers {
-		if strings.ToLower(g.Principal) == emailLower && strings.ToLower(g.Role) == "owner" {
+		if strings.ToLower(g.Principal) == principalLower && strings.ToLower(g.Role) == "owner" {
 			return shareUsers
 		}
 	}
-	return DeduplicateGrants(append(shareUsers, AnnotationGrant{Principal: email, Role: "owner"}))
+	return DeduplicateGrants(append(shareUsers, AnnotationGrant{Principal: principal, Role: "owner"}))
+}
+
+func rbacUserGrantsForClaims(shareUsers []AnnotationGrant, claims *rpc.Claims) []AnnotationGrant {
+	if claims == nil || claims.Sub == "" {
+		return shareUsers
+	}
+	shareUsers = removeGrantPrincipal(shareUsers, claims.Email)
+	return ensureCreatorOwner(shareUsers, claims.Sub)
+}
+
+func removeGrantPrincipal(grants []AnnotationGrant, principal string) []AnnotationGrant {
+	if principal == "" {
+		return grants
+	}
+	principalLower := strings.ToLower(principal)
+	filtered := make([]AnnotationGrant, 0, len(grants))
+	for _, grant := range grants {
+		if strings.ToLower(grant.Principal) == principalLower {
+			continue
+		}
+		filtered = append(filtered, grant)
+	}
+	return filtered
+}
+
+func displayUserGrants(shareUsers []AnnotationGrant, claims *rpc.Claims) []AnnotationGrant {
+	if claims == nil || claims.Sub == "" || claims.Email == "" {
+		return shareUsers
+	}
+	out := append([]AnnotationGrant(nil), shareUsers...)
+	for i := range out {
+		if strings.TrimPrefix(out[i].Principal, "oidc:") == claims.Sub {
+			out[i].Principal = claims.Email
+		}
+	}
+	return out
 }
 
 // shareGrantsToAnnotations converts a slice of ShareGrant protos to []AnnotationGrant
@@ -552,10 +454,7 @@ func shareGrantsToAnnotations(grants []*consolev1.ShareGrant) []AnnotationGrant 
 }
 
 // buildSecretMetadata creates SecretMetadata for a secret from the caller's perspective.
-// It receives the full grant slices (for the proto response) and the active maps (for RBAC).
-func (h *Handler) buildSecretMetadata(secret *corev1.Secret, shareUsers, shareRoles []AnnotationGrant, activeUsers, activeRoles, projUsers, projRoles map[string]string, claims *rpc.Claims) *consolev1.SecretMetadata {
-	accessible := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsList) == nil
-
+func (h *Handler) buildSecretMetadata(secret *corev1.Secret, shareUsers, shareRoles []AnnotationGrant, accessible bool) *consolev1.SecretMetadata {
 	// Build user grants (all grants, including expired, for display)
 	userGrants := annotationGrantsToProto(shareUsers)
 	// Build role grants
@@ -614,18 +513,6 @@ func protoRoleFromString(s string) consolev1.Role {
 
 // returnSecret checks RBAC and returns the secret data.
 func (h *Handler) returnSecret(ctx context.Context, claims *rpc.Claims, secret *corev1.Secret, project string) (*connect.Response[consolev1.GetSecretResponse], error) {
-	// Check RBAC (per-secret grants, then project grants)
-	shareUsers, _ := GetShareUsers(secret)
-	shareRoles, _ := GetShareRoles(secret)
-	now := time.Now()
-	activeUsers := ActiveGrantsMap(shareUsers, now)
-	activeRoles := ActiveGrantsMap(shareRoles, now)
-	projUsers, projRoles := h.resolveProjectGrants(ctx, project)
-	if err := h.checkAccess(claims.Email, claims.Roles, activeUsers, activeRoles, projUsers, projRoles, rbac.PermissionSecretsRead); err != nil {
-		logAuditDenied(ctx, claims, secret.Name, project)
-		return nil, err
-	}
-
 	logAuditAllowed(ctx, claims, secret.Name, project)
 
 	return connect.NewResponse(&consolev1.GetSecretResponse{
@@ -633,77 +520,14 @@ func (h *Handler) returnSecret(ctx context.Context, claims *rpc.Claims, secret *
 	}), nil
 }
 
-// resolveProjectGrants returns the active grant maps for the given project namespace.
-// Returns nil maps if no project resolver is configured.
-func (h *Handler) resolveProjectGrants(ctx context.Context, project string) (map[string]string, map[string]string) {
-	if h.projectResolver == nil {
-		return nil, nil
+func (h *Handler) requestK8s(ctx context.Context) *K8sClient {
+	if !rpc.HasImpersonatedClients(ctx) {
+		return h.k8s
 	}
-	users, roles, err := h.projectResolver.GetProjectGrants(ctx, project)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to resolve project grants",
-			slog.String("project", project),
-			slog.Any("error", err),
-		)
-		return nil, nil
+	return &K8sClient{
+		client:   rpc.ImpersonatedClientsetFromContext(ctx),
+		Resolver: h.k8s.Resolver,
 	}
-	return users, roles
-}
-
-// checkAccess verifies access using per-secret grants, then project grants.
-//
-// # Non-cascading access for secrets (intentional)
-//
-// Hierarchy walking is used ONLY to collect default-share grants at create
-// time (org → folders → project → new secret). It is NOT used for access
-// checks on existing secrets. This is a principled design decision:
-//
-//   - Templates are policy: it is appropriate for an org-level OWNER to apply
-//     a platform template everywhere — the template is a policy artifact that
-//     must reach every project.
-//   - Secrets are data: an org-level OWNER should NOT automatically be able to
-//     read a secret stored in a specific project namespace unless they have an
-//     explicit grant on that secret or project (ADR 007). Secrets may contain
-//     credentials that are intentionally isolated to a team.
-//
-// The access path for secrets is:
-//
-//  1. Per-secret grants (full permission via PermissionSecretsRead/Write/Delete).
-//  2. Project grants via ProjectCascadeSecretPerms (EDITORs and OWNERs may
-//     write; VIEWERs cannot read — PermissionSecretsRead never cascades).
-//
-// PermissionSecretsRead is NOT in ProjectCascadeSecretPerms. This means even a
-// project-level OWNER cannot read a specific secret via cascade — they need an
-// explicit per-secret grant. An org-level OWNER (with no project grant) is
-// denied at step 2 as well. Organization grants do not cascade at all
-// (see docs/adrs/007-org-grants-no-cascade.md).
-//
-// To gain read access through the default-share mechanism, the secret's
-// default-share grants (inherited at create time from ancestors) must include
-// the user's email or role — these appear as direct per-secret grants at step 1.
-func (h *Handler) checkAccess(
-	email string,
-	roles []string,
-	secretUsers, secretRoles map[string]string,
-	projUsers, projRoles map[string]string,
-	permission rbac.Permission,
-) error {
-	// 1. Check per-secret grants (full permission)
-	if err := rbac.CheckAccessGrants(email, roles, secretUsers, secretRoles, permission); err == nil {
-		return nil
-	}
-
-	// 2. Check project grants (role-per-scope cascade table)
-	if projUsers != nil || projRoles != nil {
-		if err := rbac.CheckCascadeAccess(email, roles, projUsers, projRoles, permission, rbac.ProjectCascadeSecretPerms); err == nil {
-			return nil
-		}
-	}
-
-	return connect.NewError(
-		connect.CodePermissionDenied,
-		fmt.Errorf("RBAC: authorization denied"),
-	)
 }
 
 // mapK8sError converts Kubernetes API errors to ConnectRPC errors.

--- a/console/secrets/handler_test.go
+++ b/console/secrets/handler_test.go
@@ -9,9 +9,13 @@ import (
 
 	"connectrpc.com/connect"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/rpc"
@@ -79,6 +83,11 @@ func assertResourceType(t *testing.T, r *slog.Record) {
 	}
 }
 
+func contextWithImpersonatedClient(ctx context.Context, claims *rpc.Claims, client *fake.Clientset) context.Context {
+	ctx = rpc.ContextWithClaims(ctx, claims)
+	return rpc.ContextWithImpersonatedClients(ctx, &rpc.ImpersonatedClients{Clientset: client})
+}
+
 // testProjectNS returns a project namespace fixture for the default test project.
 func testProjectNS() *corev1.Namespace {
 	return &corev1.Namespace{
@@ -90,6 +99,61 @@ func testProjectNS() *corev1.Namespace {
 				v1alpha2.LabelProject:      "test-namespace",
 			},
 		},
+	}
+}
+
+func TestHandler_UsesImpersonatedClient(t *testing.T) {
+	startupClient := fake.NewClientset(testProjectNS())
+	impersonatedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "prj-test-namespace"},
+		Data:       map[string][]byte{"key": []byte("value")},
+	}
+	impersonatedClient := fake.NewClientset(testProjectNS(), impersonatedSecret)
+	handler := NewProjectScopedHandler(NewK8sClient(startupClient, testResolver()), nil)
+	ctx := contextWithImpersonatedClient(context.Background(), &rpc.Claims{Sub: "sub-alice", Email: "alice@example.com"}, impersonatedClient)
+
+	resp, err := handler.GetSecret(ctx, connect.NewRequest(&consolev1.GetSecretRequest{
+		Name:    "my-secret",
+		Project: "test-namespace",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if string(resp.Msg.Data["key"]) != "value" {
+		t.Fatalf("expected data from impersonated client, got %q", string(resp.Msg.Data["key"]))
+	}
+}
+
+func TestHandler_ForbiddenFromAPIServerMapsToPermissionDenied(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "prj-test-namespace",
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
+		},
+		Data: map[string][]byte{"key": []byte("value")},
+	}
+	impersonatedClient := fake.NewClientset(testProjectNS(), secret)
+	impersonatedClient.Fake.PrependReactor("update", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "my-secret", nil)
+	})
+	handler := NewProjectScopedHandler(NewK8sClient(fake.NewClientset(testProjectNS(), secret), testResolver()), nil)
+	ctx := contextWithImpersonatedClient(context.Background(), &rpc.Claims{Sub: "sub-viewer", Email: "viewer@example.com"}, impersonatedClient)
+
+	_, err := handler.UpdateSecret(ctx, connect.NewRequest(&consolev1.UpdateSecretRequest{
+		Name:    "my-secret",
+		Project: "test-namespace",
+		Data:    map[string][]byte{"key": []byte("new")},
+	}))
+	if err == nil {
+		t.Fatal("expected PermissionDenied, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodePermissionDenied {
+		t.Fatalf("expected CodePermissionDenied, got %v", connectErr.Code())
 	}
 }
 
@@ -180,6 +244,7 @@ func TestHandler_GetSecret(t *testing.T) {
 	})
 
 	t.Run("returns PermissionDenied for unauthorized user", func(t *testing.T) {
+		t.Skip("obsolete: Kubernetes RBAC denial is covered by TestHandler_ForbiddenFromAPIServerMapsToPermissionDenied")
 		// Given: Authenticated user NOT in sharing annotations
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -373,6 +438,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 	})
 
 	t.Run("logs denied access with action secret_access_denied", func(t *testing.T) {
+		t.Skip("obsolete: handler no longer emits local RBAC denial audit logs")
 		// Given: Denied access (RBAC failure)
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -493,6 +559,7 @@ func TestHandler_AuditLogging(t *testing.T) {
 	})
 
 	t.Run("secret_access_denied includes project field", func(t *testing.T) {
+		t.Skip("obsolete: handler no longer emits local RBAC denial audit logs")
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
@@ -591,6 +658,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 	})
 
 	t.Run("returns PermissionDenied for editor", func(t *testing.T) {
+		t.Skip("obsolete: Kubernetes RBAC denial is covered by API-server forbidden tests")
 		// Editor lacks PERMISSION_SECRETS_DELETE
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -632,6 +700,7 @@ func TestHandler_DeleteSecret(t *testing.T) {
 	})
 
 	t.Run("returns PermissionDenied for viewer", func(t *testing.T) {
+		t.Skip("obsolete: Kubernetes RBAC denial is covered by API-server forbidden tests")
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
@@ -776,6 +845,7 @@ func TestHandler_DeleteSecret_AuditLogging(t *testing.T) {
 	})
 
 	t.Run("logs secret_delete_denied on RBAC failure", func(t *testing.T) {
+		t.Skip("obsolete: handler no longer emits local RBAC denial audit logs")
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
@@ -887,6 +957,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 	})
 
 	t.Run("returns PermissionDenied for viewer", func(t *testing.T) {
+		t.Skip("obsolete: Kubernetes RBAC denial is covered by API-server forbidden tests")
 		fakeClient := fake.NewClientset(testProjectNS())
 		k8sClient := NewK8sClient(fakeClient, testResolver())
 		handler := NewProjectScopedHandler(k8sClient, nil)
@@ -958,6 +1029,7 @@ func TestHandler_CreateSecret(t *testing.T) {
 	})
 
 	t.Run("returns PermissionDenied for empty grants", func(t *testing.T) {
+		t.Skip("obsolete: create authorization is enforced by Kubernetes RBAC")
 		// No per-secret grants and user has no matching sharing grants
 		fakeClient := fake.NewClientset(testProjectNS())
 		k8sClient := NewK8sClient(fakeClient, testResolver())
@@ -1109,6 +1181,7 @@ func TestHandler_CreateSecret_AuditLogging(t *testing.T) {
 	})
 
 	t.Run("logs secret_create_denied on RBAC failure", func(t *testing.T) {
+		t.Skip("obsolete: handler no longer emits local RBAC denial audit logs")
 		fakeClient := fake.NewClientset(testProjectNS())
 		k8sClient := NewK8sClient(fakeClient, testResolver())
 		handler := NewProjectScopedHandler(k8sClient, nil)
@@ -1227,6 +1300,7 @@ func TestHandler_UpdateSecret(t *testing.T) {
 	})
 
 	t.Run("returns PermissionDenied for viewer", func(t *testing.T) {
+		t.Skip("obsolete: Kubernetes RBAC denial is covered by API-server forbidden tests")
 		// Given: Secret shared with user as viewer, user lacks editor permission
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1436,6 +1510,7 @@ func TestHandler_UpdateSecret_AuditLogging(t *testing.T) {
 	})
 
 	t.Run("logs secret_update_denied on RBAC failure", func(t *testing.T) {
+		t.Skip("obsolete: handler no longer emits local RBAC denial audit logs")
 		// Given: User lacks write permission
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1604,7 +1679,8 @@ func TestHandler_ListSecrets(t *testing.T) {
 	})
 
 	t.Run("returns all secrets with accessibility info", func(t *testing.T) {
-		// Given: Two labeled secrets, user can only access one (no sharing grants on the other)
+		// Given: Two labeled secrets. Access is decided by the API server before
+		// the list reaches the handler, so every returned row is accessible.
 		accessibleSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "accessible-secret",
@@ -1674,8 +1750,8 @@ func TestHandler_ListSecrets(t *testing.T) {
 		if inaccessible == nil {
 			t.Fatal("expected to find 'inaccessible-secret'")
 		}
-		if inaccessible.Accessible {
-			t.Error("expected inaccessible-secret to not be accessible")
+		if !inaccessible.Accessible {
+			t.Error("expected inaccessible-secret to be accessible after Kubernetes list authorization")
 		}
 	})
 
@@ -1791,28 +1867,27 @@ func TestHandler_UpdateSharing(t *testing.T) {
 			t.Errorf("expected name 'my-secret', got %q", resp.Msg.Metadata.Name)
 		}
 
-		// Verify annotations were persisted
-		updated, err := k8sClient.GetSecret(ctx, "test-namespace", "my-secret")
+		// Verify RoleBindings were persisted.
+		shareUsers, shareRoles, err := k8sClient.ListSharing(ctx, "test-namespace")
 		if err != nil {
-			t.Fatalf("failed to get updated secret: %v", err)
-		}
-		shareUsers, err := GetShareUsers(updated)
-		if err != nil {
-			t.Fatalf("failed to parse share-users: %v", err)
+			t.Fatalf("failed to list sharing rolebindings: %v", err)
 		}
 		userMap := make(map[string]string)
 		for _, g := range shareUsers {
 			userMap[g.Principal] = g.Role
 		}
-		if userMap["alice@example.com"] != "owner" {
-			t.Errorf("expected alice=owner, got %q", userMap["alice@example.com"])
+		if userMap["user-123"] != "owner" {
+			t.Errorf("expected caller sub owner grant, got %q", userMap["user-123"])
 		}
 		if userMap["bob@example.com"] != "viewer" {
 			t.Errorf("expected bob=viewer, got %q", userMap["bob@example.com"])
 		}
-		shareRoles, err := GetShareRoles(updated)
-		if err != nil {
-			t.Fatalf("failed to parse share-roles: %v", err)
+		respUserMap := make(map[string]consolev1.Role)
+		for _, g := range resp.Msg.Metadata.UserGrants {
+			respUserMap[g.Principal] = g.Role
+		}
+		if respUserMap["alice@example.com"] != consolev1.Role_ROLE_OWNER {
+			t.Errorf("expected response metadata to display caller email as owner, got %s", respUserMap["alice@example.com"])
 		}
 		roleMap := make(map[string]string)
 		for _, g := range shareRoles {
@@ -1824,6 +1899,7 @@ func TestHandler_UpdateSharing(t *testing.T) {
 	})
 
 	t.Run("non-owner gets PermissionDenied", func(t *testing.T) {
+		t.Skip("obsolete: Kubernetes RBAC denial is covered by API-server forbidden tests")
 		// Given: Secret where caller is only a viewer
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2064,6 +2140,7 @@ func TestHandler_GetSecretRaw(t *testing.T) {
 	})
 
 	t.Run("returns PermissionDenied without Viewer grant", func(t *testing.T) {
+		t.Skip("obsolete: Kubernetes RBAC denial is covered by API-server forbidden tests")
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
@@ -2412,6 +2489,7 @@ func TestHandler_UpdateSharing_AuditLogging(t *testing.T) {
 	})
 
 	t.Run("logs sharing_update_denied on RBAC failure", func(t *testing.T) {
+		t.Skip("obsolete: handler no longer emits local RBAC denial audit logs")
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-secret",
@@ -2722,6 +2800,7 @@ func (m *mockProjectResolver) GetProjectGrants(_ context.Context, _ string) (map
 }
 
 func TestGetSecret_ProjectViewerCannotReadData(t *testing.T) {
+	t.Skip("obsolete: read authorization now comes from Kubernetes RBAC")
 	// Project viewer has no per-secret grant — should be denied GetSecret
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2759,6 +2838,7 @@ func TestGetSecret_ProjectViewerCannotReadData(t *testing.T) {
 }
 
 func TestGetSecret_ProjectEditorCannotReadData(t *testing.T) {
+	t.Skip("obsolete: read authorization now comes from Kubernetes RBAC")
 	// Project editor has no per-secret grant — should be denied GetSecret
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2920,6 +3000,7 @@ func TestUpdateSharing_ProjectOwnerCanAdmin(t *testing.T) {
 // unable to cascade to secret operations.
 
 func TestListSecrets_NoGrantsDeniesAccess(t *testing.T) {
+	t.Skip("obsolete: list authorization now comes from Kubernetes RBAC")
 	// User has no per-secret or project grant — access denied
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2952,6 +3033,7 @@ func TestListSecrets_NoGrantsDeniesAccess(t *testing.T) {
 }
 
 func TestGetSecret_NoGrantsDeniesAccess(t *testing.T) {
+	t.Skip("obsolete: read authorization now comes from Kubernetes RBAC")
 	// User has no per-secret or project grant — access denied
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3011,6 +3093,7 @@ func (m *mockCombinedResolver) GetDefaultGrants(_ context.Context, _ string) ([]
 }
 
 func TestCreateSecret_MergesDefaultGrants(t *testing.T) {
+	t.Skip("obsolete: project default sharing materializes as project RoleBindings")
 	// Default grants on the project: alice gets viewer
 	resolver := &mockCombinedResolver{
 		defaultUsers: []AnnotationGrant{{Principal: "alice@example.com", Role: "viewer"}},
@@ -3059,6 +3142,7 @@ func TestCreateSecret_MergesDefaultGrants(t *testing.T) {
 }
 
 func TestCreateSecret_RequestGrantOverridesDefaultForSamePrincipal(t *testing.T) {
+	t.Skip("obsolete: project default sharing materializes as project RoleBindings")
 	// Default gives bob viewer, request gives bob editor — editor should win.
 	// Creator is a different user (alice) so bob is not elevated to owner.
 	resolver := &mockCombinedResolver{
@@ -3145,6 +3229,7 @@ func TestCreateSecret_EmptyDefaultsNoChange(t *testing.T) {
 }
 
 func TestCreateSecret_CreatorAlwaysOwner(t *testing.T) {
+	t.Skip("obsolete: creator ownership materializes through project RoleBindings at project creation")
 	// Creator should always be added as owner after merging grants
 	resolver := &mockCombinedResolver{
 		defaultUsers: []AnnotationGrant{{Principal: "alice@example.com", Role: "viewer"}},
@@ -3195,6 +3280,7 @@ func TestCreateSecret_CreatorAlwaysOwner(t *testing.T) {
 }
 
 func TestCreateSecret_DefaultRoleGrantsMerged(t *testing.T) {
+	t.Skip("obsolete: project default sharing materializes as project RoleBindings")
 	// Default role grants should be included in created secret
 	resolver := &mockCombinedResolver{
 		defaultRoles: []AnnotationGrant{{Principal: "engineering", Role: "viewer"}},

--- a/console/secrets/k8s.go
+++ b/console/secrets/k8s.go
@@ -9,8 +9,12 @@ import (
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
+	"github.com/holos-run/holos-console/console/secretrbac"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -87,7 +91,9 @@ func (c *K8sClient) ListSecrets(ctx context.Context, project string) (*corev1.Se
 	})
 }
 
-// CreateSecret creates a new secret with the console managed-by label and sharing grants.
+// CreateSecret creates a new secret with the console managed-by label. Sharing
+// grants are accepted for the stable RPC surface but materialize as
+// RoleBindings through UpdateSharing rather than Secret annotations.
 func (c *K8sClient) CreateSecret(ctx context.Context, project, name string, data map[string][]byte, shareUsers, shareRoles []AnnotationGrant, description, url string) (*corev1.Secret, error) {
 	ns := c.Resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "creating secret in kubernetes",
@@ -95,18 +101,7 @@ func (c *K8sClient) CreateSecret(ctx context.Context, project, name string, data
 		slog.String("namespace", ns),
 		slog.String("name", name),
 	)
-	usersJSON, err := json.Marshal(shareUsers)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling share-users: %w", err)
-	}
-	rolesJSON, err := json.Marshal(shareRoles)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling share-roles: %w", err)
-	}
-	annotations := map[string]string{
-		v1alpha2.AnnotationShareUsers: string(usersJSON),
-		v1alpha2.AnnotationShareRoles: string(rolesJSON),
-	}
+	annotations := map[string]string{}
 	if description != "" {
 		annotations[v1alpha2.AnnotationDescription] = description
 	}
@@ -182,7 +177,10 @@ func (c *K8sClient) DeleteSecret(ctx context.Context, project, name string) erro
 	return c.client.CoreV1().Secrets(secret.Namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-// UpdateSharing updates the sharing annotations on an existing secret.
+// UpdateSharing reconciles the project-level Secret RoleBindings represented by
+// the stable UpdateSharing RPC. Secret access is project-namespace scoped under
+// ADR 036, so the secret name is validated for existence but not encoded into
+// the RoleBinding objects.
 // Returns FailedPrecondition if the secret does not have the console managed-by label.
 func (c *K8sClient) UpdateSharing(ctx context.Context, project, name string, shareUsers, shareRoles []AnnotationGrant) (*corev1.Secret, error) {
 	slog.DebugContext(ctx, "updating sharing on kubernetes secret",
@@ -196,20 +194,121 @@ func (c *K8sClient) UpdateSharing(ctx context.Context, project, name string, sha
 	if secret.Labels == nil || secret.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
 		return nil, fmt.Errorf("secret %q is not managed by %s", name, v1alpha2.ManagedByValue)
 	}
-	if secret.Annotations == nil {
-		secret.Annotations = make(map[string]string)
+	if err := c.reconcileProjectSecretRoleBindings(ctx, secret.Namespace, shareUsers, shareRoles); err != nil {
+		return nil, err
 	}
-	usersJSON, err := json.Marshal(shareUsers)
+	return secret, nil
+}
+
+func (c *K8sClient) ListSharing(ctx context.Context, project string) ([]AnnotationGrant, []AnnotationGrant, error) {
+	ns := c.Resolver.ProjectNamespace(project)
+	selector := labels.SelectorFromSet(labels.Set{
+		v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+		secretrbac.LabelRolePurpose: secretrbac.RolePurposeProjectSecrets,
+	})
+	list, err := c.client.RbacV1().RoleBindings(ns).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
-		return nil, fmt.Errorf("marshaling share-users: %w", err)
+		return nil, nil, err
 	}
-	rolesJSON, err := json.Marshal(shareRoles)
+	return roleBindingsToGrants(list.Items), roleBindingsToGroupGrants(list.Items), nil
+}
+
+func (c *K8sClient) reconcileProjectSecretRoleBindings(ctx context.Context, namespace string, shareUsers, shareRoles []AnnotationGrant) error {
+	desired := make(map[string]*rbacv1.RoleBinding)
+	for _, grant := range DeduplicateGrants(shareUsers) {
+		if grant.Principal == "" {
+			continue
+		}
+		binding := secretrbac.RoleBinding(namespace, secretrbac.ShareTargetUser, grant.Principal, grant.Role, nil)
+		desired[binding.Name] = binding
+	}
+	for _, grant := range DeduplicateGrants(shareRoles) {
+		if grant.Principal == "" {
+			continue
+		}
+		binding := secretrbac.RoleBinding(namespace, secretrbac.ShareTargetGroup, grant.Principal, grant.Role, nil)
+		desired[binding.Name] = binding
+	}
+
+	selector := labels.SelectorFromSet(labels.Set{
+		v1alpha2.LabelManagedBy:     v1alpha2.ManagedByValue,
+		secretrbac.LabelRolePurpose: secretrbac.RolePurposeProjectSecrets,
+	})
+	current, err := c.client.RbacV1().RoleBindings(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
-		return nil, fmt.Errorf("marshaling share-roles: %w", err)
+		return err
 	}
-	secret.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
-	secret.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
-	return c.client.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	for _, existing := range current.Items {
+		if _, ok := desired[existing.Name]; ok {
+			continue
+		}
+		if err := c.client.RbacV1().RoleBindings(namespace).Delete(ctx, existing.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	for _, binding := range desired {
+		if err := c.applyRoleBinding(ctx, binding); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *K8sClient) applyRoleBinding(ctx context.Context, binding *rbacv1.RoleBinding) error {
+	created, err := c.client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+	if err == nil {
+		*binding = *created
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := c.client.RbacV1().RoleBindings(binding.Namespace).Get(ctx, binding.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if existing.RoleRef != binding.RoleRef {
+		if err := c.client.RbacV1().RoleBindings(binding.Namespace).Delete(ctx, binding.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		created, err := c.client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+		if err == nil {
+			*binding = *created
+		}
+		return err
+	}
+	existing.Labels = binding.Labels
+	existing.Subjects = binding.Subjects
+	updated, err := c.client.RbacV1().RoleBindings(binding.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err == nil {
+		*binding = *updated
+	}
+	return err
+}
+
+func roleBindingsToGrants(bindings []rbacv1.RoleBinding) []AnnotationGrant {
+	return roleBindingsToTargetGrants(bindings, rbacv1.UserKind)
+}
+
+func roleBindingsToGroupGrants(bindings []rbacv1.RoleBinding) []AnnotationGrant {
+	return roleBindingsToTargetGrants(bindings, rbacv1.GroupKind)
+}
+
+func roleBindingsToTargetGrants(bindings []rbacv1.RoleBinding, kind string) []AnnotationGrant {
+	var grants []AnnotationGrant
+	for _, binding := range bindings {
+		role := secretrbac.RoleFromLabels(binding.Labels, binding.RoleRef.Name)
+		for _, subject := range binding.Subjects {
+			if subject.Kind != kind {
+				continue
+			}
+			grants = append(grants, AnnotationGrant{
+				Principal: secretrbac.UnprefixedPrincipal(subject.Name),
+				Role:      role,
+			})
+		}
+	}
+	return DeduplicateGrants(grants)
 }
 
 // GetShareUsers parses the console.holos.run/share-users annotation from a secret.

--- a/console/secrets/k8s_test.go
+++ b/console/secrets/k8s_test.go
@@ -181,7 +181,7 @@ func TestUpdateSecret(t *testing.T) {
 }
 
 func TestCreateSecret(t *testing.T) {
-	t.Run("creates secret with correct labels and sharing annotations", func(t *testing.T) {
+	t.Run("creates secret with correct labels and no sharing annotations", func(t *testing.T) {
 		// Given: No secrets exist
 		ns := projectNS("test-namespace")
 		fakeClient := fake.NewClientset(ns)
@@ -193,7 +193,8 @@ func TestCreateSecret(t *testing.T) {
 		shareRoles := []AnnotationGrant{{Principal: "dev-team", Role: "editor"}}
 		result, err := k8sClient.CreateSecret(context.Background(), "test-namespace", "new-secret", data, shareUsers, shareRoles, "", "")
 
-		// Then: Returns created secret with labels and sharing annotations
+		// Then: Returns created secret with labels. Sharing is represented by
+		// RoleBindings, not Secret annotations.
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -203,21 +204,11 @@ func TestCreateSecret(t *testing.T) {
 		if result.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
 			t.Errorf("expected managed-by label, got %v", result.Labels)
 		}
-		// Verify share-users annotation
-		parsedUsers, err := GetShareUsers(result)
-		if err != nil {
-			t.Fatalf("failed to parse share-users: %v", err)
+		if _, ok := result.Annotations[v1alpha2.AnnotationShareUsers]; ok {
+			t.Fatal("did not expect share-users annotation")
 		}
-		if len(parsedUsers) != 1 || parsedUsers[0].Principal != "alice@example.com" || parsedUsers[0].Role != "owner" {
-			t.Errorf("expected [{alice@example.com owner}], got %v", parsedUsers)
-		}
-		// Verify share-roles annotation
-		parsedRoles, err := GetShareRoles(result)
-		if err != nil {
-			t.Fatalf("failed to parse share-roles: %v", err)
-		}
-		if len(parsedRoles) != 1 || parsedRoles[0].Principal != "dev-team" || parsedRoles[0].Role != "editor" {
-			t.Errorf("expected [{dev-team editor}], got %v", parsedRoles)
+		if _, ok := result.Annotations[v1alpha2.AnnotationShareRoles]; ok {
+			t.Fatal("did not expect share-roles annotation")
 		}
 		if string(result.Data["key"]) != "value" {
 			t.Errorf("expected key='value', got %q", string(result.Data["key"]))

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -50,6 +51,8 @@ import (
 	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	"github.com/holos-run/holos-console/console/deployments"
 )
+
+var controllerRuntimeLoggerMu sync.Mutex
 
 // Scheme is the controller-runtime scheme shared by the embedded manager and
 // by any cache-backed client constructed from the manager. Callers that need
@@ -171,7 +174,9 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 	// as the rest of the binary. Without this, controller-runtime prints a
 	// one-shot "log.SetLogger(...) was never called" stack trace on first
 	// use (HOL-765).
+	controllerRuntimeLoggerMu.Lock()
 	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
+	controllerRuntimeLoggerMu.Unlock()
 	cacheSyncTimeout := opts.CacheSyncTimeout
 	if cacheSyncTimeout == 0 {
 		// controller-runtime's default is 2 minutes. We ship a tighter

--- a/internal/secretinjector/controller/manager.go
+++ b/internal/secretinjector/controller/manager.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -39,6 +40,8 @@ import (
 	secretsv1alpha1 "github.com/holos-run/holos-console/api/secrets/v1alpha1"
 	sicrypto "github.com/holos-run/holos-console/internal/secretinjector/crypto"
 )
+
+var controllerRuntimeLoggerMu sync.Mutex
 
 // Scheme is the controller-runtime scheme shared by the secret-injector
 // manager and any cache-backed client constructed from it. The scheme is
@@ -174,7 +177,9 @@ func NewManager(cfg *rest.Config, opts Options) (*Manager, error) {
 	// as the rest of the binary. Without this, controller-runtime prints a
 	// one-shot "log.SetLogger(...) was never called" stack trace on first
 	// use (HOL-765).
+	controllerRuntimeLoggerMu.Lock()
 	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
+	controllerRuntimeLoggerMu.Unlock()
 	cacheSyncTimeout := opts.CacheSyncTimeout
 	if cacheSyncTimeout == 0 {
 		// 90s matches the console manager so both binaries roll with the


### PR DESCRIPTION
## Summary
- provision project-scoped Secret viewer/editor/owner Roles and OIDC-prefixed RoleBindings when projects are created
- route SecretsService CRUD through the per-request impersonated Kubernetes client and map API-server authorization failures to Connect errors
- keep the UpdateSharing RPC surface stable while reconciling project Secret RoleBindings instead of Secret sharing annotations
- serialize controller-runtime logger setup to keep the race-enabled Go suite stable

## Notes
- ADR 036 is binding for this change: current-caller RBAC subjects use the OIDC sub, with response metadata mapping that subject back to the caller email for existing UI display.
- Kubernetes RoleBindings have no native nbf/exp semantics, so time-bounded grant fields remain accepted by the proto surface but are not encoded into the RBAC objects.

## Test Plan
- make test-go
- make test-ui
- make test-e2e

Fixes HOL-1032