### PR TITLE
feat(console): enforce parent owner authz on reparent (HOL-1067)

### DIFF
--- a/console/folders/handler.go
+++ b/console/folders/handler.go
@@ -282,8 +282,9 @@ func (h *Handler) UpdateFolder(
 }
 
 // reparentFolder validates and executes a folder reparent operation.
-// Checks PERMISSION_REPARENT on both source and destination parents,
-// enforces depth limits, and detects cycles.
+// Checks Owner-level permission on both source and destination parents
+// when the impersonated client is present (ADR 036 + HOL-1067), enforces
+// depth limits, and detects cycles.
 func (h *Handler) reparentFolder(
 	ctx context.Context,
 	ns *corev1.Namespace,
@@ -311,12 +312,26 @@ func (h *Handler) reparentFolder(
 		return nil
 	}
 
-	if _, err := h.k8s.GetNamespace(ctx, newParentNs); err != nil {
+	// Fetch destination parent namespace and enforce owner-level access on
+	// the impersonated path. Required so a caller cannot move a child into
+	// a parent they do not control (ADR 036 + HOL-1067).
+	destParent, err := h.k8s.GetNamespace(ctx, newParentNs)
+	if err != nil {
 		return mapK8sError(err)
 	}
+	if err := h.requireReparentOwner(ctx, claims, destParent, "reparent into destination"); err != nil {
+		return err
+	}
 
-	if _, err := h.k8s.GetNamespace(ctx, currentParentNs); err != nil {
+	// Fetch source parent namespace and enforce owner-level access on the
+	// impersonated path. Required so a caller cannot evict a child from a
+	// parent they do not control.
+	srcParent, err := h.k8s.GetNamespace(ctx, currentParentNs)
+	if err != nil {
 		return mapK8sError(err)
+	}
+	if err := h.requireReparentOwner(ctx, claims, srcParent, "reparent from source"); err != nil {
+		return err
 	}
 
 	// Cycle detection: walk new parent's ancestors; if the folder being moved
@@ -770,6 +785,24 @@ func (h *Handler) effectiveRoleForNamespace(ctx context.Context, claims *rpc.Cla
 		secrets.ActiveGrantsMap(shareUsers, time.Now()),
 		secrets.ActiveGrantsMap(shareRoles, time.Now()),
 	)
+}
+
+// requireReparentOwner enforces Owner-level permission on a parent namespace
+// for re-parent operations (HOL-1067). Owner is proven via SSAR for `delete`
+// on the namespace, consistent with requireNamespaceOwner.
+//
+// Enforcement is gated on the presence of an impersonated client because the
+// legacy in-process cascade (claims-based) is being phased out per ADR 036.
+// Wiring impersonation into a request automatically arms parent-side owner
+// gating; bootstrap and tests that have not migrated yet retain pre-HOL-1067
+// behavior.
+func (h *Handler) requireReparentOwner(ctx context.Context, claims *rpc.Claims, parent *corev1.Namespace, action string) error {
+	if !rpc.HasImpersonatedClients(ctx) {
+		return nil
+	}
+	parentShareUsers, _ := GetShareUsers(parent)
+	parentShareRoles, _ := GetShareRoles(parent)
+	return h.requireNamespaceOwner(ctx, claims, parent, parentShareUsers, parentShareRoles, action)
 }
 
 func (h *Handler) requireNamespaceOwner(ctx context.Context, claims *rpc.Claims, ns *corev1.Namespace, shareUsers, shareRoles []secrets.AnnotationGrant, action string) error {

--- a/console/folders/handler_reparent_authz_test.go
+++ b/console/folders/handler_reparent_authz_test.go
@@ -1,0 +1,133 @@
+// Tests for HOL-1067: parent-side owner authorization on UpdateFolder reparent.
+//
+// The reparent path checks Owner-level permission on both the source and the
+// destination parent namespace whenever the request carries an impersonated
+// client. Owner is proven via SSAR for `delete` on the namespace, matching
+// requireNamespaceOwner. Tests stub the SSAR reactor so each axis can simulate
+// allow/deny independently per parent namespace.
+package folders
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// reparentAuthzCase captures one denial/allow scenario for the parent-side
+// owner check on UpdateFolder reparent.
+type reparentAuthzCase struct {
+	name                string
+	allowSrc            bool
+	allowDest           bool
+	wantPermissionError bool
+}
+
+// newReparentAuthzHandler builds a handler whose fake clientset answers SSARs
+// for the `delete` verb on the source and destination parent namespaces with
+// the supplied allow flags.
+func newReparentAuthzHandler(t *testing.T, srcParentNs, destParentNs string, allowSrc, allowDest bool, namespaces ...*corev1.Namespace) (*Handler, context.Context) {
+	t.Helper()
+	objs := make([]runtime.Object, len(namespaces))
+	for i, ns := range namespaces {
+		objs[i] = ns
+	}
+	fakeClient := fake.NewClientset(objs...)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		ssar := create.GetObject().(*authzv1.SelfSubjectAccessReview)
+		attrs := ssar.Spec.ResourceAttributes
+		if attrs == nil {
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: false}
+			return true, ssar, nil
+		}
+		// Only the parent-owner gate uses verb=delete on namespaces. Any
+		// other (verb,resource) combination defaults to deny so unrelated
+		// SSAR call sites stay isolated from this test fixture.
+		if attrs.Verb != "delete" || attrs.Resource != "namespaces" {
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: false}
+			return true, ssar, nil
+		}
+		switch attrs.Name {
+		case srcParentNs:
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: allowSrc}
+		case destParentNs:
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: allowDest}
+		default:
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: false}
+		}
+		return true, ssar, nil
+	})
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s)
+	ctx := contextWithClaims("alice@example.com")
+	ctx = rpc.ContextWithImpersonatedClients(ctx, &rpc.ImpersonatedClients{Clientset: fakeClient})
+	return handler, ctx
+}
+
+func TestUpdateFolder_Reparent_ImpersonatedOwnerAuthorization(t *testing.T) {
+	cases := []reparentAuthzCase{
+		{name: "deny on source only", allowSrc: false, allowDest: true, wantPermissionError: true},
+		{name: "deny on destination only", allowSrc: true, allowDest: false, wantPermissionError: true},
+		{name: "deny on both", allowSrc: false, allowDest: false, wantPermissionError: true},
+		{name: "allow on both succeeds", allowSrc: true, allowDest: true, wantPermissionError: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Hierarchy:
+			//   org acme
+			//   ├── folder src-fld   (source parent — holds the moving folder)
+			//   ├── folder dest-fld  (destination parent)
+			//   └── folder moving    (initially under src-fld; reparented under dest-fld)
+			orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+			srcFolder := folderNSWithGrants("rp-authz-fld-src", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+			destFolder := folderNSWithGrants("rp-authz-fld-dest", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+			moving := folderNSWithGrants("rp-authz-fld-mv", "acme", "holos-fld-rp-authz-fld-src", `[{"principal":"alice@example.com","role":"owner"}]`)
+
+			handler, ctx := newReparentAuthzHandler(t,
+				"holos-fld-rp-authz-fld-src",  // source parent ns
+				"holos-fld-rp-authz-fld-dest", // destination parent ns
+				tc.allowSrc, tc.allowDest,
+				orgNs, srcFolder, destFolder, moving,
+			)
+
+			newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+			newParentName := "rp-authz-fld-dest"
+			_, err := handler.UpdateFolder(ctx, connect.NewRequest(&consolev1.UpdateFolderRequest{
+				Name:       "rp-authz-fld-mv",
+				ParentType: &newParentType,
+				ParentName: &newParentName,
+			}))
+
+			if tc.wantPermissionError {
+				if err == nil {
+					t.Fatalf("expected permission denied error, got nil")
+				}
+				connectErr, ok := err.(*connect.Error)
+				if !ok {
+					t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+				}
+				if connectErr.Code() != connect.CodePermissionDenied {
+					t.Fatalf("expected CodePermissionDenied, got %v: %v", connectErr.Code(), err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected success, got %v", err)
+			}
+		})
+	}
+}

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -547,7 +547,9 @@ func (h *Handler) UpdateProject(
 }
 
 // reparentProject validates and executes a project reparent operation.
-// Checks PERMISSION_REPARENT on both source and destination parents.
+// Checks Owner-level permission on both source and destination parents
+// when the impersonated client is present (ADR 036), so the API server
+// — not in-process Go code — gates moves between namespaces.
 // Projects have no children so no depth or cycle checks are needed.
 func (h *Handler) reparentProject(
 	ctx context.Context,
@@ -575,13 +577,26 @@ func (h *Handler) reparentProject(
 		return nil
 	}
 
-	// Verify new parent namespace exists.
-	if _, err := h.k8s.GetNamespace(ctx, newParentNs); err != nil {
+	// Fetch destination parent namespace and enforce owner-level access on
+	// the impersonated path. Required so a caller cannot move a child into
+	// a parent they do not control (ADR 036 + HOL-1067).
+	destParent, err := h.k8s.GetNamespace(ctx, newParentNs)
+	if err != nil {
 		return mapK8sError(err)
 	}
+	if err := h.requireReparentOwner(ctx, claims, destParent, "reparent into destination"); err != nil {
+		return err
+	}
 
-	if _, err := h.k8s.GetNamespace(ctx, currentParentNs); err != nil {
+	// Fetch source parent namespace and enforce owner-level access on the
+	// impersonated path. Required so a caller cannot evict a child from a
+	// parent they do not control.
+	srcParent, err := h.k8s.GetNamespace(ctx, currentParentNs)
+	if err != nil {
 		return mapK8sError(err)
+	}
+	if err := h.requireReparentOwner(ctx, claims, srcParent, "reparent from source"); err != nil {
+		return err
 	}
 
 	// Execute the reparent: update the parent label.
@@ -856,6 +871,24 @@ func (h *Handler) effectiveRoleForNamespace(ctx context.Context, claims *rpc.Cla
 		secrets.ActiveGrantsMap(shareUsers, time.Now()),
 		secrets.ActiveGrantsMap(shareRoles, time.Now()),
 	)
+}
+
+// requireReparentOwner enforces Owner-level permission on a parent namespace
+// for re-parent operations (HOL-1067). Owner is proven via SSAR for `delete`
+// on the namespace, consistent with requireNamespaceOwner.
+//
+// Enforcement is gated on the presence of an impersonated client because the
+// legacy in-process cascade (claims-based) is being phased out per ADR 036.
+// Wiring impersonation into a request automatically arms parent-side owner
+// gating; bootstrap and tests that have not migrated yet retain pre-HOL-1067
+// behavior.
+func (h *Handler) requireReparentOwner(ctx context.Context, claims *rpc.Claims, parent *corev1.Namespace, action string) error {
+	if !rpc.HasImpersonatedClients(ctx) {
+		return nil
+	}
+	parentShareUsers, _ := GetShareUsers(parent)
+	parentShareRoles, _ := GetShareRoles(parent)
+	return h.requireNamespaceOwner(ctx, claims, parent, parentShareUsers, parentShareRoles, action)
 }
 
 func (h *Handler) requireNamespaceOwner(ctx context.Context, claims *rpc.Claims, ns *corev1.Namespace, shareUsers, shareRoles []secrets.AnnotationGrant, action string) error {

--- a/console/projects/handler_reparent_authz_test.go
+++ b/console/projects/handler_reparent_authz_test.go
@@ -1,0 +1,128 @@
+// Tests for HOL-1067: parent-side owner authorization on UpdateProject reparent.
+//
+// The reparent path checks Owner-level permission on both the source and the
+// destination parent namespace whenever the request carries an impersonated
+// client. Owner is proven via SSAR for `delete` on the namespace, matching
+// requireNamespaceOwner. Tests stub the SSAR reactor so each axis can simulate
+// allow/deny independently per parent namespace.
+package projects
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/holos-run/holos-console/console/rpc"
+	consolev1 "github.com/holos-run/holos-console/gen/holos/console/v1"
+)
+
+// reparentAuthzCase captures one denial/allow scenario for the parent-side
+// owner check on UpdateProject reparent.
+type reparentAuthzCase struct {
+	name                string
+	allowSrc            bool
+	allowDest           bool
+	wantPermissionError bool
+}
+
+// newReparentAuthzHandler builds a handler whose fake clientset answers SSARs
+// for the `delete` verb on the source and destination parent namespaces with
+// the supplied allow flags.
+func newReparentAuthzHandler(t *testing.T, srcParentNs, destParentNs string, allowSrc, allowDest bool, namespaces ...*corev1.Namespace) (*Handler, context.Context) {
+	t.Helper()
+	objs := make([]runtime.Object, len(namespaces))
+	for i, ns := range namespaces {
+		objs[i] = ns
+	}
+	fakeClient := fake.NewClientset(objs...)
+	fakeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		ssar := create.GetObject().(*authzv1.SelfSubjectAccessReview)
+		attrs := ssar.Spec.ResourceAttributes
+		if attrs == nil {
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: false}
+			return true, ssar, nil
+		}
+		// Only the parent-owner gate uses verb=delete on namespaces. Any
+		// other (verb,resource) combination defaults to deny so unrelated
+		// SSAR call sites stay isolated from this test fixture.
+		if attrs.Verb != "delete" || attrs.Resource != "namespaces" {
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: false}
+			return true, ssar, nil
+		}
+		switch attrs.Name {
+		case srcParentNs:
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: allowSrc}
+		case destParentNs:
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: allowDest}
+		default:
+			ssar.Status = authzv1.SubjectAccessReviewStatus{Allowed: false}
+		}
+		return true, ssar, nil
+	})
+	k8s := NewK8sClient(fakeClient, testResolver())
+	handler := NewHandler(k8s, &mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}})
+	ctx := contextWithClaims("alice@example.com")
+	ctx = rpc.ContextWithImpersonatedClients(ctx, &rpc.ImpersonatedClients{Clientset: fakeClient})
+	return handler, ctx
+}
+
+func TestUpdateProject_Reparent_ImpersonatedOwnerAuthorization(t *testing.T) {
+	cases := []reparentAuthzCase{
+		{name: "deny on source only", allowSrc: false, allowDest: true, wantPermissionError: true},
+		{name: "deny on destination only", allowSrc: true, allowDest: false, wantPermissionError: true},
+		{name: "deny on both", allowSrc: false, allowDest: false, wantPermissionError: true},
+		{name: "allow on both succeeds", allowSrc: true, allowDest: true, wantPermissionError: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+			srcFolder := folderNSWithGrants("rp-authz-src", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+			destFolder := folderNSWithGrants("rp-authz-dest", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
+			prj := projectNSWithParent("rp-authz-prj", "acme", "holos-fld-rp-authz-src", `[{"principal":"alice@example.com","role":"editor"}]`)
+
+			handler, ctx := newReparentAuthzHandler(t,
+				"holos-fld-rp-authz-src",  // source parent ns
+				"holos-fld-rp-authz-dest", // destination parent ns
+				tc.allowSrc, tc.allowDest,
+				orgNs, srcFolder, destFolder, prj,
+			)
+
+			newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
+			newParentName := "rp-authz-dest"
+			_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+				Name:       "rp-authz-prj",
+				ParentType: &newParentType,
+				ParentName: &newParentName,
+			}))
+
+			if tc.wantPermissionError {
+				if err == nil {
+					t.Fatalf("expected permission denied error, got nil")
+				}
+				connectErr, ok := err.(*connect.Error)
+				if !ok {
+					t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+				}
+				if connectErr.Code() != connect.CodePermissionDenied {
+					t.Fatalf("expected CodePermissionDenied, got %v: %v", connectErr.Code(), err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected success, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Restore parent-side owner authorization for re-parent operations in `console/projects/handler.go` and `console/folders/handler.go`. Both handlers now SSAR-check `delete` on source and destination parent namespaces before relabeling the child, closing the deferred gap from PR #1254 (HOL-1064).
- Authorization is gated on the impersonated client (ADR 036), so the API server is the single arbiter. The non-impersonated legacy cascade path is preserved for bootstrap and as-yet-unmigrated callers.
- Added `handler_reparent_authz_test.go` in both packages covering the four denial axes plus the success path.

Fixes HOL-1067

## Test plan

- [x] `go test ./console/projects/ ./console/folders/` passes
- [x] New test cases cover: deny-source-only, deny-destination-only, deny-both, allow-both
- [x] Existing reparent tests (`TestUpdateProject_Reparent_*`, `TestUpdateFolder_Reparent_*`) still pass — they exercise the non-impersonated cascade path which is intentionally unchanged
- [ ] CI green