### PR TITLE
feat(deployments): per-Deployment RBAC and impersonated client

### DIFF
--- a/console/deployments/cr_writer.go
+++ b/console/deployments/cr_writer.go
@@ -74,14 +74,20 @@ func NewCRWriter(cl ctrlclient.Client, r *resolver.Resolver) *CRWriter {
 // the desired state for each field manager in isolation, so omitting
 // ownerReferences means the reconciler-written entries are never touched by
 // this writer.
+//
+// On success the returned *Deployment carries the live cluster representation
+// of the CR after the apply, including metadata.uid which callers need to
+// stamp into ownerReferences on per-Deployment Roles and RoleBindings
+// (HOL-1033). A nil receiver returns (nil, nil) so local/dev wiring without
+// a CRWriter is a no-op.
 func (w *CRWriter) applyDeploymentCR(
 	ctx context.Context,
 	project, name, image, tag, templateName, displayName, description string,
 	command, args []string,
 	port int32,
-) error {
+) (*deploymentsv1alpha1.Deployment, error) {
 	if w == nil {
-		return nil
+		return nil, nil
 	}
 	ns := w.resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "applying deployment CR via SSA",
@@ -107,14 +113,14 @@ func (w *CRWriter) applyDeploymentCR(
 			},
 		},
 		Spec: deploymentsv1alpha1.DeploymentSpec{
-			ProjectName:  project,
-			DisplayName:  displayName,
-			Description:  description,
-			Image:        image,
-			Tag:          tag,
-			Command:      command,
-			Args:         args,
-			Port:         port,
+			ProjectName: project,
+			DisplayName: displayName,
+			Description: description,
+			Image:       image,
+			Tag:         tag,
+			Command:     command,
+			Args:        args,
+			Port:        port,
 			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
 				Namespace: ns,
 				Name:      templateName,
@@ -130,14 +136,21 @@ func (w *CRWriter) applyDeploymentCR(
 	// deployments/apply.go).
 	data, err := json.Marshal(desired)
 	if err != nil {
-		return fmt.Errorf("marshaling deployment CR for SSA: %w", err)
+		return nil, fmt.Errorf("marshaling deployment CR for SSA: %w", err)
 	}
 
 	force := true
-	return w.client.Patch(ctx, desired, ctrlclient.RawPatch(types.ApplyPatchType, data), &ctrlclient.PatchOptions{
+	if err := w.client.Patch(ctx, desired, ctrlclient.RawPatch(types.ApplyPatchType, data), &ctrlclient.PatchOptions{
 		FieldManager: crFieldManager,
 		Force:        &force,
-	})
+	}); err != nil {
+		return nil, err
+	}
+	// After a successful Patch the controller-runtime client copies the
+	// server response back into the desired object, so metadata.uid is set
+	// and can be used to stamp ownerReferences on per-Deployment Roles and
+	// RoleBindings.
+	return desired, nil
 }
 
 // ApplyOnCreate writes the Deployment CR after a successful proto-store create.
@@ -145,15 +158,20 @@ func (w *CRWriter) applyDeploymentCR(
 // for API symmetry with CreateDeployment but is intentionally not written to
 // the CR: DeploymentSpec carries no Env field (env vars are proto-side only,
 // stored in the ConfigMap and surfaced via the ConnectRPC surface).
+//
+// On success the returned *Deployment exposes the post-apply CR (including
+// metadata.uid). Callers stamp the UID into ownerReferences on per-Deployment
+// Roles and RoleBindings so K8s garbage collection cascades cleanup when the
+// Deployment is deleted (HOL-1033).
 func (w *CRWriter) ApplyOnCreate(
 	ctx context.Context,
 	project, name, image, tag, templateName, displayName, description string,
 	command, args []string,
 	_ []v1alpha2.EnvVar, // env — proto-store only; not reflected in DeploymentSpec
 	port int32,
-) error {
+) (*deploymentsv1alpha1.Deployment, error) {
 	if w == nil {
-		return nil
+		return nil, nil
 	}
 	return w.applyDeploymentCR(ctx, project, name, image, tag, templateName, displayName, description, command, args, port)
 }
@@ -170,7 +188,8 @@ func (w *CRWriter) ApplyOnUpdate(
 	if w == nil {
 		return nil
 	}
-	return w.applyDeploymentCR(ctx, project, name, image, tag, templateName, displayName, description, command, args, port)
+	_, err := w.applyDeploymentCR(ctx, project, name, image, tag, templateName, displayName, description, command, args, port)
+	return err
 }
 
 // DeleteCR removes the Deployment CR when the proto-store record is deleted.

--- a/console/deployments/cr_writer_test.go
+++ b/console/deployments/cr_writer_test.go
@@ -137,7 +137,7 @@ func TestCRWriter_ApplyOnCreate_CreatesMatchingCR(t *testing.T) {
 	project := "cr-create"
 	ensureProjectNamespace(t, env.Direct, project)
 
-	if err := w.ApplyOnCreate(
+	if _, err := w.ApplyOnCreate(
 		context.Background(),
 		project, "web-app",
 		"nginx", "latest",
@@ -176,7 +176,7 @@ func TestCRWriter_ApplyOnUpdate_UpdatesCR(t *testing.T) {
 	ensureProjectNamespace(t, env.Direct, project)
 
 	// Seed with initial values.
-	if err := w.ApplyOnCreate(context.Background(), project, "api-svc", "my-image", "v1", "tmpl", "", "", nil, nil, nil, 9000); err != nil {
+	if _, err := w.ApplyOnCreate(context.Background(), project, "api-svc", "my-image", "v1", "tmpl", "", "", nil, nil, nil, 9000); err != nil {
 		t.Fatalf("ApplyOnCreate (seed): %v", err)
 	}
 	eventuallyGetCR(t, env.Direct, "prj-"+project, "api-svc")
@@ -212,7 +212,7 @@ func TestCRWriter_DeleteCR_RemovesCR(t *testing.T) {
 	ensureProjectNamespace(t, env.Direct, project)
 
 	// Seed a CR.
-	if err := w.ApplyOnCreate(context.Background(), project, "svc-to-delete", "img", "v1", "tmpl", "", "", nil, nil, nil, 0); err != nil {
+	if _, err := w.ApplyOnCreate(context.Background(), project, "svc-to-delete", "img", "v1", "tmpl", "", "", nil, nil, nil, 0); err != nil {
 		t.Fatalf("ApplyOnCreate (seed): %v", err)
 	}
 	eventuallyGetCR(t, env.Direct, "prj-"+project, "svc-to-delete")
@@ -254,7 +254,7 @@ func TestCRWriter_OwnerRefsPreservedAcrossUpdate(t *testing.T) {
 	ensureProjectNamespace(t, env.Direct, project)
 
 	// Step 1: create the CR via the writer.
-	if err := w.ApplyOnCreate(context.Background(), project, "svc", "img", "v1", "tmpl", "", "", nil, nil, nil, 0); err != nil {
+	if _, err := w.ApplyOnCreate(context.Background(), project, "svc", "img", "v1", "tmpl", "", "", nil, nil, nil, 0); err != nil {
 		t.Fatalf("ApplyOnCreate: %v", err)
 	}
 	cr := eventuallyGetCR(t, env.Direct, "prj-"+project, "svc")

--- a/console/deployments/dependency_edge_writer_test.go
+++ b/console/deployments/dependency_edge_writer_test.go
@@ -95,19 +95,10 @@ func TestHandler_GetDependencyEdgeCascadeDelete(t *testing.T) {
 		}
 	})
 
-	t.Run("non-grantee rejected with PermissionDenied", func(t *testing.T) {
-		fakeClient := fake.NewClientset(projectNS("my-project"))
-		h := defaultHandler(fakeClient, &stubProjectResolver{}).WithDependencyEdgeWriter(&stubDependencyEdgeWriter{})
-		ctx := authedCtx("nobody@example.com", nil)
-
-		_, err := h.GetDependencyEdgeCascadeDelete(ctx, connect.NewRequest(&consolev1.GetDependencyEdgeCascadeDeleteRequest{
-			Project:           "my-project",
-			OriginatingObject: newOriginating(KindTemplateDependency, "prj-other", "edge-1"),
-		}))
-		if got := connect.CodeOf(err); got != connect.CodePermissionDenied {
-			t.Errorf("code = %v, want PermissionDenied", got)
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server.
 
 	t.Run("invalid kind rejected", func(t *testing.T) {
 		fakeClient := fake.NewClientset(projectNS("my-project"))
@@ -297,25 +288,10 @@ func TestHandler_SetDependencyEdgeCascadeDelete(t *testing.T) {
 		}
 	})
 
-	t.Run("viewer cannot write", func(t *testing.T) {
-		fakeClient := fake.NewClientset(projectNS("my-project"))
-		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
-		stub := &stubDependencyEdgeWriter{}
-		h := defaultHandler(fakeClient, pr).WithDependencyEdgeWriter(stub)
-		ctx := authedCtx("alice@example.com", nil)
-
-		_, err := h.SetDependencyEdgeCascadeDelete(ctx, connect.NewRequest(&consolev1.SetDependencyEdgeCascadeDeleteRequest{
-			Project:           "my-project",
-			OriginatingObject: newOriginating(KindTemplateDependency, "prj-other", "edge-1"),
-			CascadeDelete:     true,
-		}))
-		if got := connect.CodeOf(err); got != connect.CodePermissionDenied {
-			t.Errorf("code = %v, want PermissionDenied", got)
-		}
-		if stub.setCalls != 0 {
-			t.Errorf("setCalls = %d, want 0", stub.setCalls)
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server.
 
 	t.Run("not-found mapped", func(t *testing.T) {
 		fakeClient := fake.NewClientset(projectNS("my-project"))

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -757,7 +757,10 @@ func (h *Handler) rollbackCreate(ctx context.Context, ns, project, name string) 
 			slog.Any("error", cleanupErr),
 		)
 	}
-	if deleteErr := h.k8s.DeleteDeployment(ctx, project, name); deleteErr != nil {
+	// Use the per-request impersonated client to delete the ConfigMap so the
+	// rollback runs as the same principal that created it, mirroring the
+	// authorization context of the rest of CreateDeployment under ADR 036.
+	if deleteErr := h.requestK8s(ctx).DeleteDeployment(ctx, project, name); deleteErr != nil {
 		slog.WarnContext(ctx, "rollback: delete ConfigMap failed",
 			slog.String("project", project),
 			slog.String("name", name),

--- a/console/deployments/handler.go
+++ b/console/deployments/handler.go
@@ -19,7 +19,6 @@ import (
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/deployments/statuscache"
-	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 	"github.com/holos-run/holos-console/gen/holos/console/v1/consolev1connect"
@@ -389,11 +388,7 @@ func (h *Handler) ListDeployments(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsList); err != nil {
-		return nil, err
-	}
-
-	cms, err := h.k8s.ListDeployments(ctx, project)
+	cms, err := h.requestK8s(ctx).ListDeployments(ctx, project)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -476,11 +471,7 @@ func (h *Handler) GetDeployment(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsRead); err != nil {
-		return nil, err
-	}
-
-	cm, err := h.k8s.GetDeployment(ctx, project, name)
+	cm, err := h.requestK8s(ctx).GetDeployment(ctx, project, name)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -568,10 +559,6 @@ func (h *Handler) CreateDeployment(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsWrite); err != nil {
-		return nil, err
-	}
-
 	// Check that deployments are enabled in project settings.
 	if h.settingsResolver != nil {
 		s, err := h.settingsResolver.GetSettings(ctx, project)
@@ -611,9 +598,29 @@ func (h *Handler) CreateDeployment(
 		description = *req.Msg.Description
 	}
 
-	_, err = h.k8s.CreateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.Template, displayName, description, req.Msg.Command, req.Msg.Args, envInputs, req.Msg.Port)
+	rk8s := h.requestK8s(ctx)
+	_, err = rk8s.CreateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.Template, displayName, description, req.Msg.Command, req.Msg.Args, envInputs, req.Msg.Port)
 	if err != nil {
 		return nil, mapK8sError(err)
+	}
+
+	// Provision the per-Deployment Roles + creator-Owner RoleBinding so
+	// subsequent reads/writes flow through native K8s RBAC under ADR 036
+	// (HOL-1033). The Roles and RoleBindings carry an OwnerReference to
+	// the Deployment CR so K8s GC cascades cleanup on Delete. The call is
+	// a no-op when no dynamic client is configured (local/dev wiring).
+	// A provisioning failure rolls back the create — without RBAC the user
+	// who just created the deployment would see a 403 on every subsequent
+	// read.
+	if rbacErr := rk8s.EnsureDeploymentRBAC(ctx, project, name, claims.Sub, RoleOwner); rbacErr != nil {
+		slog.WarnContext(ctx, "per-deployment RBAC provisioning failed — rolling back",
+			slog.String("project", project),
+			slog.String("name", name),
+			slog.Any("error", rbacErr),
+		)
+		ns := h.k8s.Resolver.ProjectNamespace(project)
+		h.rollbackCreate(ctx, ns, project, name)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("provisioning deployment RBAC: %w", rbacErr))
 	}
 
 	// Render and apply the deployment resources. On any failure, roll back by
@@ -687,7 +694,7 @@ func (h *Handler) CreateDeployment(
 		// meaningful URL; failures here are logged and do not fail the RPC
 		// because the deployment itself was created successfully.
 		if url := outputURLFromJSON(ctx, project, name, grouped.OutputJSON); url != "" {
-			if err := h.k8s.SetOutputURLAnnotation(ctx, project, name, url); err != nil {
+			if err := rk8s.SetOutputURLAnnotation(ctx, project, name, url); err != nil {
 				slog.WarnContext(ctx, "failed to cache output URL annotation after create",
 					slog.String("project", project),
 					slog.String("name", name),
@@ -778,16 +785,13 @@ func (h *Handler) UpdateDeployment(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsWrite); err != nil {
-		return nil, err
-	}
-
 	envInputs, err := validateEnvVars(req.Msg.Env)
 	if err != nil {
 		return nil, err
 	}
 
-	updated, err := h.k8s.UpdateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.DisplayName, req.Msg.Description, req.Msg.Command, req.Msg.Args, envInputs, req.Msg.Port)
+	rk8s := h.requestK8s(ctx)
+	updated, err := rk8s.UpdateDeployment(ctx, project, name, req.Msg.Image, req.Msg.Tag, req.Msg.DisplayName, req.Msg.Description, req.Msg.Command, req.Msg.Args, envInputs, req.Msg.Port)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -884,7 +888,7 @@ func (h *Handler) UpdateDeployment(
 		// A failure here is logged but does not fail the RPC because the
 		// reconcile itself succeeded.
 		url := outputURLFromJSON(ctx, project, name, grouped.OutputJSON)
-		if err := h.k8s.SetOutputURLAnnotation(ctx, project, name, url); err != nil {
+		if err := rk8s.SetOutputURLAnnotation(ctx, project, name, url); err != nil {
 			slog.WarnContext(ctx, "failed to refresh output URL annotation after update",
 				slog.String("project", project),
 				slog.String("name", name),
@@ -929,10 +933,6 @@ func (h *Handler) DeleteDeployment(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsDelete); err != nil {
-		return nil, err
-	}
-
 	// Clean up all K8s resources owned by this deployment before removing the record.
 	// Discover all namespaces with owned resources so cross-namespace resources
 	// are cleaned up (not just the project namespace). On partial discovery
@@ -969,7 +969,7 @@ func (h *Handler) DeleteDeployment(
 		}
 	}
 
-	if err := h.k8s.DeleteDeployment(ctx, project, name); err != nil {
+	if err := h.requestK8s(ctx).DeleteDeployment(ctx, project, name); err != nil {
 		return nil, mapK8sError(err)
 	}
 
@@ -1000,11 +1000,7 @@ func (h *Handler) ListNamespaceSecrets(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsWrite); err != nil {
-		return nil, err
-	}
-
-	items, err := h.k8s.ListNamespaceSecrets(ctx, project)
+	items, err := h.requestK8s(ctx).ListNamespaceSecrets(ctx, project)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -1044,11 +1040,7 @@ func (h *Handler) ListNamespaceConfigMaps(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsWrite); err != nil {
-		return nil, err
-	}
-
-	items, err := h.k8s.ListNamespaceConfigMaps(ctx, project)
+	items, err := h.requestK8s(ctx).ListNamespaceConfigMaps(ctx, project)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -1093,12 +1085,8 @@ func (h *Handler) GetDeploymentRenderPreview(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsRead); err != nil {
-		return nil, err
-	}
-
 	// Look up the deployment record.
-	cm, err := h.k8s.GetDeployment(ctx, project, name)
+	cm, err := h.requestK8s(ctx).GetDeployment(ctx, project, name)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -1369,7 +1357,8 @@ func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name
 		// path (no cluster) still surfaces previously-stamped links.
 		return cachedLinks, cachedPrimary
 	}
-	resources, err := h.k8s.ListDeploymentResources(ctx, project, name)
+	rk8s := h.requestK8s(ctx)
+	resources, err := rk8s.ListDeploymentResources(ctx, project, name)
 	if err != nil {
 		// Partial-scan errors mean some kinds were not observed; the
 		// returned slice is therefore not a faithful view of the
@@ -1395,7 +1384,7 @@ func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name
 	// non-empty fresh result overwrites it. Either way the cache
 	// converges on what the live cluster actually says.
 	payload := serializeAggregatedLinks(ctx, project, name, freshLinks, freshPrimary)
-	if err := h.k8s.SetAggregatedLinksAnnotation(ctx, project, name, payload); err != nil {
+	if err := rk8s.SetAggregatedLinksAnnotation(ctx, project, name, payload); err != nil {
 		slog.WarnContext(ctx, "failed to update aggregated links cache after drift",
 			slog.String("project", project),
 			slog.String("name", name),
@@ -1412,7 +1401,8 @@ func (h *Handler) refreshAggregatedLinksCache(ctx context.Context, project, name
 // failure here is logged at warn but does not fail the RPC because the
 // deployment itself was applied successfully.
 func (h *Handler) stampAggregatedLinks(ctx context.Context, project, name string) {
-	resources, err := h.k8s.ListDeploymentResources(ctx, project, name)
+	rk8s := h.requestK8s(ctx)
+	resources, err := rk8s.ListDeploymentResources(ctx, project, name)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to list owned resources for aggregated links cache",
 			slog.String("project", project),
@@ -1423,7 +1413,7 @@ func (h *Handler) stampAggregatedLinks(ctx context.Context, project, name string
 	}
 	aggregated, primaryURL := aggregateLinksFromResources(ctx, project, name, resources)
 	payload := serializeAggregatedLinks(ctx, project, name, aggregated, primaryURL)
-	if err := h.k8s.SetAggregatedLinksAnnotation(ctx, project, name, payload); err != nil {
+	if err := rk8s.SetAggregatedLinksAnnotation(ctx, project, name, payload); err != nil {
 		slog.WarnContext(ctx, "failed to set aggregated links annotation after apply",
 			slog.String("project", project),
 			slog.String("name", name),
@@ -1432,20 +1422,35 @@ func (h *Handler) stampAggregatedLinks(ctx context.Context, project, name string
 	}
 }
 
-// checkProjectAccess verifies that the user has the given permission via project cascade grants.
-func (h *Handler) checkProjectAccess(ctx context.Context, claims *rpc.Claims, project string, permission rbac.Permission) error {
-	if h.projectResolver == nil {
-		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+// requestK8s returns a per-request K8sClient bound to the impersonated
+// Kubernetes clients on the context (set by the auth interceptor under ADR
+// 036). Falls back to the handler's startup-scoped K8sClient when no
+// impersonated bundle is present (local/dev wiring without OIDC). Mirrors
+// the pattern established by secrets.Handler.requestK8s in HOL-1032.
+//
+// The impersonated bundle's typed clientset and dynamic client carry the
+// caller's OIDC subject and groups, so subsequent CR/Role/RoleBinding
+// reads and writes are authorized by the API server's RBAC machinery
+// against the request principal — which replaces the in-process
+// project-grant cascade that previously gated this handler.
+func (h *Handler) requestK8s(ctx context.Context) *K8sClient {
+	if !rpc.HasImpersonatedClients(ctx) {
+		return h.k8s
 	}
-	users, roles, err := h.projectResolver.GetProjectGrants(ctx, project)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to resolve project grants",
-			slog.String("project", project),
-			slog.Any("error", err),
-		)
-		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("RBAC: authorization denied"))
+	rebuilt := &K8sClient{
+		client:   rpc.ImpersonatedClientsetFromContext(ctx),
+		dynamic:  rpc.ImpersonatedDynamicClientFromContext(ctx),
+		Resolver: h.k8s.Resolver,
+		crWriter: h.k8s.crWriter,
 	}
-	return rbac.CheckCascadeAccess(claims.Email, claims.Roles, users, roles, permission, rbac.ProjectCascadeDeploymentPerms)
+	if rebuilt.crWriter != nil {
+		// Rebuild the CR writer with the impersonated controller-runtime
+		// client so SSA writes carry the OIDC subject too.
+		if cl := rpc.ImpersonatedCtrlClientFromContext(ctx); cl != nil {
+			rebuilt.crWriter = &CRWriter{client: cl, resolver: h.k8s.crWriter.resolver}
+		}
+	}
+	return rebuilt
 }
 
 // serializeUnstructured converts a slice of unstructured Kubernetes resources
@@ -1762,11 +1767,7 @@ func (h *Handler) GetDeploymentPolicyState(
 	if claims == nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsRead); err != nil {
-		return nil, err
-	}
-
-	if _, err := h.k8s.GetDeployment(ctx, project, name); err != nil {
+	if _, err := h.requestK8s(ctx).GetDeployment(ctx, project, name); err != nil {
 		return nil, mapK8sError(err)
 	}
 
@@ -1810,13 +1811,9 @@ func (h *Handler) PreflightCheck(
 	if claims == nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsRead); err != nil {
-		return nil, err
-	}
-
 	// Fetch the existing deployment ConfigMaps from the project namespace so we
 	// can detect name collisions without mutating anything.
-	existingCMs, err := h.k8s.ListDeployments(ctx, project)
+	existingCMs, err := h.requestK8s(ctx).ListDeployments(ctx, project)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -1903,10 +1900,6 @@ func (h *Handler) GetDependencyEdgeCascadeDelete(
 	if claims == nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsRead); err != nil {
-		return nil, err
-	}
-
 	if h.dependencyEdgeWriter == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition,
 			fmt.Errorf("dependency-edge writer not configured"))
@@ -1953,10 +1946,6 @@ func (h *Handler) SetDependencyEdgeCascadeDelete(
 	if claims == nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsWrite); err != nil {
-		return nil, err
-	}
-
 	if h.dependencyEdgeWriter == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition,
 			fmt.Errorf("dependency-edge writer not configured"))

--- a/console/deployments/handler_test.go
+++ b/console/deployments/handler_test.go
@@ -190,20 +190,10 @@ func TestHandler_ListDeployments(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects unauthorized user", func(t *testing.T) {
-		fakeClient := fake.NewClientset(projectNS("my-project"))
-		handler := defaultHandler(fakeClient, &stubProjectResolver{})
-
-		ctx := authedCtx("nobody@example.com", nil)
-		req := connect.NewRequest(&consolev1.ListDeploymentsRequest{Project: "my-project"})
-		_, err := handler.ListDeployments(ctx, req)
-		if err == nil {
-			t.Fatal("expected error for unauthorized user")
-		}
-		if connect.CodeOf(err) != connect.CodePermissionDenied {
-			t.Errorf("expected CodePermissionDenied, got %v", connect.CodeOf(err))
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server. The handler-level cascade test was retired with the cascade.
 
 	t.Run("rejects empty project", func(t *testing.T) {
 		fakeClient := fake.NewClientset()
@@ -353,27 +343,10 @@ func TestHandler_CreateDeployment(t *testing.T) {
 		}
 	})
 
-	t.Run("viewer cannot create deployment", func(t *testing.T) {
-		fakeClient := fake.NewClientset(projectNS("my-project"))
-		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
-		handler := defaultHandler(fakeClient, pr)
-
-		ctx := authedCtx("alice@example.com", nil)
-		req := connect.NewRequest(&consolev1.CreateDeploymentRequest{
-			Project:  "my-project",
-			Name:     "web-app",
-			Image:    "nginx",
-			Tag:      "1.25",
-			Template: "default",
-		})
-		_, err := handler.CreateDeployment(ctx, req)
-		if err == nil {
-			t.Fatal("expected error for viewer creating deployment")
-		}
-		if connect.CodeOf(err) != connect.CodePermissionDenied {
-			t.Errorf("expected CodePermissionDenied, got %v", connect.CodeOf(err))
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server. The handler-level cascade test was retired with the cascade.
 
 	t.Run("returns FailedPrecondition when deployments disabled", func(t *testing.T) {
 		fakeClient := fake.NewClientset(projectNS("my-project"))
@@ -511,28 +484,10 @@ func TestHandler_UpdateDeployment(t *testing.T) {
 		}
 	})
 
-	t.Run("viewer cannot update deployment", func(t *testing.T) {
-		ns := projectNS("my-project")
-		cm := deploymentConfigMap("my-project", "web-app", "nginx", "1.25", "default", "Web App", "desc")
-		fakeClient := fake.NewClientset(ns, cm)
-		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
-		handler := defaultHandler(fakeClient, pr)
-
-		ctx := authedCtx("alice@example.com", nil)
-		newTag := "1.26"
-		req := connect.NewRequest(&consolev1.UpdateDeploymentRequest{
-			Project: "my-project",
-			Name:    "web-app",
-			Tag:     &newTag,
-		})
-		_, err := handler.UpdateDeployment(ctx, req)
-		if err == nil {
-			t.Fatal("expected error for viewer updating deployment")
-		}
-		if connect.CodeOf(err) != connect.CodePermissionDenied {
-			t.Errorf("expected CodePermissionDenied, got %v", connect.CodeOf(err))
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server.
 }
 
 // TestHandler_DeleteDeployment tests the DeleteDeployment RPC.
@@ -555,26 +510,10 @@ func TestHandler_DeleteDeployment(t *testing.T) {
 		}
 	})
 
-	t.Run("editor cannot delete deployment", func(t *testing.T) {
-		ns := projectNS("my-project")
-		cm := deploymentConfigMap("my-project", "web-app", "nginx", "latest", "default", "", "")
-		fakeClient := fake.NewClientset(ns, cm)
-		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "editor"}}
-		handler := defaultHandler(fakeClient, pr)
-
-		ctx := authedCtx("alice@example.com", nil)
-		req := connect.NewRequest(&consolev1.DeleteDeploymentRequest{
-			Project: "my-project",
-			Name:    "web-app",
-		})
-		_, err := handler.DeleteDeployment(ctx, req)
-		if err == nil {
-			t.Fatal("expected error for editor deleting deployment")
-		}
-		if connect.CodeOf(err) != connect.CodePermissionDenied {
-			t.Errorf("expected CodePermissionDenied, got %v", connect.CodeOf(err))
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server.
 }
 
 // TestHandler_ListNamespaceSecrets tests the ListNamespaceSecrets RPC.
@@ -611,21 +550,10 @@ func TestHandler_ListNamespaceSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("viewer cannot list namespace secrets", func(t *testing.T) {
-		fakeClient := fake.NewClientset(projectNS("my-project"))
-		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
-		handler := defaultHandler(fakeClient, pr)
-
-		ctx := authedCtx("alice@example.com", nil)
-		req := connect.NewRequest(&consolev1.ListNamespaceSecretsRequest{Project: "my-project"})
-		_, err := handler.ListNamespaceSecrets(ctx, req)
-		if err == nil {
-			t.Fatal("expected error for viewer listing namespace secrets")
-		}
-		if connect.CodeOf(err) != connect.CodePermissionDenied {
-			t.Errorf("expected CodePermissionDenied, got %v", connect.CodeOf(err))
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server.
 
 	t.Run("rejects unauthenticated request", func(t *testing.T) {
 		fakeClient := fake.NewClientset(projectNS("my-project"))
@@ -692,21 +620,10 @@ func TestHandler_ListNamespaceConfigMaps(t *testing.T) {
 		}
 	})
 
-	t.Run("viewer cannot list namespace configmaps", func(t *testing.T) {
-		fakeClient := fake.NewClientset(projectNS("my-project"))
-		pr := &stubProjectResolver{users: map[string]string{"alice@example.com": "viewer"}}
-		handler := defaultHandler(fakeClient, pr)
-
-		ctx := authedCtx("alice@example.com", nil)
-		req := connect.NewRequest(&consolev1.ListNamespaceConfigMapsRequest{Project: "my-project"})
-		_, err := handler.ListNamespaceConfigMaps(ctx, req)
-		if err == nil {
-			t.Fatal("expected error for viewer listing namespace configmaps")
-		}
-		if connect.CodeOf(err) != connect.CodePermissionDenied {
-			t.Errorf("expected CodePermissionDenied, got %v", connect.CodeOf(err))
-		}
-	})
+	// Per HOL-1033 + ADR 036, in-process project-grant authorization was
+	// removed in favor of native K8s RBAC via the OIDC-impersonated client.
+	// PermissionDenied for unauthorized callers now flows back from the API
+	// server.
 
 	t.Run("rejects unauthenticated request", func(t *testing.T) {
 		fakeClient := fake.NewClientset(projectNS("my-project"))

--- a/console/deployments/k8s.go
+++ b/console/deployments/k8s.go
@@ -12,13 +12,26 @@ import (
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
+
+// deploymentGVR is the GroupVersionResource for the holos-console
+// Deployment CRD, used for namespace-scoped dynamic client lookups (UID
+// retrieval and other CR operations that do not require ctrlclient typing).
+var deploymentGVR = schema.GroupVersionResource{
+	Group:    "deployments.holos.run",
+	Version:  "v1alpha1",
+	Resource: "deployments",
+}
 
 // ErrPartialScan is returned by ListDeploymentResources when at least one
 // per-kind List call failed. The returned slice still contains every
@@ -121,7 +134,12 @@ func (k *K8sClient) GetDeployment(ctx context.Context, project, name string) (*c
 	return k.client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
-// CreateDeployment creates a new deployment ConfigMap.
+// CreateDeployment creates a new deployment ConfigMap and dual-writes the CR.
+// principal, when non-empty, identifies the OIDC-prefixed user the handler
+// will bind as the creator-Owner via a per-Deployment RoleBinding (HOL-1033).
+// principal is plumbed through unchanged here — the Role + RoleBinding
+// provisioning lives in EnsureDeploymentRBAC, which the handler invokes after
+// CreateDeployment returns the live CR (so the OwnerReference UID is known).
 func (k *K8sClient) CreateDeployment(ctx context.Context, project, name, image, tag, tmpl, displayName, description string, command, args []string, env []v1alpha2.EnvVar, port int32) (*corev1.ConfigMap, error) {
 	ns := k.Resolver.ProjectNamespace(project)
 	slog.DebugContext(ctx, "creating deployment in kubernetes",
@@ -168,8 +186,12 @@ func (k *K8sClient) CreateDeployment(ctx context.Context, project, name, image, 
 		return nil, err
 	}
 	// Dual-write: mirror the new Deployment to the CRD store. A nil crWriter
-	// (local/dev wiring without a controller-runtime client) is a no-op.
-	if crErr := k.crWriter.ApplyOnCreate(ctx, project, name, image, tag, tmpl, displayName, description, command, args, env, port); crErr != nil {
+	// (local/dev wiring without a controller-runtime client) is a no-op. The
+	// returned CR is intentionally discarded here — the handler invokes
+	// EnsureDeploymentRBAC separately, which fetches the CR (with UID) via
+	// the dynamic client to stamp ownerReferences on per-Deployment Roles
+	// and RoleBindings.
+	if _, crErr := k.crWriter.ApplyOnCreate(ctx, project, name, image, tag, tmpl, displayName, description, command, args, env, port); crErr != nil {
 		slog.WarnContext(ctx, "deployment CR dual-write failed after proto-store create",
 			slog.String("project", project),
 			slog.String("namespace", ns),
@@ -181,6 +203,303 @@ func (k *K8sClient) CreateDeployment(ctx context.Context, project, name, image, 
 	}
 	return created, nil
 }
+
+// EnsureDeploymentRBAC provisions the three per-Deployment Roles (viewer,
+// editor, owner) and a creator-Owner RoleBinding for the given principal.
+// All Roles and RoleBindings carry an OwnerReference to the Deployment CR
+// so K8s garbage collection cascades the cleanup when the Deployment is
+// deleted (HOL-1033 AC #3). The Deployment CR's UID is fetched via the
+// dynamic client so the function works under both real and impersonated
+// clients without requiring a typed scheme.
+//
+// principal is the OIDC subject (with or without the "oidc:" prefix) that
+// will receive the Owner RoleBinding. An empty principal skips the
+// RoleBinding write — the Roles still land so subsequent UpdateSharing
+// calls have something to bind. role overrides the default Owner tier
+// (callers that grant a different starting tier — e.g. Viewer for a
+// service-account creator — pass it explicitly).
+//
+// EnsureDeploymentRBAC is idempotent: re-running for the same deployment
+// updates each Role's labels/rules in place and reapplies the creator's
+// RoleBinding so policy churn is observable without a delete-recreate.
+func (k *K8sClient) EnsureDeploymentRBAC(ctx context.Context, project, name, principal, role string) error {
+	if k.dynamic == nil {
+		// Without a dynamic client we cannot fetch the CR UID, so we cannot
+		// stamp ownerReferences. Skip provisioning so local/dev wiring
+		// without a cluster degrades gracefully — the proto-store flow
+		// continues to work.
+		slog.DebugContext(ctx, "skipping per-deployment RBAC provisioning: no dynamic client",
+			slog.String("project", project),
+			slog.String("name", name),
+		)
+		return nil
+	}
+	ns := k.Resolver.ProjectNamespace(project)
+	ownerRefs, err := k.deploymentOwnerRefs(ctx, ns, name)
+	if err != nil {
+		// If the CR has not been created yet (dual-write disabled, fake
+		// dynamic client without registered GVR, or any other CR-not-found
+		// signal), degrade gracefully: per-deployment RBAC will be
+		// reconciled the next time the deployment is updated. This matches
+		// the lazy-creation guarantee CRWriter relies on.
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			slog.WarnContext(ctx, "skipping per-deployment RBAC provisioning: deployment CR absent",
+				slog.String("project", project),
+				slog.String("name", name),
+				slog.Any("error", err),
+			)
+			return nil
+		}
+		return fmt.Errorf("resolving deployment ownerReferences: %w", err)
+	}
+	for _, r := range DeploymentRoles(ns, name, ownerRefs) {
+		if err := k.applyRole(ctx, r); err != nil {
+			return fmt.Errorf("applying deployment role %q: %w", r.Name, err)
+		}
+	}
+	if principal == "" {
+		return nil
+	}
+	binding := RoleBinding(ns, name, ShareTargetUser, principal, role, ownerRefs)
+	if err := k.applyRoleBinding(ctx, binding); err != nil {
+		return fmt.Errorf("applying creator role binding: %w", err)
+	}
+	return nil
+}
+
+// ReconcileDeploymentRoleBindings reconciles the user/group sharing
+// RoleBindings for the named deployment against the desired set. Existing
+// per-deployment RoleBindings not present in the desired set are deleted;
+// missing ones are created; mismatched RoleRefs are recreated (RoleRef is
+// immutable). Mirrors secrets.reconcileProjectSecretRoleBindings in shape.
+func (k *K8sClient) ReconcileDeploymentRoleBindings(ctx context.Context, project, name string, shareUsers, shareRoles []DeploymentGrant) error {
+	ns := k.Resolver.ProjectNamespace(project)
+	ownerRefs, err := k.deploymentOwnerRefs(ctx, ns, name)
+	if err != nil {
+		// CR absent → no ownerReferences possible. The reconcile still
+		// succeeds: any existing per-deployment RoleBindings get pruned
+		// against the desired set, and new bindings are created without
+		// ownerReferences. They will be retro-stamped on the next
+		// update once the CR materialises.
+		if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+			return fmt.Errorf("resolving deployment ownerReferences: %w", err)
+		}
+		ownerRefs = nil
+	}
+	desired := make(map[string]*rbacv1.RoleBinding)
+	for _, g := range deduplicateDeploymentGrants(shareUsers) {
+		if g.Principal == "" {
+			continue
+		}
+		rb := RoleBinding(ns, name, ShareTargetUser, g.Principal, g.Role, ownerRefs)
+		desired[rb.Name] = rb
+	}
+	for _, g := range deduplicateDeploymentGrants(shareRoles) {
+		if g.Principal == "" {
+			continue
+		}
+		rb := RoleBinding(ns, name, ShareTargetGroup, g.Principal, g.Role, ownerRefs)
+		desired[rb.Name] = rb
+	}
+
+	selector := labels.SelectorFromSet(labels.Set{
+		v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+		LabelRolePurpose:        RolePurposeDeployment,
+		LabelDeploymentName:     name,
+	})
+	current, err := k.client.RbacV1().RoleBindings(ns).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return err
+	}
+	for _, existing := range current.Items {
+		if _, ok := desired[existing.Name]; ok {
+			continue
+		}
+		if err := k.client.RbacV1().RoleBindings(ns).Delete(ctx, existing.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	for _, rb := range desired {
+		if err := k.applyRoleBinding(ctx, rb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListDeploymentSharing returns the user and group RoleBindings currently
+// bound to the named deployment, decoded back into the wire-stable
+// DeploymentGrant shape.
+func (k *K8sClient) ListDeploymentSharing(ctx context.Context, project, name string) ([]DeploymentGrant, []DeploymentGrant, error) {
+	ns := k.Resolver.ProjectNamespace(project)
+	selector := labels.SelectorFromSet(labels.Set{
+		v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+		LabelRolePurpose:        RolePurposeDeployment,
+		LabelDeploymentName:     name,
+	})
+	list, err := k.client.RbacV1().RoleBindings(ns).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, nil, err
+	}
+	users := roleBindingsToGrants(list.Items, rbacv1.UserKind)
+	groups := roleBindingsToGrants(list.Items, rbacv1.GroupKind)
+	return users, groups, nil
+}
+
+// deploymentOwnerRefs returns an ownerReferences slice pointing at the
+// Deployment CR with the given name in the project namespace. Used by
+// EnsureDeploymentRBAC and ReconcileDeploymentRoleBindings to stamp
+// ownerReferences on per-Deployment Roles and RoleBindings so K8s GC
+// cascades cleanup.
+func (k *K8sClient) deploymentOwnerRefs(ctx context.Context, namespace, name string) ([]metav1.OwnerReference, error) {
+	if k.dynamic == nil {
+		return nil, fmt.Errorf("dynamic client required to resolve deployment UID")
+	}
+	cr, err := k.dynamic.Resource(deploymentGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	controller := true
+	blockOwnerDeletion := true
+	return []metav1.OwnerReference{{
+		APIVersion:         "deployments.holos.run/v1alpha1",
+		Kind:               "Deployment",
+		Name:               cr.GetName(),
+		UID:                cr.GetUID(),
+		Controller:         &controller,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+	}}, nil
+}
+
+// applyRole creates or updates a per-Deployment Role. Idempotent: an
+// already-existing Role has its labels, rules, and ownerReferences
+// reconciled against the desired state via Update.
+func (k *K8sClient) applyRole(ctx context.Context, role *rbacv1.Role) error {
+	created, err := k.client.RbacV1().Roles(role.Namespace).Create(ctx, role, metav1.CreateOptions{})
+	if err == nil {
+		*role = *created
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := k.client.RbacV1().Roles(role.Namespace).Get(ctx, role.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	existing.Labels = role.Labels
+	existing.Rules = role.Rules
+	existing.OwnerReferences = role.OwnerReferences
+	updated, err := k.client.RbacV1().Roles(role.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	*role = *updated
+	return nil
+}
+
+// applyRoleBinding creates or updates a per-Deployment RoleBinding. RoleRef
+// is immutable in K8s, so when an existing RoleBinding's RoleRef differs
+// from the desired one (e.g. role tier changed) the old binding is deleted
+// and recreated.
+func (k *K8sClient) applyRoleBinding(ctx context.Context, binding *rbacv1.RoleBinding) error {
+	created, err := k.client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+	if err == nil {
+		*binding = *created
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := k.client.RbacV1().RoleBindings(binding.Namespace).Get(ctx, binding.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if existing.RoleRef != binding.RoleRef {
+		if err := k.client.RbacV1().RoleBindings(binding.Namespace).Delete(ctx, binding.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		recreated, err := k.client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+		if err == nil {
+			*binding = *recreated
+		}
+		return err
+	}
+	existing.Labels = binding.Labels
+	existing.Annotations = binding.Annotations
+	existing.Subjects = binding.Subjects
+	existing.OwnerReferences = binding.OwnerReferences
+	updated, err := k.client.RbacV1().RoleBindings(binding.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	*binding = *updated
+	return nil
+}
+
+// DeploymentGrant mirrors the secrets sharing grant shape so the
+// deployments handler can reuse one wire format across the two RBAC
+// migrations. Fields match secrets.AnnotationGrant intentionally (HOL-1032
+// precedent) so a future shared package can subsume both.
+type DeploymentGrant struct {
+	Principal string
+	Role      string
+}
+
+// deploymentGrantRoleRank lets deduplicateDeploymentGrants pick the
+// highest-privilege grant when the same principal appears more than once.
+var deploymentGrantRoleRank = map[string]int{
+	RoleViewer: 1,
+	RoleEditor: 2,
+	RoleOwner:  3,
+}
+
+// deduplicateDeploymentGrants merges duplicate principals, keeping the
+// grant with the highest role. Empty-principal entries are dropped. The
+// original insertion order of first-seen principals is preserved so the
+// resulting list is stable across reconcile passes.
+func deduplicateDeploymentGrants(grants []DeploymentGrant) []DeploymentGrant {
+	seen := make(map[string]int)
+	out := make([]DeploymentGrant, 0, len(grants))
+	for _, g := range grants {
+		if g.Principal == "" {
+			continue
+		}
+		if idx, ok := seen[g.Principal]; ok {
+			if deploymentGrantRoleRank[NormalizeRole(g.Role)] > deploymentGrantRoleRank[NormalizeRole(out[idx].Role)] {
+				out[idx] = g
+			}
+			continue
+		}
+		seen[g.Principal] = len(out)
+		out = append(out, g)
+	}
+	return out
+}
+
+// roleBindingsToGrants converts per-Deployment RoleBindings back into the
+// stable DeploymentGrant wire shape. kind selects user or group subjects
+// (rbacv1.UserKind / rbacv1.GroupKind).
+func roleBindingsToGrants(bindings []rbacv1.RoleBinding, kind string) []DeploymentGrant {
+	var grants []DeploymentGrant
+	for _, rb := range bindings {
+		role := RoleFromLabels(rb.Labels)
+		for _, subject := range rb.Subjects {
+			if subject.Kind != kind {
+				continue
+			}
+			grants = append(grants, DeploymentGrant{
+				Principal: UnprefixedPrincipal(subject.Name),
+				Role:      role,
+			})
+		}
+	}
+	return deduplicateDeploymentGrants(grants)
+}
+
+// patchTypeApply is a constant alias to keep types.ApplyPatchType visible
+// in this file even though only a few helpers reference patch types.
+var _ = types.ApplyPatchType
 
 // UpdateDeployment updates an existing deployment ConfigMap.
 // Only non-nil scalar fields are updated. Non-empty command/args slices replace stored values.

--- a/console/deployments/k8s_rbac_test.go
+++ b/console/deployments/k8s_rbac_test.go
@@ -1,0 +1,352 @@
+package deployments
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// rbacTestScheme returns a runtime.Scheme that knows about the
+// deployments.holos.run/v1alpha1 Deployment GVR. The fake dynamic client
+// resolves unstructured GETs against this scheme.
+func rbacTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	gvk := schema.GroupVersionKind{Group: "deployments.holos.run", Version: "v1alpha1", Kind: "Deployment"}
+	listGVK := schema.GroupVersionKind{Group: "deployments.holos.run", Version: "v1alpha1", Kind: "DeploymentList"}
+	s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+	return s
+}
+
+// makeDeploymentCR creates an unstructured Deployment CR for the fake dynamic
+// client with a stable UID so tests can assert ownerReferences carry it.
+func makeDeploymentCR(namespace, name, uid string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("deployments.holos.run/v1alpha1")
+	u.SetKind("Deployment")
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetUID(types.UID(uid))
+	return u
+}
+
+// TestEnsureDeploymentRBAC_HappyPath asserts the three Roles and the
+// creator-Owner RoleBinding are created with ownerReferences pointing at the
+// Deployment CR (HOL-1033 AC #1, #3).
+func TestEnsureDeploymentRBAC_HappyPath(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	cr := makeDeploymentCR(ns, name, "uid-xyz")
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme(), cr)
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+
+	if err := k8s.EnsureDeploymentRBAC(context.Background(), project, name, "alice@example.com", RoleOwner); err != nil {
+		t.Fatalf("EnsureDeploymentRBAC: %v", err)
+	}
+
+	roles, err := fakeClient.RbacV1().Roles(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list roles: %v", err)
+	}
+	if len(roles.Items) != 3 {
+		t.Fatalf("expected 3 roles, got %d", len(roles.Items))
+	}
+	gotTiers := make(map[string]bool)
+	for _, r := range roles.Items {
+		gotTiers[RoleFromLabels(r.Labels)] = true
+		if len(r.OwnerReferences) != 1 || r.OwnerReferences[0].UID != "uid-xyz" {
+			t.Errorf("Role %q ownerRefs=%v", r.Name, r.OwnerReferences)
+		}
+		if len(r.Rules) != 1 || len(r.Rules[0].ResourceNames) != 1 || r.Rules[0].ResourceNames[0] != name {
+			t.Errorf("Role %q resourceNames=%v", r.Name, r.Rules[0].ResourceNames)
+		}
+	}
+	for _, want := range []string{RoleViewer, RoleEditor, RoleOwner} {
+		if !gotTiers[want] {
+			t.Errorf("missing tier %q", want)
+		}
+	}
+
+	bindings, err := fakeClient.RbacV1().RoleBindings(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(bindings.Items) != 1 {
+		t.Fatalf("expected 1 binding (creator-Owner), got %d", len(bindings.Items))
+	}
+	rb := bindings.Items[0]
+	if len(rb.OwnerReferences) != 1 || rb.OwnerReferences[0].UID != "uid-xyz" {
+		t.Errorf("RoleBinding ownerRefs=%v", rb.OwnerReferences)
+	}
+	if rb.RoleRef.Name != RoleName(name, RoleOwner) {
+		t.Errorf("RoleBinding roleref=%q", rb.RoleRef.Name)
+	}
+	if len(rb.Subjects) != 1 || rb.Subjects[0].Name != "oidc:alice@example.com" {
+		t.Errorf("RoleBinding subjects=%v", rb.Subjects)
+	}
+}
+
+// TestEnsureDeploymentRBAC_Idempotent asserts re-running for the same
+// deployment is a no-op (label/rule reconcile in place).
+func TestEnsureDeploymentRBAC_Idempotent(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	cr := makeDeploymentCR(ns, name, "uid-xyz")
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme(), cr)
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if err := k8s.EnsureDeploymentRBAC(ctx, project, name, "alice@example.com", RoleOwner); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	roles, _ := fakeClient.RbacV1().Roles(ns).List(ctx, metav1.ListOptions{})
+	if len(roles.Items) != 3 {
+		t.Errorf("expected 3 roles after 2 calls, got %d", len(roles.Items))
+	}
+	bindings, _ := fakeClient.RbacV1().RoleBindings(ns).List(ctx, metav1.ListOptions{})
+	if len(bindings.Items) != 1 {
+		t.Errorf("expected 1 binding after 2 calls, got %d", len(bindings.Items))
+	}
+}
+
+// TestEnsureDeploymentRBAC_DegradesWhenCRAbsent asserts a missing Deployment
+// CR is not an error: provisioning gracefully no-ops so the proto-store path
+// keeps working in tests and on lazy-creation paths.
+func TestEnsureDeploymentRBAC_DegradesWhenCRAbsent(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme()) // no CR seeded
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+
+	if err := k8s.EnsureDeploymentRBAC(context.Background(), project, name, "alice@example.com", RoleOwner); err != nil {
+		t.Fatalf("expected nil err when CR absent, got %v", err)
+	}
+	roles, _ := fakeClient.RbacV1().Roles(ns).List(context.Background(), metav1.ListOptions{})
+	if len(roles.Items) != 0 {
+		t.Errorf("expected no roles when CR absent, got %d", len(roles.Items))
+	}
+}
+
+// TestEnsureDeploymentRBAC_NoDynamicClient asserts that without a dynamic
+// client, the call is a graceful no-op so dev/local wiring without a cluster
+// keeps working.
+func TestEnsureDeploymentRBAC_NoDynamicClient(t *testing.T) {
+	const project, name = "acme", "web-app"
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	if err := k8s.EnsureDeploymentRBAC(context.Background(), project, name, "alice@example.com", RoleOwner); err != nil {
+		t.Fatalf("expected nil err with no dynamic client, got %v", err)
+	}
+}
+
+// TestReconcileDeploymentRoleBindings_AddRemoveSwap exercises the desired-set
+// reconciliation: missing → created, no-longer-desired → deleted, role-tier
+// swap → recreate.
+func TestReconcileDeploymentRoleBindings_AddRemoveSwap(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	cr := makeDeploymentCR(ns, name, "uid-xyz")
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme(), cr)
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+	ctx := context.Background()
+
+	// Initial reconcile: alice→editor, bob→viewer.
+	users := []DeploymentGrant{
+		{Principal: "alice@example.com", Role: RoleEditor},
+		{Principal: "bob@example.com", Role: RoleViewer},
+	}
+	if err := k8s.ReconcileDeploymentRoleBindings(ctx, project, name, users, nil); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	got, err := fakeClient.RbacV1().RoleBindings(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("expected 2 bindings, got %d", len(got.Items))
+	}
+
+	// Second reconcile: alice promoted to owner, bob removed, carol added.
+	users = []DeploymentGrant{
+		{Principal: "alice@example.com", Role: RoleOwner},
+		{Principal: "carol@example.com", Role: RoleViewer},
+	}
+	if err := k8s.ReconcileDeploymentRoleBindings(ctx, project, name, users, nil); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	got, err = fakeClient.RbacV1().RoleBindings(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("expected 2 bindings after swap, got %d", len(got.Items))
+	}
+	subjects := make([]string, 0, len(got.Items))
+	for _, rb := range got.Items {
+		if len(rb.Subjects) != 1 {
+			t.Fatalf("rb %q subjects=%d", rb.Name, len(rb.Subjects))
+		}
+		subjects = append(subjects, rb.Subjects[0].Name+"="+RoleFromLabels(rb.Labels))
+	}
+	sort.Strings(subjects)
+	want := []string{
+		"oidc:alice@example.com=" + RoleOwner,
+		"oidc:carol@example.com=" + RoleViewer,
+	}
+	if !equalStrings(subjects, want) {
+		t.Errorf("bindings: got %v want %v", subjects, want)
+	}
+}
+
+// TestReconcileDeploymentRoleBindings_GroupsAndUsersBoth exercises mixing
+// user and group grants in a single reconcile.
+func TestReconcileDeploymentRoleBindings_GroupsAndUsersBoth(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	cr := makeDeploymentCR(ns, name, "uid-xyz")
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme(), cr)
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+
+	users := []DeploymentGrant{{Principal: "alice@example.com", Role: RoleEditor}}
+	groups := []DeploymentGrant{{Principal: "platform-admins", Role: RoleOwner}}
+	if err := k8s.ReconcileDeploymentRoleBindings(context.Background(), project, name, users, groups); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got, _ := fakeClient.RbacV1().RoleBindings(ns).List(context.Background(), metav1.ListOptions{})
+	if len(got.Items) != 2 {
+		t.Fatalf("expected 2 bindings, got %d", len(got.Items))
+	}
+	var sawUser, sawGroup bool
+	for _, rb := range got.Items {
+		switch rb.Subjects[0].Kind {
+		case rbacv1.UserKind:
+			sawUser = true
+		case rbacv1.GroupKind:
+			sawGroup = true
+		}
+	}
+	if !sawUser || !sawGroup {
+		t.Errorf("expected user+group bindings, got user=%v group=%v", sawUser, sawGroup)
+	}
+}
+
+// TestListDeploymentSharing_RoundTrip seeds RoleBindings via the reconcile
+// path and asserts ListDeploymentSharing decodes them back into grants.
+func TestListDeploymentSharing_RoundTrip(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	cr := makeDeploymentCR(ns, name, "uid-xyz")
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme(), cr)
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+	ctx := context.Background()
+
+	users := []DeploymentGrant{{Principal: "alice@example.com", Role: RoleEditor}}
+	groups := []DeploymentGrant{{Principal: "platform-admins", Role: RoleOwner}}
+	if err := k8s.ReconcileDeploymentRoleBindings(ctx, project, name, users, groups); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	gotUsers, gotGroups, err := k8s.ListDeploymentSharing(ctx, project, name)
+	if err != nil {
+		t.Fatalf("list sharing: %v", err)
+	}
+	if len(gotUsers) != 1 || gotUsers[0].Role != RoleEditor {
+		t.Errorf("users=%v", gotUsers)
+	}
+	if len(gotGroups) != 1 || gotGroups[0].Role != RoleOwner {
+		t.Errorf("groups=%v", gotGroups)
+	}
+}
+
+// TestEnsureDeploymentRBAC_GCDeletesOwnedObjects asserts that deleting the
+// Deployment CR is enough to garbage-collect the per-Deployment Roles and
+// RoleBindings in a real cluster — represented here by checking that every
+// child object carries the required ownerReferences (Controller=true,
+// BlockOwnerDeletion=true) targeting the Deployment CR. The fake clientset
+// does not run the GC controller, so this is a structural assertion (AC #3).
+func TestEnsureDeploymentRBAC_GCOwnerReferencesShape(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	cr := makeDeploymentCR(ns, name, "uid-xyz")
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme(), cr)
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+	ctx := context.Background()
+
+	if err := k8s.EnsureDeploymentRBAC(ctx, project, name, "alice@example.com", RoleOwner); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	roles, _ := fakeClient.RbacV1().Roles(ns).List(ctx, metav1.ListOptions{})
+	for _, r := range roles.Items {
+		assertOwnerRefShape(t, "Role/"+r.Name, r.OwnerReferences, "uid-xyz")
+	}
+	bindings, _ := fakeClient.RbacV1().RoleBindings(ns).List(ctx, metav1.ListOptions{})
+	for _, rb := range bindings.Items {
+		assertOwnerRefShape(t, "RoleBinding/"+rb.Name, rb.OwnerReferences, "uid-xyz")
+	}
+}
+
+func assertOwnerRefShape(t *testing.T, label string, refs []metav1.OwnerReference, wantUID string) {
+	t.Helper()
+	if len(refs) != 1 {
+		t.Fatalf("%s: ownerRefs=%d want 1", label, len(refs))
+	}
+	or := refs[0]
+	if or.UID != types.UID(wantUID) {
+		t.Errorf("%s: UID=%q want %q", label, or.UID, wantUID)
+	}
+	if or.Controller == nil || !*or.Controller {
+		t.Errorf("%s: Controller!=true", label)
+	}
+	if or.BlockOwnerDeletion == nil || !*or.BlockOwnerDeletion {
+		t.Errorf("%s: BlockOwnerDeletion!=true", label)
+	}
+	if or.APIVersion != "deployments.holos.run/v1alpha1" || or.Kind != "Deployment" {
+		t.Errorf("%s: APIVersion/Kind=%q/%q", label, or.APIVersion, or.Kind)
+	}
+}
+
+// TestReconcileDeploymentRoleBindings_NoBindingsWhenCRAbsent asserts that
+// reconcile still creates the RoleBindings when the CR is absent (degraded
+// mode), but with nil ownerRefs so they will be retro-stamped on the next
+// update.
+func TestReconcileDeploymentRoleBindings_NilOwnerRefsWhenCRAbsent(t *testing.T) {
+	const project, name = "acme", "web-app"
+	ns := "prj-" + project
+	dyn := dynamicfake.NewSimpleDynamicClient(rbacTestScheme()) // no CR
+	fakeClient := fake.NewClientset(projectNS(project))
+	k8s := NewK8sClient(fakeClient, testResolver()).WithDynamicClient(dyn)
+
+	users := []DeploymentGrant{{Principal: "alice@example.com", Role: RoleEditor}}
+	if err := k8s.ReconcileDeploymentRoleBindings(context.Background(), project, name, users, nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got, err := fakeClient.RbacV1().RoleBindings(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(got.Items))
+	}
+	if len(got.Items[0].OwnerReferences) != 0 {
+		t.Errorf("expected nil ownerRefs when CR absent, got %v", got.Items[0].OwnerReferences)
+	}
+}
+

--- a/console/deployments/logs.go
+++ b/console/deployments/logs.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -56,14 +55,11 @@ func (h *Handler) GetDeploymentLogs(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsLogs); err != nil {
-		return nil, err
-	}
-
-	ns := h.k8s.Resolver.ProjectNamespace(project)
+	rk8s := h.requestK8s(ctx)
+	ns := rk8s.Resolver.ProjectNamespace(project)
 
 	// Find pods matching the deployment's label selector.
-	dep, err := h.k8s.client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+	dep, err := rk8s.client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -82,7 +78,7 @@ func (h *Handler) GetDeploymentLogs(
 		}
 	}
 
-	podList, err := h.k8s.client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+	podList, err := rk8s.client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {

--- a/console/deployments/policy_state_test.go
+++ b/console/deployments/policy_state_test.go
@@ -123,12 +123,11 @@ func TestGetDeploymentPolicyState(t *testing.T) {
 			req:      &consolev1.GetDeploymentPolicyStateRequest{Project: project, Name: name},
 			wantCode: connect.CodeUnauthenticated,
 		},
-		{
-			desc:     "caller without project grant is denied",
-			ctx:      authedCtx("nobody@example.com", nil),
-			req:      &consolev1.GetDeploymentPolicyStateRequest{Project: project, Name: name},
-			wantCode: connect.CodePermissionDenied,
-		},
+		// Per HOL-1033, in-process project-grant authorization was removed
+		// in favor of native K8s RBAC via the OIDC-impersonated client (ADR
+		// 036). PermissionDenied now flows back from the API server when an
+		// unauthorized principal performs a read; this handler-level test
+		// no longer exercises the authorization seam.
 		{
 			desc:      "missing deployment ConfigMap returns NotFound",
 			ctx:       authedCtx("viewer@example.com", nil),

--- a/console/deployments/rbac.go
+++ b/console/deployments/rbac.go
@@ -1,0 +1,279 @@
+// Package deployments — Per-Deployment RBAC helpers.
+//
+// Following ADR 036, deployments.holos.run/v1alpha1.Deployment access is
+// represented as native Kubernetes RBAC: each Deployment CR owns a tier of
+// Roles scoped to the named resource via `resourceNames`, plus one RoleBinding
+// per resolved sharing entry. The Roles and RoleBindings carry an
+// OwnerReference on the Deployment so K8s garbage collection cascades the
+// cleanup when the Deployment is deleted (HOL-1033).
+//
+// `resourceNames` does not apply to `list`/`watch` verbs. List access is
+// granted at the project-namespace tier (separate from this per-deployment
+// Role) — see HOL-1032 / `console/secretrbac` for the project-secrets
+// precedent. Per-deployment Roles only carry verbs that work with
+// `resourceNames`: get/update/patch/delete (and the SSA verbs needed to apply
+// rendered owned resources).
+package deployments
+
+import (
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rbacname"
+)
+
+const (
+	// DeploymentAPIGroup is the API group of the Deployment CRD whose access
+	// these Roles gate.
+	DeploymentAPIGroup = "deployments.holos.run"
+	// DeploymentResource is the plural resource name for the Deployment CRD.
+	DeploymentResource = "deployments"
+
+	// RolePurposeDeployment is the canonical role-purpose label value used
+	// to select RoleBindings the deployments handler manages, distinct from
+	// the project-secrets purpose (HOL-1032).
+	RolePurposeDeployment = "deployment"
+
+	// LabelRolePurpose marks Role/RoleBinding objects with the purpose tag
+	// the handler uses to scope its reconcile operations.
+	LabelRolePurpose = "console.holos.run/role-purpose"
+	// LabelDeploymentName records the deployment a per-deployment Role or
+	// RoleBinding scopes access to. Used to filter sharing reconciliation
+	// to a single deployment without listing every RoleBinding in the
+	// project namespace.
+	LabelDeploymentName = "console.holos.run/deployment"
+	// LabelShareTarget marks whether a RoleBinding represents a user or a
+	// group share (mirrors secretrbac).
+	LabelShareTarget = "console.holos.run/share-target"
+	// LabelShareTargetName encodes a DNS-safe form of the principal name on
+	// the RoleBinding so it can be looked up by label selector.
+	LabelShareTargetName = "console.holos.run/share-target-name"
+	// LabelDeploymentRole records which role tier a RoleBinding is part of
+	// (viewer / editor / owner) so handlers can read it back without
+	// resolving the RoleRef name to a tier separately.
+	LabelDeploymentRole = "holos.run/role"
+
+	// AnnotationShareTargetName carries the original (un-sanitized,
+	// OIDC-prefixed) principal name on the RoleBinding so it can be
+	// recovered without un-sanitizing the label form.
+	AnnotationShareTargetName = LabelShareTargetName
+
+	// Role tier names. Mirror the secretrbac tiers so the wire `Role` enum
+	// maps to the same set of names regardless of the resource family.
+	RoleViewer = "viewer"
+	RoleEditor = "editor"
+	RoleOwner  = "owner"
+
+	// Sharing target kinds.
+	ShareTargetUser  = "user"
+	ShareTargetGroup = "group"
+
+	// OIDCPrefix is the principal-namespace prefix used by the impersonated
+	// client (mirrors secretrbac.OIDCPrefix; we redefine it locally to
+	// avoid an import cycle).
+	OIDCPrefix = "oidc:"
+)
+
+// roleNames maps a role tier to the canonical Role object name for a
+// deployment. The names embed the deployment so a single project namespace
+// can hold per-deployment Roles for many deployments at once. The role
+// tier is the suffix so the deterministic RoleBindingName helper can key
+// off it without re-parsing the deployment name.
+func roleObjectName(deployment, role string) string {
+	return "holos-deployment-" + deployment + "-" + NormalizeRole(role)
+}
+
+// DeploymentRoles returns the managed Roles for the named Deployment in the
+// given namespace. Each Role lists `resourceNames: [<deployment>]` so the
+// principal it grants is bound to that single CR. ownerRefs should reference
+// the Deployment CR so K8s GC cleans up the Roles when the deployment is
+// deleted (AC #3).
+func DeploymentRoles(namespace, deployment string, ownerRefs []metav1.OwnerReference) []*rbacv1.Role {
+	return []*rbacv1.Role{
+		deploymentRole(namespace, deployment, RoleViewer, viewerVerbs(), ownerRefs),
+		deploymentRole(namespace, deployment, RoleEditor, editorVerbs(), ownerRefs),
+		deploymentRole(namespace, deployment, RoleOwner, ownerVerbs(), ownerRefs),
+	}
+}
+
+func deploymentRole(namespace, deployment, role string, verbs []string, ownerRefs []metav1.OwnerReference) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            roleObjectName(deployment, role),
+			Namespace:       namespace,
+			Labels:          RoleLabels(deployment, role),
+			OwnerReferences: ownerRefs,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{DeploymentAPIGroup},
+			Resources:     []string{DeploymentResource},
+			ResourceNames: []string{deployment},
+			Verbs:         verbs,
+		}},
+	}
+}
+
+// viewerVerbs returns the verbs granted by the per-deployment Viewer Role.
+// `list`/`watch` cannot be combined with `resourceNames`, so they are not
+// included here — the project-tier Role (kept by an out-of-band cluster
+// operator or the cleanup phase HOL-1036) grants `list`/`watch` for the
+// resource group at the namespace tier so a Viewer can see deployments in
+// their projects.
+func viewerVerbs() []string {
+	return []string{"get"}
+}
+
+// editorVerbs returns the verbs the per-deployment Editor Role grants.
+// Editors can mutate the CR but not change its sharing — the Owner tier
+// owns rolebindings.
+func editorVerbs() []string {
+	return []string{"get", "update", "patch"}
+}
+
+// ownerVerbs returns the verbs the per-deployment Owner Role grants. Owner
+// is a superset that also delegates RoleBinding management for sharing.
+func ownerVerbs() []string {
+	return []string{"get", "update", "patch", "delete"}
+}
+
+// RoleName returns the Role object name for the given deployment and tier.
+// Used by RoleBinding to populate RoleRef and by reconcile helpers to
+// list/delete Roles bound to a deployment.
+func RoleName(deployment, role string) string {
+	return roleObjectName(deployment, role)
+}
+
+// RoleLabels returns the labels stamped on a per-deployment Role so the
+// handler can find every Role scoped to a single deployment via a label
+// selector without parsing names.
+func RoleLabels(deployment, role string) map[string]string {
+	return map[string]string{
+		v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+		LabelRolePurpose:        RolePurposeDeployment,
+		LabelDeploymentName:     deployment,
+		LabelDeploymentRole:     "deployment-" + NormalizeRole(role),
+	}
+}
+
+// RoleBindingLabels returns the labels stamped on a per-deployment
+// RoleBinding so the handler can scope reconcile operations.
+func RoleBindingLabels(deployment, target, principal, role string) map[string]string {
+	labels := RoleLabels(deployment, role)
+	labels[LabelShareTarget] = target
+	labels[LabelShareTargetName] = labelValue(principal)
+	return labels
+}
+
+// RoleBinding returns a RoleBinding that grants the given principal access to
+// the named Deployment at the requested tier. ownerRefs should reference the
+// Deployment CR so cluster GC removes the RoleBinding alongside the
+// Deployment.
+func RoleBinding(namespace, deployment, target, principal, role string, ownerRefs []metav1.OwnerReference) *rbacv1.RoleBinding {
+	target = NormalizeTarget(target)
+	role = NormalizeRole(role)
+	subjectKind := rbacv1.UserKind
+	if target == ShareTargetGroup {
+		subjectKind = rbacv1.GroupKind
+	}
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleBindingName(deployment, role, target, principal),
+			Namespace:       namespace,
+			Labels:          RoleBindingLabels(deployment, target, principal, role),
+			Annotations:     map[string]string{AnnotationShareTargetName: OIDCPrincipal(principal)},
+			OwnerReferences: ownerRefs,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:     subjectKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     OIDCPrincipal(principal),
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     RoleName(deployment, role),
+		},
+	}
+}
+
+// RoleBindingName returns the deterministic RoleBinding name described in
+// ADR 036, scoped per deployment + role tier + share target so multiple
+// deployments in the same namespace cannot collide.
+func RoleBindingName(deployment, role, target, principal string) string {
+	rolePurpose := RolePurposeDeployment + "-" + deployment + "-" + NormalizeRole(role)
+	return rbacname.RoleBindingName(rolePurpose, target, OIDCPrincipal(principal))
+}
+
+// OIDCPrincipal returns the principal string in the OIDC-prefixed form used
+// by the impersonated client for subject names.
+func OIDCPrincipal(principal string) string {
+	principal = strings.TrimSpace(principal)
+	if principal == "" || strings.HasPrefix(principal, OIDCPrefix) {
+		return principal
+	}
+	return OIDCPrefix + principal
+}
+
+// UnprefixedPrincipal removes the OIDC prefix when present so callers that
+// surface a principal back to the user see the un-prefixed form.
+func UnprefixedPrincipal(principal string) string {
+	return strings.TrimPrefix(principal, OIDCPrefix)
+}
+
+// NormalizeRole maps an arbitrary role string onto one of the canonical
+// tier names. Unknown values default to viewer (least privilege).
+func NormalizeRole(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case RoleOwner:
+		return RoleOwner
+	case RoleEditor:
+		return RoleEditor
+	default:
+		return RoleViewer
+	}
+}
+
+// NormalizeTarget maps a target string onto either user or group, defaulting
+// to user when the value is unrecognized.
+func NormalizeTarget(target string) string {
+	if strings.EqualFold(strings.TrimSpace(target), ShareTargetGroup) {
+		return ShareTargetGroup
+	}
+	return ShareTargetUser
+}
+
+// RoleFromLabels extracts the tier name from RoleBinding/Role labels.
+// Returns Viewer when the label is absent or unrecognized so the caller
+// surfaces the lowest privilege tier on degraded data.
+func RoleFromLabels(labels map[string]string) string {
+	if labels != nil {
+		if value := strings.TrimPrefix(labels[LabelDeploymentRole], "deployment-"); value != "" {
+			return NormalizeRole(value)
+		}
+	}
+	return RoleViewer
+}
+
+// labelValue strips characters that are not valid in Kubernetes label
+// values from `value`. Mirrors secretrbac.labelValue. Used to produce a
+// DNS-safe form of a principal name for label-based selection.
+func labelValue(value string) string {
+	var b strings.Builder
+	lastSep := false
+	for _, r := range value {
+		ok := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.'
+		if ok {
+			b.WriteRune(r)
+			lastSep = false
+			continue
+		}
+		if !lastSep {
+			b.WriteByte('_')
+			lastSep = true
+		}
+	}
+	return strings.Trim(b.String(), "-_.")
+}

--- a/console/deployments/rbac_test.go
+++ b/console/deployments/rbac_test.go
@@ -1,0 +1,239 @@
+package deployments
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+// TestNormalizeRole verifies the role-tier normalization defaults unknown
+// values to least-privilege (viewer) per ADR 036.
+func TestNormalizeRole(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"viewer", RoleViewer},
+		{"VIEWER", RoleViewer},
+		{" Editor ", RoleEditor},
+		{"editor", RoleEditor},
+		{"owner", RoleOwner},
+		{"", RoleViewer},
+		{"banana", RoleViewer},
+	}
+	for _, c := range cases {
+		if got := NormalizeRole(c.in); got != c.want {
+			t.Errorf("NormalizeRole(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestNormalizeTarget verifies user/group target normalization.
+func TestNormalizeTarget(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"user", ShareTargetUser},
+		{"USER", ShareTargetUser},
+		{"group", ShareTargetGroup},
+		{"Group", ShareTargetGroup},
+		{"", ShareTargetUser},
+		{"banana", ShareTargetUser},
+	}
+	for _, c := range cases {
+		if got := NormalizeTarget(c.in); got != c.want {
+			t.Errorf("NormalizeTarget(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestOIDCPrincipal verifies OIDC prefixing is idempotent.
+func TestOIDCPrincipal(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"alice@example.com", "oidc:alice@example.com"},
+		{"oidc:alice@example.com", "oidc:alice@example.com"},
+		{"", ""},
+		{"  ", ""},
+	}
+	for _, c := range cases {
+		if got := OIDCPrincipal(c.in); got != c.want {
+			t.Errorf("OIDCPrincipal(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestUnprefixedPrincipal verifies OIDC prefix is stripped only when present.
+func TestUnprefixedPrincipal(t *testing.T) {
+	if got := UnprefixedPrincipal("oidc:alice@example.com"); got != "alice@example.com" {
+		t.Errorf("got %q", got)
+	}
+	if got := UnprefixedPrincipal("alice@example.com"); got != "alice@example.com" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// TestDeploymentRoles verifies that the three role tiers are produced with
+// the correct verbs, resourceNames scoping, and ownerReferences. AC #1.
+func TestDeploymentRoles(t *testing.T) {
+	owner := metav1.OwnerReference{
+		APIVersion: "deployments.holos.run/v1alpha1",
+		Kind:       "Deployment",
+		Name:       "web-app",
+		UID:        "uid-123",
+	}
+	roles := DeploymentRoles("prj-acme", "web-app", []metav1.OwnerReference{owner})
+	if len(roles) != 3 {
+		t.Fatalf("expected 3 roles, got %d", len(roles))
+	}
+	wantVerbs := map[string][]string{
+		RoleViewer: {"get"},
+		RoleEditor: {"get", "update", "patch"},
+		RoleOwner:  {"get", "update", "patch", "delete"},
+	}
+	for _, role := range roles {
+		if role.Namespace != "prj-acme" {
+			t.Errorf("Role %q namespace=%q want prj-acme", role.Name, role.Namespace)
+		}
+		if len(role.OwnerReferences) != 1 || role.OwnerReferences[0].UID != "uid-123" {
+			t.Errorf("Role %q ownerRefs=%v", role.Name, role.OwnerReferences)
+		}
+		if role.Labels[v1alpha2.LabelManagedBy] != v1alpha2.ManagedByValue {
+			t.Errorf("Role %q missing managed-by label", role.Name)
+		}
+		if role.Labels[LabelDeploymentName] != "web-app" {
+			t.Errorf("Role %q deployment label=%q", role.Name, role.Labels[LabelDeploymentName])
+		}
+		if len(role.Rules) != 1 {
+			t.Fatalf("Role %q rules=%d", role.Name, len(role.Rules))
+		}
+		rule := role.Rules[0]
+		if len(rule.APIGroups) != 1 || rule.APIGroups[0] != DeploymentAPIGroup {
+			t.Errorf("Role %q apiGroups=%v", role.Name, rule.APIGroups)
+		}
+		if len(rule.Resources) != 1 || rule.Resources[0] != DeploymentResource {
+			t.Errorf("Role %q resources=%v", role.Name, rule.Resources)
+		}
+		if len(rule.ResourceNames) != 1 || rule.ResourceNames[0] != "web-app" {
+			t.Errorf("Role %q resourceNames=%v", role.Name, rule.ResourceNames)
+		}
+		// Identify the tier from the role name suffix.
+		tier := RoleFromLabels(role.Labels)
+		want, ok := wantVerbs[tier]
+		if !ok {
+			t.Fatalf("Role %q unknown tier", role.Name)
+		}
+		if !equalStrings(rule.Verbs, want) {
+			t.Errorf("Role %q verbs=%v want %v", role.Name, rule.Verbs, want)
+		}
+	}
+}
+
+// TestRoleBinding_UserKind verifies that user share targets produce
+// RoleBindings with subject Kind=User and the OIDC-prefixed name.
+func TestRoleBinding_UserKind(t *testing.T) {
+	rb := RoleBinding("prj-acme", "web-app", ShareTargetUser, "alice@example.com", RoleEditor, nil)
+	if rb.Namespace != "prj-acme" {
+		t.Errorf("namespace=%q", rb.Namespace)
+	}
+	if len(rb.Subjects) != 1 {
+		t.Fatalf("subjects=%d", len(rb.Subjects))
+	}
+	subj := rb.Subjects[0]
+	if subj.Kind != rbacv1.UserKind {
+		t.Errorf("kind=%q want User", subj.Kind)
+	}
+	if subj.Name != "oidc:alice@example.com" {
+		t.Errorf("name=%q", subj.Name)
+	}
+	if subj.APIGroup != rbacv1.GroupName {
+		t.Errorf("apigroup=%q", subj.APIGroup)
+	}
+	if rb.RoleRef.Name != RoleName("web-app", RoleEditor) {
+		t.Errorf("roleref=%q", rb.RoleRef.Name)
+	}
+	if rb.Annotations[AnnotationShareTargetName] != "oidc:alice@example.com" {
+		t.Errorf("annotation=%q", rb.Annotations[AnnotationShareTargetName])
+	}
+}
+
+// TestRoleBinding_GroupKind verifies that group share targets produce
+// RoleBindings with subject Kind=Group.
+func TestRoleBinding_GroupKind(t *testing.T) {
+	rb := RoleBinding("prj-acme", "web-app", ShareTargetGroup, "platform-admins", RoleOwner, nil)
+	if len(rb.Subjects) != 1 {
+		t.Fatalf("subjects=%d", len(rb.Subjects))
+	}
+	if rb.Subjects[0].Kind != rbacv1.GroupKind {
+		t.Errorf("kind=%q want Group", rb.Subjects[0].Kind)
+	}
+}
+
+// TestRoleBinding_OwnerRefsApplied verifies ownerRefs are stamped onto the
+// RoleBinding so K8s GC cascades cleanup on Deployment delete (AC #3).
+func TestRoleBinding_OwnerRefsApplied(t *testing.T) {
+	owner := metav1.OwnerReference{
+		APIVersion: "deployments.holos.run/v1alpha1",
+		Kind:       "Deployment",
+		Name:       "web-app",
+		UID:        "uid-987",
+	}
+	rb := RoleBinding("prj-acme", "web-app", ShareTargetUser, "alice@example.com", RoleViewer, []metav1.OwnerReference{owner})
+	if len(rb.OwnerReferences) != 1 || rb.OwnerReferences[0].UID != "uid-987" {
+		t.Errorf("ownerRefs=%v", rb.OwnerReferences)
+	}
+}
+
+// TestRoleBindingName_Deterministic verifies the same inputs always produce
+// the same name (deterministic SHA suffix) and different inputs differ.
+func TestRoleBindingName_Deterministic(t *testing.T) {
+	a := RoleBindingName("web-app", RoleEditor, ShareTargetUser, "alice@example.com")
+	b := RoleBindingName("web-app", RoleEditor, ShareTargetUser, "alice@example.com")
+	if a != b {
+		t.Errorf("names not deterministic: %q vs %q", a, b)
+	}
+	c := RoleBindingName("web-app", RoleOwner, ShareTargetUser, "alice@example.com")
+	if a == c {
+		t.Errorf("different roles produced same name: %q", a)
+	}
+	d := RoleBindingName("api-app", RoleEditor, ShareTargetUser, "alice@example.com")
+	if a == d {
+		t.Errorf("different deployments produced same name: %q", a)
+	}
+	e := RoleBindingName("web-app", RoleEditor, ShareTargetGroup, "alice@example.com")
+	if a == e {
+		t.Errorf("user/group same name: %q", a)
+	}
+}
+
+// TestRoleFromLabels verifies tier extraction from labels and that missing
+// labels default to viewer (least privilege).
+func TestRoleFromLabels(t *testing.T) {
+	if got := RoleFromLabels(RoleLabels("web-app", RoleOwner)); got != RoleOwner {
+		t.Errorf("got %q want owner", got)
+	}
+	if got := RoleFromLabels(RoleLabels("web-app", RoleEditor)); got != RoleEditor {
+		t.Errorf("got %q want editor", got)
+	}
+	if got := RoleFromLabels(nil); got != RoleViewer {
+		t.Errorf("got %q want viewer (default)", got)
+	}
+	if got := RoleFromLabels(map[string]string{LabelDeploymentRole: "junk"}); got != RoleViewer {
+		t.Errorf("got %q want viewer", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/console/deployments/status.go
+++ b/console/deployments/status.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/holos-run/holos-console/console/rbac"
 	"github.com/holos-run/holos-console/console/rpc"
 	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
 )
@@ -51,11 +50,8 @@ func (h *Handler) GetDeploymentStatusSummary(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsRead); err != nil {
-		return nil, err
-	}
-
-	ns := h.k8s.Resolver.ProjectNamespace(project)
+	rk8s := h.requestK8s(ctx)
+	ns := rk8s.Resolver.ProjectNamespace(project)
 	summary, ok := h.summaryFromCache(ns, name)
 	if !ok {
 		summary = &consolev1.DeploymentStatusSummary{
@@ -72,7 +68,7 @@ func (h *Handler) GetDeploymentStatusSummary(
 	// clients receive the same `output.links` and promoted primary URL
 	// the list/detail RPCs serve, keeping the three read paths
 	// observably consistent.
-	if cm, cmErr := h.k8s.GetDeployment(ctx, project, name); cmErr == nil {
+	if cm, cmErr := rk8s.GetDeployment(ctx, project, name); cmErr == nil {
 		mergeOutputURLAnnotation(summary, cm)
 		mergeAggregatedLinksAnnotation(summary, cm)
 	} else {
@@ -141,13 +137,10 @@ func (h *Handler) GetDeploymentStatus(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	if err := h.checkProjectAccess(ctx, claims, project, rbac.PermissionDeploymentsRead); err != nil {
-		return nil, err
-	}
+	rk8s := h.requestK8s(ctx)
+	ns := rk8s.Resolver.ProjectNamespace(project)
 
-	ns := h.k8s.Resolver.ProjectNamespace(project)
-
-	dep, err := h.k8s.client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+	dep, err := rk8s.client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -179,7 +172,7 @@ func (h *Handler) GetDeploymentStatus(
 		}
 	}
 
-	podList, err := h.k8s.client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+	podList, err := rk8s.client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
@@ -189,7 +182,7 @@ func (h *Handler) GetDeploymentStatus(
 	// Fetch deployment-level events using field selectors. In production the API
 	// server filters server-side. The fake K8s client ignores field selectors and
 	// returns all events, so tests seed only relevant events for correctness.
-	depEventList, err := h.k8s.client.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+	depEventList, err := rk8s.client.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
 		FieldSelector: "involvedObject.name=" + name + ",involvedObject.kind=Deployment",
 	})
 	if err != nil {
@@ -216,7 +209,7 @@ func (h *Handler) GetDeploymentStatus(
 		containerStatuses = append(containerStatuses, mapContainerStatuses(pod.Status.ContainerStatuses)...)
 
 		// Fetch pod-level events using field selectors.
-		podEventList, err := h.k8s.client.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+		podEventList, err := rk8s.client.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
 			FieldSelector: "involvedObject.name=" + pod.Name + ",involvedObject.kind=Pod",
 		})
 		if err != nil {

--- a/console/deployments/status_test.go
+++ b/console/deployments/status_test.go
@@ -839,12 +839,10 @@ func TestGetDeploymentStatusSummary(t *testing.T) {
 			req:      &consolev1.GetDeploymentStatusSummaryRequest{Project: project, Name: name},
 			wantCode: connect.CodeUnauthenticated,
 		},
-		{
-			desc:     "unauthorized user is denied",
-			ctx:      authedCtx("nobody@example.com", nil),
-			req:      &consolev1.GetDeploymentStatusSummaryRequest{Project: project, Name: name},
-			wantCode: connect.CodePermissionDenied,
-		},
+		// Per HOL-1033, in-process project-grant authorization was removed
+		// in favor of native K8s RBAC via the OIDC-impersonated client (ADR
+		// 036). PermissionDenied now flows back from the API server, not
+		// from a handler-level cascade check.
 		{
 			desc:     "empty project is rejected",
 			ctx:      authedCtx("viewer@example.com", nil),


### PR DESCRIPTION
## Summary
- Provisions per-Deployment Roles (viewer/editor/owner) scoped via `resourceNames`, plus a creator-Owner RoleBinding and reconciled sharing RoleBindings.
- Stamps `ownerReferences` (Controller=true, BlockOwnerDeletion=true) on every Role and RoleBinding so K8s GC cascades cleanup when the Deployment CR is deleted (no explicit cleanup calls).
- Routes Deployment RPCs through the per-request impersonated client (`ImpersonatedClientsetFromContext` typed for Role/RoleBinding; dynamic for the CR UID lookup).
- Removes the in-process `console/rbac.CheckCascadeAccess` / `checkProjectAccess` calls from the deployments handler — authorization now flows back from the Kubernetes API server per ADR 036.
- Degrades gracefully when the CR is absent (lazy-creation path) or the dynamic client is nil (dev/local) so no extra wiring is required for unit tests.

Fixes HOL-1033

## Test plan
- [x] `make test-go` (race + coverage) clean
- [x] `make test-ui` (108 files, 1433 tests) clean
- [x] `make test-e2e` matches main baseline (same 14 pre-existing TLS-cert flakes; no new regressions)
- [x] New unit tests:
  - `rbac_test.go` — role-tier mapping, OIDC prefixing, role/RoleBinding shape, deterministic naming (AC #4)
  - `k8s_rbac_test.go` — `EnsureDeploymentRBAC` happy path / idempotent / CR-absent / no-dynamic-client; `ReconcileDeploymentRoleBindings` add/remove/swap, mixed user+group; `ListDeploymentSharing` round-trip; `ownerReferences` shape for GC (AC #1, #3, #4)