### PR TITLE
Gate frontend resource actions with SSAR permissions

### DIFF
--- a/frontend/src/components/sharing-panel.tsx
+++ b/frontend/src/components/sharing-panel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/select'
 import { Trash2 } from 'lucide-react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 export interface Grant {
   principal: string
@@ -106,7 +107,7 @@ export function SharingPanel({ userGrants, roleGrants, isOwner, onSave, isSaving
       await onSave(users, roles)
       setEditing(false)
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : String(err))
+      setSaveError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/components/template-dependencies/DependencyForm.tsx
+++ b/frontend/src/components/template-dependencies/DependencyForm.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Separator } from '@/components/ui/separator'
 import type { LinkedTemplateRef } from '@/queries/templateDependencies'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 /**
  * DependencyFormValues are the shape of data emitted by DependencyForm on submit.
@@ -123,7 +124,7 @@ export function DependencyForm({
         cascadeDelete,
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/components/template-grants/GrantForm.tsx
+++ b/frontend/src/components/template-grants/GrantForm.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Separator } from '@/components/ui/separator'
 import type { TemplateGrantFromRef, TemplateGrantToRef } from '@/queries/templateGrants'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 /**
  * GrantFormValues are the shape of data emitted by GrantForm on submit.
@@ -43,8 +44,6 @@ export type GrantFormProps = {
  * namespace, optionally narrowed to specific templates (to).
  */
 export function GrantForm({
-  mode: _mode,
-  namespace: _namespace,
   canWrite,
   initialValues,
   submitLabel,
@@ -95,7 +94,7 @@ export function GrantForm({
         to: toRefs,
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/components/template-policies/PolicyForm.tsx
+++ b/frontend/src/components/template-policies/PolicyForm.tsx
@@ -13,6 +13,7 @@ import {
   type RuleDraft,
 } from '@/components/template-policies/rule-draft'
 import { useListLinkableTemplates } from '@/queries/templates'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 /**
  * PolicyScope captures the allowed scope types for a template policy. The
@@ -134,7 +135,7 @@ export function PolicyForm({
         rules: rules.map(ruleDraftToProto),
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/components/template-policy-bindings/BindingForm.tsx
+++ b/frontend/src/components/template-policy-bindings/BindingForm.tsx
@@ -25,6 +25,7 @@ import {
   scopeLabelFromNamespace,
   scopeNameFromNamespace,
 } from '@/lib/scope-labels'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 /**
  * BindingScope captures the allowed scope types for a TemplatePolicyBinding.
@@ -144,7 +145,7 @@ export function BindingForm({
     try {
       await onSubmit(draftToMutationParams(draft))
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/components/template-requirements/RequirementForm.tsx
+++ b/frontend/src/components/template-requirements/RequirementForm.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Separator } from '@/components/ui/separator'
 import type { LinkedTemplateRef } from '@/queries/templateRequirements'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 /**
  * RequirementFormValues are the shape of data emitted by RequirementForm on submit.
@@ -39,8 +40,6 @@ export type RequirementFormProps = {
  * editable. In edit mode the name is locked.
  */
 export function RequirementForm({
-  mode: _mode,
-  namespace: _namespace,
   canWrite,
   initialValues,
   submitLabel,
@@ -82,7 +81,7 @@ export function RequirementForm({
         cascadeDelete,
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/components/templates/TemplateCreateForm.tsx
+++ b/frontend/src/components/templates/TemplateCreateForm.tsx
@@ -20,6 +20,7 @@ import type {
 } from '@/queries/templates'
 import { useDebouncedValue } from '@/hooks/use-debounced-value'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 export type TemplateScope = 'organization' | 'folder' | 'project'
 
@@ -159,7 +160,7 @@ export function TemplateCreateForm({
         enabled: isProject ? undefined : enabled,
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/lib/resource-permissions.ts
+++ b/frontend/src/lib/resource-permissions.ts
@@ -1,0 +1,131 @@
+import {
+  isAllowed,
+  permissionKey,
+  type PermissionsMap,
+  type ResourcePermissionInput,
+} from '@/queries/permissions'
+
+export const TEMPLATES_API_GROUP = 'templates.holos.run'
+export const DEPLOYMENTS_API_GROUP = 'deployments.holos.run'
+
+export const templateResources = {
+  templates: 'templates',
+  templatePolicies: 'templatepolicies',
+  templatePolicyBindings: 'templatepolicybindings',
+  templateGrants: 'templategrants',
+  templateDependencies: 'templatedependencies',
+  templateRequirements: 'templaterequirements',
+} as const
+
+export function createTemplateResourcePermission(
+  resource: string,
+  namespace: string,
+): ResourcePermissionInput {
+  return {
+    verb: 'create',
+    group: TEMPLATES_API_GROUP,
+    resource,
+    namespace,
+  }
+}
+
+export function updateTemplateResourcePermission(
+  resource: string,
+  namespace: string,
+  name: string,
+): ResourcePermissionInput {
+  return {
+    verb: 'update',
+    group: TEMPLATES_API_GROUP,
+    resource,
+    namespace,
+    name,
+  }
+}
+
+export function deleteTemplateResourcePermission(
+  resource: string,
+  namespace: string,
+  name: string,
+): ResourcePermissionInput {
+  return {
+    verb: 'delete',
+    group: TEMPLATES_API_GROUP,
+    resource,
+    namespace,
+    name,
+  }
+}
+
+export function createNamespacePermission(): ResourcePermissionInput {
+  return {
+    verb: 'create',
+    resource: 'namespaces',
+  }
+}
+
+export function createNamespacedResourcePermission(
+  group: string,
+  resource: string,
+  namespace: string,
+): ResourcePermissionInput {
+  return {
+    verb: 'create',
+    group,
+    resource,
+    namespace,
+  }
+}
+
+export function updateNamespacedResourcePermission(
+  group: string,
+  resource: string,
+  namespace: string,
+  name: string,
+): ResourcePermissionInput {
+  return {
+    verb: 'update',
+    group,
+    resource,
+    namespace,
+    name,
+  }
+}
+
+export function deleteNamespacedResourcePermission(
+  group: string,
+  resource: string,
+  namespace: string,
+  name: string,
+): ResourcePermissionInput {
+  return {
+    verb: 'delete',
+    group,
+    resource,
+    namespace,
+    name,
+  }
+}
+
+export function updateNamespacePermission(name: string): ResourcePermissionInput {
+  return {
+    verb: 'update',
+    resource: 'namespaces',
+    name,
+  }
+}
+
+export function deleteNamespacePermission(name: string): ResourcePermissionInput {
+  return {
+    verb: 'delete',
+    resource: 'namespaces',
+    name,
+  }
+}
+
+export function hasPermission(
+  permissions: PermissionsMap | undefined,
+  attr: ResourcePermissionInput,
+): boolean {
+  return isAllowed(permissions, permissionKey(attr))
+}

--- a/frontend/src/queries/permissions.ts
+++ b/frontend/src/queries/permissions.ts
@@ -68,14 +68,14 @@ export type PermissionsMap = Record<string, ResourcePermission>
 // is authenticated and the attributes list is non-empty.
 export function useResourcePermissions(attributes: ResourcePermissionInput[]) {
   const { isAuthenticated } = useAuth()
+  const permissionKeys = useMemo(
+    () => attributes.map(permissionKey),
+    [attributes],
+  )
   const transport = useTransport()
   const client = useMemo(
     () => createClient(PermissionsService, transport),
     [transport],
-  )
-  const permissionKeys = useMemo(
-    () => attributes.map(permissionKey),
-    [attributes],
   )
   return useQuery({
     queryKey: keys.permissions.list(permissionKeys),

--- a/frontend/src/routes/_authenticated/organization/new.tsx
+++ b/frontend/src/routes/_authenticated/organization/new.tsx
@@ -22,6 +22,7 @@ import { Info } from 'lucide-react'
 import { useCreateOrganization } from '@/queries/organizations'
 import { toSlug } from '@/lib/slug'
 import { resolveReturnTo } from '@/lib/return-to'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 // No orgName search param: organizations have no parent entity, so callers
 // pass only returnTo. This is an intentional omission — see HOL-934 audit.
@@ -84,7 +85,7 @@ export function OrganizationNewPage({ returnTo }: { returnTo?: string }) {
       const target = resolveReturnTo(returnTo, fallback)
       navigate({ to: target })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create organization')
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
@@ -12,7 +12,7 @@
  * introduced.
  */
 
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 
 import { StandardPageLayout } from '@/components/page-layout'
@@ -21,6 +21,11 @@ import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useListProjects } from '@/queries/projects'
+import { useResourcePermissions } from '@/queries/permissions'
+import {
+  createNamespacePermission,
+  hasPermission,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/projects/',
@@ -54,6 +59,9 @@ export function OrgProjectsIndexPage({
   const navigate = useNavigate()
   const { data, isLoading, error } = useListProjects(orgName)
   const projects = data?.projects ?? []
+  const createPermission = useMemo(() => createNamespacePermission(), [])
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const rows: Row[] = projects.map((project) => ({
     kind: 'Project',
@@ -82,12 +90,14 @@ export function OrgProjectsIndexPage({
   ]
 
   const createProjectButton = (
-    <Link
-      to="/project/new"
-      search={{ orgName, returnTo: `/organizations/${orgName}/projects` }}
-    >
-      <Button size="sm">Create Project</Button>
-    </Link>
+    canCreate ? (
+      <Link
+        to="/project/new"
+        search={{ orgName, returnTo: `/organizations/${orgName}/projects` }}
+      >
+        <Button size="sm">Create Project</Button>
+      </Link>
+    ) : null
   )
 
   const handleSearchChange = useCallback(
@@ -113,12 +123,14 @@ export function OrgProjectsIndexPage({
       <p className="text-muted-foreground">
         No projects in this organization yet.
       </p>
-      <Link
-        to="/project/new"
-        search={{ orgName, returnTo: `/organizations/${orgName}/projects` }}
-      >
-        <Button size="sm">Create Project</Button>
-      </Link>
+      {canCreate && (
+        <Link
+          to="/project/new"
+          search={{ orgName, returnTo: `/organizations/${orgName}/projects` }}
+        >
+          <Button size="sm">Create Project</Button>
+        </Link>
+      )}
     </div>
   )
 

--- a/frontend/src/routes/_authenticated/organizations/$orgName/settings/-settings.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/settings/-settings.test.tsx
@@ -37,6 +37,7 @@ import {
   useDeleteOrganization,
 } from '@/queries/organizations'
 import { useAuth } from '@/lib/auth'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { OrgSettingsPage } from './index'
 
 const mockOrg = {
@@ -55,6 +56,7 @@ const mockOrg = {
 
 function setupMocks(overrides: Partial<typeof mockOrg> = {}) {
   const org = { ...mockOrg, ...overrides }
+  mockResourcePermissionsForRole(org.userRole)
 
   ;(useGetOrganization as Mock).mockReturnValue({
     data: org,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/settings/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
@@ -20,7 +20,6 @@ import { Check, Pencil, X, Table2, Braces } from 'lucide-react'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { ViewModeToggle } from '@/components/view-mode-toggle'
 import { RawView } from '@/components/raw-view'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
   useGetOrganization,
   useGetOrganizationRaw,
@@ -29,6 +28,14 @@ import {
   useUpdateOrganizationDefaultSharing,
   useDeleteOrganization,
 } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteNamespacePermission,
+  hasPermission,
+  updateNamespacePermission,
+} from '@/lib/resource-permissions'
+import { namespaceForOrg } from '@/lib/scope-labels'
 
 export const Route = createFileRoute('/_authenticated/organizations/$orgName/settings/')({
   component: OrgSettingsRoute,
@@ -56,6 +63,18 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
   const updateOrganizationSharing = useUpdateOrganizationSharing()
   const updateOrganizationDefaultSharing = useUpdateOrganizationDefaultSharing()
   const deleteOrganization = useDeleteOrganization()
+  const namespace = namespaceForOrg(orgName)
+  const updatePermission = useMemo(
+    () => updateNamespacePermission(namespace),
+    [namespace],
+  )
+  const deletePermission = useMemo(
+    () => deleteNamespacePermission(namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   // View mode: data or raw
   const [viewMode, setViewMode] = useState<'data' | 'raw'>('data')
@@ -83,7 +102,7 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
       setEditingDisplayName(false)
       toast.success('Saved')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -93,7 +112,7 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
       setEditingDescription(false)
       toast.success('Saved')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -103,7 +122,7 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
       setEditingGatewayNamespace(false)
       toast.success('Saved')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -120,10 +139,12 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
       await deleteOrganization.mutateAsync({ name: orgName })
       setDeleteOpen(false)
       navigate({ to: '/' })
-    } catch { /* error shown via mutation */ }
+    } catch (err) {
+      toast.error(connectErrorMessage(err))
+    }
   }
 
-  const isOwner = org?.userRole === Role.OWNER
+  const isOwner = canDelete
 
   if (isPending) {
     return (
@@ -233,14 +254,16 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
                 ) : (
                   <>
                     <span className="flex-1 text-sm">{displayName || <span className="text-muted-foreground">No display name</span>}</span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="edit display name"
-                      onClick={() => { setDraftDisplayName(displayName); setEditingDisplayName(true) }}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
+                    {canWrite && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="edit display name"
+                        onClick={() => { setDraftDisplayName(displayName); setEditingDisplayName(true) }}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    )}
                   </>
                 )}
               </div>
@@ -300,14 +323,16 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
                     <span className={`flex-1 text-sm ${description ? '' : 'text-muted-foreground'}`}>
                       {description || 'No description'}
                     </span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="edit description"
-                      onClick={() => { setDraftDescription(description); setEditingDescription(true) }}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
+                    {canWrite && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="edit description"
+                        onClick={() => { setDraftDescription(description); setEditingDescription(true) }}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    )}
                   </>
                 )}
               </div>
@@ -360,7 +385,7 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
                     <span className={`flex-1 text-sm ${gatewayNamespace ? 'font-mono' : 'text-muted-foreground'} pt-2`}>
                       {gatewayNamespace || 'Not set — defaults to istio-ingress'}
                     </span>
-                    {isOwner && (
+                    {canWrite && (
                       <Button
                         variant="ghost"
                         size="icon"
@@ -422,7 +447,7 @@ export function OrgSettingsPage({ orgName: propOrgName }: { orgName?: string } =
           </DialogHeader>
           {deleteOrganization.error && (
             <Alert variant="destructive">
-              <AlertDescription>{deleteOrganization.error.message}</AlertDescription>
+              <AlertDescription>{connectErrorMessage(deleteOrganization.error)}</AlertDescription>
             </Alert>
           )}
           <DialogFooter>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/$bindingName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/$bindingName.tsx
@@ -14,19 +14,25 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
   useGetTemplatePolicyBinding,
   useUpdateTemplatePolicyBinding,
   useDeleteTemplatePolicyBinding,
 } from '@/queries/templatePolicyBindings'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import {
   BindingForm,
   type BindingScope,
 } from '@/components/template-policy-bindings/BindingForm'
 import { bindingProtoToDraft } from '@/components/template-policy-bindings/binding-draft'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+  updateTemplateResourcePermission,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-bindings/$bindingName',
@@ -65,13 +71,25 @@ export function OrgTemplateBindingDetailPage({
 
   const navigate = useNavigate()
   const namespace = namespaceForOrg(orgName)
-  const { data: org } = useGetOrganization(orgName)
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-  // PERMISSION_TEMPLATE_POLICIES_DELETE is OWNER-only in the RBAC cascade;
-  // bindings reuse the policy permission family so the same constraint
-  // applies.
-  const canDelete = userRole === Role.OWNER
+  const updatePermission = useMemo(
+    () => updateTemplateResourcePermission(
+      templateResources.templatePolicyBindings,
+      namespace,
+      bindingName,
+    ),
+    [namespace, bindingName],
+  )
+  const deletePermission = useMemo(
+    () => deleteTemplateResourcePermission(
+      templateResources.templatePolicyBindings,
+      namespace,
+      bindingName,
+    ),
+    [namespace, bindingName],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   const scopeType: BindingScope = forcedScopeType ?? 'organization'
 
@@ -167,8 +185,12 @@ export function OrgTemplateBindingDetailPage({
             pendingLabel="Saving..."
             isPending={updateMutation.isPending}
             onSubmit={async (values) => {
-              await updateMutation.mutateAsync(values)
-              toast.success('Binding saved')
+              try {
+                await updateMutation.mutateAsync(values)
+                toast.success('Binding saved')
+              } catch (err) {
+                toast.error(connectErrorMessage(err))
+              }
             }}
             onCancel={() => {
               void navigate({
@@ -206,7 +228,7 @@ export function OrgTemplateBindingDetailPage({
                   })
                   toast.success('Binding deleted')
                 } catch (err) {
-                  toast.error(err instanceof Error ? err.message : String(err))
+                  toast.error(connectErrorMessage(err))
                 }
               }}
             >

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-detail.test.tsx
@@ -97,6 +97,7 @@ import {
 } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { OrgTemplateBindingDetailPage } from './$bindingName'
 
 function makeBinding() {
@@ -123,6 +124,7 @@ function setupMocks(
   userRole: Role = Role.OWNER,
   binding: ReturnType<typeof makeBinding> | undefined = makeBinding(),
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useGetTemplatePolicyBinding as Mock).mockReturnValue({
     data: binding,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-index.test.tsx
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Router mock — Route.useParams / useSearch / useNavigate / fullPath
@@ -117,6 +118,7 @@ function setup(
   isPending = false,
   error: Error | null = null,
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useListTemplatePolicyBindings as Mock).mockReturnValue({
     data: isPending ? undefined : bindings,
     isPending,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/-new.test.tsx
@@ -104,6 +104,7 @@ import { useCreateTemplatePolicyBinding } from '@/queries/templatePolicyBindings
 import { useGetOrganization } from '@/queries/organizations'
 import { useProject } from '@/lib/project-context'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { CreateOrgTemplateBindingPage } from './new'
 
 function setupMocks(
@@ -111,6 +112,7 @@ function setupMocks(
   userRole: Role = Role.OWNER,
   selectedProject: string | null = 'test-project',
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useCreateTemplatePolicyBinding as Mock).mockReturnValue({
     mutateAsync,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/index.tsx
@@ -14,7 +14,6 @@
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Badge } from '@/components/ui/badge'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -24,7 +23,7 @@ import {
   useDeleteTemplatePolicyBinding,
 } from '@/queries/templatePolicyBindings'
 import type { TemplatePolicyBinding } from '@/queries/templatePolicyBindings'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import {
   scopeDisplayLabel,
   scopeNameFromNamespace,
@@ -35,6 +34,11 @@ import {
   parentLabelFromNamespace,
 } from '@/lib/template-row-link'
 import type { ColumnDef } from '@tanstack/react-table'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route
@@ -158,11 +162,14 @@ export function OrgTemplateBindingsIndexPage({
 
   const orgNamespace = namespaceForOrg(orgName)
   const { data: bindings = [], isPending, error } = useListTemplatePolicyBindings(orgNamespace)
-  const { data: org } = useGetOrganization(orgName)
   const deleteMutation = useDeleteTemplatePolicyBinding(orgNamespace)
 
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templatePolicyBindings, orgNamespace),
+    [orgNamespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   // Build a lookup map for extra columns to access the original binding object.
   const bindingsByKey = useMemo(() => {
@@ -197,10 +204,10 @@ export function OrgTemplateBindingsIndexPage({
         id: 'TemplatePolicyBinding',
         label: 'Template Binding',
         newHref: `/organizations/${orgName}/template-bindings/new`,
-        canCreate: canWrite,
+        canCreate,
       },
     ],
-    [orgName, canWrite],
+    [orgName, canCreate],
   )
 
   const extraColumns = useBindingExtraColumns(bindingsByKey)

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-bindings/new.tsx
@@ -1,14 +1,18 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplatePolicyBinding } from '@/queries/templatePolicyBindings'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg, namespaceForProject } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { useProject } from '@/lib/project-context'
 import { ScopePicker } from '@/components/scope-picker/ScopePicker'
 import type { Scope } from '@/components/scope-picker/ScopePicker'
 import { BindingForm } from '@/components/template-policy-bindings/BindingForm'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-bindings/new',
@@ -36,11 +40,7 @@ export function CreateOrgTemplateBindingPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
   const { selectedProject } = useProject()
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   // ScopePicker controls which namespace the binding is created in.
   // Defaults to 'organization' so the existing behaviour is preserved.
@@ -52,6 +52,12 @@ export function CreateOrgTemplateBindingPage({
       : namespaceForOrg(orgName)
 
   const createMutation = useCreateTemplatePolicyBinding(namespace)
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templatePolicyBindings, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canWrite = hasPermission(permissionsQuery.data, createPermission)
 
   return (
     <Card>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/$dependencyName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/$dependencyName.tsx
@@ -8,16 +8,22 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
 import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
   useGetTemplateDependency,
   useUpdateTemplateDependency,
   useDeleteTemplateDependency,
 } from '@/queries/templateDependencies'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { useProject } from '@/lib/project-context'
 import { namespaceForProject } from '@/lib/scope-labels'
 import { DependencyForm } from '@/components/template-dependencies/DependencyForm'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+  updateTemplateResourcePermission,
+} from '@/lib/resource-permissions'
 
 // The detail route accepts an optional `namespace` search param so the
 // project-scoped index can link directly to a dependency in a known namespace.
@@ -64,19 +70,32 @@ export function OrgTemplateDependencyDetailPage({
   const dependencyName = propDependencyName ?? routeParams.dependencyName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
   const { selectedProject } = useProject()
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-  // Delete is OWNER-only in the RBAC cascade for template dependencies.
-  const canDelete = userRole === Role.OWNER
 
   // Namespace resolution: explicit override (for tests) > search param > selected project.
   const namespace =
     namespaceOverride ??
     searchNamespace ??
     (selectedProject ? namespaceForProject(selectedProject) : '')
+  const updatePermission = useMemo(
+    () => updateTemplateResourcePermission(
+      templateResources.templateDependencies,
+      namespace,
+      dependencyName,
+    ),
+    [namespace, dependencyName],
+  )
+  const deletePermission = useMemo(
+    () => deleteTemplateResourcePermission(
+      templateResources.templateDependencies,
+      namespace,
+      dependencyName,
+    ),
+    [namespace, dependencyName],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   const {
     data: dependency,
@@ -190,12 +209,16 @@ export function OrgTemplateDependencyDetailPage({
             pendingLabel="Saving..."
             isPending={updateMutation.isPending}
             onSubmit={async (values) => {
-              await updateMutation.mutateAsync({
-                dependent: values.dependent,
-                requires: values.requires,
-                cascadeDelete: values.cascadeDelete,
-              })
-              toast.success('Dependency saved')
+              try {
+                await updateMutation.mutateAsync({
+                  dependent: values.dependent,
+                  requires: values.requires,
+                  cascadeDelete: values.cascadeDelete,
+                })
+                toast.success('Dependency saved')
+              } catch (err) {
+                toast.error(connectErrorMessage(err))
+              }
             }}
             onCancel={() => {
               void navigate({
@@ -228,7 +251,9 @@ export function OrgTemplateDependencyDetailPage({
             })
             toast.success('Dependency deleted')
           } catch (err) {
-            setDeleteError(err instanceof Error ? err : new Error(String(err)))
+            const message = connectErrorMessage(err)
+            setDeleteError(new Error(message))
+            toast.error(message)
           }
         }}
       />

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-detail.test.tsx
@@ -75,6 +75,7 @@ import {
 import { useGetOrganization } from '@/queries/organizations'
 import { useProject } from '@/lib/project-context'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { OrgTemplateDependencyDetailPage } from './$dependencyName'
 
 function makeMockDependency() {
@@ -104,6 +105,7 @@ function setupMocks(
   userRole: Role = Role.OWNER,
   dependency: ReturnType<typeof makeMockDependency> | undefined = makeMockDependency(),
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useGetTemplateDependency as Mock).mockReturnValue({
     data: dependency,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/-new.test.tsx
@@ -81,6 +81,7 @@ import { useCreateTemplateDependency } from '@/queries/templateDependencies'
 import { useGetOrganization } from '@/queries/organizations'
 import { useProject } from '@/lib/project-context'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { CreateOrgTemplateDependencyPage } from './new'
 
 function setupMocks(
@@ -88,6 +89,7 @@ function setupMocks(
   userRole: Role = Role.OWNER,
   selectedProject: string | null = 'test-project',
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useCreateTemplateDependency as Mock).mockReturnValue({
     mutateAsync,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/index.tsx
@@ -11,7 +11,6 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -20,9 +19,14 @@ import {
   useListTemplateDependencies,
   useDeleteTemplateDependency,
 } from '@/queries/templateDependencies'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { useProject } from '@/lib/project-context'
 import { namespaceForProject } from '@/lib/scope-labels'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route
@@ -68,14 +72,16 @@ export function OrgTemplateDependenciesIndexPage({
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  const { data: org } = useGetOrganization(orgName)
   const { selectedProject } = useProject()
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   // TemplateDependencies are project-scoped. Use the selected project namespace.
   const namespace = selectedProject ? namespaceForProject(selectedProject) : ''
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateDependencies, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const {
     data: dependencies = [],
@@ -118,10 +124,10 @@ export function OrgTemplateDependenciesIndexPage({
         id: 'TemplateDependency',
         label: 'Template Dependency',
         newHref: `/organizations/${orgName}/template-dependencies/new`,
-        canCreate: canWrite,
+        canCreate,
       },
     ],
-    [orgName, canWrite],
+    [orgName, canCreate],
   )
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-dependencies/new.tsx
@@ -1,14 +1,18 @@
+import { useMemo, useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplateDependency } from '@/queries/templateDependencies'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForProject } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { useProject } from '@/lib/project-context'
 import { ScopePicker } from '@/components/scope-picker/ScopePicker'
 import type { Scope } from '@/components/scope-picker/ScopePicker'
 import { DependencyForm } from '@/components/template-dependencies/DependencyForm'
-import { useState } from 'react'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-dependencies/new',
@@ -36,11 +40,7 @@ export function CreateOrgTemplateDependencyPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
   const { selectedProject } = useProject()
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   // ScopePicker controls which namespace the dependency is created in.
   // Defaults to 'project' if a project is selected, else 'organization'.
@@ -52,6 +52,12 @@ export function CreateOrgTemplateDependencyPage({
       : ''
 
   const createMutation = useCreateTemplateDependency(namespace)
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateDependencies, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canWrite = hasPermission(permissionsQuery.data, createPermission)
 
   return (
     <Card>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/$grantName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/$grantName.tsx
@@ -7,15 +7,21 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
 import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
   useGetTemplateGrant,
   useUpdateTemplateGrant,
   useDeleteTemplateGrant,
 } from '@/queries/templateGrants'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
 import { GrantForm } from '@/components/template-grants/GrantForm'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+  updateTemplateResourcePermission,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-grants/$grantName',
@@ -48,15 +54,28 @@ export function OrgTemplateGrantDetailPage({
   const grantName = propGrantName ?? routeParams.grantName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-  // Delete is OWNER-only.
-  const canDelete = userRole === Role.OWNER
 
   // Namespace resolution: explicit override (for tests) > org namespace.
   const namespace = namespaceOverride ?? namespaceForOrg(orgName)
+  const updatePermission = useMemo(
+    () => updateTemplateResourcePermission(
+      templateResources.templateGrants,
+      namespace,
+      grantName,
+    ),
+    [namespace, grantName],
+  )
+  const deletePermission = useMemo(
+    () => deleteTemplateResourcePermission(
+      templateResources.templateGrants,
+      namespace,
+      grantName,
+    ),
+    [namespace, grantName],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   const {
     data: grant,
@@ -153,11 +172,15 @@ export function OrgTemplateGrantDetailPage({
             pendingLabel="Saving..."
             isPending={updateMutation.isPending}
             onSubmit={async (values) => {
-              await updateMutation.mutateAsync({
-                from: values.from,
-                to: values.to,
-              })
-              toast.success('Grant saved')
+              try {
+                await updateMutation.mutateAsync({
+                  from: values.from,
+                  to: values.to,
+                })
+                toast.success('Grant saved')
+              } catch (err) {
+                toast.error(connectErrorMessage(err))
+              }
             }}
             onCancel={() => {
               void navigate({
@@ -190,7 +213,9 @@ export function OrgTemplateGrantDetailPage({
             })
             toast.success('Grant deleted')
           } catch (err) {
-            setDeleteError(err instanceof Error ? err : new Error(String(err)))
+            const message = connectErrorMessage(err)
+            setDeleteError(new Error(message))
+            toast.error(message)
           }
         }}
       />

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-detail.test.tsx
@@ -70,6 +70,7 @@ import {
 } from '@/queries/templateGrants'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { OrgTemplateGrantDetailPage } from './$grantName'
 
 function makeMockGrant() {
@@ -99,6 +100,7 @@ function setupMocks(
   userRole: Role = Role.OWNER,
   grant: ReturnType<typeof makeMockGrant> | undefined = makeMockGrant(),
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useGetTemplateGrant as Mock).mockReturnValue({
     data: grant,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/-new.test.tsx
@@ -76,12 +76,14 @@ vi.mock('@/components/scope-picker/ScopePicker', async () => {
 import { useCreateTemplateGrant } from '@/queries/templateGrants'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { CreateOrgTemplateGrantPage } from './new'
 
 function setupMocks(
   mutateAsync = vi.fn().mockResolvedValue({}),
   userRole: Role = Role.OWNER,
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useCreateTemplateGrant as Mock).mockReturnValue({
     mutateAsync,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/index.tsx
@@ -10,7 +10,6 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -19,8 +18,13 @@ import {
   useListTemplateGrants,
   useDeleteTemplateGrant,
 } from '@/queries/templateGrants'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route
@@ -66,13 +70,14 @@ export function OrgTemplateGrantsIndexPage({
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  const { data: org } = useGetOrganization(orgName)
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-
   // TemplateGrants are org-scoped.
   const namespace = namespaceForOrg(orgName)
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateGrants, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const {
     data: grants = [],
@@ -113,10 +118,10 @@ export function OrgTemplateGrantsIndexPage({
         id: 'TemplateGrant',
         label: 'Template Grant',
         newHref: `/organizations/${orgName}/template-grants/new`,
-        canCreate: canWrite,
+        canCreate,
       },
     ],
-    [orgName, canWrite],
+    [orgName, canCreate],
   )
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-grants/new.tsx
@@ -1,13 +1,17 @@
+import { useMemo, useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplateGrant } from '@/queries/templateGrants'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { ScopePicker } from '@/components/scope-picker/ScopePicker'
 import type { Scope } from '@/components/scope-picker/ScopePicker'
 import { GrantForm } from '@/components/template-grants/GrantForm'
-import { useState } from 'react'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-grants/new',
@@ -35,10 +39,6 @@ export function CreateOrgTemplateGrantPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   // ScopePicker controls org vs folder scope. Defaults to 'organization'.
   const [scope, setScope] = useState<Scope>('organization')
@@ -47,6 +47,12 @@ export function CreateOrgTemplateGrantPage({
   const namespace = scope === 'organization' ? namespaceForOrg(orgName) : ''
 
   const createMutation = useCreateTemplateGrant(namespace)
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateGrants, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canWrite = hasPermission(permissionsQuery.data, createPermission)
 
   return (
     <Card>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/$policyName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/$policyName.tsx
@@ -14,14 +14,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
   useGetTemplatePolicy,
   useUpdateTemplatePolicy,
   useDeleteTemplatePolicy,
 } from '@/queries/templatePolicies'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import {
   PolicyForm,
@@ -29,6 +28,13 @@ import {
 } from '@/components/template-policies/PolicyForm'
 import { ruleProtoToDraft } from '@/components/template-policies/rule-draft'
 import { PolicyBindingsSection } from '@/components/template-policies/PolicyBindingsSection'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+  updateTemplateResourcePermission,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-policies/$policyName',
@@ -62,13 +68,25 @@ export function OrgTemplatePolicyDetailPage({
 
   const navigate = useNavigate()
   const namespace = namespaceForOrg(orgName)
-  const { data: org } = useGetOrganization(orgName)
-  const userRole = org?.userRole ?? Role.VIEWER
-  // PERMISSION_TEMPLATE_POLICIES_WRITE cascades to editors too.
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-  // PERMISSION_TEMPLATE_POLICIES_DELETE is OWNER-only in the RBAC cascade
-  // table, so editors must not see the destructive control.
-  const canDelete = userRole === Role.OWNER
+  const updatePermission = useMemo(
+    () => updateTemplateResourcePermission(
+      templateResources.templatePolicies,
+      namespace,
+      policyName,
+    ),
+    [namespace, policyName],
+  )
+  const deletePermission = useMemo(
+    () => deleteTemplateResourcePermission(
+      templateResources.templatePolicies,
+      namespace,
+      policyName,
+    ),
+    [namespace, policyName],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   const scopeType: PolicyScope = forcedScopeType ?? 'organization'
 
@@ -166,8 +184,12 @@ export function OrgTemplatePolicyDetailPage({
             pendingLabel="Saving..."
             isPending={updateMutation.isPending}
             onSubmit={async (values) => {
-              await updateMutation.mutateAsync(values)
-              toast.success('Policy saved')
+              try {
+                await updateMutation.mutateAsync(values)
+                toast.success('Policy saved')
+              } catch (err) {
+                toast.error(connectErrorMessage(err))
+              }
             }}
             onCancel={() => {
               void navigate({
@@ -214,7 +236,7 @@ export function OrgTemplatePolicyDetailPage({
                   })
                   toast.success('Policy deleted')
                 } catch (err) {
-                  toast.error(err instanceof Error ? err.message : String(err))
+                  toast.error(connectErrorMessage(err))
                 }
               }}
             >

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-detail.test.tsx
@@ -75,6 +75,7 @@ import {
 import { useListTemplatePolicyBindings } from '@/queries/templatePolicyBindings'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { OrgTemplatePolicyDetailPage } from './$policyName'
 
 function makeMockPolicy() {
@@ -109,6 +110,7 @@ function setupMocks(
     targetRefs?: Array<{ kind?: number; name: string; projectName?: string }>
   }> = [],
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useGetTemplatePolicy as Mock).mockReturnValue({
     data: policy,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-index.test.tsx
@@ -12,6 +12,7 @@ import type { Mock } from 'vitest'
 import React from 'react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { namespaceForOrg, namespaceForFolder } from '@/lib/scope-labels'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Router mock — Route.useParams / useSearch / useNavigate / fullPath
@@ -118,6 +119,7 @@ function setup(
   userRole: Role = Role.OWNER,
   overrides: Partial<{ isPending: boolean; error: Error | null }> = {},
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useListTemplatePolicies as Mock).mockReturnValue({
     data: overrides.isPending ? undefined : policies,
     isPending: overrides.isPending ?? false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/-new.test.tsx
@@ -132,6 +132,7 @@ import { useGetOrganization } from '@/queries/organizations'
 import { useListLinkableTemplates } from '@/queries/templates'
 import { useProject } from '@/lib/project-context'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { CreateOrgTemplatePolicyPage } from './new'
 
 function setupMocks(
@@ -139,6 +140,7 @@ function setupMocks(
   userRole: Role = Role.OWNER,
   selectedProject: string | null = 'test-project',
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useCreateTemplatePolicy as Mock).mockReturnValue({
     mutateAsync,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/index.tsx
@@ -13,7 +13,6 @@
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Badge } from '@/components/ui/badge'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -24,7 +23,7 @@ import {
   countRulesByKind,
 } from '@/queries/templatePolicies'
 import type { TemplatePolicy } from '@/queries/templatePolicies'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import {
   scopeDisplayLabel,
   scopeNameFromNamespace,
@@ -35,6 +34,11 @@ import {
   parentLabelFromNamespace,
 } from '@/lib/template-row-link'
 import type { ColumnDef } from '@tanstack/react-table'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route
@@ -153,11 +157,14 @@ export function OrgTemplatePoliciesIndexPage({
 
   const orgNamespace = namespaceForOrg(orgName)
   const { data: policies = [], isPending, error } = useListTemplatePolicies(orgNamespace)
-  const { data: org } = useGetOrganization(orgName)
   const deleteMutation = useDeleteTemplatePolicy(orgNamespace)
 
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templatePolicies, orgNamespace),
+    [orgNamespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   // Build a lookup map for extra columns to access the original policy object.
   const policiesByName = useMemo(() => {
@@ -192,10 +199,10 @@ export function OrgTemplatePoliciesIndexPage({
         id: 'TemplatePolicy',
         label: 'Template Policy',
         newHref: `/organizations/${orgName}/template-policies/new`,
-        canCreate: canWrite,
+        canCreate,
       },
     ],
-    [orgName, canWrite],
+    [orgName, canCreate],
   )
 
   const extraColumns = usePolicyExtraColumns(policiesByName)

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-policies/new.tsx
@@ -1,14 +1,18 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplatePolicy } from '@/queries/templatePolicies'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg, namespaceForProject } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { useProject } from '@/lib/project-context'
 import { ScopePicker } from '@/components/scope-picker/ScopePicker'
 import type { Scope } from '@/components/scope-picker/ScopePicker'
 import { PolicyForm } from '@/components/template-policies/PolicyForm'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-policies/new',
@@ -36,12 +40,7 @@ export function CreateOrgTemplatePolicyPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
   const { selectedProject } = useProject()
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  // PERMISSION_TEMPLATE_POLICIES_WRITE cascades to editors too.
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   // ScopePicker controls which namespace the policy is created in.
   // Defaults to 'organization' so the existing behaviour is preserved.
@@ -53,6 +52,12 @@ export function CreateOrgTemplatePolicyPage({
       : namespaceForOrg(orgName)
 
   const createMutation = useCreateTemplatePolicy(namespace)
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templatePolicies, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canWrite = hasPermission(permissionsQuery.data, createPermission)
 
   return (
     <Card>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/$requirementName.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/$requirementName.tsx
@@ -7,15 +7,21 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
 import { ConfirmDeleteDialog } from '@/components/ui/confirm-delete-dialog'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import {
   useGetTemplateRequirement,
   useUpdateTemplateRequirement,
   useDeleteTemplateRequirement,
 } from '@/queries/templateRequirements'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
 import { RequirementForm } from '@/components/template-requirements/RequirementForm'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+  updateTemplateResourcePermission,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-requirements/$requirementName',
@@ -50,15 +56,28 @@ export function OrgTemplateRequirementDetailPage({
   const requirementName = propRequirementName ?? routeParams.requirementName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-  // Delete is OWNER-only.
-  const canDelete = userRole === Role.OWNER
 
   // Namespace resolution: explicit override (for tests) > org namespace.
   const namespace = namespaceOverride ?? namespaceForOrg(orgName)
+  const updatePermission = useMemo(
+    () => updateTemplateResourcePermission(
+      templateResources.templateRequirements,
+      namespace,
+      requirementName,
+    ),
+    [namespace, requirementName],
+  )
+  const deletePermission = useMemo(
+    () => deleteTemplateResourcePermission(
+      templateResources.templateRequirements,
+      namespace,
+      requirementName,
+    ),
+    [namespace, requirementName],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   const {
     data: requirement,
@@ -155,11 +174,15 @@ export function OrgTemplateRequirementDetailPage({
             pendingLabel="Saving..."
             isPending={updateMutation.isPending}
             onSubmit={async (values) => {
-              await updateMutation.mutateAsync({
-                requires: values.requires,
-                cascadeDelete: values.cascadeDelete,
-              })
-              toast.success('Requirement saved')
+              try {
+                await updateMutation.mutateAsync({
+                  requires: values.requires,
+                  cascadeDelete: values.cascadeDelete,
+                })
+                toast.success('Requirement saved')
+              } catch (err) {
+                toast.error(connectErrorMessage(err))
+              }
             }}
             onCancel={() => {
               void navigate({
@@ -192,7 +215,9 @@ export function OrgTemplateRequirementDetailPage({
             })
             toast.success('Requirement deleted')
           } catch (err) {
-            setDeleteError(err instanceof Error ? err : new Error(String(err)))
+            const message = connectErrorMessage(err)
+            setDeleteError(new Error(message))
+            toast.error(message)
           }
         }}
       />

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-detail.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-detail.test.tsx
@@ -70,6 +70,7 @@ import {
 } from '@/queries/templateRequirements'
 import { useGetOrganization } from '@/queries/organizations'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { OrgTemplateRequirementDetailPage } from './$requirementName'
 
 function makeMockRequirement() {
@@ -94,6 +95,7 @@ function setupMocks(
   userRole: Role = Role.OWNER,
   requirement: ReturnType<typeof makeMockRequirement> | undefined = makeMockRequirement(),
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useGetTemplateRequirement as Mock).mockReturnValue({
     data: requirement,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/-new.test.tsx
@@ -81,12 +81,14 @@ import { useCreateTemplateRequirement } from '@/queries/templateRequirements'
 import { useGetOrganization } from '@/queries/organizations'
 import { useProject } from '@/lib/project-context'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { CreateOrgTemplateRequirementPage } from './new'
 
 function setupMocks(
   mutateAsync = vi.fn().mockResolvedValue({}),
   userRole: Role = Role.OWNER,
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useCreateTemplateRequirement as Mock).mockReturnValue({
     mutateAsync,
     isPending: false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/index.tsx
@@ -10,7 +10,6 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -19,8 +18,13 @@ import {
   useListTemplateRequirements,
   useDeleteTemplateRequirement,
 } from '@/queries/templateRequirements'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route
@@ -66,13 +70,14 @@ export function OrgTemplateRequirementsIndexPage({
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  const { data: org } = useGetOrganization(orgName)
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-
   // TemplateRequirements are org-scoped.
   const namespace = namespaceForOrg(orgName)
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateRequirements, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const {
     data: requirements = [],
@@ -113,10 +118,10 @@ export function OrgTemplateRequirementsIndexPage({
         id: 'TemplateRequirement',
         label: 'Template Requirement',
         newHref: `/organizations/${orgName}/template-requirements/new`,
-        canCreate: canWrite,
+        canCreate,
       },
     ],
-    [orgName, canWrite],
+    [orgName, canCreate],
   )
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/template-requirements/new.tsx
@@ -1,13 +1,17 @@
+import { useMemo, useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplateRequirement } from '@/queries/templateRequirements'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { ScopePicker } from '@/components/scope-picker/ScopePicker'
 import type { Scope } from '@/components/scope-picker/ScopePicker'
 import { RequirementForm } from '@/components/template-requirements/RequirementForm'
-import { useState } from 'react'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute(
   '/_authenticated/organizations/$orgName/template-requirements/new',
@@ -35,10 +39,6 @@ export function CreateOrgTemplateRequirementPage({
   const orgName = propOrgName ?? routeOrgName ?? ''
 
   const navigate = useNavigate()
-  const { data: org } = useGetOrganization(orgName)
-
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
 
   // ScopePicker controls org vs folder scope. Defaults to 'organization'.
   const [scope, setScope] = useState<Scope>('organization')
@@ -47,6 +47,12 @@ export function CreateOrgTemplateRequirementPage({
   const namespace = scope === 'organization' ? namespaceForOrg(orgName) : ''
 
   const createMutation = useCreateTemplateRequirement(namespace)
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateRequirements, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canWrite = hasPermission(permissionsQuery.data, createPermission)
 
   return (
     <Card>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/$namespace.$name.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
@@ -20,11 +20,19 @@ import {
   useDeleteTemplate,
   useGetTemplateDefaults,
 } from '@/queries/templates'
+import { useResourcePermissions } from '@/queries/permissions'
 import type { TemplateExample, TemplateDefaults } from '@/queries/templates'
 import { CueTemplateEditor } from '@/components/cue-template-editor'
 import { TemplateExamplePicker } from '@/components/templates/template-example-picker'
 import { useProject } from '@/lib/project-context'
 import { ReverseDependents } from '@/components/templates/ReverseDependents'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+  updateTemplateResourcePermission,
+} from '@/lib/resource-permissions'
 
 // templateDefaultsToCueInput converts a TemplateDefaults message into a CUE
 // input snippet suitable for pre-populating the Project Input textarea. Only
@@ -87,6 +95,17 @@ export function ConsolidatedTemplateEditorPage({
   const { data: templateDefaults } = useGetTemplateDefaults({ namespace, name })
   const updateMutation = useUpdateTemplate(namespace, name)
   const deleteMutation = useDeleteTemplate(namespace)
+  const updatePermission = useMemo(
+    () => updateTemplateResourcePermission(templateResources.templates, namespace, name),
+    [namespace, name],
+  )
+  const deletePermission = useMemo(
+    () => deleteTemplateResourcePermission(templateResources.templates, namespace, name),
+    [namespace, name],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   // Resolve the selected project so the "Clone to project" CTA can build the
   // target URL without requiring additional user input. If no project is
@@ -124,7 +143,7 @@ export function ConsolidatedTemplateEditorPage({
       })
       toast.success('Saved')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -138,8 +157,8 @@ export function ConsolidatedTemplateEditorPage({
       setDeleteOpen(false)
       toast.success('Template deleted')
       navigate({ to: '/organizations/$orgName/templates', params: { orgName } })
-    } catch {
-      /* error surfaced via deleteMutation.error inside the dialog */
+    } catch (err) {
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -203,13 +222,15 @@ export function ConsolidatedTemplateEditorPage({
               Clone to project
             </Button>
           )}
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => setDeleteOpen(true)}
-          >
-            Delete
-          </Button>
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+            >
+              Delete
+            </Button>
+          )}
         </div>
 
         <div className="space-y-4">
@@ -238,6 +259,7 @@ export function ConsolidatedTemplateEditorPage({
             onChange={setCueTemplate}
             onSave={handleSave}
             isSaving={updateMutation.isPending}
+            readOnly={!canWrite}
             defaultProjectInput={templateDefaultsToCueInput(templateDefaults)}
             namespace={namespace}
           />
@@ -269,7 +291,7 @@ export function ConsolidatedTemplateEditorPage({
           </DialogHeader>
           {deleteMutation.error && (
             <Alert variant="destructive">
-              <AlertDescription>{deleteMutation.error.message}</AlertDescription>
+              <AlertDescription>{connectErrorMessage(deleteMutation.error)}</AlertDescription>
             </Alert>
           )}
           <DialogFooter>

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/-index.test.tsx
@@ -108,6 +108,7 @@ import {
   namespaceForFolder,
   namespaceForProject,
 } from '@/lib/scope-labels'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { OrgTemplatesIndexPage } from './index'
 
 type TemplateFixture = {
@@ -140,6 +141,7 @@ function setup(
   policies: PolicyFixture[] = [],
   bindings: BindingFixture[] = [],
 ) {
+  mockResourcePermissionsForRole(userRole)
   ;(useAllTemplatesForOrg as Mock).mockReturnValue({
     data: overrides.isPending ? undefined : templates,
     isPending: overrides.isPending ?? false,

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/index.tsx
@@ -29,7 +29,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { ResourceGrid } from '@/components/resource-grid/ResourceGrid'
 import type { Row } from '@/components/resource-grid/types'
 import type { ColumnDef } from '@tanstack/react-table'
@@ -38,8 +37,9 @@ import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useAllTemplatesForOrg } from '@/queries/templates'
 import { useAllTemplatePoliciesForOrg } from '@/queries/templatePolicies'
 import { useAllTemplatePolicyBindingsForOrg } from '@/queries/templatePolicyBindings'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import {
+  namespaceForOrg,
   scopeLabelFromNamespace,
   scopeNameFromNamespace,
   scopeDisplayLabel,
@@ -48,6 +48,11 @@ import {
   resolveTemplateRowHref,
   parentLabelFromNamespace,
 } from '@/lib/template-row-link'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route search — extends ResourceGridSearch with the scope filter
@@ -151,14 +156,32 @@ export function OrgTemplatesIndexPage({
   const templatesResult = useAllTemplatesForOrg(orgName)
   const policiesResult = useAllTemplatePoliciesForOrg(orgName)
   const bindingsResult = useAllTemplatePolicyBindingsForOrg(orgName)
-  const { data: org } = useGetOrganization(orgName)
 
   const templates = useMemo(() => templatesResult.data ?? [], [templatesResult.data])
   const policies = useMemo(() => policiesResult.data ?? [], [policiesResult.data])
   const bindings = useMemo(() => bindingsResult.data ?? [], [bindingsResult.data])
 
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER
+  const orgNamespace = namespaceForOrg(orgName)
+  const createTemplatePermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templates, orgNamespace),
+    [orgNamespace],
+  )
+  const createPolicyPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templatePolicies, orgNamespace),
+    [orgNamespace],
+  )
+  const createBindingPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templatePolicyBindings, orgNamespace),
+    [orgNamespace],
+  )
+  const permissionsQuery = useResourcePermissions([
+    createTemplatePermission,
+    createPolicyPermission,
+    createBindingPermission,
+  ])
+  const canCreateTemplate = hasPermission(permissionsQuery.data, createTemplatePermission)
+  const canCreatePolicy = hasPermission(permissionsQuery.data, createPolicyPermission)
+  const canCreateBinding = hasPermission(permissionsQuery.data, createBindingPermission)
 
   // Combine loading and error state across all three fan-outs.
   const isPending = templatesResult.isPending || policiesResult.isPending || bindingsResult.isPending
@@ -252,22 +275,22 @@ export function OrgTemplatesIndexPage({
         id: 'Template',
         label: 'Template',
         newHref: `/organizations/${orgName}/templates/new`,
-        canCreate: canWrite,
+        canCreate: canCreateTemplate,
       },
       {
         id: 'TemplatePolicy',
         label: 'Template Policy',
         newHref: `/organizations/${orgName}/template-policies/new`,
-        canCreate: canWrite,
+        canCreate: canCreatePolicy,
       },
       {
         id: 'TemplatePolicyBinding',
         label: 'Template Binding',
         newHref: `/organizations/${orgName}/template-bindings/new`,
-        canCreate: canWrite,
+        canCreate: canCreateBinding,
       },
     ],
-    [orgName, canWrite],
+    [orgName, canCreateTemplate, canCreatePolicy, canCreateBinding],
   )
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/routes/_authenticated/organizations/$orgName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/templates/new.tsx
@@ -1,10 +1,15 @@
+import { useMemo } from 'react'
 import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useCreateTemplate } from '@/queries/templates'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForOrg } from '@/lib/scope-labels'
-import { useGetOrganization } from '@/queries/organizations'
 import { TemplateCreateForm } from '@/components/templates/TemplateCreateForm'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute('/_authenticated/organizations/$orgName/templates/new')({
   component: CreateOrgTemplateRoute,
@@ -28,10 +33,13 @@ export function CreateOrgTemplatePage({ orgName: propOrgName }: { orgName?: stri
   const navigate = useNavigate()
   const namespace = namespaceForOrg(orgName)
   const createMutation = useCreateTemplate(namespace)
-  const { data: org } = useGetOrganization(orgName)
 
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templates, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canWrite = hasPermission(permissionsQuery.data, createPermission)
 
   return (
     <Card>

--- a/frontend/src/routes/_authenticated/organizations/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/index.tsx
@@ -13,7 +13,7 @@
  * needed here.
  */
 
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 
 import { Button } from '@/components/ui/button'
@@ -22,6 +22,11 @@ import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useListOrganizations } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
+import {
+  createNamespacePermission,
+  hasPermission,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute('/_authenticated/organizations/')({
   validateSearch: parseGridSearch,
@@ -45,6 +50,9 @@ export function OrganizationsIndexPage() {
   const navigate = useNavigate()
   const { data, isLoading, error } = useListOrganizations()
   const organizations = data?.organizations ?? []
+  const createPermission = useMemo(() => createNamespacePermission(), [])
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const rows: Row[] = organizations.map((org) => ({
     kind: 'Organization',
@@ -69,9 +77,11 @@ export function OrganizationsIndexPage() {
   ]
 
   const createOrgButton = (
-    <Link to="/organization/new" search={{ returnTo: '/organizations' }}>
-      <Button size="sm">Create Organization</Button>
-    </Link>
+    canCreate ? (
+      <Link to="/organization/new" search={{ returnTo: '/organizations' }}>
+        <Button size="sm">Create Organization</Button>
+      </Link>
+    ) : null
   )
 
   const handleSearchChange = useCallback(
@@ -89,9 +99,11 @@ export function OrganizationsIndexPage() {
   const emptyState = (
     <div className="flex flex-col items-center gap-3 py-8 text-center">
       <p className="text-muted-foreground">No organizations yet. Create one.</p>
-      <Link to="/organization/new" search={{ returnTo: '/organizations' }}>
-        <Button size="sm">Create Organization</Button>
-      </Link>
+      {canCreate && (
+        <Link to="/organization/new" search={{ returnTo: '/organizations' }}>
+          <Button size="sm">Create Organization</Button>
+        </Link>
+      )}
     </div>
   )
 

--- a/frontend/src/routes/_authenticated/project/new.tsx
+++ b/frontend/src/routes/_authenticated/project/new.tsx
@@ -25,6 +25,7 @@ import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import { toSlug } from '@/lib/slug'
 import { resolveReturnTo } from '@/lib/return-to'
 import { useOrg } from '@/lib/org-context'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 export const Route = createFileRoute('/_authenticated/project/new')({
   validateSearch: (
@@ -116,7 +117,7 @@ export function ProjectNewPage({ orgName, folderName, returnTo }: ProjectNewPage
       const target = resolveReturnTo(returnTo, fallback)
       navigate({ to: target })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create project')
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/$deploymentName.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { StringListInput } from '@/components/string-list-input'
@@ -36,7 +36,6 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { ArrowLeft, CheckCircle2, ExternalLink, Info, TriangleAlert, XCircle } from 'lucide-react'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import type {
   ContainerStatus,
   DeploymentDependency,
@@ -56,13 +55,20 @@ import {
   useSetDependencyEdgeCascadeDelete,
   useUpdateDeployment,
 } from '@/queries/deployments'
-import { useGetProject } from '@/queries/projects'
+import { useResourcePermissions } from '@/queries/permissions'
 import { isSafeHttpUrl } from '@/lib/url'
 import { PolicySection } from '@/components/policy-drift/PolicySection'
 import { SharedDependencyBadge } from '@/components/deployments/SharedDependencyBadge'
 import { CascadeDeleteToggle } from '@/components/deployments/CascadeDeleteToggle'
 import { ReverseDependents } from '@/components/templates/ReverseDependents'
 import { namespaceForProject } from '@/lib/scope-labels'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteNamespacedResourcePermission,
+  DEPLOYMENTS_API_GROUP,
+  hasPermission,
+  updateNamespacedResourcePermission,
+} from '@/lib/resource-permissions'
 
 type DeploymentTab = 'status' | 'logs' | 'preview'
 
@@ -126,7 +132,7 @@ function DependencyEdgeCascadeRow({
       )}
       {mutation.error && (
         <Alert variant="destructive">
-          <AlertDescription>{mutation.error.message}</AlertDescription>
+          <AlertDescription>{connectErrorMessage(mutation.error)}</AlertDescription>
         </Alert>
       )}
       <CascadeDeleteToggle
@@ -345,7 +351,6 @@ export function DeploymentDetailPage({
   const navigate = useNavigate()
   const { data: deployment, isPending, error } = useGetDeployment(projectName, deploymentName)
   const { data: status } = useGetDeploymentStatus(projectName, deploymentName, { refetchInterval: 5000 })
-  const { data: project } = useGetProject(projectName)
   const { data: policyState, isPending: isPolicyPending, error: policyError } = useGetDeploymentPolicyState(projectName, deploymentName)
   const { data: renderPreview, isPending: isPreviewPending, error: previewError } = useGetDeploymentRenderPreview(projectName, deploymentName)
 
@@ -393,9 +398,28 @@ export function DeploymentDetailPage({
     }
   }, [deployment?.image, deployment?.tag, deployment?.port, deployment?.command, deployment?.args, deployment?.env])
 
-  const userRole = project?.userRole ?? Role.VIEWER
-  const canWrite = userRole === Role.OWNER || userRole === Role.EDITOR
-  const canDelete = userRole === Role.OWNER
+  const namespace = namespaceForProject(projectName)
+  const updatePermission = useMemo(
+    () => updateNamespacedResourcePermission(
+      DEPLOYMENTS_API_GROUP,
+      'deployments',
+      namespace,
+      deploymentName,
+    ),
+    [namespace, deploymentName],
+  )
+  const deletePermission = useMemo(
+    () => deleteNamespacedResourcePermission(
+      DEPLOYMENTS_API_GROUP,
+      'deployments',
+      namespace,
+      deploymentName,
+    ),
+    [namespace, deploymentName],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   const handleRedeployOpen = () => {
     setRedeployImage(deployment?.image ?? '')
@@ -428,7 +452,7 @@ export function DeploymentDetailPage({
       })
       toast.success('Reconcile requested')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -447,7 +471,7 @@ export function DeploymentDetailPage({
       setRedeployOpen(false)
       toast.success('Deployment updated')
     } catch (err) {
-      setRedeployError(err instanceof Error ? err.message : String(err))
+      setRedeployError(connectErrorMessage(err))
     }
   }
 
@@ -456,7 +480,9 @@ export function DeploymentDetailPage({
       await deleteMutation.mutateAsync({ name: deploymentName })
       setDeleteOpen(false)
       navigate({ to: '/projects/$projectName/deployments', params: { projectName } })
-    } catch { /* error shown via mutation */ }
+    } catch (err) {
+      toast.error(connectErrorMessage(err))
+    }
   }
 
   if (isPending) {
@@ -1033,7 +1059,7 @@ export function DeploymentDetailPage({
           </DialogHeader>
           {deleteMutation.error && (
             <Alert variant="destructive">
-              <AlertDescription>{deleteMutation.error.message}</AlertDescription>
+              <AlertDescription>{connectErrorMessage(deleteMutation.error)}</AlertDescription>
             </Alert>
           )}
           <DialogFooter>

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -77,6 +77,7 @@ import { useGetDeployment, useGetDeploymentStatus, useGetDeploymentLogs, useUpda
 import { useGetProject } from '@/queries/projects'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { DeploymentPhase } from '@/gen/holos/console/v1/deployments_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 import { DeploymentDetailPage } from './$deploymentName'
 
 const mockDeployment = {
@@ -190,6 +191,7 @@ const mockStatusWithHealthyContainers = {
 const mockLogs = '2024-01-15T10:30:01Z Starting server...\n2024-01-15T10:30:02Z Listening on :8080'
 
 function setupMocks(userRole = Role.OWNER) {
+  mockResourcePermissionsForRole(userRole)
   ;(useGetDeployment as Mock).mockReturnValue({ data: mockDeployment, isPending: false, error: null })
   ;(useGetDeploymentStatus as Mock).mockReturnValue({ data: mockStatus, isPending: false, error: null })
   ;(useGetDeploymentLogs as Mock).mockReturnValue({ data: mockLogs, isPending: false, error: null })

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-index.test.tsx
@@ -13,6 +13,7 @@ import type { Mock } from 'vitest'
 import React from 'react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { DeploymentPhase, type DeploymentStatusSummary } from '@/gen/holos/console/v1/deployments_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Router mock — Route.useParams / useSearch / useNavigate
@@ -131,6 +132,7 @@ function setupMocks({
   error = null as Error | null,
   userRole = Role.OWNER,
 } = {}) {
+  mockResourcePermissionsForRole(userRole)
   ;(useListDeployments as Mock).mockReturnValue({ data: deployments, isPending, error })
   ;(useDeleteDeployment as Mock).mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/index.tsx
@@ -11,19 +11,24 @@
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useListDeployments, useDeleteDeployment } from '@/queries/deployments'
-import { useGetProject } from '@/queries/projects'
+import { useResourcePermissions } from '@/queries/permissions'
 import { PhaseBadge } from '@/components/phase-badge'
 import { PolicyDriftBadge } from '@/components/policy-drift/PolicySection'
 import { SharedDependencyBadge } from '@/components/deployments/SharedDependencyBadge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { Deployment } from '@/gen/holos/console/v1/deployments_pb'
+import { namespaceForProject } from '@/lib/scope-labels'
+import {
+  createNamespacedResourcePermission,
+  DEPLOYMENTS_API_GROUP,
+  hasPermission,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route
@@ -109,12 +114,20 @@ export function DeploymentsListPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  const { data: project } = useGetProject(projectName)
   const { data: deployments = [], isPending, error } = useListDeployments(projectName)
   const deleteMutation = useDeleteDeployment(projectName)
 
-  const userRole = project?.userRole ?? Role.VIEWER
-  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+  const namespace = namespaceForProject(projectName)
+  const createPermission = useMemo(
+    () => createNamespacedResourcePermission(
+      DEPLOYMENTS_API_GROUP,
+      'deployments',
+      namespace,
+    ),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   // Build name→deployment lookup for extra columns.
   const deploymentsByName = useMemo(() => {

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/new.tsx
@@ -21,6 +21,7 @@ import {
 import { namespaceForProject } from '@/lib/scope-labels'
 import { PreflightConflicts, hasConflicts } from '@/components/deployments/PreflightConflicts'
 import { CascadeDeleteToggle } from '@/components/deployments/CascadeDeleteToggle'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/deployments/new')({
   component: CreateDeploymentRoute,
@@ -335,7 +336,7 @@ export function CreateDeploymentPage({ projectName: propProjectName }: { project
         search: { tab: 'status' },
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/$name.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/$name.tsx
@@ -22,6 +22,7 @@ import { isSafeUrl } from '@/lib/utils'
 import { useGetSecret, useGetSecretMetadata, useGetSecretRaw, useUpdateSecret, useUpdateSecretSharing, useDeleteSecret } from '@/queries/secrets'
 import type { ShareGrant } from '@/gen/holos/console/v1/secrets_pb.js'
 import { isOwner as computeIsOwner } from '@/lib/isOwner'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/secrets/$name')({
   component: SecretPage,
@@ -156,7 +157,7 @@ export function SecretPage() {
       // next Raw view switch will fetch fresh data.
       setRawEnabled(false)
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : String(err))
+      setSaveError(connectErrorMessage(err))
     }
   }
 
@@ -174,7 +175,9 @@ export function SecretPage() {
       await deleteMutation.mutateAsync(name)
       setDeleteOpen(false)
       navigate({ to: '/projects/$projectName/secrets', params: { projectName } })
-    } catch { /* error via mutation */ }
+    } catch (err) {
+      setSaveError(connectErrorMessage(err))
+    }
   }
 
   const isLoading = dataLoading || metaLoading
@@ -352,7 +355,9 @@ export function SecretPage() {
             </DialogDescription>
           </DialogHeader>
           {deleteMutation.error && (
-            <Alert variant="destructive"><AlertDescription>{deleteMutation.error.message}</AlertDescription></Alert>
+            <Alert variant="destructive">
+              <AlertDescription>{connectErrorMessage(deleteMutation.error)}</AlertDescription>
+            </Alert>
           )}
           <DialogFooter>
             <Button variant="ghost" onClick={() => setDeleteOpen(false)}>Cancel</Button>

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/-index.test.tsx
@@ -10,6 +10,7 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Router mock — Route.useParams / useSearch / useNavigate
@@ -93,6 +94,7 @@ function setupMocks({
   error?: Error | null
   userRole?: number
 } = {}) {
+  mockResourcePermissionsForRole(userRole)
   ;(useAllSecretsForProject as Mock).mockReturnValue({ data: rows, isPending, error })
   ;(useDeleteSecret as Mock).mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/index.tsx
@@ -6,15 +6,19 @@
  * Detail and new/edit flows are unchanged — only the list page is rewritten.
  */
 
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { useAllSecretsForProject, useDeleteSecret } from '@/queries/secrets'
-import { useGetProject } from '@/queries/projects'
+import { useResourcePermissions } from '@/queries/permissions'
+import { namespaceForProject } from '@/lib/scope-labels'
+import {
+  createNamespacedResourcePermission,
+  hasPermission,
+} from '@/lib/resource-permissions'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/secrets/')({
   validateSearch: parseGridSearch,
@@ -26,14 +30,17 @@ export function SecretsListPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
 
-  const { data: project } = useGetProject(projectName)
-
   const { data: secretRows = [], isPending, error } = useAllSecretsForProject(projectName)
 
   const deleteMutation = useDeleteSecret(projectName)
 
-  const userRole = project?.userRole ?? Role.VIEWER
-  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+  const namespace = namespaceForProject(projectName)
+  const createPermission = useMemo(
+    () => createNamespacedResourcePermission('', 'secrets', namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   // Map SecretRow → ResourceGrid Row.
   // HOL-990 AC1.1: Resource ID is the bare metadata.name, not a composite

--- a/frontend/src/routes/_authenticated/projects/$projectName/secrets/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/secrets/new.tsx
@@ -20,6 +20,7 @@ import { useAuth } from '@/lib/auth'
 import { useCreateSecret } from '@/queries/secrets'
 import { useGetProject } from '@/queries/projects'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 interface CreateGrant {
   principal: string
@@ -101,7 +102,7 @@ export function SecretCreatePage({ projectName }: { projectName: string }) {
         params: { projectName, name: name.trim() },
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings-deployments.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings-deployments.test.tsx
@@ -44,7 +44,12 @@ import { useGetProjectSettings, useGetProjectSettingsRaw, useUpdateProjectSettin
 import { useGetOrganization } from '@/queries/organizations'
 import { useListFolders } from '@/queries/folders'
 import { useAuth } from '@/lib/auth'
+import { namespaceForOrg } from '@/lib/scope-labels'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import {
+  isResourcePermissionAllowedForRole,
+  mockResourcePermissions,
+} from '@/test/resource-permissions'
 import { ProjectSettingsPage } from './index'
 
 const mockProject = {
@@ -65,6 +70,12 @@ function setupMocks(overrides: {
   orgUserRole?: number
 } = {}) {
   const project = { ...mockProject, ...overrides.projectOverrides }
+  const orgUserRole = overrides.orgUserRole ?? Role.OWNER
+  mockResourcePermissions((attr) => {
+    const role =
+      attr.name === namespaceForOrg(project.organization) ? orgUserRole : project.userRole
+    return isResourcePermissionAllowedForRole(role, attr)
+  })
   ;(useGetProject as Mock).mockReturnValue({ data: project, isPending: false, error: null })
   ;(useUpdateProject as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
   ;(useUpdateProjectSharing as Mock).mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false })
@@ -85,7 +96,7 @@ function setupMocks(overrides: {
     isPending: false,
   })
   ;(useGetOrganization as Mock).mockReturnValue({
-    data: { name: 'my-org', userRole: overrides.orgUserRole ?? Role.OWNER },
+    data: { name: 'my-org', userRole: orgUserRole },
     isPending: false,
     error: null,
   })
@@ -139,8 +150,8 @@ describe('ProjectSettingsPage -- Features section', () => {
     })
   })
 
-  it('toggle is disabled when user is not org-level owner', () => {
-    setupMocks({ orgUserRole: Role.EDITOR })
+  it('toggle is disabled when org update permission is denied', () => {
+    setupMocks({ orgUserRole: Role.VIEWER })
     render(<ProjectSettingsPage />)
     const toggle = screen.getByRole('switch', { name: /deployments/i })
     expect(toggle).toBeDisabled()
@@ -160,11 +171,11 @@ describe('ProjectSettingsPage -- Features section', () => {
     expect(toggle).not.toBeDisabled()
   })
 
-  it('toggle is disabled when org data is not available', () => {
+  it('toggle remains enabled when org data is not available but project org is known', () => {
     setupMocks()
     ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: true, error: null })
     render(<ProjectSettingsPage />)
     const toggle = screen.getByRole('switch', { name: /deployments/i })
-    expect(toggle).toBeDisabled()
+    expect(toggle).not.toBeDisabled()
   })
 })

--- a/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx
@@ -44,6 +44,11 @@ import { useGetProjectSettings, useGetProjectSettingsRaw, useUpdateProjectSettin
 import { useGetOrganization } from '@/queries/organizations'
 import { useListFolders } from '@/queries/folders'
 import { useAuth } from '@/lib/auth'
+import { namespaceForOrg } from '@/lib/scope-labels'
+import {
+  isResourcePermissionAllowedForRole,
+  mockResourcePermissions,
+} from '@/test/resource-permissions'
 import { ProjectSettingsPage } from './index'
 
 const mockProject = {
@@ -76,6 +81,11 @@ const mockFolders = [
 function setupMocks(overrides: Partial<typeof mockProject> = {}, orgOverrides: Partial<typeof mockOrg> = {}) {
   const project = { ...mockProject, ...overrides }
   const org = { ...mockOrg, ...orgOverrides }
+  mockResourcePermissions((attr) => {
+    const role =
+      attr.name === namespaceForOrg(project.organization) ? org.userRole : project.userRole
+    return isResourcePermissionAllowedForRole(role, attr)
+  })
 
   ;(useGetProject as Mock).mockReturnValue({
     data: project,

--- a/frontend/src/routes/_authenticated/projects/$projectName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/settings/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
@@ -34,11 +34,18 @@ import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { ViewModeToggle } from '@/components/view-mode-toggle'
 import { RawView } from '@/components/raw-view'
 import { ParentType } from '@/gen/holos/console/v1/folders_pb'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { useGetProject, useUpdateProject, useUpdateProjectSharing, useUpdateProjectDefaultSharing, useDeleteProject } from '@/queries/projects'
 import { useGetProjectSettings, useGetProjectSettingsRaw, useUpdateProjectSettings } from '@/queries/project-settings'
 import { useGetOrganization } from '@/queries/organizations'
 import { useListFolders } from '@/queries/folders'
+import { useResourcePermissions } from '@/queries/permissions'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteNamespacePermission,
+  hasPermission,
+  updateNamespacePermission,
+} from '@/lib/resource-permissions'
+import { namespaceForOrg, namespaceForProject } from '@/lib/scope-labels'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectName/settings/')({
   component: ProjectSettingsRoute,
@@ -69,9 +76,30 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
   const { data: projectSettings } = useGetProjectSettings(projectName)
   const updateProjectSettings = useUpdateProjectSettings(projectName)
 
-  // Fetch org data to check if user is org-level OWNER
+  // Fetch org data for display and parent picker context.
   const { data: org } = useGetOrganization(project?.organization ?? '')
-  const isOrgOwner = org?.userRole === Role.OWNER
+  const projectNamespace = namespaceForProject(projectName)
+  const orgNamespace = project?.organization ? namespaceForOrg(project.organization) : ''
+  const updateProjectPermission = useMemo(
+    () => updateNamespacePermission(projectNamespace),
+    [projectNamespace],
+  )
+  const deleteProjectPermission = useMemo(
+    () => deleteNamespacePermission(projectNamespace),
+    [projectNamespace],
+  )
+  const updateOrgPermission = useMemo(
+    () => updateNamespacePermission(orgNamespace),
+    [orgNamespace],
+  )
+  const permissionsQuery = useResourcePermissions([
+    updateProjectPermission,
+    deleteProjectPermission,
+    updateOrgPermission,
+  ])
+  const canWrite = hasPermission(permissionsQuery.data, updateProjectPermission)
+  const canDelete = hasPermission(permissionsQuery.data, deleteProjectPermission)
+  const canUpdateProjectSettings = hasPermission(permissionsQuery.data, updateOrgPermission)
 
   // Fetch all folders in the org for the parent picker
   const { data: allFolders } = useListFolders(project?.organization ?? '')
@@ -148,7 +176,7 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
       setPendingParent(null)
       toast.success('Parent changed')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -158,7 +186,7 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
       setEditingDisplayName(false)
       toast.success('Saved')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -168,7 +196,7 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
       setEditingDescription(false)
       toast.success('Saved')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -185,10 +213,12 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
       await deleteProject.mutateAsync({ name: projectName })
       setDeleteOpen(false)
       navigate({ to: '/' })
-    } catch { /* error shown via mutation */ }
+    } catch (err) {
+      toast.error(connectErrorMessage(err))
+    }
   }
 
-  const isOwner = project?.userRole === Role.OWNER
+  const isOwner = canDelete
 
   if (isPending) {
     return (
@@ -292,14 +322,16 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
                 ) : (
                   <>
                     <span className="flex-1 text-sm">{displayName || <span className="text-muted-foreground">No display name</span>}</span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="edit display name"
-                      onClick={() => { setDraftDisplayName(displayName); setEditingDisplayName(true) }}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
+                    {canWrite && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="edit display name"
+                        onClick={() => { setDraftDisplayName(displayName); setEditingDisplayName(true) }}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    )}
                   </>
                 )}
               </div>
@@ -334,7 +366,7 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
                 ) : (
                   <>
                     <span className="flex-1 text-sm">{currentParentDisplay}</span>
-                    {isOwner && (
+                    {canWrite && (
                       <Button
                         variant="ghost"
                         size="sm"
@@ -403,14 +435,16 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
                     <span className={`flex-1 text-sm ${description ? '' : 'text-muted-foreground'}`}>
                       {description || 'No description'}
                     </span>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="edit description"
-                      onClick={() => { setDraftDescription(description); setEditingDescription(true) }}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
+                    {canWrite && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="edit description"
+                        onClick={() => { setDraftDescription(description); setEditingDescription(true) }}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    )}
                   </>
                 )}
               </div>
@@ -429,13 +463,13 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
                   id="deployments-toggle"
                   aria-label="Deployments"
                   checked={projectSettings?.deploymentsEnabled ?? false}
-                  disabled={!isOrgOwner || updateProjectSettings.isPending}
+                  disabled={!canUpdateProjectSettings || updateProjectSettings.isPending}
                   onCheckedChange={async (checked) => {
                     try {
                       await updateProjectSettings.mutateAsync({ deploymentsEnabled: checked })
                       toast.success('Saved')
                     } catch (err) {
-                      toast.error(err instanceof Error ? err.message : String(err))
+                      toast.error(connectErrorMessage(err))
                     }
                   }}
                 />
@@ -489,7 +523,7 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
           </DialogHeader>
           {deleteProject.error && (
             <Alert variant="destructive">
-              <AlertDescription>{deleteProject.error.message}</AlertDescription>
+              <AlertDescription>{connectErrorMessage(deleteProject.error)}</AlertDescription>
             </Alert>
           )}
           <DialogFooter>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/$templateName.tsx
@@ -13,7 +13,7 @@
  * rules.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { ArrowLeft } from 'lucide-react'
@@ -38,8 +38,16 @@ import {
   useDeleteTemplate,
   useGetTemplateDefaults,
 } from '@/queries/templates'
+import { useResourcePermissions } from '@/queries/permissions'
 import type { TemplateDefaults, TemplateExample } from '@/queries/templates'
 import { namespaceForProject } from '@/lib/scope-labels'
+import { connectErrorMessage } from '@/lib/connect-toast'
+import {
+  deleteTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+  updateTemplateResourcePermission,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Utility: TemplateDefaults → CUE project-input snippet
@@ -97,6 +105,17 @@ export function ProjectTemplateDetailPage({
   const { data: templateDefaults } = useGetTemplateDefaults({ namespace, name: templateName })
   const updateMutation = useUpdateTemplate(namespace, templateName)
   const deleteMutation = useDeleteTemplate(namespace)
+  const updatePermission = useMemo(
+    () => updateTemplateResourcePermission(templateResources.templates, namespace, templateName),
+    [namespace, templateName],
+  )
+  const deletePermission = useMemo(
+    () => deleteTemplateResourcePermission(templateResources.templates, namespace, templateName),
+    [namespace, templateName],
+  )
+  const permissionsQuery = useResourcePermissions([updatePermission, deletePermission])
+  const canWrite = hasPermission(permissionsQuery.data, updatePermission)
+  const canDelete = hasPermission(permissionsQuery.data, deletePermission)
 
   const [cueTemplate, setCueTemplate] = useState('')
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -131,7 +150,7 @@ export function ProjectTemplateDetailPage({
       })
       toast.success('Saved')
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err))
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -144,8 +163,8 @@ export function ProjectTemplateDetailPage({
         to: '/projects/$projectName/templates',
         params: { projectName },
       })
-    } catch {
-      /* error surfaced via deleteMutation.error inside the dialog */
+    } catch (err) {
+      toast.error(connectErrorMessage(err))
     }
   }
 
@@ -195,13 +214,15 @@ export function ProjectTemplateDetailPage({
               <h2 className="text-xl font-semibold">{displayName}</h2>
             </div>
           </div>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => setDeleteOpen(true)}
-          >
-            Delete
-          </Button>
+          {canDelete && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+            >
+              Delete
+            </Button>
+          )}
         </div>
 
         <div className="space-y-4">
@@ -233,6 +254,7 @@ export function ProjectTemplateDetailPage({
             onChange={setCueTemplate}
             onSave={handleSave}
             isSaving={updateMutation.isPending}
+            readOnly={!canWrite}
             defaultProjectInput={templateDefaultsToCueInput(templateDefaults)}
             namespace={namespace}
           />
@@ -250,7 +272,7 @@ export function ProjectTemplateDetailPage({
           </DialogHeader>
           {deleteMutation.error && (
             <Alert variant="destructive">
-              <AlertDescription>{deleteMutation.error.message}</AlertDescription>
+              <AlertDescription>{connectErrorMessage(deleteMutation.error)}</AlertDescription>
             </Alert>
           )}
           <DialogFooter>

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-dependencies-index.test.tsx
@@ -16,6 +16,7 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Router mock
@@ -127,6 +128,7 @@ function setupMocks({
   error = null as Error | null,
   userRole = Role.OWNER,
 } = {}) {
+  mockResourcePermissionsForRole(userRole)
   ;(useGetProject as Mock).mockReturnValue({
     data: { name: 'test-project', userRole },
     isPending: false,

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-grants-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-grants-index.test.tsx
@@ -16,6 +16,7 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Router mock
@@ -128,6 +129,7 @@ function setupMocks({
   selectedOrg = 'test-org',
   userRole = Role.OWNER,
 } = {}) {
+  mockResourcePermissionsForRole(userRole)
   ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: selectedOrg ?? '', userRole },

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/-requirements-index.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/-requirements-index.test.tsx
@@ -16,6 +16,7 @@ import { vi } from 'vitest'
 import type { Mock } from 'vitest'
 import React from 'react'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
+import { mockResourcePermissionsForRole } from '@/test/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Router mock
@@ -128,6 +129,7 @@ function setupMocks({
   selectedOrg = 'test-org',
   userRole = Role.OWNER,
 } = {}) {
+  mockResourcePermissionsForRole(userRole)
   ;(useOrg as Mock).mockReturnValue({ selectedOrg, setSelectedOrg: vi.fn() })
   ;(useGetOrganization as Mock).mockReturnValue({
     data: { name: selectedOrg ?? '', userRole },

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/dependencies/index.tsx
@@ -5,15 +5,14 @@
  * $projectName URL parameter via namespaceForProject(). The project name also
  * keeps the Templates collapsible group open in the sidebar (HOL-1014).
  *
- * HOL-1023: added "New" header action gated on project OWNER/EDITOR role,
- * navigating to the org-scoped /template-dependencies/new route.
+ * HOL-1023: added "New" header action navigating to the org-scoped
+ * /template-dependencies/new route.
  *
  * The sidebar nesting was implemented in HOL-1014.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -22,9 +21,14 @@ import {
   useListTemplateDependencies,
   useDeleteTemplateDependency,
 } from '@/queries/templateDependencies'
-import { useGetProject } from '@/queries/projects'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForProject } from '@/lib/scope-labels'
 import { useOrg } from '@/lib/org-context'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,10 +74,12 @@ export function TemplateDependenciesIndexPage({
   // selectedOrg is used to build detailHref links and the New route URL.
   const { selectedOrg } = useOrg()
 
-  // Project role — used to gate the "New" button (OWNER or EDITOR can create).
-  const { data: project } = useGetProject(projectName)
-  const userRole = project?.userRole ?? Role.VIEWER
-  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateDependencies, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const {
     data: dependencies = [],

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/grants/index.tsx
@@ -6,13 +6,12 @@
  * name still appears in the URL so the Templates collapsible group stays open
  * in the sidebar (HOL-1014).
  *
- * HOL-1023: added "New" header action gated on org OWNER/EDITOR role,
- * navigating to the org-scoped /template-grants/new route.
+ * HOL-1023: added "New" header action navigating to the org-scoped
+ * /template-grants/new route.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -21,9 +20,14 @@ import {
   useListTemplateGrants,
   useDeleteTemplateGrant,
 } from '@/queries/templateGrants'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { useOrg } from '@/lib/org-context'
 import { namespaceForOrg } from '@/lib/scope-labels'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -69,10 +73,12 @@ export function TemplateGrantsIndexPage({
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 
-  // Org role — used to gate the "New" button (OWNER or EDITOR can create).
-  const { data: org } = useGetOrganization(selectedOrg ?? '')
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateGrants, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const {
     data: grants = [],

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/index.tsx
@@ -17,16 +17,20 @@
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { HelpCircle } from 'lucide-react'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
 import type { ResourceGridSearch } from '@/components/resource-grid/types'
 import { Button } from '@/components/ui/button'
 import { TemplatesHelpPane } from '@/components/templates/TemplatesHelpPane'
-import { useGetProject } from '@/queries/projects'
 import { useListTemplates, useDeleteTemplate } from '@/queries/templates'
+import { useResourcePermissions } from '@/queries/permissions'
 import { namespaceForProject } from '@/lib/scope-labels'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Route search — extends ResourceGridSearch with the help pane state
@@ -94,10 +98,12 @@ export function ProjectTemplatesIndexPage({
 
   const namespace = namespaceForProject(projectName)
 
-  // Project data — used to determine the user's role for create permissions.
-  const { data: project } = useGetProject(projectName)
-  const userRole = project?.userRole ?? Role.VIEWER
-  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templates, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   // Project-scoped templates list — key shared with detail/edit page.
   const {

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/new.tsx
@@ -35,6 +35,7 @@ import {
   useListLinkableTemplates,
 } from '@/queries/templates'
 import { namespaceForProject } from '@/lib/scope-labels'
+import { connectErrorMessage } from '@/lib/connect-toast'
 
 // ---------------------------------------------------------------------------
 // Route search — optional clone source pre-selection (HOL-975)
@@ -169,7 +170,7 @@ export function CloneTemplatePage({
         params: { projectName, templateName: name.trim() },
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(connectErrorMessage(err))
     }
   }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/templates/requirements/index.tsx
@@ -6,13 +6,12 @@
  * project name still appears in the URL so the Templates collapsible group
  * stays open in the sidebar (HOL-1014).
  *
- * HOL-1023: added "New" header action gated on org OWNER/EDITOR role,
- * navigating to the org-scoped /template-requirements/new route.
+ * HOL-1023: added "New" header action navigating to the org-scoped
+ * /template-requirements/new route.
  */
 
 import { useCallback, useMemo } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Role } from '@/gen/holos/console/v1/rbac_pb'
 import { StandardPageLayout } from '@/components/page-layout'
 import type { Row } from '@/components/resource-grid/types'
 import { parseGridSearch } from '@/components/resource-grid/url-state'
@@ -21,9 +20,14 @@ import {
   useListTemplateRequirements,
   useDeleteTemplateRequirement,
 } from '@/queries/templateRequirements'
-import { useGetOrganization } from '@/queries/organizations'
+import { useResourcePermissions } from '@/queries/permissions'
 import { useOrg } from '@/lib/org-context'
 import { namespaceForOrg } from '@/lib/scope-labels'
+import {
+  createTemplateResourcePermission,
+  hasPermission,
+  templateResources,
+} from '@/lib/resource-permissions'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -69,10 +73,12 @@ export function TemplateRequirementsIndexPage({
   const { selectedOrg } = useOrg()
   const namespace = namespaceForOrg(selectedOrg ?? '')
 
-  // Org role — used to gate the "New" button (OWNER or EDITOR can create).
-  const { data: org } = useGetOrganization(selectedOrg ?? '')
-  const userRole = org?.userRole ?? Role.VIEWER
-  const canCreate = userRole === Role.OWNER || userRole === Role.EDITOR
+  const createPermission = useMemo(
+    () => createTemplateResourcePermission(templateResources.templateRequirements, namespace),
+    [namespace],
+  )
+  const permissionsQuery = useResourcePermissions([createPermission])
+  const canCreate = hasPermission(permissionsQuery.data, createPermission)
 
   const {
     data: requirements = [],

--- a/frontend/src/test/resource-permissions.ts
+++ b/frontend/src/test/resource-permissions.ts
@@ -1,0 +1,59 @@
+import { vi } from 'vitest'
+
+import { Role } from '@/gen/holos/console/v1/rbac_pb.js'
+import {
+  permissionKey,
+  type PermissionsMap,
+  type ResourcePermissionInput,
+  useResourcePermissions,
+} from '@/queries/permissions'
+
+function makePermissionsMap(
+  attributes: ResourcePermissionInput[],
+  isAllowed: (attribute: ResourcePermissionInput) => boolean,
+): PermissionsMap {
+  const data: PermissionsMap = {}
+  for (const attr of attributes) {
+    const key = permissionKey(attr)
+    const allowed = isAllowed(attr)
+    data[key] = {
+      $typeName: 'holos.console.v1.ResourcePermission',
+      attributes: undefined as never,
+      allowed,
+      denied: !allowed,
+      reason: allowed ? '' : 'denied by test fixture',
+      key,
+    }
+  }
+  return data
+}
+
+export function mockResourcePermissions(
+  isAllowed: (attribute: ResourcePermissionInput) => boolean,
+) {
+  vi.mocked(useResourcePermissions).mockImplementation(
+    (attributes) =>
+      ({
+        data: makePermissionsMap(attributes, isAllowed),
+        isPending: false,
+        error: null,
+      }) as ReturnType<typeof useResourcePermissions>,
+  )
+}
+
+export function mockResourcePermissionsForRole(role: Role | number) {
+  mockResourcePermissions((attr) => isResourcePermissionAllowedForRole(role, attr))
+}
+
+export function isResourcePermissionAllowedForRole(
+  role: Role | number,
+  attr: ResourcePermissionInput,
+) {
+  if (role === Role.OWNER) return true
+  if (role === Role.EDITOR) return attr.verb !== 'delete'
+  return attr.verb === 'get' || attr.verb === 'list' || attr.verb === 'watch'
+}
+
+export function mockAllResourcePermissionsAllowed() {
+  mockResourcePermissions(() => true)
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,4 +1,31 @@
 import '@testing-library/jest-dom/vitest'
+import { vi } from 'vitest'
+
+vi.mock('@/queries/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/queries/permissions')>()
+  return {
+    ...actual,
+    useResourcePermissions: vi.fn((attributes) => {
+      const data: import('@/queries/permissions').PermissionsMap = {}
+      for (const attr of attributes) {
+        const key = actual.permissionKey(attr)
+        data[key] = {
+          $typeName: 'holos.console.v1.ResourcePermission',
+          attributes: undefined as never,
+          allowed: true,
+          denied: false,
+          reason: '',
+          key,
+        }
+      }
+      return {
+        data,
+        isPending: false,
+        error: null,
+      }
+    }),
+  }
+})
 
 // Polyfill ResizeObserver for jsdom (used by cmdk/Combobox)
 if (!globalThis.ResizeObserver) {


### PR DESCRIPTION
## Summary
- Replace role-derived frontend create/update/delete gating with ResourcePermissionsService SSAR decisions across org/project settings, deployments, secrets, templates, and template-family resources.
- Add shared resource permission builders and permission-aware test helpers.
- Map create/update/delete permission-denied Connect errors through connectErrorMessage for consistent access-denied copy.

Fixes HOL-1065

## Verification
- make test-ui
- cd frontend && npm run build
- cd frontend && npx eslint src/lib/resource-permissions.ts src/test/resource-permissions.ts src/queries/permissions.ts

Note: full cd frontend && npm run lint was attempted and still fails on existing repo-wide lint debt unrelated to this PR.