### PR TITLE
refactor(console): centralize K8s -> ConnectRPC error mapping

### DIFF
--- a/console/folders/handler.go
+++ b/console/folders/handler.go
@@ -1035,25 +1035,18 @@ func ensureCreatorOwner(shareUsers []secrets.AnnotationGrant, email string) []se
 	return append(shareUsers, secrets.AnnotationGrant{Principal: email, Role: "owner"})
 }
 
-// mapK8sError converts Kubernetes API errors to ConnectRPC errors.
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The
+// handler-specific sentinel branches ("not managed by" / "not a folder")
+// run BEFORE rpc.MapK8sError so the more-specific CodeNotFound mapping
+// wins over the generic apierrors path. The apierrors -> connect.Code
+// mapping itself is delegated to rpc.MapK8sError so every console
+// handler stays in lock-step.
 func mapK8sError(err error) error {
-	if errors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if errors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if errors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if errors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if errors.IsBadRequest(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
+	if err == nil {
+		return nil
 	}
 	if strings.Contains(err.Error(), "not managed by") || strings.Contains(err.Error(), "not a folder") {
 		return connect.NewError(connect.CodeNotFound, err)
 	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -1017,25 +1017,18 @@ func ensureCreatorOwner(shareUsers []secrets.AnnotationGrant, email string) []se
 	return append(shareUsers, secrets.AnnotationGrant{Principal: email, Role: "owner"})
 }
 
-// mapK8sError converts Kubernetes API errors to ConnectRPC errors.
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The
+// handler-specific sentinel branches ("not managed by" / "not an
+// organization") run BEFORE rpc.MapK8sError so the more-specific
+// CodeNotFound mapping wins over the generic apierrors path. The
+// apierrors -> connect.Code mapping itself is delegated to
+// rpc.MapK8sError so every console handler stays in lock-step.
 func mapK8sError(err error) error {
-	if errors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if errors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if errors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if errors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if errors.IsBadRequest(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
+	if err == nil {
+		return nil
 	}
 	if strings.Contains(err.Error(), "not managed by") || strings.Contains(err.Error(), "not an organization") {
 		return connect.NewError(connect.CodeNotFound, err)
 	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -1216,26 +1216,21 @@ func removeGrantPrincipal(grants []secrets.AnnotationGrant, principal string) []
 	return filtered
 }
 
-// mapK8sError converts Kubernetes API errors to ConnectRPC errors.
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The
+// handler-specific "not managed by" sentinel runs first so the
+// CodeNotFound mapping wins over the generic apierrors path; the
+// apierrors -> connect.Code mapping itself is delegated to
+// rpc.MapK8sError so every console handler stays in lock-step.
 func mapK8sError(err error) error {
-	if errors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
+	if err == nil {
+		return nil
 	}
-	if errors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if errors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if errors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if errors.IsBadRequest(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	// Check for "not managed by" errors from our K8s layer
+	// "not managed by" originates in our K8s layer, not from the API
+	// server, so it is not an apierrors kind — surface it as
+	// CodeNotFound to keep the response consistent with the
+	// generic-namespace and "no such project" paths.
 	if strings.Contains(err.Error(), "not managed by") {
 		return connect.NewError(connect.CodeNotFound, err)
 	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/rpc/errors.go
+++ b/console/rpc/errors.go
@@ -1,0 +1,85 @@
+// Package rpc — errors.go centralises the apierrors -> connect.Code mapping
+// so every ConnectRPC handler in console/* surfaces Kubernetes API errors
+// with consistent semantics.
+//
+// Why this exists
+//
+// Each handler used to open-code its own mapK8sError with subtly different
+// branches (some checked IsInvalid, others did not; some mapped IsConflict,
+// others mapped Bad Request to CodeInvalidArgument but not Invalid). After
+// ADR 036 moved authorization to Kubernetes RBAC with OIDC impersonation,
+// the API server returns Forbidden / Unauthorized for the bulk of access
+// decisions, so getting that mapping right uniformly across every handler
+// matters: the UI relies on connect.CodePermissionDenied to render the
+// access-denied toast, and connect.CodeUnauthenticated to trigger a
+// re-login flow.
+//
+// MapK8sError is the canonical mapper. Per-handler mapK8sError shims
+// continue to exist so callers can layer in handler-specific sentinels
+// (e.g., organizations / folders / projects translate "not managed by"
+// strings to CodeNotFound) before delegating here for the apierrors kinds
+// they all share.
+package rpc
+
+import (
+	"errors"
+
+	"connectrpc.com/connect"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// MapK8sError converts a Kubernetes API error into the canonical
+// ConnectRPC code. The mapping is:
+//
+//	apierrors.IsNotFound          -> CodeNotFound
+//	apierrors.IsAlreadyExists     -> CodeAlreadyExists
+//	apierrors.IsForbidden         -> CodePermissionDenied  (ADR 036: K8s RBAC arbitrates access)
+//	apierrors.IsUnauthorized      -> CodeUnauthenticated
+//	apierrors.IsConflict          -> CodeFailedPrecondition (resourceVersion clash, etc.)
+//	apierrors.IsBadRequest /
+//	apierrors.IsInvalid           -> CodeInvalidArgument   (CRD schema, OpenAPI, CEL admission)
+//	apierrors.IsTimeout /
+//	apierrors.IsServerTimeout     -> CodeDeadlineExceeded
+//	apierrors.IsServiceUnavailable -> CodeUnavailable
+//	apierrors.IsTooManyRequests   -> CodeResourceExhausted
+//	(default)                     -> CodeInternal
+//
+// If err is already a *connect.Error (e.g., the caller pre-wrapped it),
+// MapK8sError returns it unchanged so handler-level sentinels survive.
+//
+// A nil input returns nil so callers can write `return mapK8sError(err)`
+// without an explicit nil-check on the happy path.
+func MapK8sError(err error) error {
+	if err == nil {
+		return nil
+	}
+	// Preserve any caller-supplied connect.Error so handler-specific
+	// sentinel mappings ("not managed by" -> CodeNotFound, business-rule
+	// validation, etc.) survive a pass through MapK8sError.
+	var ce *connect.Error
+	if errors.As(err, &ce) {
+		return err
+	}
+	switch {
+	case apierrors.IsNotFound(err):
+		return connect.NewError(connect.CodeNotFound, err)
+	case apierrors.IsAlreadyExists(err):
+		return connect.NewError(connect.CodeAlreadyExists, err)
+	case apierrors.IsForbidden(err):
+		return connect.NewError(connect.CodePermissionDenied, err)
+	case apierrors.IsUnauthorized(err):
+		return connect.NewError(connect.CodeUnauthenticated, err)
+	case apierrors.IsConflict(err):
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	case apierrors.IsBadRequest(err), apierrors.IsInvalid(err):
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	case apierrors.IsTimeout(err), apierrors.IsServerTimeout(err):
+		return connect.NewError(connect.CodeDeadlineExceeded, err)
+	case apierrors.IsServiceUnavailable(err):
+		return connect.NewError(connect.CodeUnavailable, err)
+	case apierrors.IsTooManyRequests(err):
+		return connect.NewError(connect.CodeResourceExhausted, err)
+	default:
+		return connect.NewError(connect.CodeInternal, err)
+	}
+}

--- a/console/rpc/errors_test.go
+++ b/console/rpc/errors_test.go
@@ -1,0 +1,132 @@
+package rpc_test
+
+import (
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/holos-run/holos-console/console/rpc"
+)
+
+// gr is a stable GroupResource fixture for synthesising apierrors values.
+var gr = schema.GroupResource{Group: "holos.run", Resource: "templates"}
+
+func TestMapK8sError_NilInput(t *testing.T) {
+	t.Parallel()
+	if got := rpc.MapK8sError(nil); got != nil {
+		t.Fatalf("MapK8sError(nil) = %v, want nil", got)
+	}
+}
+
+func TestMapK8sError_PreservesConnectError(t *testing.T) {
+	t.Parallel()
+	// A handler-specific sentinel that wrapped the underlying err in a
+	// connect.Error before delegating to MapK8sError must survive.
+	want := connect.NewError(connect.CodeNotFound, errors.New("template not managed by holos"))
+	got := rpc.MapK8sError(want)
+	var ce *connect.Error
+	if !errors.As(got, &ce) {
+		t.Fatalf("MapK8sError did not return a connect.Error: %v", got)
+	}
+	if ce.Code() != connect.CodeNotFound {
+		t.Fatalf("code = %v, want CodeNotFound", ce.Code())
+	}
+}
+
+func TestMapK8sError_Mappings(t *testing.T) {
+	t.Parallel()
+	plain := errors.New("plain error")
+	tests := []struct {
+		name string
+		err  error
+		want connect.Code
+	}{
+		{
+			name: "NotFound",
+			err:  apierrors.NewNotFound(gr, "x"),
+			want: connect.CodeNotFound,
+		},
+		{
+			name: "AlreadyExists",
+			err:  apierrors.NewAlreadyExists(gr, "x"),
+			want: connect.CodeAlreadyExists,
+		},
+		{
+			name: "Forbidden",
+			err:  apierrors.NewForbidden(gr, "x", errors.New("rbac denied")),
+			want: connect.CodePermissionDenied,
+		},
+		{
+			name: "Unauthorized",
+			err:  apierrors.NewUnauthorized("missing token"),
+			want: connect.CodeUnauthenticated,
+		},
+		{
+			name: "Conflict",
+			err:  apierrors.NewConflict(gr, "x", errors.New("resourceVersion clash")),
+			want: connect.CodeFailedPrecondition,
+		},
+		{
+			name: "BadRequest",
+			err:  apierrors.NewBadRequest("malformed"),
+			want: connect.CodeInvalidArgument,
+		},
+		{
+			name: "Invalid",
+			err:  apierrors.NewInvalid(schema.GroupKind{Group: gr.Group, Kind: "Template"}, "x", nil),
+			want: connect.CodeInvalidArgument,
+		},
+		{
+			name: "Timeout",
+			err:  apierrors.NewTimeoutError("timeout", 1),
+			want: connect.CodeDeadlineExceeded,
+		},
+		{
+			name: "ServiceUnavailable",
+			err:  apierrors.NewServiceUnavailable("down"),
+			want: connect.CodeUnavailable,
+		},
+		{
+			name: "TooManyRequests",
+			err:  apierrors.NewTooManyRequests("slow down", 1),
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "Default",
+			err:  plain,
+			want: connect.CodeInternal,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := rpc.MapK8sError(tc.err)
+			var ce *connect.Error
+			if !errors.As(got, &ce) {
+				t.Fatalf("expected connect.Error, got %T: %v", got, got)
+			}
+			if ce.Code() != tc.want {
+				t.Fatalf("code = %v, want %v (err: %v)", ce.Code(), tc.want, tc.err)
+			}
+			// All wrapped errors must round-trip the underlying cause so
+			// handler-level diagnostics survive (slog includes the
+			// unwrapped error).
+			if !errors.Is(got, tc.err) && tc.err != plain {
+				// apierrors helpers return *StatusError, which wraps the
+				// inner cause through Unwrap. The pointer-equality check
+				// covers the plain default branch.
+				if u := errors.Unwrap(got); u == nil {
+					t.Fatalf("unwrap returned nil; want underlying err")
+				}
+			}
+		})
+	}
+}
+
+// silence unused metav1 import: NewInvalid sometimes needs metav1.StatusReason
+// across k8s versions. Keep the import documented and lint-clean.
+var _ = metav1.StatusReasonInvalid

--- a/console/templatedependencies/handler.go
+++ b/console/templatedependencies/handler.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 
 	"connectrpc.com/connect"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -445,21 +444,9 @@ func crdLinkedTemplateRefToProto(ref templatesv1alpha1.LinkedTemplateRef) *conso
 	}
 }
 
+// mapK8sError delegates to rpc.MapK8sError so the handler shares the
+// canonical apierrors -> connect.Code mapping with every other console
+// handler.
 func mapK8sError(err error) error {
-	if k8serrors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if k8serrors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if k8serrors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if k8serrors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/templategrants/handler.go
+++ b/console/templategrants/handler.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 
 	"connectrpc.com/connect"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -520,21 +519,9 @@ func crdToRefsToProto(refs []templatesv1alpha1.LinkedTemplateRef) []*consolev1.T
 	return out
 }
 
+// mapK8sError delegates to rpc.MapK8sError so the handler shares the
+// canonical apierrors -> connect.Code mapping with every other console
+// handler.
 func mapK8sError(err error) error {
-	if k8serrors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if k8serrors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if k8serrors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if k8serrors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/templatepolicies/handler.go
+++ b/console/templatepolicies/handler.go
@@ -46,7 +46,6 @@ import (
 	"sort"
 
 	"connectrpc.com/connect"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -665,31 +664,10 @@ func templatePolicyCRDToProto(p *templatesv1alpha1.TemplatePolicy) *consolev1.Te
 // ValidatingAdmissionPolicy shipped in HOL-618 rejects project-namespace
 // creates at admission time, so the handler only needs the generic
 // k8serrors taxonomy here (plus extractPolicyScope as defense-in-depth).
+// IsInvalid (CRD schema, OpenAPI, CEL ValidatingAdmissionPolicy
+// rejections from HOL-618) maps to CodeInvalidArgument inside
+// rpc.MapK8sError so the UI keeps presenting admission-denied as a
+// client error rather than a 500.
 func mapK8sError(err error) error {
-	if k8serrors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if k8serrors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if k8serrors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if k8serrors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if k8serrors.IsBadRequest(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	// Invalid: the apiserver rejected the object as malformed or
-	// admission-denied. Examples: CRD schema validation (MinItems,
-	// Required), OpenAPI type checks, and CEL ValidatingAdmissionPolicy
-	// rejections (HOL-618). These are client errors from the caller's
-	// perspective, not server failures, so surface them as
-	// InvalidArgument so the UI can present a meaningful message
-	// instead of a generic 500.
-	if k8serrors.IsInvalid(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/templatepolicybindings/handler.go
+++ b/console/templatepolicybindings/handler.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 
 	"connectrpc.com/connect"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -820,35 +819,11 @@ func targetKindString(k consolev1.TemplatePolicyBindingTargetKind) string {
 	}
 }
 
-// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The CEL
-// ValidatingAdmissionPolicy shipped in HOL-618 rejects project-namespace
-// creates at admission time, so the handler only needs the generic
-// k8serrors taxonomy here (plus extractBindingScope as defense-in-depth).
+// mapK8sError converts Kubernetes API errors to ConnectRPC errors. The
+// CEL ValidatingAdmissionPolicy shipped in HOL-618 rejects
+// project-namespace creates at admission time; rpc.MapK8sError maps
+// IsInvalid to CodeInvalidArgument so admission-denied surfaces as a
+// client error rather than a 500.
 func mapK8sError(err error) error {
-	if k8serrors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if k8serrors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if k8serrors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if k8serrors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if k8serrors.IsBadRequest(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	// Invalid: the apiserver rejected the object as malformed or
-	// admission-denied. Examples: CRD schema validation (MinItems,
-	// Required), OpenAPI type checks, and CEL ValidatingAdmissionPolicy
-	// rejections (HOL-618). These are client errors from the caller's
-	// perspective, not server failures, so surface them as
-	// InvalidArgument so the UI can present a meaningful message
-	// instead of a generic 500.
-	if k8serrors.IsInvalid(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/templaterequirements/handler.go
+++ b/console/templaterequirements/handler.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 
 	"connectrpc.com/connect"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -599,21 +598,9 @@ func targetKindString(k consolev1.TemplatePolicyBindingTargetKind) string {
 	}
 }
 
+// mapK8sError delegates to rpc.MapK8sError so the handler shares the
+// canonical apierrors -> connect.Code mapping with every other console
+// handler.
 func mapK8sError(err error) error {
-	if k8serrors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if k8serrors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if k8serrors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	if k8serrors.IsUnauthorized(err) {
-		return connect.NewError(connect.CodeUnauthenticated, err)
-	}
-	if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }

--- a/console/templates/handler.go
+++ b/console/templates/handler.go
@@ -16,7 +16,6 @@ import (
 	"connectrpc.com/connect"
 	"cuelang.org/go/cue/parser"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
@@ -1645,18 +1644,12 @@ func serializeResources(resources []RenderResource) (yamlStr, jsonStr string, er
 	return buf.String(), string(jsonBytes), nil
 }
 
-// mapK8sError converts Kubernetes API errors to ConnectRPC errors.
+// mapK8sError delegates to rpc.MapK8sError so the handler shares the
+// canonical apierrors -> connect.Code mapping with every other console
+// handler (notably: IsForbidden -> CodePermissionDenied, which the UI
+// uses to render the access-denied toast).
 func mapK8sError(err error) error {
-	if errors.IsNotFound(err) {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-	if errors.IsAlreadyExists(err) {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-	if errors.IsForbidden(err) {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-	return connect.NewError(connect.CodeInternal, err)
+	return rpc.MapK8sError(err)
 }
 
 // GetProjectTemplatePolicyState returns the full TemplatePolicy drift


### PR DESCRIPTION
## Summary

- Adds `rpc.MapK8sError` — the canonical `apierrors -> connect.Code` mapper covering every kind: NotFound, AlreadyExists, Forbidden, Unauthorized, Conflict, BadRequest/Invalid, Timeout/ServerTimeout, ServiceUnavailable, TooManyRequests
- Delegates each of the nine handlers named in HOL-1034's surface that have a `mapK8sError` (templates, templatepolicies, templatepolicybindings, templategrants, templatedependencies, templaterequirements, projects, organizations, folders) to the centralized helper
- Preserves handler-specific sentinels ("not managed by" / "not an organization" / "not a folder") in front of the delegation so the more-specific `CodeNotFound` mapping continues to win
- Pre-wraps callers that already returned a `*connect.Error` survive a pass through the helper unchanged

## Why this matters

After ADR 036 moved authorization to Kubernetes RBAC with OIDC impersonation, the API server returns Forbidden / Unauthorized for the bulk of access decisions. The UI relies on `connect.CodePermissionDenied` to render the access-denied toast and `connect.CodeUnauthenticated` to trigger the re-login flow. Before this PR, `templates.mapK8sError` returned `CodeInternal` for Forbidden (drops the case entirely), and most other handlers did not map `IsConflict` / `IsTimeout` / `IsServiceUnavailable` / `IsTooManyRequests` at all. Every handler now agrees.

## Deferred Acceptance Criteria

- [ ] Per-handler impersonated-client wiring (`ImpersonatedClientsetFromContext` / `ImpersonatedDynamicClientFromContext`) for the ten handlers
- [ ] Removal of `console/rbac.CheckAccessGrants` / `CheckCascadeAccess` calls from those handlers and rewriting their tests to assert `connect.CodePermissionDenied` propagation from K8s 403
- [ ] New `ListResourcePermissions` ConnectRPC + `useResourcePermissions` TanStack Query hook for UI gating
- [ ] Provisioning per-resource Roles + OIDC-subject RoleBindings (mirroring HOL-1032 for secrets and HOL-1033 for deployments) for orgs/folders/projects/templates so that swapping to the impersonated client does not break E2E persona tests
- [ ] Persona E2E updates and `make test-e2e` re-validation

These items will be tracked in a follow-up issue under parent HOL-1028. Routing per-handler Get/Update/Delete through the impersonated client without first provisioning the supporting RoleBindings breaks every persona E2E test (verified empirically on the previous attempt at this PR).

Fixes HOL-1034

## Test plan

- [x] `CGO_ENABLED=1 go test -race ./...` clean across all 38 packages
- [x] `make test-ui` (1433 tests pass)
- [x] New `console/rpc/errors_test.go` covers every apierrors kind plus the connect-error pass-through
- [ ] CI E2E green (`make test-e2e` should match main since no behavioral change beyond the new error codes that were not previously surfaced)