### PR TITLE
feat(console): add template resource RBAC reconcilers

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -279,8 +279,8 @@ func (s *Server) Serve(ctx context.Context) error {
 				s.cfg.ClientID,
 				s.cfg.RolesClaim,
 				internalClient,
-				rpc.WithImpersonationConfig(restConfig, controllermgr.Scheme),
 			),
+			rpc.ImpersonationInterceptor(restConfig, controllermgr.Scheme),
 		)
 	} else {
 		// Fallback to public interceptors if auth not configured

--- a/console/resourcerbac/rbac.go
+++ b/console/resourcerbac/rbac.go
@@ -1,0 +1,385 @@
+// Package resourcerbac provides per-resource RBAC helpers for
+// templates.holos.run resources.
+package resourcerbac
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/rbacname"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	TemplatesAPIGroup = "templates.holos.run"
+
+	LabelRolePurpose     = "console.holos.run/role-purpose"
+	LabelResourceKind    = "console.holos.run/resource-kind"
+	LabelResourceName    = "console.holos.run/resource-name"
+	LabelShareTarget     = "console.holos.run/share-target"
+	LabelShareTargetName = "console.holos.run/share-target-name"
+	LabelResourceRole    = "holos.run/role"
+
+	AnnotationCreatorSubject  = "console.holos.run/creator-sub"
+	AnnotationShareTargetName = LabelShareTargetName
+
+	RoleViewer = "viewer"
+	RoleEditor = "editor"
+	RoleOwner  = "owner"
+
+	ShareTargetUser  = "user"
+	ShareTargetGroup = "group"
+
+	OIDCPrefix = "oidc:"
+)
+
+// KindConfig describes the RBAC surface for one templates.holos.run resource
+// kind.
+type KindConfig struct {
+	Kind           string
+	Resource       string
+	RolePurpose    string
+	ControllerName string
+	NewObject      func() metav1.Object
+}
+
+var (
+	Templates = KindConfig{
+		Kind:           "Template",
+		Resource:       "templates",
+		RolePurpose:    "template",
+		ControllerName: "template-rbac-controller",
+		NewObject:      func() metav1.Object { return &templatesv1alpha1.Template{} },
+	}
+	TemplatePolicies = KindConfig{
+		Kind:           "TemplatePolicy",
+		Resource:       "templatepolicies",
+		RolePurpose:    "templatepolicy",
+		ControllerName: "template-policy-rbac-controller",
+		NewObject:      func() metav1.Object { return &templatesv1alpha1.TemplatePolicy{} },
+	}
+	TemplatePolicyBindings = KindConfig{
+		Kind:           "TemplatePolicyBinding",
+		Resource:       "templatepolicybindings",
+		RolePurpose:    "templatepolicybinding",
+		ControllerName: "template-policy-binding-rbac-controller",
+		NewObject:      func() metav1.Object { return &templatesv1alpha1.TemplatePolicyBinding{} },
+	}
+	TemplateGrants = KindConfig{
+		Kind:           "TemplateGrant",
+		Resource:       "templategrants",
+		RolePurpose:    "templategrant",
+		ControllerName: "template-grant-rbac-controller",
+		NewObject:      func() metav1.Object { return &templatesv1alpha1.TemplateGrant{} },
+	}
+	TemplateDependencies = KindConfig{
+		Kind:           "TemplateDependency",
+		Resource:       "templatedependencies",
+		RolePurpose:    "templatedependency",
+		ControllerName: "template-dependency-rbac-controller",
+		NewObject:      func() metav1.Object { return &templatesv1alpha1.TemplateDependency{} },
+	}
+	TemplateRequirements = KindConfig{
+		Kind:           "TemplateRequirement",
+		Resource:       "templaterequirements",
+		RolePurpose:    "templaterequirement",
+		ControllerName: "template-requirement-rbac-controller",
+		NewObject:      func() metav1.Object { return &templatesv1alpha1.TemplateRequirement{} },
+	}
+)
+
+// AllKindConfigs returns every templates.holos.run kind managed by this
+// package.
+func AllKindConfigs() []KindConfig {
+	return []KindConfig{
+		Templates,
+		TemplatePolicies,
+		TemplatePolicyBindings,
+		TemplateGrants,
+		TemplateDependencies,
+		TemplateRequirements,
+	}
+}
+
+// EnsureResourceRBAC provisions the viewer/editor/owner Roles for obj and,
+// when obj carries console.holos.run/creator-sub, an owner RoleBinding for
+// the creating OIDC subject. Roles and RoleBindings are owner-referenced to
+// obj so Kubernetes garbage collection removes them when the resource is
+// deleted.
+func EnsureResourceRBAC(ctx context.Context, client kubernetes.Interface, obj metav1.Object, cfg KindConfig) error {
+	if client == nil {
+		return fmt.Errorf("resource RBAC client is required")
+	}
+	if obj == nil {
+		return fmt.Errorf("resource object is required")
+	}
+	namespace, name := obj.GetNamespace(), obj.GetName()
+	if namespace == "" || name == "" {
+		return fmt.Errorf("resource namespace and name are required")
+	}
+	ownerRefs := OwnerReferences(obj, cfg)
+	for _, role := range ResourceRoles(namespace, name, cfg, ownerRefs) {
+		if err := applyRole(ctx, client, role); err != nil {
+			return fmt.Errorf("applying %s role %q: %w", cfg.Kind, role.Name, err)
+		}
+	}
+	creatorSub := creatorSubject(obj)
+	if creatorSub == "" {
+		return nil
+	}
+	binding := RoleBinding(namespace, name, cfg, ShareTargetUser, creatorSub, RoleOwner, ownerRefs)
+	if err := applyRoleBinding(ctx, client, binding); err != nil {
+		return fmt.Errorf("applying %s owner role binding: %w", cfg.Kind, err)
+	}
+	return nil
+}
+
+func creatorSubject(obj metav1.Object) string {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(annotations[AnnotationCreatorSubject])
+}
+
+func ResourceRoles(namespace, name string, cfg KindConfig, ownerRefs []metav1.OwnerReference) []*rbacv1.Role {
+	return []*rbacv1.Role{
+		resourceRole(namespace, name, cfg, RoleViewer, viewerVerbs(), nil, ownerRefs),
+		resourceRole(namespace, name, cfg, RoleEditor, editorVerbs(), nil, ownerRefs),
+		resourceRole(namespace, name, cfg, RoleOwner, ownerVerbs(), ownerRules(name, cfg), ownerRefs),
+	}
+}
+
+func resourceRole(namespace, name string, cfg KindConfig, role string, verbs []string, extraRules []rbacv1.PolicyRule, ownerRefs []metav1.OwnerReference) *rbacv1.Role {
+	rules := []rbacv1.PolicyRule{{
+		APIGroups:     []string{TemplatesAPIGroup},
+		Resources:     []string{cfg.Resource},
+		ResourceNames: []string{name},
+		Verbs:         verbs,
+	}}
+	rules = append(rules, extraRules...)
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleName(name, cfg, role),
+			Namespace:       namespace,
+			Labels:          RoleLabels(name, cfg, role),
+			OwnerReferences: ownerRefs,
+		},
+		Rules: rules,
+	}
+}
+
+func viewerVerbs() []string {
+	return []string{"get"}
+}
+
+func editorVerbs() []string {
+	return []string{"get", "update", "patch"}
+}
+
+func ownerVerbs() []string {
+	return []string{"get", "update", "patch", "delete"}
+}
+
+func ownerRules(name string, cfg KindConfig) []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{rbacv1.GroupName},
+			Resources: []string{"rolebindings"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups:     []string{rbacv1.GroupName},
+			Resources:     []string{"roles"},
+			ResourceNames: []string{RoleName(name, cfg, RoleViewer), RoleName(name, cfg, RoleEditor), RoleName(name, cfg, RoleOwner)},
+			Verbs:         []string{"get", "list", "watch", "bind"},
+		},
+	}
+}
+
+func RoleName(name string, cfg KindConfig, role string) string {
+	return "holos-" + cfg.RolePurpose + "-" + name + "-" + NormalizeRole(role)
+}
+
+func RoleLabels(name string, cfg KindConfig, role string) map[string]string {
+	return map[string]string{
+		v1alpha2.LabelManagedBy: v1alpha2.ManagedByValue,
+		LabelRolePurpose:        cfg.RolePurpose,
+		LabelResourceKind:       strings.ToLower(cfg.Kind),
+		LabelResourceName:       name,
+		LabelResourceRole:       cfg.RolePurpose + "-" + NormalizeRole(role),
+	}
+}
+
+func RoleBindingLabels(name string, cfg KindConfig, target, principal, role string) map[string]string {
+	labels := RoleLabels(name, cfg, role)
+	labels[LabelShareTarget] = NormalizeTarget(target)
+	labels[LabelShareTargetName] = labelValue(principal)
+	return labels
+}
+
+func RoleBinding(namespace, name string, cfg KindConfig, target, principal, role string, ownerRefs []metav1.OwnerReference) *rbacv1.RoleBinding {
+	target = NormalizeTarget(target)
+	role = NormalizeRole(role)
+	subjectKind := rbacv1.UserKind
+	if target == ShareTargetGroup {
+		subjectKind = rbacv1.GroupKind
+	}
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleBindingName(name, cfg, role, target, principal),
+			Namespace:       namespace,
+			Labels:          RoleBindingLabels(name, cfg, target, principal, role),
+			Annotations:     map[string]string{AnnotationShareTargetName: OIDCPrincipal(principal)},
+			OwnerReferences: ownerRefs,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:     subjectKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     OIDCPrincipal(principal),
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     RoleName(name, cfg, role),
+		},
+	}
+}
+
+func RoleBindingName(name string, cfg KindConfig, role, target, principal string) string {
+	rolePurpose := cfg.RolePurpose + "-" + name + "-" + NormalizeRole(role)
+	return rbacname.RoleBindingName(rolePurpose, target, OIDCPrincipal(principal))
+}
+
+func OwnerReferences(obj metav1.Object, cfg KindConfig) []metav1.OwnerReference {
+	controller := true
+	blockOwnerDeletion := true
+	return []metav1.OwnerReference{{
+		APIVersion:         templatesv1alpha1.GroupVersion.String(),
+		Kind:               cfg.Kind,
+		Name:               obj.GetName(),
+		UID:                obj.GetUID(),
+		Controller:         &controller,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+	}}
+}
+
+func OIDCPrincipal(principal string) string {
+	principal = strings.TrimSpace(principal)
+	if principal == "" || strings.HasPrefix(principal, OIDCPrefix) {
+		return principal
+	}
+	return OIDCPrefix + principal
+}
+
+func NormalizeRole(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case RoleOwner:
+		return RoleOwner
+	case RoleEditor:
+		return RoleEditor
+	default:
+		return RoleViewer
+	}
+}
+
+func NormalizeTarget(target string) string {
+	if strings.EqualFold(strings.TrimSpace(target), ShareTargetGroup) {
+		return ShareTargetGroup
+	}
+	return ShareTargetUser
+}
+
+func RoleFromLabels(labels map[string]string) string {
+	if labels != nil {
+		for _, cfg := range AllKindConfigs() {
+			if value := strings.TrimPrefix(labels[LabelResourceRole], cfg.RolePurpose+"-"); value != labels[LabelResourceRole] {
+				return NormalizeRole(value)
+			}
+		}
+	}
+	return RoleViewer
+}
+
+func applyRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.Role) error {
+	created, err := client.RbacV1().Roles(role.Namespace).Create(ctx, role, metav1.CreateOptions{})
+	if err == nil {
+		*role = *created
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := client.RbacV1().Roles(role.Namespace).Get(ctx, role.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	existing.Labels = role.Labels
+	existing.Rules = role.Rules
+	existing.OwnerReferences = role.OwnerReferences
+	updated, err := client.RbacV1().Roles(role.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	*role = *updated
+	return nil
+}
+
+func applyRoleBinding(ctx context.Context, client kubernetes.Interface, binding *rbacv1.RoleBinding) error {
+	created, err := client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+	if err == nil {
+		*binding = *created
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := client.RbacV1().RoleBindings(binding.Namespace).Get(ctx, binding.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if existing.RoleRef != binding.RoleRef {
+		if err := client.RbacV1().RoleBindings(binding.Namespace).Delete(ctx, binding.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		recreated, err := client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
+		if err == nil {
+			*binding = *recreated
+		}
+		return err
+	}
+	existing.Labels = binding.Labels
+	existing.Annotations = binding.Annotations
+	existing.Subjects = binding.Subjects
+	existing.OwnerReferences = binding.OwnerReferences
+	updated, err := client.RbacV1().RoleBindings(binding.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	*binding = *updated
+	return nil
+}
+
+func labelValue(value string) string {
+	var b strings.Builder
+	lastSep := false
+	for _, r := range value {
+		ok := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.'
+		if ok {
+			b.WriteRune(r)
+			lastSep = false
+			continue
+		}
+		if !lastSep {
+			b.WriteByte('_')
+			lastSep = true
+		}
+	}
+	return strings.Trim(b.String(), "-_.")
+}

--- a/console/resourcerbac/rbac_test.go
+++ b/console/resourcerbac/rbac_test.go
@@ -1,0 +1,158 @@
+package resourcerbac
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEnsureResourceRBACProvisioningForEveryKind(t *testing.T) {
+	for _, cfg := range AllKindConfigs() {
+		t.Run(cfg.Kind, func(t *testing.T) {
+			obj := cfg.NewObject()
+			obj.SetNamespace("holos-prj-demo")
+			obj.SetName("sample")
+			obj.SetUID(types.UID("uid-" + cfg.Resource))
+			obj.SetAnnotations(map[string]string{
+				AnnotationCreatorSubject: "user-123",
+			})
+			client := fake.NewClientset()
+
+			if err := EnsureResourceRBAC(context.Background(), client, obj, cfg); err != nil {
+				t.Fatalf("EnsureResourceRBAC: %v", err)
+			}
+
+			roles, err := client.RbacV1().Roles("holos-prj-demo").List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("list roles: %v", err)
+			}
+			if len(roles.Items) != 3 {
+				t.Fatalf("roles = %d, want 3", len(roles.Items))
+			}
+
+			gotVerbs := make(map[string][]string)
+			for _, role := range roles.Items {
+				if len(role.OwnerReferences) != 1 {
+					t.Fatalf("Role %q ownerRefs = %d, want 1", role.Name, len(role.OwnerReferences))
+				}
+				assertOwnerRef(t, role.OwnerReferences[0], cfg, "sample", types.UID("uid-"+cfg.Resource))
+				if len(role.Rules) == 0 {
+					t.Fatalf("Role %q has no rules", role.Name)
+				}
+				rule := role.Rules[0]
+				if len(rule.APIGroups) != 1 || rule.APIGroups[0] != TemplatesAPIGroup {
+					t.Fatalf("Role %q apiGroups = %v", role.Name, rule.APIGroups)
+				}
+				if len(rule.Resources) != 1 || rule.Resources[0] != cfg.Resource {
+					t.Fatalf("Role %q resources = %v, want %s", role.Name, rule.Resources, cfg.Resource)
+				}
+				if len(rule.ResourceNames) != 1 || rule.ResourceNames[0] != "sample" {
+					t.Fatalf("Role %q resourceNames = %v, want sample", role.Name, rule.ResourceNames)
+				}
+				gotVerbs[RoleFromLabels(role.Labels)] = append([]string(nil), rule.Verbs...)
+			}
+			assertStringSlice(t, gotVerbs[RoleViewer], []string{"get"})
+			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get", "update", "patch"})
+			assertStringSlice(t, gotVerbs[RoleOwner], []string{"get", "update", "patch", "delete"})
+
+			bindings, err := client.RbacV1().RoleBindings("holos-prj-demo").List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("list rolebindings: %v", err)
+			}
+			if len(bindings.Items) != 1 {
+				t.Fatalf("rolebindings = %d, want 1", len(bindings.Items))
+			}
+			rb := bindings.Items[0]
+			if len(rb.OwnerReferences) != 1 {
+				t.Fatalf("RoleBinding ownerRefs = %d, want 1", len(rb.OwnerReferences))
+			}
+			assertOwnerRef(t, rb.OwnerReferences[0], cfg, "sample", types.UID("uid-"+cfg.Resource))
+			if rb.Subjects[0].Name != "oidc:user-123" {
+				t.Fatalf("RoleBinding subject = %q, want oidc:user-123", rb.Subjects[0].Name)
+			}
+			if rb.RoleRef.Name != RoleName("sample", cfg, RoleOwner) {
+				t.Fatalf("RoleBinding roleRef = %q, want owner role", rb.RoleRef.Name)
+			}
+		})
+	}
+}
+
+func TestEnsureResourceRBACWithoutCreatorSubjectCreatesRolesOnly(t *testing.T) {
+	obj := Templates.NewObject()
+	obj.SetNamespace("holos-prj-demo")
+	obj.SetName("sample")
+	obj.SetUID("uid-template")
+	client := fake.NewClientset()
+
+	if err := EnsureResourceRBAC(context.Background(), client, obj, Templates); err != nil {
+		t.Fatalf("EnsureResourceRBAC: %v", err)
+	}
+	bindings, err := client.RbacV1().RoleBindings("holos-prj-demo").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list rolebindings: %v", err)
+	}
+	if len(bindings.Items) != 0 {
+		t.Fatalf("rolebindings = %d, want 0", len(bindings.Items))
+	}
+}
+
+func TestResourceRoleOwnerIncludesSharingDelegation(t *testing.T) {
+	roles := ResourceRoles("holos-prj-demo", "sample", TemplatePolicies, nil)
+	var owner *metav1.ObjectMeta
+	var ownerRules int
+	for _, role := range roles {
+		if RoleFromLabels(role.Labels) == RoleOwner {
+			owner = &role.ObjectMeta
+			ownerRules = len(role.Rules)
+		}
+	}
+	if owner == nil {
+		t.Fatal("owner role not found")
+	}
+	if ownerRules != 3 {
+		t.Fatalf("owner role rules = %d, want resource rule plus sharing delegation rules", ownerRules)
+	}
+}
+
+func assertOwnerRef(t *testing.T, got metav1.OwnerReference, cfg KindConfig, name string, uid types.UID) {
+	t.Helper()
+	if got.APIVersion != templatesv1alpha1.GroupVersion.String() {
+		t.Fatalf("owner apiVersion = %q, want %q", got.APIVersion, templatesv1alpha1.GroupVersion.String())
+	}
+	if got.Kind != cfg.Kind {
+		t.Fatalf("owner kind = %q, want %q", got.Kind, cfg.Kind)
+	}
+	if got.Name != name {
+		t.Fatalf("owner name = %q, want %q", got.Name, name)
+	}
+	if got.UID != uid {
+		t.Fatalf("owner uid = %q, want %q", got.UID, uid)
+	}
+	if got.Controller == nil || !*got.Controller {
+		t.Fatalf("owner controller = %v, want true", got.Controller)
+	}
+	if got.BlockOwnerDeletion == nil || !*got.BlockOwnerDeletion {
+		t.Fatalf("owner blockOwnerDeletion = %v, want true", got.BlockOwnerDeletion)
+	}
+}
+
+func assertStringSlice(t *testing.T, got, want []string) {
+	t.Helper()
+	got = append([]string(nil), got...)
+	want = append([]string(nil), want...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("verbs = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("verbs = %v, want %v", got, want)
+		}
+	}
+}

--- a/console/resourcerbac/reconciler.go
+++ b/console/resourcerbac/reconciler.go
@@ -1,0 +1,58 @@
+package resourcerbac
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Reconciler keeps per-resource RBAC objects in sync for one
+// templates.holos.run kind.
+type Reconciler struct {
+	Client client.Client
+	Kube   kubernetes.Interface
+	Config KindConfig
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	obj, ok := r.Config.NewObject().(client.Object)
+	if !ok {
+		return ctrl.Result{}, fmt.Errorf("%s RBAC object does not implement client.Object", r.Config.Kind)
+	}
+	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if err := EnsureResourceRBAC(ctx, r.Kube, obj, r.Config); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	obj, ok := r.Config.NewObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("%s RBAC object does not implement client.Object", r.Config.Kind)
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(r.Config.ControllerName).
+		For(obj).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Complete(r)
+}
+
+func setup(mgr ctrl.Manager, kube kubernetes.Interface, cfg KindConfig) error {
+	return (&Reconciler{
+		Client: mgr.GetClient(),
+		Kube:   kube,
+		Config: cfg,
+	}).SetupWithManager(mgr)
+}

--- a/console/resourcerbac/templatedependencies_reconciler.go
+++ b/console/resourcerbac/templatedependencies_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupTemplateDependencyReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, TemplateDependencies)
+}

--- a/console/resourcerbac/templategrants_reconciler.go
+++ b/console/resourcerbac/templategrants_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupTemplateGrantReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, TemplateGrants)
+}

