### PR TITLE
feat(console): add top resource RBAC reconcilers

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -44,11 +44,13 @@ const (
 	ResourceTypeTemplateGrant = "template-grant"
 
 	// Annotations.
-	AnnotationDisplayName  = "console.holos.run/display-name"
-	AnnotationDescription  = "console.holos.run/description"
-	AnnotationCreatorEmail = "console.holos.run/creator-email"
-	AnnotationShareUsers   = "console.holos.run/share-users"
-	AnnotationShareRoles   = "console.holos.run/share-roles"
+	AnnotationDisplayName    = "console.holos.run/display-name"
+	AnnotationDescription    = "console.holos.run/description"
+	AnnotationCreatorEmail   = "console.holos.run/creator-email"
+	AnnotationCreatorSubject = "console.holos.run/creator-sub"
+	AnnotationShareUsers     = "console.holos.run/share-users"
+	AnnotationShareRoles     = "console.holos.run/share-roles"
+	AnnotationRBACShareUsers = "console.holos.run/rbac-share-users"
 	// AnnotationDefaultShareUsers specifies the default share users annotation.
 	// This annotation appears on org, folder, and project namespaces and drives
 	// the default-share cascade chain applied when a new Secret is created

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -48,11 +48,13 @@
 #ResourceTypeTemplateGrant: "template-grant"
 
 // Annotations.
-#AnnotationDisplayName:  "console.holos.run/display-name"
-#AnnotationDescription:  "console.holos.run/description"
-#AnnotationCreatorEmail: "console.holos.run/creator-email"
-#AnnotationShareUsers:   "console.holos.run/share-users"
-#AnnotationShareRoles:   "console.holos.run/share-roles"
+#AnnotationDisplayName:    "console.holos.run/display-name"
+#AnnotationDescription:    "console.holos.run/description"
+#AnnotationCreatorEmail:   "console.holos.run/creator-email"
+#AnnotationCreatorSubject: "console.holos.run/creator-sub"
+#AnnotationShareUsers:     "console.holos.run/share-users"
+#AnnotationShareRoles:     "console.holos.run/share-roles"
+#AnnotationRBACShareUsers: "console.holos.run/rbac-share-users"
 
 // AnnotationDefaultShareUsers specifies the default share users annotation.
 // This annotation appears on org, folder, and project namespaces and drives

--- a/config/holos-console/admission/admission_test.go
+++ b/config/holos-console/admission/admission_test.go
@@ -1,0 +1,139 @@
+package admission_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	envtesthelpers "github.com/holos-run/holos-console/internal/envtest"
+)
+
+func TestNamespaceShareAnnotationsPolicyProtectsLabelsAndShares(t *testing.T) {
+	data, err := os.ReadFile("namespace-share-annotations-console-only.yaml")
+	if err != nil {
+		t.Fatalf("reading policy: %v", err)
+	}
+	docs := envtesthelpers.SplitYAMLDocuments(data)
+	if len(docs) == 0 {
+		t.Fatal("policy file has no YAML documents")
+	}
+
+	policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	if err := yaml.Unmarshal(docs[0], policy); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+
+	var matchExpression string
+	for _, condition := range policy.Spec.MatchConditions {
+		if condition.Name == "console-managed-or-share-annotated-namespace" {
+			matchExpression = condition.Expression
+			break
+		}
+	}
+	for _, want := range []string{
+		`app.kubernetes.io/managed-by`,
+		`console.holos.run/share-users`,
+		`console.holos.run/share-roles`,
+		`console.holos.run/default-share-users`,
+		`console.holos.run/default-share-roles`,
+		`console.holos.run/default-folder`,
+		`console.holos.run/rbac-share-users`,
+		`console.holos.run/creator-email`,
+		`console.holos.run/creator-sub`,
+		`console.holos.run/resource-type`,
+		`console.holos.run/organization`,
+		`console.holos.run/folder`,
+		`console.holos.run/project`,
+		`console.holos.run/parent`,
+	} {
+		if !strings.Contains(matchExpression, want) {
+			t.Fatalf("match condition does not cover %q: %s", want, matchExpression)
+		}
+	}
+
+	for _, name := range []string{
+		"oldShareUsers",
+		"newShareUsers",
+		"oldShareRoles",
+		"newShareRoles",
+		"oldDefaultShareUsers",
+		"newDefaultShareUsers",
+		"oldDefaultShareRoles",
+		"newDefaultShareRoles",
+		"oldDefaultFolder",
+		"newDefaultFolder",
+		"oldRBACShareUsers",
+		"newRBACShareUsers",
+		"oldCreatorEmail",
+		"newCreatorEmail",
+		"oldCreatorSubject",
+		"newCreatorSubject",
+		"oldManagedBy",
+		"newManagedBy",
+		"oldResourceType",
+		"newResourceType",
+		"oldOrganization",
+		"newOrganization",
+		"oldFolder",
+		"newFolder",
+		"oldProject",
+		"newProject",
+		"oldParent",
+		"newParent",
+	} {
+		assertPolicyVariable(t, policy, name)
+	}
+
+	if len(policy.Spec.Validations) != 1 {
+		t.Fatalf("validations = %d, want 1", len(policy.Spec.Validations))
+	}
+	validation := policy.Spec.Validations[0].Expression
+	for _, want := range []string{
+		`variables.oldShareUsers == variables.newShareUsers`,
+		`variables.oldShareRoles == variables.newShareRoles`,
+		`variables.oldDefaultShareUsers == variables.newDefaultShareUsers`,
+		`variables.oldDefaultShareRoles == variables.newDefaultShareRoles`,
+		`variables.oldDefaultFolder == variables.newDefaultFolder`,
+		`variables.oldRBACShareUsers == variables.newRBACShareUsers`,
+		`variables.oldCreatorEmail == variables.newCreatorEmail`,
+		`variables.oldCreatorSubject == variables.newCreatorSubject`,
+		`variables.oldManagedBy == variables.newManagedBy`,
+		`variables.oldResourceType == variables.newResourceType`,
+		`variables.oldOrganization == variables.newOrganization`,
+		`variables.oldFolder == variables.newFolder`,
+		`variables.oldProject == variables.newProject`,
+		`variables.oldParent == variables.newParent`,
+	} {
+		if !strings.Contains(validation, want) {
+			t.Fatalf("validation does not enforce %q: %s", want, validation)
+		}
+	}
+
+	for _, name := range []string{"excluded-holos-console", "excluded-cluster-admins"} {
+		if !hasMatchCondition(policy, name) {
+			t.Fatalf("missing match condition %q", name)
+		}
+	}
+}
+
+func assertPolicyVariable(t *testing.T, policy *admissionregistrationv1.ValidatingAdmissionPolicy, name string) {
+	t.Helper()
+	for _, variable := range policy.Spec.Variables {
+		if variable.Name == name {
+			return
+		}
+	}
+	t.Fatalf("missing policy variable %q", name)
+}
+
+func hasMatchCondition(policy *admissionregistrationv1.ValidatingAdmissionPolicy, name string) bool {
+	for _, condition := range policy.Spec.MatchConditions {
+		if condition.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/config/holos-console/admission/kustomization.yaml
+++ b/config/holos-console/admission/kustomization.yaml
@@ -4,6 +4,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- namespace-share-annotations-console-only.yaml
 - renderstate-folder-or-org-only.yaml
 - templatedependency-project-only.yaml
 - templategrant-namespace-allowed.yaml

--- a/config/holos-console/admission/namespace-share-annotations-console-only.yaml
+++ b/config/holos-console/admission/namespace-share-annotations-console-only.yaml
@@ -1,0 +1,77 @@
+# Namespace share annotations drive generated Kubernetes RBAC. Direct
+# namespace patch rights must not let a principal grant itself a stronger
+# RoleBinding, so share mutations go through holos-console's checked RPC path.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: namespace-share-annotations-console-only
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["namespaces"]
+  matchConditions:
+  - name: console-managed-namespace
+    expression: >-
+      (
+        has(oldObject.metadata.labels)
+        && "app.kubernetes.io/managed-by" in oldObject.metadata.labels
+        && oldObject.metadata.labels["app.kubernetes.io/managed-by"] == "console.holos.run"
+      )
+      || (
+        has(object.metadata.labels)
+        && "app.kubernetes.io/managed-by" in object.metadata.labels
+        && object.metadata.labels["app.kubernetes.io/managed-by"] == "console.holos.run"
+      )
+  - name: excluded-holos-console
+    expression: >-
+      request.userInfo.username != "system:serviceaccount:holos-system:holos-console"
+  variables:
+  - name: oldShareUsers
+    expression: >-
+      has(oldObject.metadata.annotations)
+      && "console.holos.run/share-users" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/share-users"]
+      : ""
+  - name: newShareUsers
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/share-users" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/share-users"]
+      : ""
+  - name: oldShareRoles
+    expression: >-
+      has(oldObject.metadata.annotations)
+      && "console.holos.run/share-roles" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/share-roles"]
+      : ""
+  - name: newShareRoles
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/share-roles" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/share-roles"]
+      : ""
+  validations:
+  - expression: >-
+      variables.oldShareUsers == variables.newShareUsers
+      && variables.oldShareRoles == variables.newShareRoles
+    message: "Namespace share annotations can only be changed through the holos-console service account."
+    reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: namespace-share-annotations-console-only
+spec:
+  policyName: namespace-share-annotations-console-only
+  validationActions:
+  - Deny
+  matchResources:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["namespaces"]

--- a/config/holos-console/admission/namespace-share-annotations-console-only.yaml
+++ b/config/holos-console/admission/namespace-share-annotations-console-only.yaml
@@ -11,28 +11,78 @@ spec:
     resourceRules:
     - apiGroups: [""]
       apiVersions: ["v1"]
-      operations: ["UPDATE"]
+      operations: ["CREATE", "UPDATE"]
       resources: ["namespaces"]
   matchConditions:
-  - name: console-managed-namespace
+  - name: console-managed-or-share-annotated-namespace
     expression: >-
       (
-        has(oldObject.metadata.labels)
-        && "app.kubernetes.io/managed-by" in oldObject.metadata.labels
-        && oldObject.metadata.labels["app.kubernetes.io/managed-by"] == "console.holos.run"
+        oldObject != null
+        && has(oldObject.metadata.labels)
+        && (
+          (
+            "app.kubernetes.io/managed-by" in oldObject.metadata.labels
+            && oldObject.metadata.labels["app.kubernetes.io/managed-by"] == "console.holos.run"
+          )
+          || "console.holos.run/resource-type" in oldObject.metadata.labels
+          || "console.holos.run/organization" in oldObject.metadata.labels
+          || "console.holos.run/folder" in oldObject.metadata.labels
+          || "console.holos.run/project" in oldObject.metadata.labels
+          || "console.holos.run/parent" in oldObject.metadata.labels
+        )
       )
       || (
         has(object.metadata.labels)
-        && "app.kubernetes.io/managed-by" in object.metadata.labels
-        && object.metadata.labels["app.kubernetes.io/managed-by"] == "console.holos.run"
+        && (
+          (
+            "app.kubernetes.io/managed-by" in object.metadata.labels
+            && object.metadata.labels["app.kubernetes.io/managed-by"] == "console.holos.run"
+          )
+          || "console.holos.run/resource-type" in object.metadata.labels
+          || "console.holos.run/organization" in object.metadata.labels
+          || "console.holos.run/folder" in object.metadata.labels
+          || "console.holos.run/project" in object.metadata.labels
+          || "console.holos.run/parent" in object.metadata.labels
+        )
+      )
+      || (
+        oldObject != null
+        && has(oldObject.metadata.annotations)
+        && (
+          "console.holos.run/share-users" in oldObject.metadata.annotations
+          || "console.holos.run/share-roles" in oldObject.metadata.annotations
+          || "console.holos.run/default-share-users" in oldObject.metadata.annotations
+          || "console.holos.run/default-share-roles" in oldObject.metadata.annotations
+          || "console.holos.run/default-folder" in oldObject.metadata.annotations
+          || "console.holos.run/rbac-share-users" in oldObject.metadata.annotations
+          || "console.holos.run/creator-email" in oldObject.metadata.annotations
+          || "console.holos.run/creator-sub" in oldObject.metadata.annotations
+        )
+      )
+      || (
+        has(object.metadata.annotations)
+        && (
+          "console.holos.run/share-users" in object.metadata.annotations
+          || "console.holos.run/share-roles" in object.metadata.annotations
+          || "console.holos.run/default-share-users" in object.metadata.annotations
+          || "console.holos.run/default-share-roles" in object.metadata.annotations
+          || "console.holos.run/default-folder" in object.metadata.annotations
+          || "console.holos.run/rbac-share-users" in object.metadata.annotations
+          || "console.holos.run/creator-email" in object.metadata.annotations
+          || "console.holos.run/creator-sub" in object.metadata.annotations
+        )
       )
   - name: excluded-holos-console
     expression: >-
       request.userInfo.username != "system:serviceaccount:holos-system:holos-console"
+  - name: excluded-cluster-admins
+    expression: >-
+      !("system:masters" in request.userInfo.groups)
   variables:
   - name: oldShareUsers
     expression: >-
-      has(oldObject.metadata.annotations)
+      oldObject != null
+      && has(oldObject.metadata.annotations)
       && "console.holos.run/share-users" in oldObject.metadata.annotations
       ? oldObject.metadata.annotations["console.holos.run/share-users"]
       : ""
@@ -44,7 +94,8 @@ spec:
       : ""
   - name: oldShareRoles
     expression: >-
-      has(oldObject.metadata.annotations)
+      oldObject != null
+      && has(oldObject.metadata.annotations)
       && "console.holos.run/share-roles" in oldObject.metadata.annotations
       ? oldObject.metadata.annotations["console.holos.run/share-roles"]
       : ""
@@ -54,11 +105,198 @@ spec:
       && "console.holos.run/share-roles" in object.metadata.annotations
       ? object.metadata.annotations["console.holos.run/share-roles"]
       : ""
+  - name: oldDefaultShareUsers
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.annotations)
+      && "console.holos.run/default-share-users" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/default-share-users"]
+      : ""
+  - name: newDefaultShareUsers
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/default-share-users" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/default-share-users"]
+      : ""
+  - name: oldDefaultShareRoles
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.annotations)
+      && "console.holos.run/default-share-roles" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/default-share-roles"]
+      : ""
+  - name: newDefaultShareRoles
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/default-share-roles" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/default-share-roles"]
+      : ""
+  - name: oldDefaultFolder
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.annotations)
+      && "console.holos.run/default-folder" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/default-folder"]
+      : ""
+  - name: newDefaultFolder
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/default-folder" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/default-folder"]
+      : ""
+  - name: oldRBACShareUsers
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.annotations)
+      && "console.holos.run/rbac-share-users" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/rbac-share-users"]
+      : ""
+  - name: newRBACShareUsers
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/rbac-share-users" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/rbac-share-users"]
+      : ""
+  - name: oldCreatorSubject
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.annotations)
+      && "console.holos.run/creator-sub" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/creator-sub"]
+      : ""
+  - name: newCreatorSubject
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/creator-sub" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/creator-sub"]
+      : ""
+  - name: oldCreatorEmail
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.annotations)
+      && "console.holos.run/creator-email" in oldObject.metadata.annotations
+      ? oldObject.metadata.annotations["console.holos.run/creator-email"]
+      : ""
+  - name: newCreatorEmail
+    expression: >-
+      has(object.metadata.annotations)
+      && "console.holos.run/creator-email" in object.metadata.annotations
+      ? object.metadata.annotations["console.holos.run/creator-email"]
+      : ""
+  - name: oldManagedBy
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.labels)
+      && "app.kubernetes.io/managed-by" in oldObject.metadata.labels
+      ? oldObject.metadata.labels["app.kubernetes.io/managed-by"]
+      : ""
+  - name: newManagedBy
+    expression: >-
+      has(object.metadata.labels)
+      && "app.kubernetes.io/managed-by" in object.metadata.labels
+      ? object.metadata.labels["app.kubernetes.io/managed-by"]
+      : ""
+  - name: oldResourceType
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.labels)
+      && "console.holos.run/resource-type" in oldObject.metadata.labels
+      ? oldObject.metadata.labels["console.holos.run/resource-type"]
+      : ""
+  - name: newResourceType
+    expression: >-
+      has(object.metadata.labels)
+      && "console.holos.run/resource-type" in object.metadata.labels
+      ? object.metadata.labels["console.holos.run/resource-type"]
+      : ""
+  - name: oldOrganization
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.labels)
+      && "console.holos.run/organization" in oldObject.metadata.labels
+      ? oldObject.metadata.labels["console.holos.run/organization"]
+      : ""
+  - name: newOrganization
+    expression: >-
+      has(object.metadata.labels)
+      && "console.holos.run/organization" in object.metadata.labels
+      ? object.metadata.labels["console.holos.run/organization"]
+      : ""
+  - name: oldFolder
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.labels)
+      && "console.holos.run/folder" in oldObject.metadata.labels
+      ? oldObject.metadata.labels["console.holos.run/folder"]
+      : ""
+  - name: newFolder
+    expression: >-
+      has(object.metadata.labels)
+      && "console.holos.run/folder" in object.metadata.labels
+      ? object.metadata.labels["console.holos.run/folder"]
+      : ""
+  - name: oldProject
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.labels)
+      && "console.holos.run/project" in oldObject.metadata.labels
+      ? oldObject.metadata.labels["console.holos.run/project"]
+      : ""
+  - name: newProject
+    expression: >-
+      has(object.metadata.labels)
+      && "console.holos.run/project" in object.metadata.labels
+      ? object.metadata.labels["console.holos.run/project"]
+      : ""
+  - name: oldParent
+    expression: >-
+      oldObject != null
+      && has(oldObject.metadata.labels)
+      && "console.holos.run/parent" in oldObject.metadata.labels
+      ? oldObject.metadata.labels["console.holos.run/parent"]
+      : ""
+  - name: newParent
+    expression: >-
+      has(object.metadata.labels)
+      && "console.holos.run/parent" in object.metadata.labels
+      ? object.metadata.labels["console.holos.run/parent"]
+      : ""
   validations:
   - expression: >-
