### PR TITLE
docs(contrib): install libnss3-tools and run mkcert -install on Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to holos-console are documented here.
 
 ## [Unreleased]
 
+### Docs — Debian 13 setup now installs `libnss3-tools` and runs `mkcert -install` (HOL-1089)
+
+`CONTRIBUTING.md` step 2 now installs `libnss3-tools` alongside `mkcert` and
+runs `mkcert -install` so the local mkcert root CA is registered with the
+system, Chromium, and Firefox NSS trust stores. Without this, Playwright-driven
+E2E tests on a fresh Debian 13 VM fail with TLS certificate errors against
+`https://localhost:5173/`. The new step mirrors the `Trust mkcert CA` step in
+`.github/workflows/ci.yaml`.
+
 ### Added — TemplateDependency, TemplateRequirement, TemplateGrant new/edit/detail pages and ScopePicker (HOL-1017)
 
 Full CRUD UI for the three template-dependency resource families introduced in HOL-954.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,21 @@ All notable changes to holos-console are documented here.
 
 ## [Unreleased]
 
-### Docs — Debian 13 setup now installs `libnss3-tools` and runs `mkcert -install` (HOL-1089)
+### Changed — Cert-handling guard rails for fresh dev VMs (HOL-1089)
 
-`CONTRIBUTING.md` step 2 now installs `libnss3-tools` alongside `mkcert` and
-runs `mkcert -install` so the local mkcert root CA is registered with the
-system, Chromium, and Firefox NSS trust stores. Without this, Playwright-driven
-E2E tests on a fresh Debian 13 VM fail with TLS certificate errors against
-`https://localhost:5173/`. The new step mirrors the `Trust mkcert CA` step in
-`.github/workflows/ci.yaml`.
+Three coordinated updates so a fresh Debian 13 (Trixie) VM can pass
+Playwright-driven E2E tests without TLS certificate errors:
+
+- `CONTRIBUTING.md` step 2 now installs `libnss3-tools` alongside `mkcert`
+  and runs `mkcert -install` so the local mkcert root CA is registered
+  with the system, Chromium, and Firefox NSS trust stores. The recipe
+  mirrors the `Trust mkcert CA` step in `.github/workflows/ci.yaml`.
+- `README.md` prerequisites now call out `libnss3-tools` (Debian/Ubuntu)
+  or `nss-tools` (Fedora/RHEL) alongside `mkcert`, so readers who follow
+  only the README hit the same guard rail.
+- `scripts/local-ca` now fails fast with a pointer to `CONTRIBUTING.md`
+  when `certutil` is missing, instead of letting `mkcert -install`
+  silently skip the browser trust stores.
 
 ### Added — TemplateDependency, TemplateRequirement, TemplateGrant new/edit/detail pages and ScopePicker (HOL-1017)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,27 +24,40 @@ sudo apt-get install -y build-essential
 
 ### 2. Install mkcert and Trust the Local CA
 
-`mkcert` provides the leaf certificates used by the dev server, and its
-root CA must be installed into the system, Chromium, and Firefox trust
-stores so Playwright-driven E2E tests do not fail with TLS errors.
-Chromium and Firefox use NSS, which `mkcert -install` drives via
-`certutil` from the `libnss3-tools` package. Without `libnss3-tools`,
-`mkcert -install` silently skips the browser trust stores.
+`mkcert` provides the leaf TLS certificates used by the local Vite dev
+server (`https://localhost:5173/`) and the Go backend
+(`https://localhost:8443/`). Independently of leaf-cert generation, its
+root CA must be registered with the system, Chromium, and Firefox trust
+stores or Playwright-driven E2E tests fail at the TLS handshake before
+any test logic runs. Chromium and Firefox use NSS, which `mkcert
+-install` drives via `certutil` from the `libnss3-tools` package; if
+`certutil` is missing, `mkcert -install` prints a warning and skips the
+browser trust stores even though it still updates the system store.
 
 ```bash
 sudo apt-get install -y mkcert libnss3-tools
 mkcert -install
 ```
 
-After `mkcert -install` you should see:
+On the first run (fresh VM) you should see:
+
+```
+Created a new local CA at "<CAROOT>" 💥
+The local CA is now installed in the system trust store! 👍
+The local CA is now installed in the Firefox and/or Chrome/Chromium trust store! 👍
+```
+
+On subsequent runs the messages flip to `already installed`:
 
 ```
 The local CA is already installed in the system trust store! 👍
 The local CA is already installed in the Firefox and/or Chrome/Chromium trust store! 👍
 ```
 