--- a/console/resourcerbac/templatepolicies_reconciler.go
+++ b/console/resourcerbac/templatepolicies_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupTemplatePolicyReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, TemplatePolicies)
+}

--- a/console/resourcerbac/templatepolicybindings_reconciler.go
+++ b/console/resourcerbac/templatepolicybindings_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupTemplatePolicyBindingReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, TemplatePolicyBindings)
+}

--- a/console/resourcerbac/templaterequirements_reconciler.go
+++ b/console/resourcerbac/templaterequirements_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupTemplateRequirementReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, TemplateRequirements)
+}

--- a/console/resourcerbac/templates_reconciler.go
+++ b/console/resourcerbac/templates_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupTemplateReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, Templates)
+}

--- a/console/rpc/impersonation.go
+++ b/console/rpc/impersonation.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"connectrpc.com/connect"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,26 @@ func NewImpersonatedClients(claims *Claims, base *rest.Config, scheme *runtime.S
 		Groups:   PrefixedOIDCGroups(claims.Roles),
 	}
 	return newClientsForConfig(config, scheme)
+}
+
+// ImpersonationInterceptor builds per-request Kubernetes clients from the
+// authenticated OIDC claims already stored on the request context. It is kept
+// separate from auth so handlers can migrate to Impersonated*FromContext
+// without depending on a particular token verifier implementation.
+func ImpersonationInterceptor(base *rest.Config, scheme *runtime.Scheme) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			clients, err := NewImpersonatedClients(ClaimsFromContext(ctx), base, scheme)
+			if err != nil {
+				if errors.Is(err, ErrUnauthenticatedImpersonation) {
+					return nil, connect.NewError(connect.CodeUnauthenticated, err)
+				}
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
+			ctx = ContextWithImpersonatedClients(ctx, clients)
+			return next(ctx, req)
+		}
+	}
 }
 
 // PrefixedOIDCGroups maps OIDC group claims into the Kubernetes principal