-      variables.oldShareUsers == variables.newShareUsers
-      && variables.oldShareRoles == variables.newShareRoles
-    message: "Namespace share annotations can only be changed through the holos-console service account."
+      request.operation == "CREATE"
+      ? (
+        variables.newShareUsers == ""
+        && variables.newShareRoles == ""
+        && variables.newDefaultShareUsers == ""
+        && variables.newDefaultShareRoles == ""
+        && variables.newDefaultFolder == ""
+        && variables.newRBACShareUsers == ""
+        && variables.newCreatorSubject == ""
+        && variables.newCreatorEmail == ""
+        && variables.newManagedBy == ""
+        && variables.newResourceType == ""
+        && variables.newOrganization == ""
+        && variables.newFolder == ""
+        && variables.newProject == ""
+        && variables.newParent == ""
+      )
+      : (
+        variables.oldShareUsers == variables.newShareUsers
+        && variables.oldShareRoles == variables.newShareRoles
+        && variables.oldDefaultShareUsers == variables.newDefaultShareUsers
+        && variables.oldDefaultShareRoles == variables.newDefaultShareRoles
+        && variables.oldDefaultFolder == variables.newDefaultFolder
+        && variables.oldRBACShareUsers == variables.newRBACShareUsers
+        && variables.oldCreatorSubject == variables.newCreatorSubject
+        && variables.oldCreatorEmail == variables.newCreatorEmail
+        && variables.oldManagedBy == variables.newManagedBy
+        && variables.oldResourceType == variables.newResourceType
+        && variables.oldOrganization == variables.newOrganization
+        && variables.oldFolder == variables.newFolder
+        && variables.oldProject == variables.newProject
+        && variables.oldParent == variables.newParent
+      )
+    message: "Namespace share annotations and console classification labels can only be changed through the holos-console service account."
     reason: Forbidden
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -73,5 +311,5 @@ spec:
     resourceRules:
     - apiGroups: [""]
       apiVersions: ["v1"]
-      operations: ["UPDATE"]
+      operations: ["CREATE", "UPDATE"]
       resources: ["namespaces"]

