### PR TITLE
feat(migration): translate Secret sharing annotations to RoleBindings

### DIFF
--- a/cmd/holos-console-migrate-rbac/main.go
+++ b/cmd/holos-console-migrate-rbac/main.go
@@ -1,0 +1,628 @@
+// Command holos-console-migrate-rbac is a one-shot operator-run migration
+// tool that translates the legacy Secret-sharing annotations
+// (`console.holos.run/share-users`, `console.holos.run/share-roles`,
+// `console.holos.run/default-share-users`,
+// `console.holos.run/default-share-roles`) into native Kubernetes
+// RoleBindings against the project-scoped Roles provisioned during
+// HOL-1032 (Phase 4).
+//
+// The tool runs in dry-run mode by default; pass --apply to perform
+// writes. It is idempotent: re-running it after a successful migration is
+// a no-op once every annotation has been translated and stripped.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/tabwriter"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/secretrbac"
+	"github.com/holos-run/holos-console/console/secrets"
+	"github.com/holos-run/holos-console/console/sharing/legacy"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		// flag.ContinueOnError surfaces --help as flag.ErrHelp; the
+		// flag package has already printed usage to stderr, so exit
+		// cleanly rather than spamming `error: flag: help requested`.
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+// options control a migration run. Exposed for testing.
+type options struct {
+	apply      bool
+	kubeconfig string
+}
+
+func parseFlags(args []string, errOut io.Writer) (*options, error) {
+	fs := flag.NewFlagSet("holos-console-migrate-rbac", flag.ContinueOnError)
+	fs.SetOutput(errOut)
+	fs.Usage = func() {
+		fmt.Fprintf(errOut, "Usage: %s [flags]\n\n", fs.Name())
+		fmt.Fprintln(errOut, "One-shot migration: translate legacy Secret-sharing annotations into RoleBindings.")
+		fmt.Fprintln(errOut, "Runs as the console service-account (the operator-supplied kubeconfig).")
+		fmt.Fprintln(errOut)
+		fmt.Fprintln(errOut, "Flags:")
+		fs.PrintDefaults()
+	}
+	opts := &options{}
+	fs.BoolVar(&opts.apply, "apply", false, "Perform writes. Without --apply the tool only reports planned changes.")
+	defaultKubeconfig := ""
+	if home := homedir.HomeDir(); home != "" {
+		defaultKubeconfig = filepath.Join(home, ".kube", "config")
+	}
+	fs.StringVar(&opts.kubeconfig, "kubeconfig", defaultKubeconfig, "Path to kubeconfig (defaults to in-cluster config when empty)")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return opts, nil
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	opts, err := parseFlags(args, stderr)
+	if err != nil {
+		return err
+	}
+	client, err := buildClient(opts.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("building kube client: %w", err)
+	}
+	ctx := context.Background()
+	report, err := Migrate(ctx, client, opts.apply)
+	if err != nil {
+		return err
+	}
+	return PrintReport(stdout, report, opts.apply)
+}
+
+func buildClient(kubeconfig string) (kubernetes.Interface, error) {
+	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ConfigOverrides{},
+	)
+	cfg, err := loader.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+// NamespaceReport captures the per-namespace migration plan and the
+// outcome when --apply is set. It is the building block of Report and is
+// rendered by PrintReport in stable key order.
+type NamespaceReport struct {
+	Namespace string
+	// BindingsCreated names the RoleBindings the tool created (or would
+	// create in dry-run mode) keyed by binding name.
+	BindingsCreated []string
+	// BindingsAlreadyPresent names the RoleBindings that already existed
+	// with the desired RoleRef and Subjects, so the tool skipped them.
+	BindingsAlreadyPresent []string
+	// NamespaceAnnotationsStripped lists the keys removed from the
+	// namespace itself.
+	NamespaceAnnotationsStripped []string
+	// SecretsProcessed records one entry per managed Secret in the
+	// namespace.
+	SecretsProcessed []SecretReport
+	// Warnings collects non-fatal observations (e.g. time-bounded grant
+	// dropped, malformed annotation skipped, etc.) so the operator can
+	// review them before re-running.
+	Warnings []string
+	// Error captures a per-namespace fatal error so a single failed
+	// namespace does not abort the whole sweep.
+	Error string
+}
+
+// SecretReport records the result for a single Secret in a namespace.
+type SecretReport struct {
+	Name                string
+	AnnotationsStripped []string
+}
+
+// Report is the aggregate result of a Migrate call.
+type Report struct {
+	Namespaces []NamespaceReport
+}
+
+// Migrate walks every namespace labelled with
+// `app.kubernetes.io/managed-by=console.holos.run`, parses the legacy
+// share annotations on the namespace itself and on every managed
+// `v1.Secret` in that namespace, materialises the equivalent
+// RoleBindings against the project-scoped Roles, and (when apply is
+// true) strips the annotations after the bindings are confirmed.
+//
+// The returned Report contains one NamespaceReport per managed namespace
+// in sorted order. A per-namespace error stops processing of that
+// namespace but does not abort the sweep, so the operator gets a single
+// rollup of every problem encountered.
+func Migrate(ctx context.Context, client kubernetes.Interface, apply bool) (*Report, error) {
+	report := &Report{}
+	selector := labels.SelectorFromSet(labels.Set{
+		v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+	})
+	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing managed namespaces: %w", err)
+	}
+	sort.Slice(nsList.Items, func(i, j int) bool {
+		return nsList.Items[i].Name < nsList.Items[j].Name
+	})
+	for i := range nsList.Items {
+		nr := migrateNamespace(ctx, client, &nsList.Items[i], apply)
+		report.Namespaces = append(report.Namespaces, nr)
+	}
+	return report, nil
+}
+
+// migrateNamespace processes a single managed namespace.
+func migrateNamespace(ctx context.Context, client kubernetes.Interface, ns *corev1.Namespace, apply bool) NamespaceReport {
+	nr := NamespaceReport{Namespace: ns.Name}
+
+	// Only project namespaces hold actionable share-users / share-roles
+	// grants. Org and folder namespaces only ever held the
+	// default-share-* annotations, which seed projects rather than
+	// represent grants directly. Those are passed through unchanged so
+	// the cascade chain on new-project creation continues to work
+	// during the upgrade window.
+	if ns.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeProject {
+		nr.Warnings = append(nr.Warnings, fmt.Sprintf("skipping non-project namespace (resource-type=%q): default-share-* annotations remain in place to preserve the cascade chain", ns.Labels[v1alpha2.LabelResourceType]))
+		return nr
+	}
+	rolesPresent, err := projectRolesPresent(ctx, client, ns.Name)
+	if err != nil {
+		nr.Error = fmt.Sprintf("checking for project Roles: %v", err)
+		return nr
+	}
+	if !rolesPresent {
+		nr.Error = fmt.Sprintf("project secret Roles missing in %q — run the Phase 4 reconciler before re-running the migration", ns.Name)
+		return nr
+	}
+
+	// Translate namespace-level grants. share-users and share-roles on
+	// a project namespace seed the project-level Secret RoleBindings.
+	nsUsers, nsUsersWarn := parseAnnotation(ns.Annotations, v1alpha2.AnnotationShareUsers, "namespace", ns.Name)
+	nsRoles, nsRolesWarn := parseAnnotation(ns.Annotations, v1alpha2.AnnotationShareRoles, "namespace", ns.Name)
+	nr.Warnings = append(nr.Warnings, nsUsersWarn...)
+	nr.Warnings = append(nr.Warnings, nsRolesWarn...)
+	if nsUsersWarn != nil || nsRolesWarn != nil {
+		// Malformed JSON on the namespace itself: stop before we touch
+		// any binding. The operator must hand-fix the JSON first.
+		nr.Error = "malformed namespace annotation — see warnings"
+		return nr
+	}
+	nsUsers, uTimeWarn := filterTimeBounded(nsUsers, "namespace", ns.Name)
+	nsRoles, rTimeWarn := filterTimeBounded(nsRoles, "namespace", ns.Name)
+	nr.Warnings = append(nr.Warnings, uTimeWarn...)
+	nr.Warnings = append(nr.Warnings, rTimeWarn...)
+
+	desired := buildDesiredBindings(ns.Name, nsUsers, nsRoles)
+
+	// Translate per-Secret grants. Under ADR 036 all Secret access in a
+	// project is namespace-scoped, so per-Secret grants collapse onto
+	// the same project-level Role: every (target, principal, role)
+	// triple yields the same binding regardless of which Secret it
+	// came from.
+	secretList, err := client.CoreV1().Secrets(ns.Name).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{
+			v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+		}).String(),
+	})
+	if err != nil {
+		nr.Error = fmt.Sprintf("listing managed Secrets: %v", err)
+		return nr
+	}
+	sort.Slice(secretList.Items, func(i, j int) bool {
+		return secretList.Items[i].Name < secretList.Items[j].Name
+	})
+	for i := range secretList.Items {
+		secret := &secretList.Items[i]
+		sr := SecretReport{Name: secret.Name}
+		users, sUsersWarn := parseAnnotation(secret.Annotations, v1alpha2.AnnotationShareUsers, "secret", ns.Name+"/"+secret.Name)
+		roles, sRolesWarn := parseAnnotation(secret.Annotations, v1alpha2.AnnotationShareRoles, "secret", ns.Name+"/"+secret.Name)
+		nr.Warnings = append(nr.Warnings, sUsersWarn...)
+		nr.Warnings = append(nr.Warnings, sRolesWarn...)
+		if sUsersWarn != nil || sRolesWarn != nil {
+			// A malformed Secret annotation must not be silently
+			// stripped. Surface it; do not attempt to merge or
+			// strip this Secret on the current run.
+			nr.SecretsProcessed = append(nr.SecretsProcessed, sr)
+			continue
+		}
+		users, uWarn := filterTimeBounded(users, "secret", ns.Name+"/"+secret.Name)
+		roles, rWarn := filterTimeBounded(roles, "secret", ns.Name+"/"+secret.Name)
+		nr.Warnings = append(nr.Warnings, uWarn...)
+		nr.Warnings = append(nr.Warnings, rWarn...)
+		mergeBindings(desired, ns.Name, users, roles)
+
+		// Strip the share annotations after the loop body has merged
+		// them into the desired set. The actual write is deferred
+		// until every desired binding has been applied below.
+		// Recording the planned strip here keeps the per-secret
+		// summary table accurate in dry-run.
+		if hasAnyShareAnnotation(secret.Annotations) {
+			sr.AnnotationsStripped = listShareAnnotations(secret.Annotations)
+		}
+		nr.SecretsProcessed = append(nr.SecretsProcessed, sr)
+	}
+
+	// Reconcile the desired RoleBindings against the existing state.
+	// Idempotency comes from comparing existing bindings (matched by
+	// name) against the desired set: an already-present binding whose
+	// RoleRef and Subjects match is left alone.
+	bindingNames := make([]string, 0, len(desired))
+	for name := range desired {
+		bindingNames = append(bindingNames, name)
+	}
+	sort.Strings(bindingNames)
+	for _, name := range bindingNames {
+		binding := desired[name]
+		existing, err := client.RbacV1().RoleBindings(ns.Name).Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case err == nil:
+			if roleBindingsMatch(existing, binding) {
+				nr.BindingsAlreadyPresent = append(nr.BindingsAlreadyPresent, name)
+				continue
+			}
+			if apply {
+				if err := client.RbacV1().RoleBindings(ns.Name).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+					nr.Error = fmt.Sprintf("deleting stale RoleBinding %q: %v", name, err)
+					return nr
+				}
+				if _, err := client.RbacV1().RoleBindings(ns.Name).Create(ctx, binding, metav1.CreateOptions{}); err != nil {
+					nr.Error = fmt.Sprintf("recreating RoleBinding %q: %v", name, err)
+					return nr
+				}
+			}
+			nr.BindingsCreated = append(nr.BindingsCreated, name)
+		case apierrors.IsNotFound(err):
+			if apply {
+				if _, err := client.RbacV1().RoleBindings(ns.Name).Create(ctx, binding, metav1.CreateOptions{}); err != nil {
+					nr.Error = fmt.Sprintf("creating RoleBinding %q: %v", name, err)
+					return nr
+				}
+			}
+			nr.BindingsCreated = append(nr.BindingsCreated, name)
+		default:
+			nr.Error = fmt.Sprintf("getting RoleBinding %q: %v", name, err)
+			return nr
+		}
+	}
+
+	// Strip annotations only after every binding has been confirmed.
+	// Invariant: the migration never removes an annotation whose
+	// translated binding is not yet in place. On a partial-failure
+	// mid-loop the next run picks up where the previous one left off.
+	if apply {
+		for i := range secretList.Items {
+			secret := &secretList.Items[i]
+			if !hasAnyShareAnnotation(secret.Annotations) {
+				continue
+			}
+			// Skip secrets whose previous parse failed: their
+			// annotations are still present but malformed.
+			if hasMalformedShareAnnotation(secret.Annotations) {
+				continue
+			}
+			if _, err := stripSecretAnnotations(ctx, client, secret); err != nil {
+				nr.Error = fmt.Sprintf("stripping annotations from Secret %q: %v", secret.Name, err)
+				return nr
+			}
+		}
+	}
+	if hasAnyShareAnnotation(ns.Annotations) {
+		if apply {
+			stripped, err := stripNamespaceAnnotations(ctx, client, ns)
+			if err != nil {
+				nr.Error = fmt.Sprintf("stripping namespace annotations: %v", err)
+				return nr
+			}
+			nr.NamespaceAnnotationsStripped = stripped
+		} else {
+			nr.NamespaceAnnotationsStripped = listShareAnnotations(ns.Annotations)
+		}
+	}
+	return nr
+}
+
+// projectRolesPresent verifies all three project-secret Roles are
+// present in the namespace. It looks them up by their stable names
+// rather than by label so a partially relabelled cluster still gets a
+// definitive "missing" answer.
+func projectRolesPresent(ctx context.Context, client kubernetes.Interface, namespace string) (bool, error) {
+	for _, role := range []string{
+		secretrbac.RoleName(secretrbac.RoleViewer),
+		secretrbac.RoleName(secretrbac.RoleEditor),
+		secretrbac.RoleName(secretrbac.RoleOwner),
+	} {
+		_, err := client.RbacV1().Roles(namespace).Get(ctx, role, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// parseAnnotation wraps legacy.ParseGrants and converts a malformed
+// annotation into an explicit warning. The caller is expected to skip
+// the offending resource until the operator hand-fixes the JSON; this
+// function returns nil grants in that case so the caller's "no grants"
+// path runs.
+func parseAnnotation(annotations map[string]string, key, kind, qualifiedName string) ([]secrets.AnnotationGrant, []string) {
+	grants, err := legacy.ParseGrants(annotations, key)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("MALFORMED %s %s annotation %s: %v — skipping this resource until the operator hand-fixes the JSON", kind, qualifiedName, key, err)}
+	}
+	return grants, nil
+}
+
+// filterTimeBounded drops grants that carry an `nbf` or `exp` timestamp
+// and emits one warning per dropped grant. ADR 036 commits to dropping
+// the time-bounded-grant feature for the MVP; the migration preserves
+// that decision visibly so an operator can see exactly which grants
+// would have to be re-issued in a future release.
+func filterTimeBounded(grants []secrets.AnnotationGrant, kind, qualifiedName string) ([]secrets.AnnotationGrant, []string) {
+	out := grants[:0:0]
+	var warnings []string
+	for _, g := range grants {
+		if g.Nbf != nil || g.Exp != nil {
+			warnings = append(warnings, fmt.Sprintf("DROPPING time-bounded grant on %s %s: principal=%q role=%q nbf=%v exp=%v — re-issue manually if still required", kind, qualifiedName, g.Principal, g.Role, derefInt64(g.Nbf), derefInt64(g.Exp)))
+			continue
+		}
+		out = append(out, g)
+	}
+	return out, warnings
+}
+
+func derefInt64(p *int64) any {
+	if p == nil {
+		return "nil"
+	}
+	return *p
+}
+
+// buildDesiredBindings starts a desired-bindings map seeded with the
+// namespace-level grants. The result is keyed by RoleBinding name so
+// later per-Secret grants merge on the same key (deduplicating
+// principals at the highest role level via secrets.DeduplicateGrants
+// before encoding).
+func buildDesiredBindings(namespace string, users, roles []secrets.AnnotationGrant) map[string]*rbacv1.RoleBinding {
+	desired := map[string]*rbacv1.RoleBinding{}
+	mergeBindings(desired, namespace, users, roles)
+	return desired
+}
+
+// mergeBindings adds every (user-target) and (group-target) grant from
+// the input slices into desired, keyed by binding name. When two
+// callers contribute the same (target, principal) pair at different
+// roles, the highest-role wins because secretrbac.RoleBindingName
+// includes the role in the binding name — different roles produce
+// different binding names rather than colliding.
+func mergeBindings(desired map[string]*rbacv1.RoleBinding, namespace string, users, roles []secrets.AnnotationGrant) {
+	for _, g := range secrets.DeduplicateGrants(users) {
+		if g.Principal == "" {
+			continue
+		}
+		b := secretrbac.RoleBinding(namespace, secretrbac.ShareTargetUser, g.Principal, g.Role, nil)
+		if _, ok := desired[b.Name]; ok {
+			continue
+		}
+		desired[b.Name] = b
+	}
+	for _, g := range secrets.DeduplicateGrants(roles) {
+		if g.Principal == "" {
+			continue
+		}
+		b := secretrbac.RoleBinding(namespace, secretrbac.ShareTargetGroup, g.Principal, g.Role, nil)
+		if _, ok := desired[b.Name]; ok {
+			continue
+		}
+		desired[b.Name] = b
+	}
+}
+
+// roleBindingsMatch decides whether an existing binding already
+// represents the desired state. The comparison covers the RoleRef and
+// the Subjects slice (order-independent for the small slices the
+// migration produces).
+func roleBindingsMatch(existing, desired *rbacv1.RoleBinding) bool {
+	if existing.RoleRef != desired.RoleRef {
+		return false
+	}
+	if len(existing.Subjects) != len(desired.Subjects) {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, s := range existing.Subjects {
+		seen[subjectKey(s)] = true
+	}
+	for _, s := range desired.Subjects {
+		if !seen[subjectKey(s)] {
+			return false
+		}
+	}
+	return true
+}
+
+func subjectKey(s rbacv1.Subject) string {
+	return s.APIGroup + "|" + s.Kind + "|" + s.Name
+}
+
+// hasAnyShareAnnotation reports whether at least one of the legacy
+// sharing annotation keys is present.
+func hasAnyShareAnnotation(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+	for _, key := range legacy.AnnotationKeys() {
+		if _, ok := annotations[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMalformedShareAnnotation re-runs the legacy parser to detect a
+// malformed annotation. We use this on the strip pass so we never strip
+// a Secret whose previous parse returned an error.
+func hasMalformedShareAnnotation(annotations map[string]string) bool {
+	if _, err := legacy.ShareUsers(annotations); err != nil {
+		return true
+	}
+	if _, err := legacy.ShareRoles(annotations); err != nil {
+		return true
+	}
+	return false
+}
+
+// listShareAnnotations returns the legacy keys present on annotations,
+// in canonical order.
+func listShareAnnotations(annotations map[string]string) []string {
+	var out []string
+	if annotations == nil {
+		return out
+	}
+	for _, key := range legacy.AnnotationKeys() {
+		if _, ok := annotations[key]; ok {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// stripSecretAnnotations removes every legacy share annotation from a
+// Secret and returns the stripped key names. The Secret is rewritten
+// via Update; the caller's next migration run re-attempts on conflict.
+func stripSecretAnnotations(ctx context.Context, client kubernetes.Interface, secret *corev1.Secret) ([]string, error) {
+	stripped := listShareAnnotations(secret.Annotations)
+	if len(stripped) == 0 {
+		return nil, nil
+	}
+	live, err := client.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if live.Annotations == nil {
+		return nil, nil
+	}
+	for _, key := range stripped {
+		delete(live.Annotations, key)
+	}
+	if _, err := client.CoreV1().Secrets(secret.Namespace).Update(ctx, live, metav1.UpdateOptions{}); err != nil {
+		return nil, err
+	}
+	return stripped, nil
+}
+
+// stripNamespaceAnnotations removes the legacy share-users and
+// share-roles annotations from a project namespace. Default-share-*
+// annotations are intentionally preserved: they seed new projects via
+// the cascade chain and have no equivalent RoleBinding.
+func stripNamespaceAnnotations(ctx context.Context, client kubernetes.Interface, ns *corev1.Namespace) ([]string, error) {
+	target := []string{
+		v1alpha2.AnnotationShareUsers,
+		v1alpha2.AnnotationShareRoles,
+	}
+	stripped := make([]string, 0, len(target))
+	for _, key := range target {
+		if _, ok := ns.Annotations[key]; ok {
+			stripped = append(stripped, key)
+		}
+	}
+	if len(stripped) == 0 {
+		return nil, nil
+	}
+	live, err := client.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if live.Annotations == nil {
+		return nil, nil
+	}
+	for _, key := range stripped {
+		delete(live.Annotations, key)
+	}
+	if _, err := client.CoreV1().Namespaces().Update(ctx, live, metav1.UpdateOptions{}); err != nil {
+		return nil, err
+	}
+	return stripped, nil
+}
+
+// PrintReport renders a human-readable summary of a migration run.
+func PrintReport(w io.Writer, report *Report, applied bool) error {
+	if report == nil {
+		return nil
+	}
+	mode := "DRY-RUN"
+	if applied {
+		mode = "APPLIED"
+	}
+	if _, err := fmt.Fprintf(w, "holos-console-migrate-rbac (%s)\n", mode); err != nil {
+		return err
+	}
+	if len(report.Namespaces) == 0 {
+		_, err := fmt.Fprintln(w, "no managed namespaces found.")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAMESPACE\tBINDINGS\tALREADY-PRESENT\tNS-ANNOTATIONS-STRIPPED\tSECRETS\tWARNINGS\tERROR")
+	for _, nr := range report.Namespaces {
+		errSummary := nr.Error
+		if errSummary == "" {
+			errSummary = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			nr.Namespace,
+			len(nr.BindingsCreated),
+			len(nr.BindingsAlreadyPresent),
+			len(nr.NamespaceAnnotationsStripped),
+			len(nr.SecretsProcessed),
+			len(nr.Warnings),
+			errSummary,
+		)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	// Render warnings + errors in detail under the table so an
+	// operator can copy/paste them into a follow-up runbook.
+	for _, nr := range report.Namespaces {
+		for _, warn := range nr.Warnings {
+			if _, err := fmt.Fprintf(w, "WARN  %s: %s\n", nr.Namespace, warn); err != nil {
+				return err
+			}
+		}
+		if nr.Error != "" {
+			if _, err := fmt.Fprintf(w, "ERROR %s: %s\n", nr.Namespace, nr.Error); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/holos-console-migrate-rbac/main.go
+++ b/cmd/holos-console-migrate-rbac/main.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"text/tabwriter"
 
@@ -29,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/secretrbac"
@@ -69,11 +67,7 @@ func parseFlags(args []string, errOut io.Writer) (*options, error) {
 	}
 	opts := &options{}
 	fs.BoolVar(&opts.apply, "apply", false, "Perform writes. Without --apply the tool only reports planned changes.")
-	defaultKubeconfig := ""
-	if home := homedir.HomeDir(); home != "" {
-		defaultKubeconfig = filepath.Join(home, ".kube", "config")
-	}
-	fs.StringVar(&opts.kubeconfig, "kubeconfig", defaultKubeconfig, "Path to kubeconfig (defaults to in-cluster config when empty)")
+	fs.StringVar(&opts.kubeconfig, "kubeconfig", "", "Path to kubeconfig (defaults to KUBECONFIG env, then ~/.kube/config, then in-cluster config)")
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
@@ -97,9 +91,24 @@ func run(args []string, stdout, stderr io.Writer) error {
 	return PrintReport(stdout, report, opts.apply)
 }
 
+// buildClient resolves a kubernetes client config in the following
+// precedence order, mirroring kubectl behaviour:
+//
+//  1. --kubeconfig flag (when non-empty);
+//  2. KUBECONFIG environment variable;
+//  3. ~/.kube/config (when present);
+//  4. in-cluster service-account config.
+//
+// Setting ExplicitPath to a non-existent file is fatal under
+// clientcmd, so when no explicit path is provided we use the default
+// loading rules which silently fall through to the in-cluster path.
 func buildClient(kubeconfig string) (kubernetes.Interface, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		rules.ExplicitPath = kubeconfig
+	}
 	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		rules,
 		&clientcmd.ConfigOverrides{},
 	)
 	cfg, err := loader.ClientConfig()
@@ -388,7 +397,7 @@ func parseAnnotation(annotations map[string]string, key, kind, qualifiedName str
 // that decision visibly so an operator can see exactly which grants
 // would have to be re-issued in a future release.
 func filterTimeBounded(grants []secrets.AnnotationGrant, kind, qualifiedName string) ([]secrets.AnnotationGrant, []string) {
-	out := grants[:0:0]
+	out := make([]secrets.AnnotationGrant, 0, len(grants))
 	var warnings []string
 	for _, g := range grants {
 		if g.Nbf != nil || g.Exp != nil {

--- a/cmd/holos-console-migrate-rbac/main_test.go
+++ b/cmd/holos-console-migrate-rbac/main_test.go
@@ -1,0 +1,453 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/secretrbac"
+)
+
+// projectNamespaceFixture builds a project namespace seeded with the
+// given annotations and labels.
+func projectNamespaceFixture(name string, annotations map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// orgNamespaceFixture builds an org namespace (which the migration
+// should skip).
+func orgNamespaceFixture(name string, annotations map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// withProjectRoles seeds the cluster with the three project-secret
+// Roles for the given namespace so the migration tool's preflight
+// passes.
+func withProjectRoles(namespace string, extras ...runtime.Object) []runtime.Object {
+	objs := append([]runtime.Object(nil), extras...)
+	for _, role := range secretrbac.ProjectSecretRoles(namespace, nil) {
+		objs = append(objs, role)
+	}
+	return objs
+}
+
+func TestMigrate_NamespaceLevelGrants_DryRun(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+		v1alpha2.AnnotationShareRoles: `[{"principal":"team-finance","role":"editor"}]`,
+	})
+	objs := withProjectRoles(ns.Name, ns)
+	client := fake.NewClientset(objs...)
+
+	report, err := Migrate(context.Background(), client, false)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if len(report.Namespaces) != 1 {
+		t.Fatalf("expected 1 namespace report, got %d", len(report.Namespaces))
+	}
+	nr := report.Namespaces[0]
+	if nr.Error != "" {
+		t.Errorf("unexpected error: %s", nr.Error)
+	}
+	if len(nr.BindingsCreated) != 2 {
+		t.Errorf("expected 2 bindings (one user + one group), got %d (%v)", len(nr.BindingsCreated), nr.BindingsCreated)
+	}
+	// Dry-run: verify no actual bindings were written.
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 0 {
+		t.Errorf("dry-run wrote %d bindings, expected 0", len(bindings.Items))
+	}
+	// Dry-run: namespace annotations remain.
+	live, _ := client.CoreV1().Namespaces().Get(context.Background(), ns.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareUsers]; !ok {
+		t.Errorf("dry-run stripped share-users annotation")
+	}
+}
+
+func TestMigrate_NamespaceLevelGrants_Apply(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+		v1alpha2.AnnotationShareRoles: `[{"principal":"team-finance","role":"editor"}]`,
+	})
+	objs := withProjectRoles(ns.Name, ns)
+	client := fake.NewClientset(objs...)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	nr := report.Namespaces[0]
+	if nr.Error != "" {
+		t.Fatalf("unexpected error: %s", nr.Error)
+	}
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 2 {
+		t.Fatalf("expected 2 bindings, got %d", len(bindings.Items))
+	}
+
+	// Verify Subject + RoleRef shape.
+	for _, b := range bindings.Items {
+		switch b.Subjects[0].Kind {
+		case rbacv1.UserKind:
+			if b.Subjects[0].Name != "oidc:alice@example.com" {
+				t.Errorf("unexpected subject name: %q", b.Subjects[0].Name)
+			}
+			if b.RoleRef.Name != "holos-project-secrets-viewer" {
+				t.Errorf("unexpected RoleRef.Name: %q", b.RoleRef.Name)
+			}
+		case rbacv1.GroupKind:
+			if b.Subjects[0].Name != "oidc:team-finance" {
+				t.Errorf("unexpected subject name: %q", b.Subjects[0].Name)
+			}
+			if b.RoleRef.Name != "holos-project-secrets-editor" {
+				t.Errorf("unexpected RoleRef.Name: %q", b.RoleRef.Name)
+			}
+		default:
+			t.Errorf("unexpected subject kind: %q", b.Subjects[0].Kind)
+		}
+	}
+
+	// Annotations stripped.
+	live, _ := client.CoreV1().Namespaces().Get(context.Background(), ns.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareUsers]; ok {
+		t.Errorf("share-users annotation still present after apply")
+	}
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareRoles]; ok {
+		t.Errorf("share-roles annotation still present after apply")
+	}
+}
+
+func TestMigrate_AlreadyMigrated_NoOp(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", nil)
+	// Pre-existing binding identical to what the migration would
+	// produce.
+	desired := secretrbac.RoleBinding(ns.Name, secretrbac.ShareTargetUser, "alice@example.com", "viewer", nil)
+	objs := withProjectRoles(ns.Name, ns, desired)
+	client := fake.NewClientset(objs...)
+
+	first, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("first Migrate returned error: %v", err)
+	}
+	if got := len(first.Namespaces[0].BindingsCreated); got != 0 {
+		t.Errorf("expected 0 bindings created on no-op, got %d", got)
+	}
+
+	// Re-run: still a no-op.
+	second, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("second Migrate returned error: %v", err)
+	}
+	if got := len(second.Namespaces[0].BindingsCreated); got != 0 {
+		t.Errorf("expected 0 bindings created on second run, got %d", got)
+	}
+}
+
+func TestMigrate_PerSecretGrants_Apply(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", nil)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-creds",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+			},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationShareUsers: `[{"principal":"bob@example.com","role":"editor"}]`,
+			},
+		},
+	}
+	objs := withProjectRoles(ns.Name, ns, secret)
+	client := fake.NewClientset(objs...)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	nr := report.Namespaces[0]
+	if nr.Error != "" {
+		t.Fatalf("unexpected error: %s", nr.Error)
+	}
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(bindings.Items))
+	}
+	live, _ := client.CoreV1().Secrets(ns.Name).Get(context.Background(), secret.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareUsers]; ok {
+		t.Errorf("share-users still present on Secret after apply")
+	}
+}
+
+func TestMigrate_MalformedAnnotation_NamespaceLevel(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers: "not-json",
+	})
+	objs := withProjectRoles(ns.Name, ns)
+	client := fake.NewClientset(objs...)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	nr := report.Namespaces[0]
+	if nr.Error == "" {
+		t.Fatal("expected per-namespace Error for malformed annotation, got none")
+	}
+	// No bindings written.
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 0 {
+		t.Errorf("expected no bindings written, got %d", len(bindings.Items))
+	}
+	// Annotation still present.
+	live, _ := client.CoreV1().Namespaces().Get(context.Background(), ns.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareUsers]; !ok {
+		t.Error("malformed annotation must remain in place for hand-fix")
+	}
+	if !containsAny(nr.Warnings, "MALFORMED") {
+		t.Errorf("expected warning to mention MALFORMED; got %v", nr.Warnings)
+	}
+}
+
+func TestMigrate_MalformedAnnotation_PerSecretSkipsSecretButNotNamespace(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+	})
+	bad := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad",
+			Namespace: ns.Name,
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationShareUsers: "not-json",
+			},
+		},
+	}
+	objs := withProjectRoles(ns.Name, ns, bad)
+	client := fake.NewClientset(objs...)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	nr := report.Namespaces[0]
+	// Namespace-level grant should still produce its binding.
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 1 {
+		t.Errorf("expected 1 binding from the namespace grant, got %d", len(bindings.Items))
+	}
+	// Bad Secret must keep its annotation.
+	live, _ := client.CoreV1().Secrets(ns.Name).Get(context.Background(), bad.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareUsers]; !ok {
+		t.Error("malformed Secret annotation must remain in place for hand-fix")
+	}
+	if !containsAny(nr.Warnings, "MALFORMED") {
+		t.Errorf("expected MALFORMED warning, got %v", nr.Warnings)
+	}
+}
+
+func TestMigrate_TimeBoundedGrants_AreDroppedWithWarning(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer","exp":1700000000}]`,
+	})
+	objs := withProjectRoles(ns.Name, ns)
+	client := fake.NewClientset(objs...)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	nr := report.Namespaces[0]
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 0 {
+		t.Errorf("time-bounded grant must not produce a binding; got %d", len(bindings.Items))
+	}
+	if !containsAny(nr.Warnings, "DROPPING time-bounded grant") {
+		t.Errorf("expected DROPPING time-bounded grant warning; got %v", nr.Warnings)
+	}
+}
+
+func TestMigrate_RolesMissing_FailsLoudly(t *testing.T) {
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+	})
+	client := fake.NewClientset(ns)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	nr := report.Namespaces[0]
+	if !strings.Contains(nr.Error, "project secret Roles missing") {
+		t.Errorf("expected missing-roles error; got %q", nr.Error)
+	}
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 0 {
+		t.Errorf("must not write any binding when Roles are missing; got %d", len(bindings.Items))
+	}
+	live, _ := client.CoreV1().Namespaces().Get(context.Background(), ns.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareUsers]; !ok {
+		t.Error("must not strip annotations when Roles are missing")
+	}
+}
+
+func TestMigrate_NonProjectNamespacesAreSkipped(t *testing.T) {
+	org := orgNamespaceFixture("holos-org-acme", map[string]string{
+		v1alpha2.AnnotationDefaultShareUsers: `[{"principal":"a","role":"viewer"}]`,
+	})
+	client := fake.NewClientset(org)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	nr := report.Namespaces[0]
+	if nr.Error != "" {
+		t.Errorf("expected no error on org namespace skip, got %q", nr.Error)
+	}
+	if len(nr.BindingsCreated) != 0 {
+		t.Errorf("expected 0 bindings on org namespace, got %d", len(nr.BindingsCreated))
+	}
+	// default-share-* must remain so the cascade chain keeps working.
+	live, _ := client.CoreV1().Namespaces().Get(context.Background(), org.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationDefaultShareUsers]; !ok {
+		t.Error("default-share-users must be preserved on org namespace")
+	}
+}
+
+func TestMigrate_DefaultShareAnnotations_AreNotStripped(t *testing.T) {
+	// On a project namespace, default-share-* annotations seed new
+	// resources but have no equivalent RoleBinding. They must survive
+	// the migration so the cascade chain keeps producing the right
+	// grants on subsequent project creation.
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers:        `[{"principal":"alice@example.com","role":"viewer"}]`,
+		v1alpha2.AnnotationDefaultShareUsers: `[{"principal":"a","role":"viewer"}]`,
+	})
+	objs := withProjectRoles(ns.Name, ns)
+	client := fake.NewClientset(objs...)
+
+	if _, err := Migrate(context.Background(), client, true); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	live, _ := client.CoreV1().Namespaces().Get(context.Background(), ns.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[v1alpha2.AnnotationDefaultShareUsers]; !ok {
+		t.Error("default-share-users must be preserved on project namespace")
+	}
+	if _, ok := live.Annotations[v1alpha2.AnnotationShareUsers]; ok {
+		t.Error("share-users must be stripped after migration")
+	}
+}
+
+func TestMigrate_DeduplicatesAcrossNamespaceAndSecret(t *testing.T) {
+	// alice gets viewer at the namespace level and editor at the
+	// per-Secret level. Different roles produce different binding
+	// names, so there will be one viewer + one editor.
+	ns := projectNamespaceFixture("holos-prj-finance", map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"}]`,
+	})
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-creds",
+			Namespace: ns.Name,
+			Labels:    map[string]string{v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue},
+			Annotations: map[string]string{
+				v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"editor"}]`,
+			},
+		},
+	}
+	objs := withProjectRoles(ns.Name, ns, secret)
+	client := fake.NewClientset(objs...)
+
+	if _, err := Migrate(context.Background(), client, true); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	bindings, _ := client.RbacV1().RoleBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+	if len(bindings.Items) != 2 {
+		t.Fatalf("expected 2 bindings (one viewer, one editor for alice), got %d", len(bindings.Items))
+	}
+}
+
+func TestPrintReport_ApplyAndDryRunHeaders(t *testing.T) {
+	report := &Report{
+		Namespaces: []NamespaceReport{
+			{Namespace: "holos-prj-a", BindingsCreated: []string{"b1"}},
+			{Namespace: "holos-prj-b", Error: "boom"},
+		},
+	}
+	var dry, applied bytes.Buffer
+	if err := PrintReport(&dry, report, false); err != nil {
+		t.Fatalf("PrintReport(dry): %v", err)
+	}
+	if err := PrintReport(&applied, report, true); err != nil {
+		t.Fatalf("PrintReport(applied): %v", err)
+	}
+	if !strings.Contains(dry.String(), "DRY-RUN") {
+		t.Errorf("dry-run output missing DRY-RUN marker: %s", dry.String())
+	}
+	if !strings.Contains(applied.String(), "APPLIED") {
+		t.Errorf("applied output missing APPLIED marker: %s", applied.String())
+	}
+	if !strings.Contains(applied.String(), "ERROR holos-prj-b: boom") {
+		t.Errorf("error detail missing: %s", applied.String())
+	}
+}
+
+func TestParseFlags_DefaultsToDryRun(t *testing.T) {
+	opts, err := parseFlags(nil, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if opts.apply {
+		t.Errorf("expected --apply default false, got true")
+	}
+}
+
+func TestParseFlags_ApplyFlag(t *testing.T) {
+	opts, err := parseFlags([]string{"--apply"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if !opts.apply {
+		t.Errorf("expected --apply true, got false")
+	}
+}
+
+// --- helpers ---
+
+// containsAny reports whether any entry in haystack contains needle as
+// a substring.
+func containsAny(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/console/folders/k8s.go
+++ b/console/folders/k8s.go
@@ -10,6 +10,7 @@ import (
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/secrets"
+	"github.com/holos-run/holos-console/console/sharing/legacy"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -391,16 +392,5 @@ func (a *FolderCreatorAdapter) GetFolder(ctx context.Context, name string) (*cor
 }
 
 func parseGrantAnnotation(ns *corev1.Namespace, key string) ([]secrets.AnnotationGrant, error) {
-	if ns.Annotations == nil {
-		return nil, nil
-	}
-	value, ok := ns.Annotations[key]
-	if !ok {
-		return nil, nil
-	}
-	var grants []secrets.AnnotationGrant
-	if err := json.Unmarshal([]byte(value), &grants); err != nil {
-		return nil, fmt.Errorf("invalid %s annotation: %w", key, err)
-	}
-	return grants, nil
+	return legacy.ParseGrants(ns.Annotations, key)
 }

--- a/console/organizations/k8s.go
+++ b/console/organizations/k8s.go
@@ -10,6 +10,7 @@ import (
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/secrets"
+	"github.com/holos-run/holos-console/console/sharing/legacy"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -322,16 +323,5 @@ func (c *K8sClient) UpdateOrganizationDefaultSharing(ctx context.Context, name s
 }
 
 func parseGrantAnnotation(ns *corev1.Namespace, key string) ([]secrets.AnnotationGrant, error) {
-	if ns.Annotations == nil {
-		return nil, nil
-	}
-	value, ok := ns.Annotations[key]
-	if !ok {
-		return nil, nil
-	}
-	var grants []secrets.AnnotationGrant
-	if err := json.Unmarshal([]byte(value), &grants); err != nil {
-		return nil, fmt.Errorf("invalid %s annotation: %w", key, err)
-	}
-	return grants, nil
+	return legacy.ParseGrants(ns.Annotations, key)
 }

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -11,6 +11,7 @@ import (
 	"github.com/holos-run/holos-console/console/resolver"
 	"github.com/holos-run/holos-console/console/secretrbac"
 	"github.com/holos-run/holos-console/console/secrets"
+	"github.com/holos-run/holos-console/console/sharing/legacy"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -528,16 +529,5 @@ func (a *ProjectCreatorAdapter) NamespaceExists(ctx context.Context, nsName stri
 }
 
 func parseGrantAnnotation(ns *corev1.Namespace, key string) ([]secrets.AnnotationGrant, error) {
-	if ns.Annotations == nil {
-		return nil, nil
-	}
-	value, ok := ns.Annotations[key]
-	if !ok {
-		return nil, nil
-	}
-	var grants []secrets.AnnotationGrant
-	if err := json.Unmarshal([]byte(value), &grants); err != nil {
-		return nil, fmt.Errorf("invalid %s annotation: %w", key, err)
-	}
-	return grants, nil
+	return legacy.ParseGrants(ns.Annotations, key)
 }

--- a/console/sharing/legacy/parse.go
+++ b/console/sharing/legacy/parse.go
@@ -1,0 +1,90 @@
+// Package legacy provides shared parsers for the pre-RBAC sharing
+// annotations stored on v1.Secret and v1.Namespace objects.
+//
+// Before ADR 036 moved authorization to native Kubernetes RBAC with OIDC
+// impersonation, holos-console encoded sharing grants as JSON arrays in the
+// `console.holos.run/share-users`, `console.holos.run/share-roles`,
+// `console.holos.run/default-share-users`, and
+// `console.holos.run/default-share-roles` annotations. The
+// per-resource handler packages (organizations, folders, projects,
+// secrets) each open-coded an identical parser. This package centralises
+// the unmarshalling so the migration tool in
+// `cmd/holos-console-migrate-rbac` can reuse the exact same decoder
+// without dragging in a handler package.
+//
+// The package is intentionally tiny and dependency-free: it imports only
+// the API constants from `api/v1alpha2` and the `secrets.AnnotationGrant`
+// shape so the on-disk representation stays in sync with the existing
+// reconciler.
+package legacy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/secrets"
+)
+
+// AnnotationKeys returns the four legacy sharing annotation keys handled
+// by this package. The order is stable (share-users, share-roles,
+// default-share-users, default-share-roles) so callers iterating the
+// result slice produce deterministic output.
+func AnnotationKeys() []string {
+	return []string{
+		v1alpha2.AnnotationShareUsers,
+		v1alpha2.AnnotationShareRoles,
+		v1alpha2.AnnotationDefaultShareUsers,
+		v1alpha2.AnnotationDefaultShareRoles,
+	}
+}
+
+// ParseGrants unmarshals the JSON array stored in annotations[key].
+//
+// Returns:
+//   - nil, nil when annotations is nil or the key is absent;
+//   - the decoded slice when the value is a valid JSON array;
+//   - a wrapped error including the annotation key on malformed JSON.
+//
+// The function never silently skips invalid JSON: a malformed annotation
+// must be visible to the operator running the migration so that they can
+// hand-correct the data before the RoleBindings are written.
+func ParseGrants(annotations map[string]string, key string) ([]secrets.AnnotationGrant, error) {
+	if annotations == nil {
+		return nil, nil
+	}
+	value, ok := annotations[key]
+	if !ok {
+		return nil, nil
+	}
+	var grants []secrets.AnnotationGrant
+	if err := json.Unmarshal([]byte(value), &grants); err != nil {
+		return nil, fmt.Errorf("invalid %s annotation: %w", key, err)
+	}
+	return grants, nil
+}
+
+// ShareUsers returns the parsed share-users grants for the given
+// annotations map (typically taken from a v1.Secret or v1.Namespace).
+func ShareUsers(annotations map[string]string) ([]secrets.AnnotationGrant, error) {
+	return ParseGrants(annotations, v1alpha2.AnnotationShareUsers)
+}
+
+// ShareRoles returns the parsed share-roles grants for the given
+// annotations map.
+func ShareRoles(annotations map[string]string) ([]secrets.AnnotationGrant, error) {
+	return ParseGrants(annotations, v1alpha2.AnnotationShareRoles)
+}
+
+// DefaultShareUsers returns the parsed default-share-users grants for the
+// given annotations map. These appear on org, folder, and project
+// namespaces and seed the cascade chain applied to new Secrets.
+func DefaultShareUsers(annotations map[string]string) ([]secrets.AnnotationGrant, error) {
+	return ParseGrants(annotations, v1alpha2.AnnotationDefaultShareUsers)
+}
+
+// DefaultShareRoles returns the parsed default-share-roles grants for the
+// given annotations map.
+func DefaultShareRoles(annotations map[string]string) ([]secrets.AnnotationGrant, error) {
+	return ParseGrants(annotations, v1alpha2.AnnotationDefaultShareRoles)
+}

--- a/console/sharing/legacy/parse_test.go
+++ b/console/sharing/legacy/parse_test.go
@@ -1,0 +1,149 @@
+package legacy
+
+import (
+	"strings"
+	"testing"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+func TestParseGrants_NilAnnotations(t *testing.T) {
+	got, err := ParseGrants(nil, v1alpha2.AnnotationShareUsers)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil grants, got %#v", got)
+	}
+}
+
+func TestParseGrants_KeyAbsent(t *testing.T) {
+	got, err := ParseGrants(map[string]string{"unrelated": "x"}, v1alpha2.AnnotationShareUsers)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil grants, got %#v", got)
+	}
+}
+
+func TestParseGrants_ValidJSON(t *testing.T) {
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"viewer"},{"principal":"bob@example.com","role":"editor"}]`,
+	}
+	got, err := ParseGrants(annotations, v1alpha2.AnnotationShareUsers)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 grants, got %d", len(got))
+	}
+	if got[0].Principal != "alice@example.com" || got[0].Role != "viewer" {
+		t.Errorf("unexpected first grant: %#v", got[0])
+	}
+	if got[1].Principal != "bob@example.com" || got[1].Role != "editor" {
+		t.Errorf("unexpected second grant: %#v", got[1])
+	}
+}
+
+func TestParseGrants_TimeBoundedFields(t *testing.T) {
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"x","role":"viewer","nbf":100,"exp":200}]`,
+	}
+	got, err := ParseGrants(annotations, v1alpha2.AnnotationShareUsers)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(got))
+	}
+	if got[0].Nbf == nil || *got[0].Nbf != 100 {
+		t.Errorf("expected nbf=100, got %#v", got[0].Nbf)
+	}
+	if got[0].Exp == nil || *got[0].Exp != 200 {
+		t.Errorf("expected exp=200, got %#v", got[0].Exp)
+	}
+}
+
+func TestParseGrants_MalformedJSON_ReturnsErrorWithKey(t *testing.T) {
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareUsers: "not json",
+	}
+	_, err := ParseGrants(annotations, v1alpha2.AnnotationShareUsers)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), v1alpha2.AnnotationShareUsers) {
+		t.Errorf("expected error to include annotation key %q, got %q", v1alpha2.AnnotationShareUsers, err.Error())
+	}
+}
+
+func TestShareUsers_Helper(t *testing.T) {
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareUsers: `[{"principal":"a","role":"viewer"}]`,
+	}
+	got, err := ShareUsers(annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Principal != "a" {
+		t.Errorf("unexpected grants: %#v", got)
+	}
+}
+
+func TestShareRoles_Helper(t *testing.T) {
+	annotations := map[string]string{
+		v1alpha2.AnnotationShareRoles: `[{"principal":"team-a","role":"editor"}]`,
+	}
+	got, err := ShareRoles(annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Role != "editor" {
+		t.Errorf("unexpected grants: %#v", got)
+	}
+}
+
+func TestDefaultShareUsers_Helper(t *testing.T) {
+	annotations := map[string]string{
+		v1alpha2.AnnotationDefaultShareUsers: `[{"principal":"a","role":"viewer"}]`,
+	}
+	got, err := DefaultShareUsers(annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(got))
+	}
+}
+
+func TestDefaultShareRoles_Helper(t *testing.T) {
+	annotations := map[string]string{
+		v1alpha2.AnnotationDefaultShareRoles: `[{"principal":"team-a","role":"editor"}]`,
+	}
+	got, err := DefaultShareRoles(annotations)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(got))
+	}
+}
+
+func TestAnnotationKeys_StableOrder(t *testing.T) {
+	keys := AnnotationKeys()
+	want := []string{
+		v1alpha2.AnnotationShareUsers,
+		v1alpha2.AnnotationShareRoles,
+		v1alpha2.AnnotationDefaultShareUsers,
+		v1alpha2.AnnotationDefaultShareRoles,
+	}
+	if len(keys) != len(want) {
+		t.Fatalf("expected %d keys, got %d", len(want), len(keys))
+	}
+	for i := range keys {
+		if keys[i] != want[i] {
+			t.Errorf("AnnotationKeys()[%d]=%q, want %q", i, keys[i], want[i])
+		}
+	}
+}

--- a/docs/migration/rbac-2026-04.md
+++ b/docs/migration/rbac-2026-04.md
@@ -1,0 +1,198 @@
+# RBAC Migration: Secret-Sharing Annotations to RoleBindings (2026-04)
+
+## Summary
+
+Before ADR 036, the holos-console encoded Secret-sharing grants in JSON
+annotations on `v1.Secret` and `v1.Namespace` objects. After ADR 036, every
+authorisation decision flows through native Kubernetes RBAC via the
+impersonating client. This migration translates the legacy annotations into
+equivalent `RoleBinding`s against the project-scoped Secret Roles
+provisioned by the Phase 4 reconciler (HOL-1032), then strips the
+annotations.
+
+The migration tool ships as
+`cmd/holos-console-migrate-rbac` and is **operator-run** — it uses the
+console's own service-account identity, not the impersonated path, because
+the operator (not an end-user) is responsible for back-filling cluster
+state during the upgrade window.
+
+This is the only resource kind with a migration path. Per the parent issue
+HOL-1028's acceptance criteria, Deployments and other CRs do not need
+backwards compatibility.
+
+## Preconditions
+
+Before running the migration, confirm the following:
+
+1. **Phase 4 RBAC has been applied.** The console must have written the
+   three project-scoped Roles (`holos-project-secrets-viewer`,
+   `holos-project-secrets-editor`, `holos-project-secrets-owner`) into
+   every project namespace. The migration verifies this on a per-namespace
+   basis and refuses to write bindings into a namespace where the Roles are
+   missing — silently producing dangling bindings against a missing Role
+   would leave the cluster in a worse state than before the migration.
+
+   To confirm a single namespace, run:
+
+   ```bash
+   kubectl get roles -n <project-namespace> \
+     holos-project-secrets-viewer \
+     holos-project-secrets-editor \
+     holos-project-secrets-owner
+   ```
+
+   To confirm at scale, list every project namespace and verify each has
+   all three Roles. If any are missing, restart the console pod (which
+   triggers the Phase 4 reconciler) before continuing.
+
+2. **The console is running the post-ADR-036 image.** The new image
+   provisions the project-scoped Roles as part of namespace reconciliation.
+   Older images do not, and the migration will report missing Roles for
+   every project.
+
+3. **Backups.** Before running with `--apply`, snapshot every project
+   namespace's annotations in case rollback is needed:
+
+   ```bash
+   for ns in $(kubectl get ns -l app.kubernetes.io/managed-by=console.holos.run \
+     -l console.holos.run/resource-type=project -o name); do
+     name="${ns#namespace/}"
+     kubectl get -n "$name" namespace "$name" \
+       -o jsonpath='{.metadata.annotations}' \
+       > "/tmp/backup-${name}-namespace.json"
+     kubectl get -n "$name" secrets \
+       -l app.kubernetes.io/managed-by=console.holos.run \
+       -o json \
+       > "/tmp/backup-${name}-secrets.json"
+   done
+   ```
+
+   These backups are the **rollback source of truth** — see "Rollback"
+   below.
+
+## Run Order
+
+1. **Dry run.** Inspect the planned changes:
+
+   ```bash
+   holos-console-migrate-rbac
+   ```
+
+   The default mode is `--apply=false`. The tool prints a per-namespace
+   summary table:
+
+   | NAMESPACE | BINDINGS | ALREADY-PRESENT | NS-ANNOTATIONS-STRIPPED | SECRETS | WARNINGS | ERROR |
+   | --------- | -------: | --------------: | ----------------------: | ------: | -------: | ----- |
+   | holos-prj-finance | 3 | 0 | 2 | 7 | 0 | - |
+
+   - `BINDINGS` — number of RoleBindings the migration would create.
+   - `ALREADY-PRESENT` — RoleBindings already in the desired state (a
+     re-run after a partial-failure should land here).
+   - `NS-ANNOTATIONS-STRIPPED` — number of share-users / share-roles
+     annotations that would be removed from the namespace itself.
+   - `SECRETS` — count of managed Secrets visited.
+   - `WARNINGS` — count of dropped time-bounded grants and malformed
+     annotations.
+   - `ERROR` — per-namespace fatal error (`-` if none).
+
+   Below the table, the tool prints every warning and error in detail so
+   they can be copied into a follow-up runbook.
+
+2. **Resolve warnings.**
+
+   - **MALFORMED annotations** must be hand-fixed before the migration
+     can proceed for that resource. The tool refuses to translate
+     malformed JSON: if a Secret's `console.holos.run/share-users`
+     annotation is invalid, the tool leaves the Secret untouched and
+     prints a warning. Fix the JSON and re-run.
+
+   - **Time-bounded grants** (`nbf` or `exp` set) are dropped because
+     ADR 036 does not commit to a time-bounded RBAC primitive. The
+     warning lists each dropped principal and role; re-issue these
+     grants manually if the customer still needs them.
+
+3. **Apply.** Once dry-run output is clean, run with `--apply`:
+
+   ```bash
+   holos-console-migrate-rbac --apply
+   ```
+
+   The tool is idempotent — re-running it after success produces a
+   summary with `BINDINGS=0` for every namespace.
+
+4. **Validate.** Pick a project namespace and verify:
+
+   ```bash
+   kubectl get rolebindings -n <project-namespace> \
+     -l app.kubernetes.io/managed-by=console.holos.run \
+     -l console.holos.run/role-purpose=project-secrets
+   kubectl get namespace <project-namespace> \
+     -o jsonpath='{.metadata.annotations}' | jq
+   ```
+
+   The annotations `console.holos.run/share-users` and
+   `console.holos.run/share-roles` must be absent. The
+   `console.holos.run/default-share-users` and
+   `console.holos.run/default-share-roles` annotations remain — they seed
+   the cascade chain for future project creation and have no equivalent
+   RoleBinding.
+
+## Expected Duration
+
+On a customer cluster of ~100 project namespaces with 5–10 Secrets each:
+
+| Phase   | Duration |
+| ------- | -------- |
+| Dry run | 30 – 60 seconds |
+| Apply   | 1 – 3 minutes (one Update per Secret + one Update per Namespace + one Create per RoleBinding) |
+
+The tool issues one List call per resource type and one Get/Update per
+mutated object, so the total request count scales linearly with the
+number of bindings + the number of stripped annotations.
+
+## Rollback
+
+The migration writes RoleBindings and removes annotations. To roll back:
+
+1. **Re-add the annotations** from the backup snapshots taken in
+   "Preconditions" step 3:
+
+   ```bash
+   for f in /tmp/backup-*-namespace.json; do
+     name="$(basename "$f" -namespace.json | sed 's/^backup-//')"
+     kubectl annotate --overwrite namespace "$name" \
+       "$(jq -r 'to_entries | map("\(.key)=\(.value)") | .[]' "$f")"
+   done
+   ```
+
+   For Secrets, restore from the snapshot via `kubectl apply -f` after
+   re-adding the missing annotation keys.
+
+2. **Delete the migration RoleBindings.** All bindings created by the
+   migration carry the `console.holos.run/role-purpose=project-secrets`
+   label; deleting the matching set restores pre-migration state:
+
+   ```bash
+   kubectl delete rolebinding -A \
+     -l app.kubernetes.io/managed-by=console.holos.run \
+     -l console.holos.run/role-purpose=project-secrets
+   ```
+
+3. **Roll the console image back to the pre-ADR-036 build.** The new
+   image's secrets handler reads grants from RoleBindings; a rollback
+   without restoring the annotations leaves end-users with the same
+   broken UI experience the migration was meant to fix.
+
+After rollback, investigate the cause of the failed migration in the
+tool's per-namespace output and re-run once the issue is resolved.
+
+## Related
+
+- Parent: [HOL-1028](https://linear.app/holos-run/issue/HOL-1028) — RBAC
+  delivery plan.
+- Phase 1: [HOL-1029](https://linear.app/holos-run/issue/HOL-1029) — ADR
+  036.
+- Phase 4: [HOL-1032](https://linear.app/holos-run/issue/HOL-1032) —
+  project-scoped Secret RBAC reconciler.
+- This phase: [HOL-1035](https://linear.app/holos-run/issue/HOL-1035) —
+  Secret-sharing annotations migration tool.


### PR DESCRIPTION
## Summary

- Add `cmd/holos-console-migrate-rbac` — operator-run, dry-run-by-default migration that walks every `app.kubernetes.io/managed-by=console.holos.run` namespace, translates legacy `share-users` / `share-roles` annotations on the namespace itself and on every managed `v1.Secret` into RoleBindings against the project-scoped Secret Roles provisioned in Phase 4 (HOL-1032), and strips the annotations after bindings are confirmed.
- Idempotent: re-running after success or partial-failure is a no-op for already-present bindings; a re-run picks up wherever the previous run left off.
- Refuses to write into a namespace where the Phase 4 project-secret Roles are missing (fails loudly per the issue's acceptance criteria).
- Drops time-bounded grants (`nbf` / `exp`) with one warning per grant per ADR 036's decision to defer the time-bounded primitive.
- Surfaces malformed JSON visibly (skips the offending resource until the operator hand-fixes the data); the namespace's malformed annotation is reported as a per-namespace error and no bindings are written for that namespace.
- Preserves `default-share-*` annotations on every namespace because those seed the cascade chain for new projects and have no equivalent RoleBinding.
- Lift the shared annotation parser into `console/sharing/legacy` and delegate the four duplicate `parseGrantAnnotation` copies in `organizations`, `folders`, `projects` to it. The fourth copy in `console/secrets/k8s.go` is left in place to avoid an import cycle with `legacy` (which depends on `secrets.AnnotationGrant`).
- Operator runbook lands at `docs/migration/rbac-2026-04.md` covering preconditions, run order, expected duration, and rollback (re-add annotations from a backup before deleting the migration RoleBindings).

Fixes HOL-1035

## Test plan

- [x] `make test-go` — passes; `console/sharing/legacy` reaches 100.0% coverage and `cmd/holos-console-migrate-rbac` reaches 66.5% covering dry-run/apply, idempotent re-run, malformed namespace + malformed per-Secret, time-bounded-grant drop, roles-missing, non-project-namespace skip, default-share preservation, and namespace+secret de-duplication paths.
- [x] `go vet ./...` — clean.
- [x] `go build -o /tmp/holos-console-migrate-rbac ./cmd/holos-console-migrate-rbac/` — builds; `--help` exits 0 with the correct usage block.