--- a/console/rpc/impersonation_test.go
+++ b/console/rpc/impersonation_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"connectrpc.com/connect"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,6 +47,44 @@ func TestNewImpersonatedClientsAddsOIDCImpersonationHeaders(t *testing.T) {
 	}
 	if got.Get("Impersonate-Extra-Email") != "" {
 		t.Fatalf("Impersonate-Extra-Email = %q, want empty", got.Get("Impersonate-Extra-Email"))
+	}
+}
+
+func TestImpersonationInterceptorBuildsClientsFromClaimsContext(t *testing.T) {
+	headers := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers <- r.Header.Clone()
+		writeNamespaceList(t, w)
+	}))
+	defer server.Close()
+
+	interceptor := ImpersonationInterceptor(testRESTConfig(server.URL), nil)
+	handler := interceptor(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		if !HasImpersonatedClients(ctx) {
+			t.Fatal("impersonated clients missing from context")
+		}
+		if _, err := ImpersonatedDynamicClientFromContext(ctx).Resource(schema.GroupVersionResource{
+			Version:  "v1",
+			Resource: "namespaces",
+		}).List(ctx, metav1.ListOptions{}); err != nil {
+			t.Fatalf("list namespaces through impersonated dynamic client: %v", err)
+		}
+		return nil, nil
+	})
+	ctx := ContextWithClaims(context.Background(), &Claims{
+		Sub:   "subject-123",
+		Roles: []string{"platform-admins"},
+	})
+
+	if _, err := handler(ctx, connect.NewRequest[any](nil)); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+	got := <-headers
+	if got.Get("Impersonate-User") != "oidc:subject-123" {
+		t.Fatalf("Impersonate-User = %q, want oidc:subject-123", got.Get("Impersonate-User"))
+	}
+	if got.Get("Impersonate-Group") != "oidc:platform-admins" {
+		t.Fatalf("Impersonate-Group = %q, want oidc:platform-admins", got.Get("Impersonate-Group"))
 	}
 }
 

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -39,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,6 +51,7 @@ import (
 	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
 	v1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	"github.com/holos-run/holos-console/console/deployments"
+	"github.com/holos-run/holos-console/console/resourcerbac"
 )
 
 var controllerRuntimeLoggerMu sync.Mutex