--- a/config/holos-console/rbac/rbac_test.go
+++ b/config/holos-console/rbac/rbac_test.go
@@ -72,6 +72,24 @@ func TestRoleGrantsImpersonationAndRBACReconciliation(t *testing.T) {
 	if !hasRule(role.Rules, wantRoleBindings) {
 		t.Fatalf("ClusterRole missing RoleBinding reconciliation rule %+v in rules: %+v", wantRoleBindings, role.Rules)
 	}
+
+	wantClusterRoles := rbacv1.PolicyRule{
+		APIGroups: []string{"rbac.authorization.k8s.io"},
+		Resources: []string{"clusterroles"},
+		Verbs:     []string{"bind", "create", "delete", "escalate", "get", "list", "patch", "update", "watch"},
+	}
+	if !hasRule(role.Rules, wantClusterRoles) {
+		t.Fatalf("ClusterRole missing ClusterRole reconciliation rule %+v in rules: %+v", wantClusterRoles, role.Rules)
+	}
+
+	wantClusterRoleBindings := rbacv1.PolicyRule{
+		APIGroups: []string{"rbac.authorization.k8s.io"},
+		Resources: []string{"clusterrolebindings"},
+		Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
+	}
+	if !hasRule(role.Rules, wantClusterRoleBindings) {
+		t.Fatalf("ClusterRole missing ClusterRoleBinding reconciliation rule %+v in rules: %+v", wantClusterRoleBindings, role.Rules)
+	}
 }
 
 func TestClusterRoleBindingTargetsConsoleServiceAccount(t *testing.T) {
@@ -122,13 +140,26 @@ func mustReadYAML(t *testing.T, path string, out any) {
 func hasRule(rules []rbacv1.PolicyRule, want rbacv1.PolicyRule) bool {
 	for _, rule := range rules {
 		if reflect.DeepEqual(rule.APIGroups, want.APIGroups) &&
-			reflect.DeepEqual(rule.Resources, want.Resources) &&
+			containsAll(rule.Resources, want.Resources) &&
 			reflect.DeepEqual(rule.ResourceNames, want.ResourceNames) &&
 			reflect.DeepEqual(rule.Verbs, want.Verbs) {
 			return true
 		}
 	}
 	return false
+}
+
+func containsAll(got, want []string) bool {
+	seen := make(map[string]struct{}, len(got))
+	for _, value := range got {
+		seen[value] = struct{}{}
+	}
+	for _, value := range want {
+		if _, ok := seen[value]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func hasResource(rules []rbacv1.PolicyRule, apiGroup, resource string) bool {

--- a/config/holos-console/rbac/role.yaml
+++ b/config/holos-console/rbac/role.yaml
@@ -61,6 +61,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
   - rolebindings
   verbs:
   - create
@@ -73,6 +74,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterroles
   - roles
   verbs:
   - bind

--- a/console/folders/handler.go
+++ b/console/folders/handler.go
@@ -240,7 +240,7 @@ func (h *Handler) CreateFolder(
 	const maxCreateRetries = 3
 	for attempt := range maxCreateRetries + 1 {
 		_, err = h.k8s.CreateFolder(ctx, name, req.Msg.DisplayName, req.Msg.Description,
-			req.Msg.Organization, parentNs, claims.Email, shareUsers, shareRoles, nil, nil)
+			req.Msg.Organization, parentNs, claims.Email, claims.Sub, shareUsers, shareRoles, nil, nil)
 		if err == nil {
 			break
 		}
@@ -642,7 +642,17 @@ func (h *Handler) UpdateFolderSharing(
 	newShareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
 	newShareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
 
-	updated, err := h.k8s.UpdateFolderSharing(ctx, req.Msg.Name, newShareUsers, newShareRoles)
+	storedCreator := secrets.UserIdentity{
+		Email:   ns.Annotations[v1alpha2.AnnotationCreatorEmail],
+		Subject: ns.Annotations[v1alpha2.AnnotationCreatorSubject],
+	}
+	rbacShareUsers := secrets.RBACUserGrantsForSubjects(
+		newShareUsers,
+		storedCreator,
+		secrets.UserIdentity{Email: claims.Email, Subject: claims.Sub},
+	)
+
+	updated, err := h.k8s.UpdateFolderSharing(ctx, req.Msg.Name, newShareUsers, newShareRoles, rbacShareUsers)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}

--- a/console/folders/k8s.go
+++ b/console/folders/k8s.go
@@ -123,7 +123,7 @@ func (c *K8sClient) NamespaceExists(ctx context.Context, nsName string) (bool, e
 // populate_defaults=true.
 func (c *K8sClient) CreateFolder(
 	ctx context.Context,
-	name, displayName, description, org, parentNs, creatorEmail string,
+	name, displayName, description, org, parentNs, creatorEmail, creatorSubject string,
 	shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant,
 ) (*corev1.Namespace, error) {
 	nsName := c.Resolver.FolderNamespace(name)
@@ -167,6 +167,17 @@ func (c *K8sClient) CreateFolder(
 	}
 	if creatorEmail != "" {
 		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
+	}
+	if creatorSubject != "" {
+		annotations[v1alpha2.AnnotationCreatorSubject] = creatorSubject
+	}
+	rbacShareUsers := secrets.RBACUserGrantsForSubjects(shareUsers, secrets.UserIdentity{Email: creatorEmail, Subject: creatorSubject})
+	if len(rbacShareUsers) > 0 {
+		rbacUsersJSON, err := json.Marshal(rbacShareUsers)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling rbac-share-users: %w", err)
+		}
+		annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsersJSON)
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -243,7 +254,7 @@ func (c *K8sClient) DeleteFolder(ctx context.Context, name string) error {
 }
 
 // UpdateFolderSharing updates the sharing annotations on a folder.
-func (c *K8sClient) UpdateFolderSharing(ctx context.Context, name string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (c *K8sClient) UpdateFolderSharing(ctx context.Context, name string, shareUsers, shareRoles, rbacShareUsers []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	slog.DebugContext(ctx, "updating folder sharing in kubernetes",
 		slog.String("name", name),
 	)
@@ -262,8 +273,13 @@ func (c *K8sClient) UpdateFolderSharing(ctx context.Context, name string, shareU
 	if err != nil {
 		return nil, fmt.Errorf("marshaling share-roles: %w", err)
 	}
+	rbacUsersJSON, err := json.Marshal(rbacShareUsers)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling rbac-share-users: %w", err)
+	}
 	ns.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
 	ns.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
+	ns.Annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsersJSON)
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 
@@ -371,8 +387,8 @@ type FolderCreatorAdapter struct {
 // share grants so that the seeded default folder inherits the org's default
 // role grants and propagates them as its own default-share cascade (matching
 // the ancestor-default-share merge done by folders.Handler.CreateFolder).
-func (a *FolderCreatorAdapter) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
-	return a.K8s.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+func (a *FolderCreatorAdapter) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+	return a.K8s.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, creatorSubject, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 }
 
 // DeleteFolder delegates to the K8sClient.

--- a/console/folders/k8s_test.go
+++ b/console/folders/k8s_test.go
@@ -119,7 +119,7 @@ func TestCreateFolder_CreatesNamespaceWithLabels(t *testing.T) {
 	k8s := NewK8sClient(fakeClient, testResolver())
 
 	shareUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
-	result, err := k8s.CreateFolder(context.Background(), "eng", "Engineering", "Eng team", "acme", "holos-org-acme", "alice@example.com", shareUsers, nil, nil, nil)
+	result, err := k8s.CreateFolder(context.Background(), "eng", "Engineering", "Eng team", "acme", "holos-org-acme", "alice@example.com", "", shareUsers, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -188,7 +188,7 @@ func TestUpdateFolderSharing_UpdatesAnnotations(t *testing.T) {
 	k8s := NewK8sClient(fakeClient, testResolver())
 
 	newUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
-	result, err := k8s.UpdateFolderSharing(context.Background(), "eng", newUsers, nil)
+	result, err := k8s.UpdateFolderSharing(context.Background(), "eng", newUsers, nil, newUsers)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/console/oidc/token_exchange.go
+++ b/console/oidc/token_exchange.go
@@ -198,6 +198,22 @@ func encodeSubject(userID, connID string) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
+// TestUserSubjectForEmail returns the OIDC sub claim minted by the embedded
+// Dex dev-token endpoint for a static test user email.
+func TestUserSubjectForEmail(email string) (string, bool) {
+	for i := range TestUsers {
+		if TestUsers[i].Email != email {
+			continue
+		}
+		subject, err := encodeSubject(TestUsers[i].UserID, "holos")
+		if err != nil {
+			return "", false
+		}
+		return subject, true
+	}
+	return "", false
+}
+
 // signatureAlgorithm determines the JWS algorithm for the given key.
 // This mirrors Dex's signatureAlgorithm function.
 func signatureAlgorithm(jwk *jose.JSONWebKey) (jose.SignatureAlgorithm, error) {

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -37,7 +37,7 @@ type ProjectLister interface {
 // inherits the org's default role grants via the same merge logic
 // folders.Handler.CreateFolder applies to user-initiated folder creates.
 type FolderCreator interface {
-	CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
+	CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
 	DeleteFolder(ctx context.Context, name string) error
 	NamespaceExists(ctx context.Context, nsName string) (bool, error)
 }
@@ -59,7 +59,7 @@ type TemplateSeeder interface {
 // pattern as FolderCreator. DeleteProject is needed for rollback when later
 // seeding steps fail.
 type ProjectCreator interface {
-	CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error
+	CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error
 	DeleteProject(ctx context.Context, name string) error
 	NamespaceExists(ctx context.Context, nsName string) (bool, error)
 }
@@ -235,7 +235,7 @@ func (h *Handler) CreateOrganization(
 	// Ensure creator is included as owner
 	shareUsers = ensureCreatorOwner(shareUsers, claims.Email)
 
-	if _, err := h.k8s.CreateOrganization(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, claims.Email, shareUsers, shareRoles); err != nil {
+	if _, err := h.k8s.CreateOrganization(ctx, req.Msg.Name, req.Msg.DisplayName, req.Msg.Description, claims.Email, claims.Sub, shareUsers, shareRoles); err != nil {
 		return nil, mapK8sError(err)
 	}
 
@@ -271,7 +271,7 @@ func (h *Handler) CreateOrganization(
 		}
 
 		var err error
-		folderName, err = h.createDefaultFolder(ctx, req.Msg.Name, folderDisplayName, claims.Email, shareUsers, shareRoles)
+		folderName, err = h.createDefaultFolder(ctx, req.Msg.Name, folderDisplayName, claims.Email, claims.Sub, shareUsers, shareRoles)
 		if err != nil {
 			// Rollback: delete the org namespace on default folder failure.
 			// The folder namespace does not exist yet (creation failed), so
@@ -311,7 +311,7 @@ func (h *Handler) CreateOrganization(
 
 	// Seed example resources when populate_defaults is requested.
 	if req.Msg.GetPopulateDefaults() {
-		if err := h.seedDefaults(ctx, req.Msg.Name, claims.Email, shareUsers, shareRoles); err != nil {
+		if err := h.seedDefaults(ctx, req.Msg.Name, claims.Email, claims.Sub, shareUsers, shareRoles); err != nil {
 			slog.ErrorContext(ctx, "populate defaults failed, rolling back org",
 				slog.String("organization", req.Msg.Name),
 				slog.Any("error", err),
@@ -356,7 +356,7 @@ func (h *Handler) CreateOrganization(
 // projects.ProjectGrantResolver.GetDefaultGrants. Persisting a snapshot on the
 // folder itself would cause later changes to org default sharing to be
 // shadowed by stale folder defaults.
-func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (string, error) {
+func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName, creatorEmail, creatorSubject string, shareUsers, shareRoles []secrets.AnnotationGrant) (string, error) {
 	exists := func(ctx context.Context, nsName string) (bool, error) {
 		return h.folderCreator.NamespaceExists(ctx, nsName)
 	}
@@ -383,7 +383,7 @@ func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName,
 	// Pass nil for the folder's own default-share grants. Descendants resolve
 	// the org defaults dynamically via the ancestor walk, so persisting a copy
 	// here would cause stale defaults to shadow future org changes.
-	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, folderShareUsers, folderShareRoles, nil, nil); err != nil {
+	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, creatorSubject, folderShareUsers, folderShareRoles, nil, nil); err != nil {
 		return "", fmt.Errorf("creating folder namespace: %w", err)
 	}
 	return folderName, nil
@@ -442,7 +442,7 @@ func roleAnnotationString(r rbac.Role) string {
 //
 // Each step performs incremental rollback of resources it created on failure.
 // The caller is responsible for rolling back the org and folder namespaces.
-func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
+func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail, creatorSubject string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
 	if h.templateSeeder == nil || h.projectCreator == nil {
 		return fmt.Errorf("defaults seeder not configured")
 	}
@@ -484,7 +484,7 @@ func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail string
 	projectShareUsers := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareUsers...), orgDefaultUsers...))
 	projectShareRoles := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareRoles...), orgDefaultRoles...))
 
-	if err := h.projectCreator.CreateProject(ctx, projectName, projectDisplayName, "", orgName, parentNs, creatorEmail, projectShareUsers, projectShareRoles, orgDefaultUsers, orgDefaultRoles); err != nil {
+	if err := h.projectCreator.CreateProject(ctx, projectName, projectDisplayName, "", orgName, parentNs, creatorEmail, creatorSubject, projectShareUsers, projectShareRoles, orgDefaultUsers, orgDefaultRoles); err != nil {
 		return fmt.Errorf("creating default project: %w", err)
 	}
 
@@ -722,7 +722,17 @@ func (h *Handler) UpdateOrganizationSharing(
 	newShareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
 	newShareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
 
-	updated, err := h.k8s.UpdateOrganizationSharing(ctx, req.Msg.Name, newShareUsers, newShareRoles)
+	storedCreator := secrets.UserIdentity{
+		Email:   ns.Annotations[v1alpha2.AnnotationCreatorEmail],
+		Subject: ns.Annotations[v1alpha2.AnnotationCreatorSubject],
+	}
+	rbacShareUsers := secrets.RBACUserGrantsForSubjects(
+		newShareUsers,
+		storedCreator,
+		secrets.UserIdentity{Email: claims.Email, Subject: claims.Sub},
+	)
+
+	updated, err := h.k8s.UpdateOrganizationSharing(ctx, req.Msg.Name, newShareUsers, newShareRoles, rbacShareUsers)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -106,12 +106,12 @@ func newTestHandlerWithOpts(opts testHandlerOpts, namespaces ...*corev1.Namespac
 type k8sFolderCreator struct {
 	client   *fake.Clientset
 	resolver *resolver.Resolver
-	createFn func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
+	createFn func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
 }
 
-func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	if f.createFn != nil {
-		return f.createFn(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+		return f.createFn(ctx, name, displayName, description, org, parentNs, creatorEmail, creatorSubject, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	}
 	usersJSON, _ := json.Marshal(shareUsers)
 	rolesJSON, _ := json.Marshal(shareRoles)
@@ -132,6 +132,9 @@ func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, 
 	}
 	if creatorEmail != "" {
 		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
+	}
+	if creatorSubject != "" {
+		annotations[v1alpha2.AnnotationCreatorSubject] = creatorSubject
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1026,7 +1029,7 @@ func TestCreateOrganization_RollbackOnFolderFailure(t *testing.T) {
 	failFC := &k8sFolderCreator{
 		client:   fakeClient,
 		resolver: r,
-		createFn: func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+		createFn: func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 			return nil, fmt.Errorf("simulated folder creation failure")
 		},
 	}
@@ -1431,7 +1434,7 @@ type k8sProjectCreator struct {
 	createErr error
 }
 
-func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error {
+func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error {
 	if p.createErr != nil {
 		return p.createErr
 	}
@@ -1454,6 +1457,9 @@ func (p *k8sProjectCreator) CreateProject(ctx context.Context, name, displayName
 	}
 	if creatorEmail != "" {
 		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
+	}
+	if creatorSubject != "" {
+		annotations[v1alpha2.AnnotationCreatorSubject] = creatorSubject
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1527,6 +1533,9 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 		projectNs, err := pc.client.CoreV1().Namespaces().Get(context.Background(), projectNsName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected default project namespace %q to exist, got %v", projectNsName, err)
+		}
+		if got, want := projectNs.Annotations[v1alpha2.AnnotationCreatorSubject], "sub-alice@example.com"; got != want {
+			t.Fatalf("expected default project creator-sub annotation %q, got %q", want, got)
 		}
 
 		// Verify the seeded project inherited the org's default role grants
@@ -2041,14 +2050,14 @@ type orderingFolderCreator struct {
 	seenDefaultRolesAnnotation bool
 }
 
-func (o *orderingFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (o *orderingFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	ns, err := o.k8s.GetOrganization(ctx, org)
 	if err == nil && ns.Annotations != nil {
 		if _, ok := ns.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
 			o.seenDefaultRolesAnnotation = true
 		}
 	}
-	return o.inner.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+	return o.inner.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, creatorSubject, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 }
 
 func (o *orderingFolderCreator) DeleteFolder(ctx context.Context, name string) error {

--- a/console/organizations/k8s.go
+++ b/console/organizations/k8s.go
@@ -82,7 +82,7 @@ func (c *K8sClient) GetOrganization(ctx context.Context, name string) (*corev1.N
 }
 
 // CreateOrganization creates a new namespace with organization labels and annotations.
-func (c *K8sClient) CreateOrganization(ctx context.Context, name, displayName, description, creatorEmail string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (c *K8sClient) CreateOrganization(ctx context.Context, name, displayName, description, creatorEmail, creatorSubject string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	nsName := c.resolver.OrgNamespace(name)
 	slog.DebugContext(ctx, "creating organization in kubernetes",
 		slog.String("name", name),
@@ -108,6 +108,17 @@ func (c *K8sClient) CreateOrganization(ctx context.Context, name, displayName, d
 	}
 	if creatorEmail != "" {
 		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
+	}
+	if creatorSubject != "" {
+		annotations[v1alpha2.AnnotationCreatorSubject] = creatorSubject
+	}
+	rbacShareUsers := secrets.RBACUserGrantsForSubjects(shareUsers, secrets.UserIdentity{Email: creatorEmail, Subject: creatorSubject})
+	if len(rbacShareUsers) > 0 {
+		rbacUsersJSON, err := json.Marshal(rbacShareUsers)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling rbac-share-users: %w", err)
+		}
+		annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsersJSON)
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -227,7 +238,7 @@ func (c *K8sClient) SetGatewayNamespace(ctx context.Context, name, value string)
 }
 
 // UpdateOrganizationSharing updates the sharing annotations on an organization namespace.
-func (c *K8sClient) UpdateOrganizationSharing(ctx context.Context, name string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (c *K8sClient) UpdateOrganizationSharing(ctx context.Context, name string, shareUsers, shareRoles, rbacShareUsers []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	slog.DebugContext(ctx, "updating organization sharing in kubernetes",
 		slog.String("name", name),
 	)
@@ -246,8 +257,13 @@ func (c *K8sClient) UpdateOrganizationSharing(ctx context.Context, name string, 
 	if err != nil {
 		return nil, fmt.Errorf("marshaling share-roles: %w", err)
 	}
+	rbacUsersJSON, err := json.Marshal(rbacShareUsers)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling rbac-share-users: %w", err)
+	}
 	ns.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
 	ns.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
+	ns.Annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsersJSON)
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 

--- a/console/organizations/k8s_test.go
+++ b/console/organizations/k8s_test.go
@@ -188,7 +188,7 @@ func TestCreateOrganization_CreatesNamespaceWithPrefixAndLabels(t *testing.T) {
 	k8s := NewK8sClient(fakeClient, testResolver())
 
 	shareUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
-	result, err := k8s.CreateOrganization(context.Background(), "acme", "ACME Corp", "Test org", "", shareUsers, nil)
+	result, err := k8s.CreateOrganization(context.Background(), "acme", "ACME Corp", "Test org", "", "", shareUsers, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -217,7 +217,7 @@ func TestCreateOrganization_SetsOrganizationLabel(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "", nil, nil)
+	result, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -239,7 +239,7 @@ func TestCreateOrganization_ReturnsAlreadyExists(t *testing.T) {
 	fakeClient := fake.NewClientset(existing)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	_, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "", nil, nil)
+	_, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -512,7 +512,7 @@ func TestUpdateOrgSharing_UpdatesAnnotations(t *testing.T) {
 	newGroups := []secrets.AnnotationGrant{
 		{Principal: "engineering", Role: "viewer"},
 	}
-	result, err := k8s.UpdateOrganizationSharing(context.Background(), "acme", newUsers, newGroups)
+	result, err := k8s.UpdateOrganizationSharing(context.Background(), "acme", newUsers, newGroups, newUsers)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -753,7 +753,7 @@ func TestUpdateOrgSharing_RejectsNonOrg(t *testing.T) {
 	fakeClient := fake.NewClientset(ns)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	_, err := k8s.UpdateOrganizationSharing(context.Background(), "fake", nil, nil)
+	_, err := k8s.UpdateOrganizationSharing(context.Background(), "fake", nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -763,7 +763,7 @@ func TestCreateOrganization_StoresCreatorEmailAnnotation(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "creator@example.com", nil, nil)
+	result, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "creator@example.com", "", nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -776,7 +776,7 @@ func TestCreateOrganization_EmptyCreatorEmail_NoAnnotation(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "", nil, nil)
+	result, err := k8s.CreateOrganization(context.Background(), "acme", "", "", "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -329,10 +329,8 @@ func (h *Handler) CreateProject(
 	// Keep the legacy project metadata grant email-shaped for UI display, but
 	// bind the RBAC owner to the stable OIDC subject per ADR 036.
 	shareUsers = ensureCreatorOwner(shareUsers, claims.Email)
-	rbacShareUsers := removeGrantPrincipal(shareUsers, claims.Email)
-	if claims.Sub != "" {
-		rbacShareUsers = ensureCreatorOwner(rbacShareUsers, claims.Sub)
-	}
+	rbacShareUsers := secrets.RBACUserGrantsForSubjects(shareUsers, secrets.UserIdentity{Email: claims.Email, Subject: claims.Sub})
+	topResourceRBACUsers := rbacShareUsers
 
 	// Create the project namespace, retrying on AlreadyExists when the name was
 	// auto-generated (race between GenerateIdentifier check and K8s create).
@@ -342,7 +340,7 @@ func (h *Handler) CreateProject(
 	// single branch.
 	const maxCreateRetries = 3
 	for attempt := range maxCreateRetries + 1 {
-		err = h.createProjectOnce(ctx, name, req.Msg, parentNs, claims.Email, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles, rbacShareUsers)
+		err = h.createProjectOnce(ctx, name, req.Msg, parentNs, claims.Email, claims.Sub, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles, rbacShareUsers, topResourceRBACUsers)
 		if err == nil {
 			break
 		}
@@ -394,8 +392,10 @@ func (h *Handler) createProjectOnce(
 	msg *consolev1.CreateProjectRequest,
 	parentNs string,
 	creatorEmail string,
+	creatorSubject string,
 	shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant,
 	rbacShareUsers []secrets.AnnotationGrant,
+	topResourceRBACUsers []secrets.AnnotationGrant,
 ) error {
 	// Always build the base Namespace object up front — both paths need
 	// it (the typed Create call still uses it, and the pipeline needs
@@ -403,6 +403,19 @@ func (h *Handler) createProjectOnce(
 	baseNs, err := h.k8s.BuildProjectNamespace(name, msg.DisplayName, msg.Description, msg.Organization, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	if err != nil {
 		return err
+	}
+	if baseNs.Annotations == nil {
+		baseNs.Annotations = make(map[string]string)
+	}
+	if len(topResourceRBACUsers) > 0 {
+		raw, err := json.Marshal(topResourceRBACUsers)
+		if err != nil {
+			return fmt.Errorf("marshaling rbac-share-users: %w", err)
+		}
+		baseNs.Annotations[v1alpha2.AnnotationRBACShareUsers] = string(raw)
+	}
+	if creatorSubject != "" {
+		baseNs.Annotations[v1alpha2.AnnotationCreatorSubject] = creatorSubject
 	}
 
 	// Pipeline (HOL-812): resolve ProjectNamespace bindings; if any
@@ -771,7 +784,17 @@ func (h *Handler) UpdateProjectSharing(
 	newShareUsers := shareGrantsToAnnotations(req.Msg.UserGrants)
 	newShareRoles := shareGrantsToAnnotations(req.Msg.RoleGrants)
 
-	updated, err := h.k8s.UpdateProjectSharing(ctx, req.Msg.Name, newShareUsers, newShareRoles)
+	storedCreator := secrets.UserIdentity{
+		Email:   ns.Annotations[v1alpha2.AnnotationCreatorEmail],
+		Subject: ns.Annotations[v1alpha2.AnnotationCreatorSubject],
+	}
+	rbacShareUsers := secrets.RBACUserGrantsForSubjects(
+		newShareUsers,
+		storedCreator,
+		secrets.UserIdentity{Email: claims.Email, Subject: claims.Sub},
+	)
+
+	updated, err := h.k8s.UpdateProjectSharing(ctx, req.Msg.Name, newShareUsers, newShareRoles, rbacShareUsers)
 	if err != nil {
 		return nil, mapK8sError(err)
 	}
@@ -1199,21 +1222,6 @@ func ensureCreatorOwner(shareUsers []secrets.AnnotationGrant, principal string) 
 		}
 	}
 	return append(shareUsers, secrets.AnnotationGrant{Principal: principal, Role: "owner"})
-}
-
-func removeGrantPrincipal(grants []secrets.AnnotationGrant, principal string) []secrets.AnnotationGrant {
-	if principal == "" {
-		return append([]secrets.AnnotationGrant(nil), grants...)
-	}
-	principalLower := strings.ToLower(principal)
-	filtered := make([]secrets.AnnotationGrant, 0, len(grants))
-	for _, grant := range grants {
-		if strings.ToLower(grant.Principal) == principalLower {
-			continue
-		}
-		filtered = append(filtered, grant)
-	}
-	return filtered
 }
 
 // mapK8sError converts Kubernetes API errors to ConnectRPC errors. The

--- a/console/projects/k8s.go
+++ b/console/projects/k8s.go
@@ -161,7 +161,7 @@ func (c *K8sClient) BuildProjectNamespace(name, displayName, description, org, p
 // CreateProject creates a new namespace with managed-by and resource-type labels.
 // parentNs is the Kubernetes namespace name of the immediate parent (org or folder namespace).
 // When non-empty, it is stored in the v1alpha2.AnnotationParent label for hierarchy traversal.
-func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	slog.DebugContext(ctx, "creating project in kubernetes",
 		slog.String("name", name),
 		slog.String("namespace", c.Resolver.ProjectNamespace(name)),
@@ -170,6 +170,23 @@ func (c *K8sClient) CreateProject(ctx context.Context, name, displayName, descri
 	ns, err := c.BuildProjectNamespace(name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	if err != nil {
 		return nil, err
+	}
+	if creatorSubject != "" {
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		ns.Annotations[v1alpha2.AnnotationCreatorSubject] = creatorSubject
+	}
+	rbacShareUsers := secrets.RBACUserGrantsForSubjects(shareUsers, secrets.UserIdentity{Email: creatorEmail, Subject: creatorSubject})
+	if len(rbacShareUsers) > 0 {
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		rbacUsersJSON, err := json.Marshal(rbacShareUsers)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling rbac-share-users: %w", err)
+		}
+		ns.Annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsersJSON)
 	}
 	return c.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 }
@@ -356,7 +373,7 @@ func (c *K8sClient) DeleteProject(ctx context.Context, name string) error {
 }
 
 // UpdateProjectSharing updates the sharing annotations on a managed namespace.
-func (c *K8sClient) UpdateProjectSharing(ctx context.Context, name string, shareUsers, shareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
+func (c *K8sClient) UpdateProjectSharing(ctx context.Context, name string, shareUsers, shareRoles, rbacShareUsers []secrets.AnnotationGrant) (*corev1.Namespace, error) {
 	slog.DebugContext(ctx, "updating project sharing in kubernetes",
 		slog.String("name", name),
 	)
@@ -375,8 +392,13 @@ func (c *K8sClient) UpdateProjectSharing(ctx context.Context, name string, share
 	if err != nil {
 		return nil, fmt.Errorf("marshaling share-roles: %w", err)
 	}
+	rbacUsersJSON, err := json.Marshal(rbacShareUsers)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling rbac-share-users: %w", err)
+	}
 	ns.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
 	ns.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
+	ns.Annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsersJSON)
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 
@@ -513,8 +535,8 @@ type ProjectCreatorAdapter struct {
 // CreateProject creates a project namespace, forwarding default sharing grants
 // so that seeded default projects inherit org-level defaults, mirroring the
 // production path in projects.Handler.CreateProject.
-func (a *ProjectCreatorAdapter) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error {
-	_, err := a.K8s.CreateProject(ctx, name, displayName, description, org, parentNs, creatorEmail, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
+func (a *ProjectCreatorAdapter) CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error {
+	_, err := a.K8s.CreateProject(ctx, name, displayName, description, org, parentNs, creatorEmail, creatorSubject, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
 	return err
 }
 

--- a/console/projects/k8s_test.go
+++ b/console/projects/k8s_test.go
@@ -257,7 +257,7 @@ func TestCreateProject_UsesPrefixNamespace(t *testing.T) {
 	shareUsers := []secrets.AnnotationGrant{{Principal: "alice@example.com", Role: "owner"}}
 	shareRoles := []secrets.AnnotationGrant{{Principal: "engineering", Role: "editor"}}
 
-	result, err := k8s.CreateProject(context.Background(), "new-project", "New Project", "A test project", "acme", "", "", shareUsers, shareRoles, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "new-project", "New Project", "A test project", "acme", "", "", "", shareUsers, shareRoles, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -282,7 +282,7 @@ func TestCreateProject_SetsOrgLabelWhenProvided(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "acme", "", "", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "acme", "", "", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -295,7 +295,7 @@ func TestCreateProject_OmitsOrgLabelWhenEmpty(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "", "", "", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "foo", "", "", "", "", "", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -318,7 +318,7 @@ func TestCreateProject_ReturnsAlreadyExistsForDuplicateName(t *testing.T) {
 	fakeClient := fake.NewClientset(existing)
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	_, err := k8s.CreateProject(context.Background(), "existing", "", "", "", "", "", nil, nil, nil, nil)
+	_, err := k8s.CreateProject(context.Background(), "existing", "", "", "", "", "", "", nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -593,7 +593,7 @@ func TestUpdateProjectSharing_UpdatesShareAnnotations(t *testing.T) {
 		{Principal: "engineering", Role: "viewer"},
 	}
 
-	result, err := k8s.UpdateProjectSharing(context.Background(), "my-project", newUsers, newGroups)
+	result, err := k8s.UpdateProjectSharing(context.Background(), "my-project", newUsers, newGroups, newUsers)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -610,7 +610,7 @@ func TestCreateProject_StoresCreatorEmailAnnotation(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", "creator@example.com", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", "creator@example.com", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -619,11 +619,24 @@ func TestCreateProject_StoresCreatorEmailAnnotation(t *testing.T) {
 	}
 }
 
+func TestCreateProject_StoresCreatorSubjectAnnotation(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	k8s := NewK8sClient(fakeClient, testResolver())
+
+	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", "", "user-123", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Annotations[v1alpha2.AnnotationCreatorSubject] != "user-123" {
+		t.Errorf("expected creator-sub annotation %q, got %q", "user-123", result.Annotations[v1alpha2.AnnotationCreatorSubject])
+	}
+}
+
 func TestCreateProject_EmptyCreatorEmail_NoAnnotation(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	k8s := NewK8sClient(fakeClient, testResolver())
 
-	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", "", nil, nil, nil, nil)
+	result, err := k8s.CreateProject(context.Background(), "my-project", "", "", "acme", "", "", "", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/console/projects/projectapply/applier_envtest_test.go
+++ b/console/projects/projectapply/applier_envtest_test.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	crdmgrtesting "github.com/holos-run/holos-console/console/crdmgr/testing"
@@ -95,11 +96,51 @@ func newEnvtestApplier(t *testing.T) (*Applier, dynamic.Interface, *crdmgrtestin
 		// StartManager already issued t.Skip.
 		return nil, nil, nil
 	}
-	dyn, err := dynamic.NewForConfig(env.Cfg)
+	ensureConsoleServiceAccountRBAC(t, env)
+	cfg := rest.CopyConfig(env.Cfg)
+	cfg.Impersonate.UserName = "system:serviceaccount:holos-system:holos-console"
+	cfg.Impersonate.Groups = []string{
+		"system:serviceaccounts",
+		"system:serviceaccounts:holos-system",
+		"system:authenticated",
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
 	if err != nil {
 		t.Fatalf("constructing dynamic client: %v", err)
 	}
 	return NewApplier(dyn, DefaultGVRResolver{}), dyn, env
+}
+
+func ensureConsoleServiceAccountRBAC(t *testing.T, env *crdmgrtesting.Env) {
+	t.Helper()
+	ctx := context.Background()
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "holos-console-projectapply-envtest"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		}},
+	}
+	if err := env.Direct.Create(ctx, role); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating envtest ClusterRole: %v", err)
+	}
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "holos-console-projectapply-envtest"},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      "holos-console",
+			Namespace: "holos-system",
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     role.Name,
+		},
+	}
+	if err := env.Direct.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating envtest ClusterRoleBinding: %v", err)
+	}
 }
 
 // namespaceUnstructured constructs the unstructured Namespace the

--- a/console/resourcerbac/folders_reconciler.go
+++ b/console/resourcerbac/folders_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupFolderReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, Folders)
+}

--- a/console/resourcerbac/organizations_reconciler.go
+++ b/console/resourcerbac/organizations_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupOrganizationReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, Organizations)
+}

--- a/console/resourcerbac/projects_reconciler.go
+++ b/console/resourcerbac/projects_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupProjectReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, Projects)
+}

--- a/console/resourcerbac/rbac.go
+++ b/console/resourcerbac/rbac.go
@@ -269,9 +269,6 @@ func resourceRules(name string, cfg KindConfig, role string) []rbacv1.PolicyRule
 	switch NormalizeRole(role) {
 	case RoleEditor:
 		verbs = editorVerbs()
-		if cfg.ClusterScoped {
-			verbs = viewerVerbs()
-		}
 	case RoleOwner:
 		verbs = ownerVerbs()
 		extraRules = ownerRules(name, cfg)
@@ -286,6 +283,13 @@ func resourceRules(name string, cfg KindConfig, role string) []rbacv1.PolicyRule
 		ResourceNames: []string{name},
 		Verbs:         verbs,
 	}}
+	if cfg.ClusterScoped {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{apiGroup},
+			Resources: []string{cfg.Resource},
+			Verbs:     []string{"list", "watch"},
+		})
+	}
 	return append(rules, extraRules...)
 }
 
@@ -514,9 +518,7 @@ func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj
 			return err
 		}
 		for _, grant := range activeGrants(users, now) {
-			if isSubjectPrincipal(grant.Principal) {
-				addDesired(ShareTargetUser, grant)
-			}
+			addDesired(ShareTargetUser, grant)
 		}
 		groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
 		if err != nil {
@@ -578,9 +580,7 @@ func reconcileClusterRoleBindings(ctx context.Context, client kubernetes.Interfa
 		return err
 	}
 	for _, grant := range activeGrants(users, now) {
-		if isSubjectPrincipal(grant.Principal) {
-			addDesired(ShareTargetUser, grant)
-		}
+		addDesired(ShareTargetUser, grant)
 	}
 	groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
 	if err != nil {
@@ -628,11 +628,6 @@ func activeGrants(grants []secrets.AnnotationGrant, now time.Time) []secrets.Ann
 		filtered = append(filtered, grant)
 	}
 	return secrets.DeduplicateGrants(filtered)
-}
-
-func isSubjectPrincipal(principal string) bool {
-	principal = strings.TrimSpace(principal)
-	return principal != "" && !strings.Contains(principal, "@")
 }
 
 // NextGrantRequeueAfter returns the delay until the next share annotation

--- a/console/resourcerbac/rbac.go
+++ b/console/resourcerbac/rbac.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
@@ -56,6 +57,7 @@ type KindConfig struct {
 	ObjectName      func(metav1.Object) string
 	RBACNamespace   func(metav1.Object) string
 	Matches         func(metav1.Object) bool
+	ClusterScoped   bool
 }
 
 var (
@@ -130,6 +132,7 @@ var (
 		OwnerKind:       "Namespace",
 		ObjectName:      namespaceObjectName,
 		RBACNamespace:   namespaceRBACNamespace,
+		ClusterScoped:   true,
 		Matches: func(obj metav1.Object) bool {
 			// TODO(HOL-1061 cleanup): delete this generic Resource surface
 			// when console/resources is retired; until then it mirrors the
@@ -152,6 +155,7 @@ func namespaceKindConfig(kind, rolePurpose, controllerName, resourceType string)
 		OwnerKind:       "Namespace",
 		ObjectName:      namespaceObjectName,
 		RBACNamespace:   namespaceRBACNamespace,
+		ClusterScoped:   true,
 		Matches: func(obj metav1.Object) bool {
 			return isManagedNamespace(obj) && obj.GetLabels()[v1alpha2.LabelResourceType] == resourceType
 		},
@@ -201,12 +205,15 @@ func EnsureResourceRBAC(ctx context.Context, client kubernetes.Interface, obj me
 		return fmt.Errorf("resource namespace and name are required")
 	}
 	ownerRefs := OwnerReferences(obj, cfg)
+	if cfg.ClusterScoped {
+		return ensureClusterResourceRBAC(ctx, client, obj, cfg, name, ownerRefs, time.Now())
+	}
 	for _, role := range ResourceRoles(namespace, name, cfg, ownerRefs) {
 		if err := applyRole(ctx, client, role); err != nil {
 			return fmt.Errorf("applying %s role %q: %w", cfg.Kind, role.Name, err)
 		}
 	}
-	return reconcileRoleBindings(ctx, client, obj, cfg, namespace, name, ownerRefs)
+	return reconcileRoleBindings(ctx, client, obj, cfg, namespace, name, ownerRefs, time.Now())
 }
 
 func creatorSubject(obj metav1.Object) string {
@@ -219,13 +226,53 @@ func creatorSubject(obj metav1.Object) string {
 
 func ResourceRoles(namespace, name string, cfg KindConfig, ownerRefs []metav1.OwnerReference) []*rbacv1.Role {
 	return []*rbacv1.Role{
-		resourceRole(namespace, name, cfg, RoleViewer, viewerVerbs(), nil, ownerRefs),
-		resourceRole(namespace, name, cfg, RoleEditor, editorVerbs(), nil, ownerRefs),
-		resourceRole(namespace, name, cfg, RoleOwner, ownerVerbs(), ownerRules(name, cfg), ownerRefs),
+		resourceRole(namespace, name, cfg, RoleViewer, ownerRefs),
+		resourceRole(namespace, name, cfg, RoleEditor, ownerRefs),
+		resourceRole(namespace, name, cfg, RoleOwner, ownerRefs),
 	}
 }
 
-func resourceRole(namespace, name string, cfg KindConfig, role string, verbs []string, extraRules []rbacv1.PolicyRule, ownerRefs []metav1.OwnerReference) *rbacv1.Role {
+func resourceRole(namespace, name string, cfg KindConfig, role string, ownerRefs []metav1.OwnerReference) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleName(name, cfg, role),
+			Namespace:       namespace,
+			Labels:          RoleLabels(name, cfg, role),
+			OwnerReferences: ownerRefs,
+		},
+		Rules: resourceRules(name, cfg, role),
+	}
+}
+
+func ClusterResourceRoles(name string, cfg KindConfig, ownerRefs []metav1.OwnerReference) []*rbacv1.ClusterRole {
+	return []*rbacv1.ClusterRole{
+		clusterResourceRole(name, cfg, RoleViewer, ownerRefs),
+		clusterResourceRole(name, cfg, RoleEditor, ownerRefs),
+		clusterResourceRole(name, cfg, RoleOwner, ownerRefs),
+	}
+}
+
+func clusterResourceRole(name string, cfg KindConfig, role string, ownerRefs []metav1.OwnerReference) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleName(name, cfg, role),
+			Labels:          RoleLabels(name, cfg, role),
+			OwnerReferences: ownerRefs,
+		},
+		Rules: resourceRules(name, cfg, role),
+	}
+}
+
+func resourceRules(name string, cfg KindConfig, role string) []rbacv1.PolicyRule {
+	verbs := viewerVerbs()
+	var extraRules []rbacv1.PolicyRule
+	switch NormalizeRole(role) {
+	case RoleEditor:
+		verbs = editorVerbs()
+	case RoleOwner:
+		verbs = ownerVerbs()
+		extraRules = ownerRules(name, cfg)
+	}
 	apiGroup := cfg.APIGroup
 	if cfg.APIGroup == "" && cfg.OwnerAPIVersion == "" {
 		apiGroup = TemplatesAPIGroup
@@ -236,16 +283,7 @@ func resourceRole(namespace, name string, cfg KindConfig, role string, verbs []s
 		ResourceNames: []string{name},
 		Verbs:         verbs,
 	}}
-	rules = append(rules, extraRules...)
-	return &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            RoleName(name, cfg, role),
-			Namespace:       namespace,
-			Labels:          RoleLabels(name, cfg, role),
-			OwnerReferences: ownerRefs,
-		},
-		Rules: rules,
-	}
+	return append(rules, extraRules...)
 }
 
 func viewerVerbs() []string {
@@ -261,6 +299,21 @@ func ownerVerbs() []string {
 }
 
 func ownerRules(name string, cfg KindConfig) []rbacv1.PolicyRule {
+	if cfg.ClusterScoped {
+		return []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{rbacv1.GroupName},
+				Resources: []string{"clusterrolebindings"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups:     []string{rbacv1.GroupName},
+				Resources:     []string{"clusterroles"},
+				ResourceNames: []string{RoleName(name, cfg, RoleViewer), RoleName(name, cfg, RoleEditor), RoleName(name, cfg, RoleOwner)},
+				Verbs:         []string{"get", "list", "watch", "bind"},
+			},
+		}
+	}
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{rbacv1.GroupName},
@@ -320,6 +373,33 @@ func RoleBinding(namespace, name string, cfg KindConfig, target, principal, role
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "Role",
+			Name:     RoleName(name, cfg, role),
+		},
+	}
+}
+
+func ClusterRoleBinding(name string, cfg KindConfig, target, principal, role string, ownerRefs []metav1.OwnerReference) *rbacv1.ClusterRoleBinding {
+	target = NormalizeTarget(target)
+	role = NormalizeRole(role)
+	subjectKind := rbacv1.UserKind
+	if target == ShareTargetGroup {
+		subjectKind = rbacv1.GroupKind
+	}
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            RoleBindingName(name, cfg, role, target, principal),
+			Labels:          RoleBindingLabels(name, cfg, target, principal, role),
+			Annotations:     map[string]string{AnnotationShareTargetName: OIDCPrincipal(principal)},
+			OwnerReferences: ownerRefs,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:     subjectKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     OIDCPrincipal(principal),
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
 			Name:     RoleName(name, cfg, role),
 		},
 	}
@@ -422,7 +502,7 @@ func RoleFromLabels(labels map[string]string) string {
 	return RoleViewer
 }
 
-func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj metav1.Object, cfg KindConfig, namespace, name string, ownerRefs []metav1.OwnerReference) error {
+func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj metav1.Object, cfg KindConfig, namespace, name string, ownerRefs []metav1.OwnerReference, now time.Time) error {
 	desired := make(map[string]*rbacv1.RoleBinding)
 	addDesired := func(target string, grant secrets.AnnotationGrant) {
 		if strings.TrimSpace(grant.Principal) == "" {
@@ -438,14 +518,14 @@ func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj
 	if err != nil {
 		return err
 	}
-	for _, grant := range secrets.DeduplicateGrants(users) {
+	for _, grant := range activeGrants(users, now) {
 		addDesired(ShareTargetUser, grant)
 	}
 	groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
 	if err != nil {
 		return err
 	}
-	for _, grant := range secrets.DeduplicateGrants(groups) {
+	for _, grant := range activeGrants(groups, now) {
 		addDesired(ShareTargetGroup, grant)
 	}
 
@@ -472,6 +552,106 @@ func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj
 		}
 	}
 	return nil
+}
+
+func ensureClusterResourceRBAC(ctx context.Context, client kubernetes.Interface, obj metav1.Object, cfg KindConfig, name string, ownerRefs []metav1.OwnerReference, now time.Time) error {
+	for _, role := range ClusterResourceRoles(name, cfg, ownerRefs) {
+		if err := applyClusterRole(ctx, client, role); err != nil {
+			return fmt.Errorf("applying %s cluster role %q: %w", cfg.Kind, role.Name, err)
+		}
+	}
+	return reconcileClusterRoleBindings(ctx, client, obj, cfg, name, ownerRefs, now)
+}
+
+func reconcileClusterRoleBindings(ctx context.Context, client kubernetes.Interface, obj metav1.Object, cfg KindConfig, name string, ownerRefs []metav1.OwnerReference, now time.Time) error {
+	desired := make(map[string]*rbacv1.ClusterRoleBinding)
+	addDesired := func(target string, grant secrets.AnnotationGrant) {
+		if strings.TrimSpace(grant.Principal) == "" {
+			return
+		}
+		binding := ClusterRoleBinding(name, cfg, target, grant.Principal, grant.Role, ownerRefs)
+		desired[binding.Name] = binding
+	}
+	if creatorSub := creatorSubject(obj); creatorSub != "" {
+		addDesired(ShareTargetUser, secrets.AnnotationGrant{Principal: creatorSub, Role: RoleOwner})
+	}
+	users, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
+	if err != nil {
+		return err
+	}
+	for _, grant := range activeGrants(users, now) {
+		addDesired(ShareTargetUser, grant)
+	}
+	groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
+	if err != nil {
+		return err
+	}
+	for _, grant := range activeGrants(groups, now) {
+		addDesired(ShareTargetGroup, grant)
+	}
+
+	selector := labels.SelectorFromSet(labels.Set{
+		LabelRolePurpose:  cfg.RolePurpose,
+		LabelResourceName: name,
+	}).String()
+	current, err := client.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return fmt.Errorf("listing %s cluster role bindings: %w", cfg.Kind, err)
+	}
+	for i := range current.Items {
+		existing := current.Items[i]
+		if _, ok := desired[existing.Name]; ok {
+			continue
+		}
+		if err := client.RbacV1().ClusterRoleBindings().Delete(ctx, existing.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting stale %s cluster role binding %q: %w", cfg.Kind, existing.Name, err)
+		}
+	}
+	for _, binding := range desired {
+		if err := applyClusterRoleBinding(ctx, client, binding); err != nil {
+			return fmt.Errorf("applying %s annotated cluster role binding %q: %w", cfg.Kind, binding.Name, err)
+		}
+	}
+	return nil
+}
+
+func activeGrants(grants []secrets.AnnotationGrant, now time.Time) []secrets.AnnotationGrant {
+	nowUnix := now.Unix()
+	filtered := make([]secrets.AnnotationGrant, 0, len(grants))
+	for _, grant := range grants {
+		if grant.Nbf != nil && *grant.Nbf > nowUnix {
+			continue
+		}
+		if grant.Exp != nil && *grant.Exp <= nowUnix {
+			continue
+		}
+		filtered = append(filtered, grant)
+	}
+	return secrets.DeduplicateGrants(filtered)
+}
+
+// NextGrantRequeueAfter returns the delay until the next share annotation
+// validity boundary. Reconcilers use it to remove expired RoleBindings and
+// add not-yet-active grants without waiting for another object update.
+func NextGrantRequeueAfter(obj metav1.Object, now time.Time) time.Duration {
+	users, _ := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
+	groups, _ := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
+	nowUnix := now.Unix()
+	var next int64
+	for _, grant := range append(users, groups...) {
+		for _, boundary := range [](*int64){grant.Nbf, grant.Exp} {
+			if boundary == nil || *boundary <= nowUnix {
+				continue
+			}
+			if next == 0 || *boundary < next {
+				next = *boundary
+			}
+		}
+	}
+	if next == 0 {
+		return 0
+	}
+	return time.Duration(next-nowUnix) * time.Second
 }
 
 func parseShareGrants(annotations map[string]string, key string) ([]secrets.AnnotationGrant, error) {
@@ -509,6 +689,30 @@ func applyRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.Ro
 	return nil
 }
 
+func applyClusterRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.ClusterRole) error {
+	created, err := client.RbacV1().ClusterRoles().Create(ctx, role, metav1.CreateOptions{})
+	if err == nil {
+		*role = *created
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := client.RbacV1().ClusterRoles().Get(ctx, role.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	existing.Labels = role.Labels
+	existing.Rules = role.Rules
+	existing.OwnerReferences = role.OwnerReferences
+	updated, err := client.RbacV1().ClusterRoles().Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	*role = *updated
+	return nil
+}
+
 func applyRoleBinding(ctx context.Context, client kubernetes.Interface, binding *rbacv1.RoleBinding) error {
 	created, err := client.RbacV1().RoleBindings(binding.Namespace).Create(ctx, binding, metav1.CreateOptions{})
 	if err == nil {
@@ -537,6 +741,41 @@ func applyRoleBinding(ctx context.Context, client kubernetes.Interface, binding 
 	existing.Subjects = binding.Subjects
 	existing.OwnerReferences = binding.OwnerReferences
 	updated, err := client.RbacV1().RoleBindings(binding.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	*binding = *updated
+	return nil
+}
+
+func applyClusterRoleBinding(ctx context.Context, client kubernetes.Interface, binding *rbacv1.ClusterRoleBinding) error {
+	created, err := client.RbacV1().ClusterRoleBindings().Create(ctx, binding, metav1.CreateOptions{})
+	if err == nil {
+		*binding = *created
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing, err := client.RbacV1().ClusterRoleBindings().Get(ctx, binding.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if existing.RoleRef != binding.RoleRef {
+		if err := client.RbacV1().ClusterRoleBindings().Delete(ctx, binding.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		recreated, err := client.RbacV1().ClusterRoleBindings().Create(ctx, binding, metav1.CreateOptions{})
+		if err == nil {
+			*binding = *recreated
+		}
+		return err
+	}
+	existing.Labels = binding.Labels
+	existing.Annotations = binding.Annotations
+	existing.Subjects = binding.Subjects
+	existing.OwnerReferences = binding.OwnerReferences
+	updated, err := client.RbacV1().ClusterRoleBindings().Update(ctx, existing, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/console/resourcerbac/rbac.go
+++ b/console/resourcerbac/rbac.go
@@ -300,19 +300,7 @@ func ownerVerbs() []string {
 
 func ownerRules(name string, cfg KindConfig) []rbacv1.PolicyRule {
 	if cfg.ClusterScoped {
-		return []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{rbacv1.GroupName},
-				Resources: []string{"clusterrolebindings"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
-			},
-			{
-				APIGroups:     []string{rbacv1.GroupName},
-				Resources:     []string{"clusterroles"},
-				ResourceNames: []string{RoleName(name, cfg, RoleViewer), RoleName(name, cfg, RoleEditor), RoleName(name, cfg, RoleOwner)},
-				Verbs:         []string{"get", "list", "watch", "bind"},
-			},
-		}
+		return nil
 	}
 	return []rbacv1.PolicyRule{
 		{
@@ -413,6 +401,9 @@ func RoleBindingName(name string, cfg KindConfig, role, target, principal string
 func OwnerReferences(obj metav1.Object, cfg KindConfig) []metav1.OwnerReference {
 	controller := true
 	blockOwnerDeletion := true
+	if cfg.ClusterScoped {
+		blockOwnerDeletion = false
+	}
 	apiVersion := cfg.OwnerAPIVersion
 	if apiVersion == "" {
 		apiVersion = templatesv1alpha1.GroupVersion.String()

--- a/console/resourcerbac/rbac.go
+++ b/console/resourcerbac/rbac.go
@@ -1,18 +1,22 @@
-// Package resourcerbac provides per-resource RBAC helpers for
-// templates.holos.run resources.
+// Package resourcerbac provides per-resource RBAC helpers for console-owned
+// resources.
 package resourcerbac
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	templatesv1alpha1 "github.com/holos-run/holos-console/api/templates/v1alpha1"
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/rbacname"
+	"github.com/holos-run/holos-console/console/secrets"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -39,14 +43,19 @@ const (
 	OIDCPrefix = "oidc:"
 )
 
-// KindConfig describes the RBAC surface for one templates.holos.run resource
-// kind.
+// KindConfig describes the RBAC surface for one console-managed resource kind.
 type KindConfig struct {
-	Kind           string
-	Resource       string
-	RolePurpose    string
-	ControllerName string
-	NewObject      func() metav1.Object
+	Kind            string
+	Resource        string
+	RolePurpose     string
+	ControllerName  string
+	NewObject       func() metav1.Object
+	APIGroup        string
+	OwnerAPIVersion string
+	OwnerKind       string
+	ObjectName      func(metav1.Object) string
+	RBACNamespace   func(metav1.Object) string
+	Matches         func(metav1.Object) bool
 }
 
 var (
@@ -92,7 +101,62 @@ var (
 		ControllerName: "template-requirement-rbac-controller",
 		NewObject:      func() metav1.Object { return &templatesv1alpha1.TemplateRequirement{} },
 	}
+	Organizations = namespaceKindConfig(
+		"Organization",
+		"organization",
+		"organization-rbac-controller",
+		v1alpha2.ResourceTypeOrganization,
+	)
+	Folders = namespaceKindConfig(
+		"Folder",
+		"folder",
+		"folder-rbac-controller",
+		v1alpha2.ResourceTypeFolder,
+	)
+	Projects = namespaceKindConfig(
+		"Project",
+		"project",
+		"project-rbac-controller",
+		v1alpha2.ResourceTypeProject,
+	)
+	Resources = KindConfig{
+		Kind:            "Resource",
+		Resource:        "namespaces",
+		RolePurpose:     "resource",
+		ControllerName:  "resource-rbac-controller",
+		NewObject:       func() metav1.Object { return &corev1.Namespace{} },
+		APIGroup:        "",
+		OwnerAPIVersion: "v1",
+		OwnerKind:       "Namespace",
+		ObjectName:      namespaceObjectName,
+		RBACNamespace:   namespaceRBACNamespace,
+		Matches: func(obj metav1.Object) bool {
+			// TODO(HOL-1061 cleanup): delete this generic Resource surface
+			// when console/resources is retired; until then it mirrors the
+			// folder/project namespaces currently listed by that handler.
+			resourceType := obj.GetLabels()[v1alpha2.LabelResourceType]
+			return isManagedNamespace(obj) && (resourceType == v1alpha2.ResourceTypeFolder || resourceType == v1alpha2.ResourceTypeProject)
+		},
+	}
 )
+
+func namespaceKindConfig(kind, rolePurpose, controllerName, resourceType string) KindConfig {
+	return KindConfig{
+		Kind:            kind,
+		Resource:        "namespaces",
+		RolePurpose:     rolePurpose,
+		ControllerName:  controllerName,
+		NewObject:       func() metav1.Object { return &corev1.Namespace{} },
+		APIGroup:        "",
+		OwnerAPIVersion: "v1",
+		OwnerKind:       "Namespace",
+		ObjectName:      namespaceObjectName,
+		RBACNamespace:   namespaceRBACNamespace,
+		Matches: func(obj metav1.Object) bool {
+			return isManagedNamespace(obj) && obj.GetLabels()[v1alpha2.LabelResourceType] == resourceType
+		},
+	}
+}
 
 // AllKindConfigs returns every templates.holos.run kind managed by this
 // package.
@@ -107,11 +171,21 @@ func AllKindConfigs() []KindConfig {
 	}
 }
 
-// EnsureResourceRBAC provisions the viewer/editor/owner Roles for obj and,
-// when obj carries console.holos.run/creator-sub, an owner RoleBinding for
-// the creating OIDC subject. Roles and RoleBindings are owner-referenced to
-// obj so Kubernetes garbage collection removes them when the resource is
-// deleted.
+// TopResourceKindConfigs returns the namespace-backed resources managed by
+// the top-level console resource handlers.
+func TopResourceKindConfigs() []KindConfig {
+	return []KindConfig{
+		Organizations,
+		Folders,
+		Projects,
+		Resources,
+	}
+}
+
+// EnsureResourceRBAC provisions the viewer/editor/owner Roles for obj and
+// reconciles RoleBindings from creator/share annotations. Roles and
+// RoleBindings are owner-referenced to obj so Kubernetes garbage collection
+// removes them when the resource is deleted.
 func EnsureResourceRBAC(ctx context.Context, client kubernetes.Interface, obj metav1.Object, cfg KindConfig) error {
 	if client == nil {
 		return fmt.Errorf("resource RBAC client is required")
@@ -119,7 +193,10 @@ func EnsureResourceRBAC(ctx context.Context, client kubernetes.Interface, obj me
 	if obj == nil {
 		return fmt.Errorf("resource object is required")
 	}
-	namespace, name := obj.GetNamespace(), obj.GetName()
+	if !matches(obj, cfg) {
+		return nil
+	}
+	namespace, name := rbacNamespace(obj, cfg), objectName(obj, cfg)
 	if namespace == "" || name == "" {
 		return fmt.Errorf("resource namespace and name are required")
 	}
@@ -129,15 +206,7 @@ func EnsureResourceRBAC(ctx context.Context, client kubernetes.Interface, obj me
 			return fmt.Errorf("applying %s role %q: %w", cfg.Kind, role.Name, err)
 		}
 	}
-	creatorSub := creatorSubject(obj)
-	if creatorSub == "" {
-		return nil
-	}
-	binding := RoleBinding(namespace, name, cfg, ShareTargetUser, creatorSub, RoleOwner, ownerRefs)
-	if err := applyRoleBinding(ctx, client, binding); err != nil {
-		return fmt.Errorf("applying %s owner role binding: %w", cfg.Kind, err)
-	}
-	return nil
+	return reconcileRoleBindings(ctx, client, obj, cfg, namespace, name, ownerRefs)
 }
 
 func creatorSubject(obj metav1.Object) string {
@@ -157,8 +226,12 @@ func ResourceRoles(namespace, name string, cfg KindConfig, ownerRefs []metav1.Ow
 }
 
 func resourceRole(namespace, name string, cfg KindConfig, role string, verbs []string, extraRules []rbacv1.PolicyRule, ownerRefs []metav1.OwnerReference) *rbacv1.Role {
+	apiGroup := cfg.APIGroup
+	if cfg.APIGroup == "" && cfg.OwnerAPIVersion == "" {
+		apiGroup = TemplatesAPIGroup
+	}
 	rules := []rbacv1.PolicyRule{{
-		APIGroups:     []string{TemplatesAPIGroup},
+		APIGroups:     []string{apiGroup},
 		Resources:     []string{cfg.Resource},
 		ResourceNames: []string{name},
 		Verbs:         verbs,
@@ -260,14 +333,55 @@ func RoleBindingName(name string, cfg KindConfig, role, target, principal string
 func OwnerReferences(obj metav1.Object, cfg KindConfig) []metav1.OwnerReference {
 	controller := true
 	blockOwnerDeletion := true
+	apiVersion := cfg.OwnerAPIVersion
+	if apiVersion == "" {
+		apiVersion = templatesv1alpha1.GroupVersion.String()
+	}
+	kind := cfg.OwnerKind
+	if kind == "" {
+		kind = cfg.Kind
+	}
 	return []metav1.OwnerReference{{
-		APIVersion:         templatesv1alpha1.GroupVersion.String(),
-		Kind:               cfg.Kind,
+		APIVersion:         apiVersion,
+		Kind:               kind,
 		Name:               obj.GetName(),
 		UID:                obj.GetUID(),
 		Controller:         &controller,
 		BlockOwnerDeletion: &blockOwnerDeletion,
 	}}
+}
+
+func matches(obj metav1.Object, cfg KindConfig) bool {
+	if cfg.Matches == nil {
+		return true
+	}
+	return cfg.Matches(obj)
+}
+
+func objectName(obj metav1.Object, cfg KindConfig) string {
+	if cfg.ObjectName != nil {
+		return cfg.ObjectName(obj)
+	}
+	return obj.GetName()
+}
+
+func rbacNamespace(obj metav1.Object, cfg KindConfig) string {
+	if cfg.RBACNamespace != nil {
+		return cfg.RBACNamespace(obj)
+	}
+	return obj.GetNamespace()
+}
+
+func namespaceObjectName(obj metav1.Object) string {
+	return obj.GetName()
+}
+
+func namespaceRBACNamespace(obj metav1.Object) string {
+	return obj.GetName()
+}
+
+func isManagedNamespace(obj metav1.Object) bool {
+	return obj.GetLabels()[v1alpha2.LabelManagedBy] == v1alpha2.ManagedByValue
 }
 
 func OIDCPrincipal(principal string) string {
@@ -298,13 +412,77 @@ func NormalizeTarget(target string) string {
 
 func RoleFromLabels(labels map[string]string) string {
 	if labels != nil {
-		for _, cfg := range AllKindConfigs() {
+		configs := append(AllKindConfigs(), TopResourceKindConfigs()...)
+		for _, cfg := range configs {
 			if value := strings.TrimPrefix(labels[LabelResourceRole], cfg.RolePurpose+"-"); value != labels[LabelResourceRole] {
 				return NormalizeRole(value)
 			}
 		}
 	}
 	return RoleViewer
+}
+
+func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj metav1.Object, cfg KindConfig, namespace, name string, ownerRefs []metav1.OwnerReference) error {
+	desired := make(map[string]*rbacv1.RoleBinding)
+	addDesired := func(target string, grant secrets.AnnotationGrant) {
+		if strings.TrimSpace(grant.Principal) == "" {
+			return
+		}
+		binding := RoleBinding(namespace, name, cfg, target, grant.Principal, grant.Role, ownerRefs)
+		desired[binding.Name] = binding
+	}
+	if creatorSub := creatorSubject(obj); creatorSub != "" {
+		addDesired(ShareTargetUser, secrets.AnnotationGrant{Principal: creatorSub, Role: RoleOwner})
+	}
+	users, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
+	if err != nil {
+		return err
+	}
+	for _, grant := range secrets.DeduplicateGrants(users) {
+		addDesired(ShareTargetUser, grant)
+	}
+	groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
+	if err != nil {
+		return err
+	}
+	for _, grant := range secrets.DeduplicateGrants(groups) {
+		addDesired(ShareTargetGroup, grant)
+	}
+
+	selector := labels.SelectorFromSet(labels.Set{
+		LabelRolePurpose:  cfg.RolePurpose,
+		LabelResourceName: name,
+	}).String()
+	current, err := client.RbacV1().RoleBindings(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return fmt.Errorf("listing %s role bindings: %w", cfg.Kind, err)
+	}
+	for i := range current.Items {
+		existing := current.Items[i]
+		if _, ok := desired[existing.Name]; ok {
+			continue
+		}
+		if err := client.RbacV1().RoleBindings(namespace).Delete(ctx, existing.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting stale %s role binding %q: %w", cfg.Kind, existing.Name, err)
+		}
+	}
+	for _, binding := range desired {
+		if err := applyRoleBinding(ctx, client, binding); err != nil {
+			return fmt.Errorf("applying %s annotated role binding %q: %w", cfg.Kind, binding.Name, err)
+		}
+	}
+	return nil
+}
+
+func parseShareGrants(annotations map[string]string, key string) ([]secrets.AnnotationGrant, error) {
+	if annotations == nil || annotations[key] == "" {
+		return nil, nil
+	}
+	var grants []secrets.AnnotationGrant
+	if err := json.Unmarshal([]byte(annotations[key]), &grants); err != nil {
+		return nil, fmt.Errorf("invalid %s annotation: %w", key, err)
+	}
+	return grants, nil
 }
 
 func applyRole(ctx context.Context, client kubernetes.Interface, role *rbacv1.Role) error {

--- a/console/resourcerbac/rbac.go
+++ b/console/resourcerbac/rbac.go
@@ -31,7 +31,7 @@ const (
 	LabelShareTargetName = "console.holos.run/share-target-name"
 	LabelResourceRole    = "holos.run/role"
 
-	AnnotationCreatorSubject  = "console.holos.run/creator-sub"
+	AnnotationCreatorSubject  = v1alpha2.AnnotationCreatorSubject
 	AnnotationShareTargetName = LabelShareTargetName
 
 	RoleViewer = "viewer"
@@ -287,7 +287,7 @@ func resourceRules(name string, cfg KindConfig, role string) []rbacv1.PolicyRule
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{apiGroup},
 			Resources: []string{cfg.Resource},
-			Verbs:     []string{"list", "watch"},
+			Verbs:     []string{"list"},
 		})
 	}
 	return append(rules, extraRules...)
@@ -509,17 +509,23 @@ func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj
 		binding := RoleBinding(namespace, name, cfg, target, grant.Principal, grant.Role, ownerRefs)
 		desired[binding.Name] = binding
 	}
-	if creatorSub := creatorSubject(obj); creatorSub != "" {
-		addDesired(ShareTargetUser, secrets.AnnotationGrant{Principal: creatorSub, Role: RoleOwner})
+	users := []secrets.AnnotationGrant{}
+	if !cfg.ClusterScoped {
+		if creatorSub := creatorSubject(obj); creatorSub != "" {
+			users = append(users, secrets.AnnotationGrant{Principal: creatorSub, Role: RoleOwner})
+		}
 	}
 	if cfg.ClusterScoped {
-		users, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
+		annotatedUsers, err := parseUserShareGrants(obj.GetAnnotations())
 		if err != nil {
 			return err
 		}
-		for _, grant := range activeGrants(users, now) {
-			addDesired(ShareTargetUser, grant)
-		}
+		users = append(users, annotatedUsers...)
+	}
+	for _, grant := range activeGrants(users, now) {
+		addDesired(ShareTargetUser, grant)
+	}
+	if cfg.ClusterScoped {
 		groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
 		if err != nil {
 			return err
@@ -572,13 +578,12 @@ func reconcileClusterRoleBindings(ctx context.Context, client kubernetes.Interfa
 		binding := ClusterRoleBinding(name, cfg, target, grant.Principal, grant.Role, ownerRefs)
 		desired[binding.Name] = binding
 	}
-	if creatorSub := creatorSubject(obj); creatorSub != "" {
-		addDesired(ShareTargetUser, secrets.AnnotationGrant{Principal: creatorSub, Role: RoleOwner})
-	}
-	users, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
+	users := []secrets.AnnotationGrant{}
+	annotatedUsers, err := parseUserShareGrants(obj.GetAnnotations())
 	if err != nil {
 		return err
 	}
+	users = append(users, annotatedUsers...)
 	for _, grant := range activeGrants(users, now) {
 		addDesired(ShareTargetUser, grant)
 	}
@@ -634,7 +639,7 @@ func activeGrants(grants []secrets.AnnotationGrant, now time.Time) []secrets.Ann
 // validity boundary. Reconcilers use it to remove expired RoleBindings and
 // add not-yet-active grants without waiting for another object update.
 func NextGrantRequeueAfter(obj metav1.Object, now time.Time) time.Duration {
-	users, _ := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
+	users, _ := parseUserShareGrants(obj.GetAnnotations())
 	groups, _ := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
 	nowUnix := now.Unix()
 	var next int64
@@ -652,6 +657,10 @@ func NextGrantRequeueAfter(obj metav1.Object, now time.Time) time.Duration {
 		return 0
 	}
 	return time.Duration(next-nowUnix) * time.Second
+}
+
+func parseUserShareGrants(annotations map[string]string) ([]secrets.AnnotationGrant, error) {
+	return parseShareGrants(annotations, v1alpha2.AnnotationRBACShareUsers)
 }
 
 func parseShareGrants(annotations map[string]string, key string) ([]secrets.AnnotationGrant, error) {

--- a/console/resourcerbac/rbac.go
+++ b/console/resourcerbac/rbac.go
@@ -269,6 +269,9 @@ func resourceRules(name string, cfg KindConfig, role string) []rbacv1.PolicyRule
 	switch NormalizeRole(role) {
 	case RoleEditor:
 		verbs = editorVerbs()
+		if cfg.ClusterScoped {
+			verbs = viewerVerbs()
+		}
 	case RoleOwner:
 		verbs = ownerVerbs()
 		extraRules = ownerRules(name, cfg)
@@ -505,19 +508,23 @@ func reconcileRoleBindings(ctx context.Context, client kubernetes.Interface, obj
 	if creatorSub := creatorSubject(obj); creatorSub != "" {
 		addDesired(ShareTargetUser, secrets.AnnotationGrant{Principal: creatorSub, Role: RoleOwner})
 	}
-	users, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
-	if err != nil {
-		return err
-	}
-	for _, grant := range activeGrants(users, now) {
-		addDesired(ShareTargetUser, grant)
-	}
-	groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
-	if err != nil {
-		return err
-	}
-	for _, grant := range activeGrants(groups, now) {
-		addDesired(ShareTargetGroup, grant)
+	if cfg.ClusterScoped {
+		users, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareUsers)
+		if err != nil {
+			return err
+		}
+		for _, grant := range activeGrants(users, now) {
+			if isSubjectPrincipal(grant.Principal) {
+				addDesired(ShareTargetUser, grant)
+			}
+		}
+		groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
+		if err != nil {
+			return err
+		}
+		for _, grant := range activeGrants(groups, now) {
+			addDesired(ShareTargetGroup, grant)
+		}
 	}
 
 	selector := labels.SelectorFromSet(labels.Set{
@@ -571,7 +578,9 @@ func reconcileClusterRoleBindings(ctx context.Context, client kubernetes.Interfa
 		return err
 	}
 	for _, grant := range activeGrants(users, now) {
-		addDesired(ShareTargetUser, grant)
+		if isSubjectPrincipal(grant.Principal) {
+			addDesired(ShareTargetUser, grant)
+		}
 	}
 	groups, err := parseShareGrants(obj.GetAnnotations(), v1alpha2.AnnotationShareRoles)
 	if err != nil {
@@ -619,6 +628,11 @@ func activeGrants(grants []secrets.AnnotationGrant, now time.Time) []secrets.Ann
 		filtered = append(filtered, grant)
 	}
 	return secrets.DeduplicateGrants(filtered)
+}
+
+func isSubjectPrincipal(principal string) bool {
+	principal = strings.TrimSpace(principal)
+	return principal != "" && !strings.Contains(principal, "@")
 }
 
 // NextGrantRequeueAfter returns the delay until the next share annotation

--- a/console/resourcerbac/reconciler.go
+++ b/console/resourcerbac/reconciler.go
@@ -3,6 +3,7 @@ package resourcerbac
 import (
 	"context"
 	"fmt"
+	"time"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +34,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := EnsureResourceRBAC(ctx, r.Kube, obj, r.Config); err != nil {
 		return ctrl.Result{}, err
 	}
+	if requeueAfter := NextGrantRequeueAfter(obj, time.Now()); requeueAfter > 0 {
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -46,6 +50,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(obj).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		Complete(r)
 }
 

--- a/console/resourcerbac/resources_reconciler.go
+++ b/console/resourcerbac/resources_reconciler.go
@@ -1,0 +1,10 @@
+package resourcerbac
+
+import (
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupResourceReconciler(mgr ctrl.Manager, kube kubernetes.Interface) error {
+	return setup(mgr, kube, Resources)
+}

--- a/console/resourcerbac/top_resources_test.go
+++ b/console/resourcerbac/top_resources_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
 	"github.com/holos-run/holos-console/console/secrets"
@@ -35,7 +36,7 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 				t.Fatalf("EnsureResourceRBAC: %v", err)
 			}
 
-			roles, err := client.RbacV1().Roles(tc.namespace).List(context.Background(), metav1.ListOptions{})
+			roles, err := client.RbacV1().ClusterRoles().List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				t.Fatalf("list roles: %v", err)
 			}
@@ -43,6 +44,7 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 				t.Fatalf("roles = %d, want 3", len(roles.Items))
 			}
 			gotVerbs := make(map[string][]string)
+			var ownerRules []rbacv1.PolicyRule
 			for _, role := range roles.Items {
 				if len(role.OwnerReferences) != 1 {
 					t.Fatalf("Role %q ownerRefs = %d, want 1", role.Name, len(role.OwnerReferences))
@@ -56,10 +58,14 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 				assertStringSlice(t, rule.Resources, []string{"namespaces"})
 				assertStringSlice(t, rule.ResourceNames, []string{tc.namespace})
 				gotVerbs[RoleFromLabels(role.Labels)] = append([]string(nil), rule.Verbs...)
+				if RoleFromLabels(role.Labels) == RoleOwner {
+					ownerRules = role.Rules
+				}
 			}
 			assertStringSlice(t, gotVerbs[RoleViewer], []string{"get"})
 			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get", "update", "patch"})
 			assertStringSlice(t, gotVerbs[RoleOwner], []string{"get", "update", "patch", "delete"})
+			assertClusterOwnerDelegationRules(t, ownerRules)
 		})
 	}
 }
@@ -83,16 +89,46 @@ func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
 		t.Fatalf("EnsureResourceRBAC: %v", err)
 	}
 
-	bindings, err := client.RbacV1().RoleBindings("holos-prj-demo").List(context.Background(), metav1.ListOptions{})
+	bindings, err := client.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("list rolebindings: %v", err)
 	}
-	assertBinding(t, bindings.Items, "oidc:platform@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
-	assertBinding(t, bindings.Items, "oidc:product@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
-	assertBinding(t, bindings.Items, "oidc:sre@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleViewer))
-	assertBinding(t, bindings.Items, "oidc:owner", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleOwner))
-	assertBinding(t, bindings.Items, "oidc:editor", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleEditor))
-	assertBinding(t, bindings.Items, "oidc:viewer", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleViewer))
+	assertClusterBinding(t, bindings.Items, "oidc:platform@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertClusterBinding(t, bindings.Items, "oidc:product@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
+	assertClusterBinding(t, bindings.Items, "oidc:sre@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleViewer))
+	assertClusterBinding(t, bindings.Items, "oidc:owner", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertClusterBinding(t, bindings.Items, "oidc:editor", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleEditor))
+	assertClusterBinding(t, bindings.Items, "oidc:viewer", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleViewer))
+}
+
+func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
+	now := time.Now().Unix()
+	expired := now - 10
+	future := now + 60
+	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
+		[]secrets.AnnotationGrant{
+			{Principal: "active@localhost", Role: RoleOwner},
+			{Principal: "expired@localhost", Role: RoleOwner, Exp: &expired},
+			{Principal: "future@localhost", Role: RoleOwner, Nbf: &future},
+		},
+		nil,
+	)
+	client := fake.NewClientset()
+
+	if err := EnsureResourceRBAC(context.Background(), client, obj, Projects); err != nil {
+		t.Fatalf("EnsureResourceRBAC: %v", err)
+	}
+
+	bindings, err := client.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list clusterrolebindings: %v", err)
+	}
+	assertClusterBinding(t, bindings.Items, "oidc:active@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertNoClusterBinding(t, bindings.Items, "oidc:expired@localhost")
+	assertNoClusterBinding(t, bindings.Items, "oidc:future@localhost")
+	if got := NextGrantRequeueAfter(obj, time.Unix(now, 0)); got <= 0 {
+		t.Fatalf("NextGrantRequeueAfter = %v, want positive duration for future grant", got)
+	}
 }
 
 func TestEnsureTopResourceRBACSkipsMismatchedNamespace(t *testing.T) {
@@ -102,7 +138,7 @@ func TestEnsureTopResourceRBACSkipsMismatchedNamespace(t *testing.T) {
 	if err := EnsureResourceRBAC(context.Background(), client, obj, Organizations); err != nil {
 		t.Fatalf("EnsureResourceRBAC: %v", err)
 	}
-	roles, err := client.RbacV1().Roles("holos-prj-demo").List(context.Background(), metav1.ListOptions{})
+	roles, err := client.RbacV1().ClusterRoles().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("list roles: %v", err)
 	}
@@ -163,7 +199,7 @@ func assertNamespaceOwnerRef(t *testing.T, got metav1.OwnerReference, name strin
 	}
 }
 
-func assertBinding(t *testing.T, bindings []rbacv1.RoleBinding, subjectName, subjectKind, roleRef string) {
+func assertClusterBinding(t *testing.T, bindings []rbacv1.ClusterRoleBinding, subjectName, subjectKind, roleRef string) {
 	t.Helper()
 	for _, binding := range bindings {
 		if binding.RoleRef.Name != roleRef || len(binding.Subjects) != 1 {
@@ -175,4 +211,31 @@ func assertBinding(t *testing.T, bindings []rbacv1.RoleBinding, subjectName, sub
 		}
 	}
 	t.Fatalf("missing binding subject=%s kind=%s roleRef=%s in %#v", subjectName, subjectKind, roleRef, bindings)
+}
+
+func assertNoClusterBinding(t *testing.T, bindings []rbacv1.ClusterRoleBinding, subjectName string) {
+	t.Helper()
+	for _, binding := range bindings {
+		if len(binding.Subjects) == 1 && binding.Subjects[0].Name == subjectName {
+			t.Fatalf("unexpected binding for subject=%s: %#v", subjectName, binding)
+		}
+	}
+}
+
+func assertClusterOwnerDelegationRules(t *testing.T, rules []rbacv1.PolicyRule) {
+	t.Helper()
+	var hasClusterRoles, hasClusterRoleBindings bool
+	for _, rule := range rules {
+		for _, resource := range rule.Resources {
+			if resource == "clusterroles" {
+				hasClusterRoles = true
+			}
+			if resource == "clusterrolebindings" {
+				hasClusterRoleBindings = true
+			}
+		}
+	}
+	if !hasClusterRoles || !hasClusterRoleBindings {
+		t.Fatalf("owner rules missing cluster-scoped sharing delegation: %#v", rules)
+	}
 }

--- a/console/resourcerbac/top_resources_test.go
+++ b/console/resourcerbac/top_resources_test.go
@@ -65,7 +65,7 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 			assertStringSlice(t, gotVerbs[RoleViewer], []string{"get"})
 			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get", "update", "patch"})
 			assertStringSlice(t, gotVerbs[RoleOwner], []string{"get", "update", "patch", "delete"})
-			assertClusterOwnerDelegationRules(t, ownerRules)
+			assertNoClusterOwnerDelegationRules(t, ownerRules)
 		})
 	}
 }
@@ -194,8 +194,8 @@ func assertNamespaceOwnerRef(t *testing.T, got metav1.OwnerReference, name strin
 	if got.Controller == nil || !*got.Controller {
 		t.Fatalf("owner controller = %v, want true", got.Controller)
 	}
-	if got.BlockOwnerDeletion == nil || !*got.BlockOwnerDeletion {
-		t.Fatalf("owner blockOwnerDeletion = %v, want true", got.BlockOwnerDeletion)
+	if got.BlockOwnerDeletion == nil || *got.BlockOwnerDeletion {
+		t.Fatalf("owner blockOwnerDeletion = %v, want false", got.BlockOwnerDeletion)
 	}
 }
 
@@ -222,20 +222,13 @@ func assertNoClusterBinding(t *testing.T, bindings []rbacv1.ClusterRoleBinding, 
 	}
 }
 
-func assertClusterOwnerDelegationRules(t *testing.T, rules []rbacv1.PolicyRule) {
+func assertNoClusterOwnerDelegationRules(t *testing.T, rules []rbacv1.PolicyRule) {
 	t.Helper()
-	var hasClusterRoles, hasClusterRoleBindings bool
 	for _, rule := range rules {
 		for _, resource := range rule.Resources {
-			if resource == "clusterroles" {
-				hasClusterRoles = true
-			}
-			if resource == "clusterrolebindings" {
-				hasClusterRoleBindings = true
+			if resource == "clusterroles" || resource == "clusterrolebindings" {
+				t.Fatalf("owner rules grant cluster-scoped RBAC mutation: %#v", rules)
 			}
 		}
-	}
-	if !hasClusterRoles || !hasClusterRoleBindings {
-		t.Fatalf("owner rules missing cluster-scoped sharing delegation: %#v", rules)
 	}
 }

--- a/console/resourcerbac/top_resources_test.go
+++ b/console/resourcerbac/top_resources_test.go
@@ -50,14 +50,18 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 					t.Fatalf("Role %q ownerRefs = %d, want 1", role.Name, len(role.OwnerReferences))
 				}
 				assertNamespaceOwnerRef(t, role.OwnerReferences[0], tc.namespace, types.UID("uid-"+tc.namespace))
-				if len(role.Rules) == 0 {
-					t.Fatalf("Role %q has no rules", role.Name)
+				if len(role.Rules) != 2 {
+					t.Fatalf("Role %q rules = %d, want resource rule plus list rule", role.Name, len(role.Rules))
 				}
 				rule := role.Rules[0]
 				assertStringSlice(t, rule.APIGroups, []string{""})
 				assertStringSlice(t, rule.Resources, []string{"namespaces"})
 				assertStringSlice(t, rule.ResourceNames, []string{tc.namespace})
-				assertClusterListRule(t, role.Rules)
+				listRule := role.Rules[1]
+				assertStringSlice(t, listRule.APIGroups, []string{""})
+				assertStringSlice(t, listRule.Resources, []string{"namespaces"})
+				assertStringSlice(t, listRule.ResourceNames, nil)
+				assertStringSlice(t, listRule.Verbs, []string{"list"})
 				gotVerbs[RoleFromLabels(role.Labels)] = append([]string(nil), rule.Verbs...)
 				if RoleFromLabels(role.Labels) == RoleOwner {
 					ownerRules = role.Rules
@@ -74,9 +78,9 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
 	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
 		[]secrets.AnnotationGrant{
-			{Principal: "platform@localhost", Role: RoleOwner},
-			{Principal: "product@localhost", Role: RoleEditor},
-			{Principal: "sre@localhost", Role: RoleViewer},
+			{Principal: "platform-sub", Role: RoleOwner},
+			{Principal: "product-sub", Role: RoleEditor},
+			{Principal: "sre-sub", Role: RoleViewer},
 		},
 		[]secrets.AnnotationGrant{
 			{Principal: "owner", Role: RoleOwner},
@@ -94,12 +98,44 @@ func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list rolebindings: %v", err)
 	}
-	assertClusterBinding(t, bindings.Items, "oidc:platform@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
-	assertClusterBinding(t, bindings.Items, "oidc:product@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
-	assertClusterBinding(t, bindings.Items, "oidc:sre@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleViewer))
+	assertClusterBinding(t, bindings.Items, "oidc:platform-sub", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertClusterBinding(t, bindings.Items, "oidc:product-sub", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
+	assertClusterBinding(t, bindings.Items, "oidc:sre-sub", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleViewer))
 	assertClusterBinding(t, bindings.Items, "oidc:owner", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleOwner))
 	assertClusterBinding(t, bindings.Items, "oidc:editor", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleEditor))
 	assertClusterBinding(t, bindings.Items, "oidc:viewer", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleViewer))
+}
+
+func TestEnsureTopResourceRBACUsesRBACShareUsersAnnotation(t *testing.T) {
+	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject, nil, nil)
+	displayUsers, err := json.Marshal([]secrets.AnnotationGrant{
+		{Principal: "alice@example.com", Role: RoleEditor},
+	})
+	if err != nil {
+		t.Fatalf("marshal share users: %v", err)
+	}
+	rbacUsers, err := json.Marshal([]secrets.AnnotationGrant{
+		{Principal: "alice-sub", Role: RoleEditor},
+	})
+	if err != nil {
+		t.Fatalf("marshal rbac share users: %v", err)
+	}
+	obj.Annotations[v1alpha2.AnnotationShareUsers] = string(displayUsers)
+	obj.Annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsers)
+	obj.Annotations[v1alpha2.AnnotationCreatorSubject] = "creator-sub"
+	client := fake.NewClientset()
+
+	if err := EnsureResourceRBAC(context.Background(), client, obj, Projects); err != nil {
+		t.Fatalf("EnsureResourceRBAC: %v", err)
+	}
+
+	bindings, err := client.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list clusterrolebindings: %v", err)
+	}
+	assertClusterBinding(t, bindings.Items, "oidc:alice-sub", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
+	assertNoClusterBinding(t, bindings.Items, "oidc:creator-sub")
+	assertNoClusterBinding(t, bindings.Items, "oidc:alice@example.com")
 }
 
 func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
@@ -108,9 +144,9 @@ func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
 	future := now + 60
 	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
 		[]secrets.AnnotationGrant{
-			{Principal: "active@localhost", Role: RoleOwner},
-			{Principal: "expired@localhost", Role: RoleOwner, Exp: &expired},
-			{Principal: "future@localhost", Role: RoleOwner, Nbf: &future},
+			{Principal: "active-sub", Role: RoleOwner},
+			{Principal: "expired-sub", Role: RoleOwner, Exp: &expired},
+			{Principal: "future-sub", Role: RoleOwner, Nbf: &future},
 		},
 		nil,
 	)
@@ -124,9 +160,9 @@ func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list clusterrolebindings: %v", err)
 	}
-	assertClusterBinding(t, bindings.Items, "oidc:active@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
-	assertNoClusterBinding(t, bindings.Items, "oidc:expired@localhost")
-	assertNoClusterBinding(t, bindings.Items, "oidc:future@localhost")
+	assertClusterBinding(t, bindings.Items, "oidc:active-sub", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertNoClusterBinding(t, bindings.Items, "oidc:expired-sub")
+	assertNoClusterBinding(t, bindings.Items, "oidc:future-sub")
 	if got := NextGrantRequeueAfter(obj, time.Unix(now, 0)); got <= 0 {
 		t.Fatalf("NextGrantRequeueAfter = %v, want positive duration for future grant", got)
 	}
@@ -156,7 +192,7 @@ func managedNamespace(t *testing.T, name, resourceType string, users, groups []s
 		if err != nil {
 			t.Fatalf("marshal users: %v", err)
 		}
-		annotations[v1alpha2.AnnotationShareUsers] = string(raw)
+		annotations[v1alpha2.AnnotationRBACShareUsers] = string(raw)
 	}
 	if groups != nil {
 		raw, err := json.Marshal(groups)
@@ -221,20 +257,6 @@ func assertNoClusterBinding(t *testing.T, bindings []rbacv1.ClusterRoleBinding, 
 			t.Fatalf("unexpected binding for subject=%s: %#v", subjectName, binding)
 		}
 	}
-}
-
-func assertClusterListRule(t *testing.T, rules []rbacv1.PolicyRule) {
-	t.Helper()
-	for _, rule := range rules {
-		if len(rule.ResourceNames) != 0 {
-			continue
-		}
-		if len(rule.APIGroups) == 1 && rule.APIGroups[0] == "" && len(rule.Resources) == 1 && rule.Resources[0] == "namespaces" {
-			assertStringSlice(t, rule.Verbs, []string{"list", "watch"})
-			return
-		}
-	}
-	t.Fatalf("missing cluster-scoped list/watch rule: %#v", rules)
 }
 
 func assertNoClusterOwnerDelegationRules(t *testing.T, rules []rbacv1.PolicyRule) {

--- a/console/resourcerbac/top_resources_test.go
+++ b/console/resourcerbac/top_resources_test.go
@@ -63,7 +63,7 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 				}
 			}
 			assertStringSlice(t, gotVerbs[RoleViewer], []string{"get"})
-			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get", "update", "patch"})
+			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get"})
 			assertStringSlice(t, gotVerbs[RoleOwner], []string{"get", "update", "patch", "delete"})
 			assertNoClusterOwnerDelegationRules(t, ownerRules)
 		})
@@ -72,11 +72,7 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 
 func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
 	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
-		[]secrets.AnnotationGrant{
-			{Principal: "platform@localhost", Role: RoleOwner},
-			{Principal: "product@localhost", Role: RoleEditor},
-			{Principal: "sre@localhost", Role: RoleViewer},
-		},
+		nil,
 		[]secrets.AnnotationGrant{
 			{Principal: "owner", Role: RoleOwner},
 			{Principal: "editor", Role: RoleEditor},
@@ -93,9 +89,6 @@ func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list rolebindings: %v", err)
 	}
-	assertClusterBinding(t, bindings.Items, "oidc:platform@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
-	assertClusterBinding(t, bindings.Items, "oidc:product@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
-	assertClusterBinding(t, bindings.Items, "oidc:sre@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleViewer))
 	assertClusterBinding(t, bindings.Items, "oidc:owner", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleOwner))
 	assertClusterBinding(t, bindings.Items, "oidc:editor", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleEditor))
 	assertClusterBinding(t, bindings.Items, "oidc:viewer", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleViewer))
@@ -107,9 +100,9 @@ func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
 	future := now + 60
 	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
 		[]secrets.AnnotationGrant{
-			{Principal: "active@localhost", Role: RoleOwner},
-			{Principal: "expired@localhost", Role: RoleOwner, Exp: &expired},
-			{Principal: "future@localhost", Role: RoleOwner, Nbf: &future},
+			{Principal: "active-subject", Role: RoleOwner},
+			{Principal: "expired-subject", Role: RoleOwner, Exp: &expired},
+			{Principal: "future-subject", Role: RoleOwner, Nbf: &future},
 		},
 		nil,
 	)
@@ -123,12 +116,34 @@ func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list clusterrolebindings: %v", err)
 	}
-	assertClusterBinding(t, bindings.Items, "oidc:active@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
-	assertNoClusterBinding(t, bindings.Items, "oidc:expired@localhost")
-	assertNoClusterBinding(t, bindings.Items, "oidc:future@localhost")
+	assertClusterBinding(t, bindings.Items, "oidc:active-subject", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertNoClusterBinding(t, bindings.Items, "oidc:expired-subject")
+	assertNoClusterBinding(t, bindings.Items, "oidc:future-subject")
 	if got := NextGrantRequeueAfter(obj, time.Unix(now, 0)); got <= 0 {
 		t.Fatalf("NextGrantRequeueAfter = %v, want positive duration for future grant", got)
 	}
+}
+
+func TestEnsureTopResourceRBACSkipsEmailShapedUserGrants(t *testing.T) {
+	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
+		[]secrets.AnnotationGrant{
+			{Principal: "product@localhost", Role: RoleOwner},
+			{Principal: "subject-123", Role: RoleEditor},
+		},
+		nil,
+	)
+	client := fake.NewClientset()
+
+	if err := EnsureResourceRBAC(context.Background(), client, obj, Projects); err != nil {
+		t.Fatalf("EnsureResourceRBAC: %v", err)
+	}
+
+	bindings, err := client.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list clusterrolebindings: %v", err)
+	}
+	assertNoClusterBinding(t, bindings.Items, "oidc:product@localhost")
+	assertClusterBinding(t, bindings.Items, "oidc:subject-123", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
 }
 
 func TestEnsureTopResourceRBACSkipsMismatchedNamespace(t *testing.T) {

--- a/console/resourcerbac/top_resources_test.go
+++ b/console/resourcerbac/top_resources_test.go
@@ -1,0 +1,178 @@
+package resourcerbac
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/secrets"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		cfg          KindConfig
+		resourceType string
+		namespace    string
+	}{
+		{name: "Organization", cfg: Organizations, resourceType: v1alpha2.ResourceTypeOrganization, namespace: "holos-org-platform"},
+		{name: "Folder", cfg: Folders, resourceType: v1alpha2.ResourceTypeFolder, namespace: "holos-fld-default"},
+		{name: "Project", cfg: Projects, resourceType: v1alpha2.ResourceTypeProject, namespace: "holos-prj-demo"},
+		{name: "ResourceFolder", cfg: Resources, resourceType: v1alpha2.ResourceTypeFolder, namespace: "holos-fld-default"},
+		{name: "ResourceProject", cfg: Resources, resourceType: v1alpha2.ResourceTypeProject, namespace: "holos-prj-demo"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := managedNamespace(t, tc.namespace, tc.resourceType, nil, nil)
+			client := fake.NewClientset()
+
+			if err := EnsureResourceRBAC(context.Background(), client, obj, tc.cfg); err != nil {
+				t.Fatalf("EnsureResourceRBAC: %v", err)
+			}
+
+			roles, err := client.RbacV1().Roles(tc.namespace).List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("list roles: %v", err)
+			}
+			if len(roles.Items) != 3 {
+				t.Fatalf("roles = %d, want 3", len(roles.Items))
+			}
+			gotVerbs := make(map[string][]string)
+			for _, role := range roles.Items {
+				if len(role.OwnerReferences) != 1 {
+					t.Fatalf("Role %q ownerRefs = %d, want 1", role.Name, len(role.OwnerReferences))
+				}
+				assertNamespaceOwnerRef(t, role.OwnerReferences[0], tc.namespace, types.UID("uid-"+tc.namespace))
+				if len(role.Rules) == 0 {
+					t.Fatalf("Role %q has no rules", role.Name)
+				}
+				rule := role.Rules[0]
+				assertStringSlice(t, rule.APIGroups, []string{""})
+				assertStringSlice(t, rule.Resources, []string{"namespaces"})
+				assertStringSlice(t, rule.ResourceNames, []string{tc.namespace})
+				gotVerbs[RoleFromLabels(role.Labels)] = append([]string(nil), rule.Verbs...)
+			}
+			assertStringSlice(t, gotVerbs[RoleViewer], []string{"get"})
+			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get", "update", "patch"})
+			assertStringSlice(t, gotVerbs[RoleOwner], []string{"get", "update", "patch", "delete"})
+		})
+	}
+}
+
+func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
+	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
+		[]secrets.AnnotationGrant{
+			{Principal: "platform@localhost", Role: RoleOwner},
+			{Principal: "product@localhost", Role: RoleEditor},
+			{Principal: "sre@localhost", Role: RoleViewer},
+		},
+		[]secrets.AnnotationGrant{
+			{Principal: "owner", Role: RoleOwner},
+			{Principal: "editor", Role: RoleEditor},
+			{Principal: "viewer", Role: RoleViewer},
+		},
+	)
+	client := fake.NewClientset()
+
+	if err := EnsureResourceRBAC(context.Background(), client, obj, Projects); err != nil {
+		t.Fatalf("EnsureResourceRBAC: %v", err)
+	}
+
+	bindings, err := client.RbacV1().RoleBindings("holos-prj-demo").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list rolebindings: %v", err)
+	}
+	assertBinding(t, bindings.Items, "oidc:platform@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertBinding(t, bindings.Items, "oidc:product@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
+	assertBinding(t, bindings.Items, "oidc:sre@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleViewer))
+	assertBinding(t, bindings.Items, "oidc:owner", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertBinding(t, bindings.Items, "oidc:editor", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleEditor))
+	assertBinding(t, bindings.Items, "oidc:viewer", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleViewer))
+}
+
+func TestEnsureTopResourceRBACSkipsMismatchedNamespace(t *testing.T) {
+	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject, nil, nil)
+	client := fake.NewClientset()
+
+	if err := EnsureResourceRBAC(context.Background(), client, obj, Organizations); err != nil {
+		t.Fatalf("EnsureResourceRBAC: %v", err)
+	}
+	roles, err := client.RbacV1().Roles("holos-prj-demo").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list roles: %v", err)
+	}
+	if len(roles.Items) != 0 {
+		t.Fatalf("roles = %d, want 0 for mismatched namespace resource type", len(roles.Items))
+	}
+}
+
+func managedNamespace(t *testing.T, name, resourceType string, users, groups []secrets.AnnotationGrant) *corev1.Namespace {
+	t.Helper()
+	annotations := map[string]string{}
+	if users != nil {
+		raw, err := json.Marshal(users)
+		if err != nil {
+			t.Fatalf("marshal users: %v", err)
+		}
+		annotations[v1alpha2.AnnotationShareUsers] = string(raw)
+	}
+	if groups != nil {
+		raw, err := json.Marshal(groups)
+		if err != nil {
+			t.Fatalf("marshal groups: %v", err)
+		}
+		annotations[v1alpha2.AnnotationShareRoles] = string(raw)
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  types.UID("uid-" + name),
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: resourceType,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+func assertNamespaceOwnerRef(t *testing.T, got metav1.OwnerReference, name string, uid types.UID) {
+	t.Helper()
+	if got.APIVersion != "v1" {
+		t.Fatalf("owner apiVersion = %q, want v1", got.APIVersion)
+	}
+	if got.Kind != "Namespace" {
+		t.Fatalf("owner kind = %q, want Namespace", got.Kind)
+	}
+	if got.Name != name {
+		t.Fatalf("owner name = %q, want %q", got.Name, name)
+	}
+	if got.UID != uid {
+		t.Fatalf("owner uid = %q, want %q", got.UID, uid)
+	}
+	if got.Controller == nil || !*got.Controller {
+		t.Fatalf("owner controller = %v, want true", got.Controller)
+	}
+	if got.BlockOwnerDeletion == nil || !*got.BlockOwnerDeletion {
+		t.Fatalf("owner blockOwnerDeletion = %v, want true", got.BlockOwnerDeletion)
+	}
+}
+
+func assertBinding(t *testing.T, bindings []rbacv1.RoleBinding, subjectName, subjectKind, roleRef string) {
+	t.Helper()
+	for _, binding := range bindings {
+		if binding.RoleRef.Name != roleRef || len(binding.Subjects) != 1 {
+			continue
+		}
+		subject := binding.Subjects[0]
+		if subject.Name == subjectName && subject.Kind == subjectKind {
+			return
+		}
+	}
+	t.Fatalf("missing binding subject=%s kind=%s roleRef=%s in %#v", subjectName, subjectKind, roleRef, bindings)
+}

--- a/console/resourcerbac/top_resources_test.go
+++ b/console/resourcerbac/top_resources_test.go
@@ -57,13 +57,14 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 				assertStringSlice(t, rule.APIGroups, []string{""})
 				assertStringSlice(t, rule.Resources, []string{"namespaces"})
 				assertStringSlice(t, rule.ResourceNames, []string{tc.namespace})
+				assertClusterListRule(t, role.Rules)
 				gotVerbs[RoleFromLabels(role.Labels)] = append([]string(nil), rule.Verbs...)
 				if RoleFromLabels(role.Labels) == RoleOwner {
 					ownerRules = role.Rules
 				}
 			}
 			assertStringSlice(t, gotVerbs[RoleViewer], []string{"get"})
-			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get"})
+			assertStringSlice(t, gotVerbs[RoleEditor], []string{"get", "update", "patch"})
 			assertStringSlice(t, gotVerbs[RoleOwner], []string{"get", "update", "patch", "delete"})
 			assertNoClusterOwnerDelegationRules(t, ownerRules)
 		})
@@ -72,7 +73,11 @@ func TestEnsureTopResourceRBACProvisioningForEveryKind(t *testing.T) {
 
 func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
 	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
-		nil,
+		[]secrets.AnnotationGrant{
+			{Principal: "platform@localhost", Role: RoleOwner},
+			{Principal: "product@localhost", Role: RoleEditor},
+			{Principal: "sre@localhost", Role: RoleViewer},
+		},
 		[]secrets.AnnotationGrant{
 			{Principal: "owner", Role: RoleOwner},
 			{Principal: "editor", Role: RoleEditor},
@@ -89,6 +94,9 @@ func TestEnsureTopResourceRBACDevPersonaBindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list rolebindings: %v", err)
 	}
+	assertClusterBinding(t, bindings.Items, "oidc:platform@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertClusterBinding(t, bindings.Items, "oidc:product@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
+	assertClusterBinding(t, bindings.Items, "oidc:sre@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleViewer))
 	assertClusterBinding(t, bindings.Items, "oidc:owner", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleOwner))
 	assertClusterBinding(t, bindings.Items, "oidc:editor", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleEditor))
 	assertClusterBinding(t, bindings.Items, "oidc:viewer", rbacv1.GroupKind, RoleName("holos-prj-demo", Projects, RoleViewer))
@@ -100,9 +108,9 @@ func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
 	future := now + 60
 	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
 		[]secrets.AnnotationGrant{
-			{Principal: "active-subject", Role: RoleOwner},
-			{Principal: "expired-subject", Role: RoleOwner, Exp: &expired},
-			{Principal: "future-subject", Role: RoleOwner, Nbf: &future},
+			{Principal: "active@localhost", Role: RoleOwner},
+			{Principal: "expired@localhost", Role: RoleOwner, Exp: &expired},
+			{Principal: "future@localhost", Role: RoleOwner, Nbf: &future},
 		},
 		nil,
 	)
@@ -116,34 +124,12 @@ func TestEnsureTopResourceRBACFiltersInactiveGrants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list clusterrolebindings: %v", err)
 	}
-	assertClusterBinding(t, bindings.Items, "oidc:active-subject", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
-	assertNoClusterBinding(t, bindings.Items, "oidc:expired-subject")
-	assertNoClusterBinding(t, bindings.Items, "oidc:future-subject")
+	assertClusterBinding(t, bindings.Items, "oidc:active@localhost", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleOwner))
+	assertNoClusterBinding(t, bindings.Items, "oidc:expired@localhost")
+	assertNoClusterBinding(t, bindings.Items, "oidc:future@localhost")
 	if got := NextGrantRequeueAfter(obj, time.Unix(now, 0)); got <= 0 {
 		t.Fatalf("NextGrantRequeueAfter = %v, want positive duration for future grant", got)
 	}
-}
-
-func TestEnsureTopResourceRBACSkipsEmailShapedUserGrants(t *testing.T) {
-	obj := managedNamespace(t, "holos-prj-demo", v1alpha2.ResourceTypeProject,
-		[]secrets.AnnotationGrant{
-			{Principal: "product@localhost", Role: RoleOwner},
-			{Principal: "subject-123", Role: RoleEditor},
-		},
-		nil,
-	)
-	client := fake.NewClientset()
-
-	if err := EnsureResourceRBAC(context.Background(), client, obj, Projects); err != nil {
-		t.Fatalf("EnsureResourceRBAC: %v", err)
-	}
-
-	bindings, err := client.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("list clusterrolebindings: %v", err)
-	}
-	assertNoClusterBinding(t, bindings.Items, "oidc:product@localhost")
-	assertClusterBinding(t, bindings.Items, "oidc:subject-123", rbacv1.UserKind, RoleName("holos-prj-demo", Projects, RoleEditor))
 }
 
 func TestEnsureTopResourceRBACSkipsMismatchedNamespace(t *testing.T) {
@@ -235,6 +221,20 @@ func assertNoClusterBinding(t *testing.T, bindings []rbacv1.ClusterRoleBinding, 
 			t.Fatalf("unexpected binding for subject=%s: %#v", subjectName, binding)
 		}
 	}
+}
+
+func assertClusterListRule(t *testing.T, rules []rbacv1.PolicyRule) {
+	t.Helper()
+	for _, rule := range rules {
+		if len(rule.ResourceNames) != 0 {
+			continue
+		}
+		if len(rule.APIGroups) == 1 && rule.APIGroups[0] == "" && len(rule.Resources) == 1 && rule.Resources[0] == "namespaces" {
+			assertStringSlice(t, rule.Verbs, []string{"list", "watch"})
+			return
+		}
+	}
+	t.Fatalf("missing cluster-scoped list/watch rule: %#v", rules)
 }
 
 func assertNoClusterOwnerDelegationRules(t *testing.T, rules []rbacv1.PolicyRule) {

--- a/console/secrets/k8s_test.go
+++ b/console/secrets/k8s_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+	"github.com/holos-run/holos-console/console/oidc"
 	"github.com/holos-run/holos-console/console/resolver"
 )
 
@@ -30,6 +31,57 @@ func projectNS(project string) *corev1.Namespace {
 				v1alpha2.LabelProject:      project,
 			},
 		},
+	}
+}
+
+func TestRBACUserGrantsForSubjects(t *testing.T) {
+	grants := RBACUserGrantsForSubjects([]AnnotationGrant{
+		{Principal: "alice@example.com", Role: "editor"},
+		{Principal: "admin@localhost", Role: "owner"},
+		{Principal: "product@localhost", Role: "editor"},
+		{Principal: "unresolved@example.com", Role: "viewer"},
+		{Principal: "subject-bob", Role: "viewer"},
+		{Principal: "oidc:subject-carol", Role: "owner"},
+	}, UserIdentity{Email: "alice@example.com", Subject: "subject-alice"}, UserIdentity{Email: "admin@localhost", Subject: "live-admin-sub"})
+
+	got := map[string]string{}
+	for _, grant := range grants {
+		got[grant.Principal] = grant.Role
+	}
+	if got["subject-alice"] != "editor" {
+		t.Fatalf("current user email was not resolved to subject: %v", grants)
+	}
+	if got["live-admin-sub"] != "owner" {
+		t.Fatalf("live caller subject did not override static dev persona subject: %v", grants)
+	}
+	staticAdminSubject, ok := oidc.TestUserSubjectForEmail("admin@localhost")
+	if !ok {
+		t.Fatalf("admin dev persona subject not found")
+	}
+	if _, ok := got[staticAdminSubject]; ok {
+		t.Fatalf("static dev persona subject overrode live caller subject: %v", grants)
+	}
+	if _, ok := got["alice@example.com"]; ok {
+		t.Fatalf("resolved email principal was copied into RBAC grants: %v", grants)
+	}
+	if _, ok := got["unresolved@example.com"]; ok {
+		t.Fatalf("unresolved email principal was copied into RBAC grants: %v", grants)
+	}
+	productSubject, ok := oidc.TestUserSubjectForEmail("product@localhost")
+	if !ok {
+		t.Fatalf("product dev persona subject not found")
+	}
+	if got[productSubject] != "editor" {
+		t.Fatalf("dev persona email was not resolved to subject: %v", grants)
+	}
+	if _, ok = got["product@localhost"]; ok {
+		t.Fatalf("dev persona email principal was copied into RBAC grants: %v", grants)
+	}
+	if got["subject-bob"] != "viewer" {
+		t.Fatalf("subject grant not preserved: %v", grants)
+	}
+	if got["oidc:subject-carol"] != "owner" {
+		t.Fatalf("prefixed subject grant not preserved: %v", grants)
 	}
 }
 

--- a/console/secrets/rbac_grants.go
+++ b/console/secrets/rbac_grants.go
@@ -1,0 +1,71 @@
+package secrets
+
+import (
+	"strings"
+
+	"github.com/holos-run/holos-console/console/oidc"
+)
+
+// UserIdentity maps a display email principal to the OIDC subject Kubernetes
+// sees through ADR 036 impersonation.
+type UserIdentity struct {
+	Email   string
+	Subject string
+}
+
+// RBACUserGrantsForSubjects converts email-shaped UI sharing grants into the
+// subject-shaped principals used for Kubernetes RBAC when the subject is known.
+// Unknown email principals are omitted because ADR 036 RBAC subjects must be
+// OIDC sub values, not email addresses.
+func RBACUserGrantsForSubjects(shareUsers []AnnotationGrant, identities ...UserIdentity) []AnnotationGrant {
+	subjectsByEmail := make(map[string]string, len(identities)+4)
+	for _, identity := range identities {
+		addEmailSubject(subjectsByEmail, identity.Email, identity.Subject)
+	}
+	for _, user := range oidc.TestUsers {
+		if subject, ok := oidc.TestUserSubjectForEmail(user.Email); ok {
+			addEmailSubjectIfAbsent(subjectsByEmail, user.Email, subject)
+		}
+	}
+
+	result := make([]AnnotationGrant, 0, len(shareUsers))
+	for _, grant := range shareUsers {
+		principal := strings.TrimSpace(grant.Principal)
+		if principal == "" {
+			continue
+		}
+		unprefixed := strings.TrimPrefix(principal, "oidc:")
+		if strings.Contains(unprefixed, "@") {
+			if subject := subjectsByEmail[strings.ToLower(unprefixed)]; subject != "" {
+				grant.Principal = subject
+			} else {
+				continue
+			}
+		} else {
+			grant.Principal = principal
+		}
+		result = append(result, grant)
+	}
+	return DeduplicateGrants(result)
+}
+
+func addEmailSubject(subjectsByEmail map[string]string, email, subject string) {
+	email = strings.TrimSpace(email)
+	subject = strings.TrimSpace(subject)
+	if email == "" || subject == "" {
+		return
+	}
+	subjectsByEmail[strings.ToLower(email)] = strings.TrimPrefix(subject, "oidc:")
+}
+
+func addEmailSubjectIfAbsent(subjectsByEmail map[string]string, email, subject string) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return
+	}
+	key := strings.ToLower(email)
+	if subjectsByEmail[key] != "" {
+		return
+	}
+	addEmailSubject(subjectsByEmail, email, subject)
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -321,6 +321,18 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 	if err := resourcerbac.SetupTemplateRequirementReconciler(mgr, rbacClientset); err != nil {
 		return nil, fmt.Errorf("controller.NewManager: registering TemplateRequirement RBAC reconciler: %w", err)
 	}
+	if err := resourcerbac.SetupOrganizationReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering Organization RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupFolderReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering Folder RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupProjectReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering Project RBAC reconciler: %w", err)
+	}
+	if err := resourcerbac.SetupResourceReconciler(mgr, rbacClientset); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering Resource RBAC reconciler: %w", err)
+	}
 
 	// Prime the Namespace informer so the reconcilers (HOL-621+) can read
 	// console.holos.run/resource-type labels without round-trips. Namespace

--- a/internal/controller/rbac.go
+++ b/internal/controller/rbac.go
@@ -49,6 +49,8 @@ limitations under the License.
 // +kubebuilder:rbac:groups=deployments.holos.run,resources=deployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete;escalate;bind
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete;escalate;bind
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=users;groups;serviceaccounts,verbs=impersonate
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch


### PR DESCRIPTION
## Summary
- Add namespace-backed RBAC configs and reconcilers for organizations, folders, projects, and the generic resources surface
- Reconcile viewer/editor/owner Roles plus OIDC user/group RoleBindings from creator and share annotations
- Register the new reconcilers with the embedded controller manager and cover verb sets plus dev persona bindings in unit tests

Fixes HOL-1063

## Test plan
- [x] go test ./console/resourcerbac
- [x] make test-go