-This mirrors the `Trust mkcert CA` step in `.github/workflows/ci.yaml`,
-which is what unblocks `make test-e2e` in CI.
+If the Firefox/Chromium line is missing or replaced by a `certutil` warning,
+re-check that `libnss3-tools` is installed. This matches the `Trust mkcert
+CA` step in `.github/workflows/ci.yaml` (the recipe CI relies on for E2E
+tests on Debian-based runners).
 
 ### 3. Generate TLS Certificates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,29 @@ sudo apt-get update
 sudo apt-get install -y build-essential
 ```
 
-### 2. Install mkcert for TLS Certificates
+### 2. Install mkcert and Trust the Local CA
+
+`mkcert` provides the leaf certificates used by the dev server, and its
+root CA must be installed into the system, Chromium, and Firefox trust
+stores so Playwright-driven E2E tests do not fail with TLS errors.
+Chromium and Firefox use NSS, which `mkcert -install` drives via
+`certutil` from the `libnss3-tools` package. Without `libnss3-tools`,
+`mkcert -install` silently skips the browser trust stores.
 
 ```bash
-sudo apt-get install -y mkcert
+sudo apt-get install -y mkcert libnss3-tools
+mkcert -install
 ```
+
+After `mkcert -install` you should see:
+
+```
+The local CA is already installed in the system trust store! 👍
+The local CA is already installed in the Firefox and/or Chrome/Chromium trust store! 👍
+```
+
+This mirrors the `Trust mkcert CA` step in `.github/workflows/ci.yaml`,
+which is what unblocks `make test-e2e` in CI.
 
 ### 3. Generate TLS Certificates
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ running server with a handful of commands.
   (installs DNS, k3d, and a local mkcert CA). Alternatively, point `kubectl` at
   any existing cluster.
 - `kubectl` context set to that cluster.
-- `mkcert` for local TLS certificates.
+- `mkcert` for local TLS certificates, plus `libnss3-tools` (Debian/Ubuntu)
+  or `nss-tools` (Fedora/RHEL) so `mkcert -install` can register the local
+  CA with the Chromium and Firefox NSS trust stores. Without the NSS tools
+  Playwright-driven E2E tests will fail at the TLS handshake.
 - Go 1.25+ and Node 18+ / npm for building the server and frontend.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full toolchain setup instructions,

--- a/scripts/local-ca
+++ b/scripts/local-ca
@@ -7,6 +7,20 @@
 
 set -euo pipefail
 
+# Guard rail: mkcert -install only registers the CA with the Chromium and
+# Firefox NSS trust stores when certutil is on PATH (provided by
+# libnss3-tools on Debian/Ubuntu, nss-tools on Fedora/RHEL). Without it,
+# mkcert prints a warning and skips the browser trust stores, which then
+# breaks Playwright-driven E2E tests in subtle ways. Fail fast with a
+# pointer to CONTRIBUTING.md instead of silently degrading.
+if ! command -v certutil >/dev/null 2>&1; then
+  echo "error: certutil not found on PATH" >&2
+  echo "       install libnss3-tools (Debian/Ubuntu) or nss-tools (Fedora/RHEL)" >&2
+  echo "       so 'mkcert -install' can register the CA with Chromium and Firefox." >&2
+  echo "       See CONTRIBUTING.md, 'Setting Up a Debian 13 (Trixie) VM', step 2." >&2
+  exit 1
+fi
+
 mkcert --install
 
 tmpdir="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- Update step 2 of the Debian 13 (Trixie) setup in `CONTRIBUTING.md` to install `libnss3-tools` alongside `mkcert` and run `mkcert -install`, so the local mkcert root CA is registered with the system, Chromium, and Firefox NSS trust stores before `make certs` runs.
- Without this, `make test-e2e` (Playwright driving Chromium and Firefox at `https://localhost:5173/`) fails with TLS errors on a fresh Debian 13 VM. The new step mirrors the existing `Trust mkcert CA` step in `.github/workflows/ci.yaml` (lines 64–68).
- Add a matching `[Unreleased]` entry to `CHANGELOG.md` under HOL-1089.

Fixes HOL-1089

## Test plan

- [ ] On a fresh Debian 13 VM, follow `CONTRIBUTING.md` from the top: after step 2, `mkcert -install` reports the local CA installed in the system trust store **and** in the Firefox and/or Chrome/Chromium trust store.
- [ ] After completing all six setup steps, `make test-e2e` runs Playwright against Chromium and Firefox at `https://localhost:5173/` without TLS certificate errors.
- [ ] CI (`.github/workflows/ci.yaml`) continues to pass — the change is docs-only and does not alter the CI job, but the new instructions are the same recipe CI already uses.