@@ -222,6 +224,10 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 	}
 
 	m := &Manager{mgr: mgr, cacheSyncTimeout: cacheSyncTimeout, logger: logger}
+	rbacClientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("controller.NewManager: building RBAC clientset: %w", err)
+	}
 
 	// Register the three reconcilers. Each reconciler owns its own event
 	// recorder keyed by controller name so emitted events are attributable
@@ -295,6 +301,25 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 		Validator: grantCache,
 	}).SetupWithManager(mgr); err != nil {
 		return nil, fmt.Errorf("controller.NewManager: registering TemplateRequirementReconciler: %w", err)
+	}
+
+	if err := resourcerbac.SetupTemplateReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering Template RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupTemplatePolicyReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplatePolicy RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupTemplatePolicyBindingReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplatePolicyBinding RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupTemplateGrantReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplateGrant RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupTemplateDependencyReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplateDependency RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupTemplateRequirementReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering TemplateRequirement RBAC reconciler: %w", err)
 	}
 
 	// Prime the Namespace informer so the reconcilers (HOL-621+) can read


### PR DESCRIPTION
## Summary
- split Kubernetes impersonation into an explicit ConnectRPC interceptor wired after auth
- add shared template-family per-resource RBAC builders and reconcilers for six template kinds
- register the RBAC reconcilers with the embedded controller manager

Fixes HOL-1062

## Test plan
- [x] go test ./console/rpc
- [x] go test ./console/resourcerbac
- [x] go test ./internal/controller
- [x] make test-go