### PR TITLE
refactor(console): drop default folder org logic

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -66,10 +66,9 @@ const (
 	AnnotationURL               = "console.holos.run/url"
 	AnnotationEnabled           = "console.holos.run/enabled"
 	AnnotationSettings          = "console.holos.run/project-settings"
-	// AnnotationDefaultFolder stores the identifier (slug) of the default folder
-	// for an organization. Written when the org is created and updatable via
-	// UpdateOrganization. New projects without an explicit parent are placed in
-	// this folder (ADR 022 Decision 3).
+	// AnnotationDefaultFolder is a legacy organization annotation retained for
+	// admission and migration cleanup. Console handlers no longer write or read
+	// it when creating organizations or projects.
 	AnnotationDefaultFolder = "console.holos.run/default-folder"
 	// AnnotationGatewayNamespace stores the Kubernetes namespace that hosts
 	// the platform Gateway referenced by templates rendered for an

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -73,10 +73,9 @@
 #AnnotationEnabled:           "console.holos.run/enabled"
 #AnnotationSettings:          "console.holos.run/project-settings"
 
-// AnnotationDefaultFolder stores the identifier (slug) of the default folder
-// for an organization. Written when the org is created and updatable via
-// UpdateOrganization. New projects without an explicit parent are placed in
-// this folder (ADR 022 Decision 3).
+// AnnotationDefaultFolder is a legacy organization annotation retained for
+// admission and migration cleanup. Console handlers no longer write or read
+// it when creating organizations or projects.
 #AnnotationDefaultFolder: "console.holos.run/default-folder"
 
 // AnnotationGatewayNamespace stores the Kubernetes namespace that hosts

--- a/console/console.go
+++ b/console/console.go
@@ -345,17 +345,13 @@ func (s *Server) Serve(ctx context.Context) error {
 		nsResolver := &resolver.Resolver{NamespacePrefix: s.cfg.NamespacePrefix, OrganizationPrefix: s.cfg.OrganizationPrefix, FolderPrefix: s.cfg.FolderPrefix, ProjectPrefix: s.cfg.ProjectPrefix}
 		slog.Info("kubernetes client initialized")
 
-		// Folder K8s client created first so the org handler can auto-create default folders.
 		foldersK8s := folders.NewK8sClient(k8sClientset, nsResolver)
 
 		// Organization service (projectsK8s created first for linked-project precondition check)
 		orgsK8s := organizations.NewK8sClient(k8sClientset, nsResolver)
 		orgGrantResolver := organizations.NewOrgGrantResolver(orgsK8s)
 		projectsK8s := projects.NewK8sClient(k8sClientset, nsResolver)
-		folderPrefix := nsResolver.NamespacePrefix + nsResolver.FolderPrefix
-		foldersAdapter := &folders.FolderCreatorAdapter{K8s: foldersK8s}
-		orgsHandler := organizations.NewHandler(orgsK8s, projectsK8s, s.cfg.DisableOrgCreation, s.cfg.OrgCreatorUsers, s.cfg.OrgCreatorRoles).
-			WithFolderCreator(foldersAdapter, foldersK8s, folderPrefix)
+		orgsHandler := organizations.NewHandler(orgsK8s, projectsK8s, s.cfg.DisableOrgCreation, s.cfg.OrgCreatorUsers, s.cfg.OrgCreatorRoles)
 		orgsPath, orgsHTTPHandler := consolev1connect.NewOrganizationServiceHandler(orgsHandler, protectedInterceptors)
 		mux.Handle(orgsPath, orgsHTTPHandler)
 

--- a/console/folders/k8s.go
+++ b/console/folders/k8s.go
@@ -464,39 +464,6 @@ func GetDefaultShareRoles(ns *corev1.Namespace) ([]secrets.AnnotationGrant, erro
 	return parseGrantAnnotation(ns, v1alpha2.AnnotationDefaultShareRoles)
 }
 
-// FolderCreatorAdapter adapts the folders K8sClient to satisfy the
-// organizations.FolderCreator interface. It mirrors
-// projects.ProjectCreatorAdapter so that the organizations package can create
-// the seeded default folder through the folders package without importing the
-// folders Handler directly.
-type FolderCreatorAdapter struct {
-	K8s *K8sClient
-}
-
-// CreateFolder creates a folder namespace, forwarding both active and default
-// share grants so that the seeded default folder inherits the org's default
-// role grants and propagates them as its own default-share cascade (matching
-// the ancestor-default-share merge done by folders.Handler.CreateFolder).
-func (a *FolderCreatorAdapter) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
-	return a.K8s.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, creatorSubject, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
-}
-
-// DeleteFolder delegates to the K8sClient.
-func (a *FolderCreatorAdapter) DeleteFolder(ctx context.Context, name string) error {
-	return a.K8s.DeleteFolder(ctx, name)
-}
-
-// NamespaceExists delegates to the K8sClient.
-func (a *FolderCreatorAdapter) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
-	return a.K8s.NamespaceExists(ctx, nsName)
-}
-
-// GetFolder delegates to the K8sClient so the adapter can also satisfy
-// organizations.FolderLister in test and production wiring.
-func (a *FolderCreatorAdapter) GetFolder(ctx context.Context, name string) (*corev1.Namespace, error) {
-	return a.K8s.GetFolder(ctx, name)
-}
-
 func parseGrantAnnotation(ns *corev1.Namespace, key string) ([]secrets.AnnotationGrant, error) {
 	return legacy.ParseGrants(ns.Annotations, key)
 }

--- a/console/organizations/handler.go
+++ b/console/organizations/handler.go
@@ -27,25 +27,6 @@ type ProjectLister interface {
 	ListProjects(ctx context.Context, org, parentNs string) ([]*corev1.Namespace, error)
 }
 
-// FolderCreator creates and deletes a folder namespace. Used by CreateOrganization to
-// auto-create the default folder without importing the folders package directly.
-// DeleteFolder is needed for rollback when later steps of org creation fail.
-//
-// CreateFolder accepts both active (shareUsers/shareRoles) and default
-// (defaultShareUsers/defaultShareRoles) grants so that the seeded default folder
-// inherits the org's default role grants via the same merge logic
-// folders.Handler.CreateFolder applies to user-initiated folder creates.
-type FolderCreator interface {
-	CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
-	DeleteFolder(ctx context.Context, name string) error
-	NamespaceExists(ctx context.Context, nsName string) (bool, error)
-}
-
-// FolderLister retrieves folder namespaces for validation.
-type FolderLister interface {
-	GetFolder(ctx context.Context, name string) (*corev1.Namespace, error)
-}
-
 // TemplateSeeder seeds default templates into a scope. Used by
 // CreateOrganization to seed example templates when populate_defaults is true.
 type TemplateSeeder interface {
@@ -54,9 +35,8 @@ type TemplateSeeder interface {
 }
 
 // ProjectCreator creates and deletes a project namespace. Used by CreateOrganization to
-// create a default project when populate_defaults is true, following the same
-// pattern as FolderCreator. DeleteProject is needed for rollback when later
-// seeding steps fail.
+// create a default project when populate_defaults is true. DeleteProject is
+// needed for rollback when later seeding steps fail.
 type ProjectCreator interface {
 	CreateProject(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) error
 	DeleteProject(ctx context.Context, name string) error
@@ -68,9 +48,6 @@ type Handler struct {
 	consolev1connect.UnimplementedOrganizationServiceHandler
 	k8s             *K8sClient
 	projectLister   ProjectLister
-	folderCreator   FolderCreator
-	folderLister    FolderLister
-	folderPrefix    string // namespace prefix + folder prefix (e.g. "holos-fld-")
 	templateSeeder  TemplateSeeder
 	projectCreator  ProjectCreator
 	projectPrefix   string // namespace prefix + project prefix (e.g. "holos-prj-")
@@ -85,15 +62,6 @@ type Handler struct {
 // creatorRoles are allowed to create organizations.
 func NewHandler(k8s *K8sClient, projectLister ProjectLister, disableCreation bool, creatorUsers, creatorRoles []string) *Handler {
 	return &Handler{k8s: k8s, projectLister: projectLister, disableCreation: disableCreation, creatorUsers: creatorUsers, creatorRoles: creatorRoles}
-}
-
-// WithFolderCreator sets the folder creator used to auto-create the default
-// folder when a new organization is created.
-func (h *Handler) WithFolderCreator(fc FolderCreator, fl FolderLister, folderPrefix string) *Handler {
-	h.folderCreator = fc
-	h.folderLister = fl
-	h.folderPrefix = folderPrefix
-	return h
 }
 
 // WithDefaultsSeeder sets the template seeder and project creator used to
@@ -179,8 +147,7 @@ func (h *Handler) GetOrganization(
 	}), nil
 }
 
-// CreateOrganization creates a new organization and its default folder.
-// If default folder creation fails, the org namespace is rolled back.
+// CreateOrganization creates a new organization.
 func (h *Handler) CreateOrganization(
 	ctx context.Context,
 	req *connect.Request[consolev1.CreateOrganizationRequest],
@@ -218,9 +185,9 @@ func (h *Handler) CreateOrganization(
 	}
 
 	// Seed org default role grants (Owner, Editor, Viewer) onto the org
-	// namespace *before* creating the default folder or project. This ensures
-	// the default folder and default project inherit the correct org-level
-	// default role grants via GetOrgDefaultGrants().
+	// namespace before creating the default project. This ensures the default
+	// project inherits the correct org-level default role grants via
+	// GetOrgDefaultGrants().
 	if req.Msg.GetPopulateDefaults() {
 		if err := h.seedOrgDefaultSharing(ctx, req.Msg.Name); err != nil {
 			slog.ErrorContext(ctx, "seeding org default role grants failed, rolling back org",
@@ -237,53 +204,6 @@ func (h *Handler) CreateOrganization(
 		}
 	}
 
-	// Auto-create the default folder as an immediate child of the org.
-	// folderName is hoisted so the seed-defaults rollback can also delete
-	// the folder namespace (Kubernetes namespaces are flat — deleting the
-	// org does not cascade to the folder or project namespaces).
-	var folderName string
-	if h.folderCreator != nil {
-		folderDisplayName := "Default"
-
-		var err error
-		folderName, err = h.createDefaultFolder(ctx, req.Msg.Name, folderDisplayName, claims.Email, claims.Sub, shareUsers, shareRoles)
-		if err != nil {
-			// Rollback: delete the org namespace on default folder failure.
-			// The folder namespace does not exist yet (creation failed), so
-			// only the org needs cleanup.
-			slog.ErrorContext(ctx, "default folder creation failed, rolling back org",
-				slog.String("organization", req.Msg.Name),
-				slog.Any("error", err),
-			)
-			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
-				slog.ErrorContext(ctx, "org rollback failed",
-					slog.String("organization", req.Msg.Name),
-					slog.Any("error", delErr),
-				)
-			}
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("creating default folder: %w", err))
-		}
-
-		// Store the default folder identifier on the org namespace.
-		if err := h.k8s.SetDefaultFolder(ctx, req.Msg.Name, folderName); err != nil {
-			slog.ErrorContext(ctx, "failed to set default folder annotation, rolling back",
-				slog.String("organization", req.Msg.Name),
-				slog.String("folder", folderName),
-				slog.Any("error", err),
-			)
-			// Roll back folder then org: the folder was already created but the
-			// annotation write failed, so we must explicitly remove it.
-			h.rollbackFolder(ctx, folderName)
-			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
-				slog.ErrorContext(ctx, "org rollback after annotation failure failed",
-					slog.String("organization", req.Msg.Name),
-					slog.Any("error", delErr),
-				)
-			}
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("setting default folder annotation: %w", err))
-		}
-	}
-
 	// Seed example resources when populate_defaults is requested.
 	if req.Msg.GetPopulateDefaults() {
 		if err := h.seedDefaults(ctx, req.Msg.Name, claims.Email, claims.Sub, shareUsers, shareRoles); err != nil {
@@ -292,9 +212,8 @@ func (h *Handler) CreateOrganization(
 				slog.Any("error", err),
 			)
 			// seedDefaults performs incremental rollback for resources it
-			// created (e.g. project namespace). Here we clean up the folder
-			// and org namespaces which were created before seeding began.
-			h.rollbackFolder(ctx, folderName)
+			// created (e.g. project namespace). Here we clean up the org
+			// namespace which was created before seeding began.
 			if delErr := h.k8s.DeleteOrganization(ctx, req.Msg.Name); delErr != nil {
 				slog.ErrorContext(ctx, "org rollback after seed failure failed",
 					slog.String("organization", req.Msg.Name),
@@ -318,73 +237,13 @@ func (h *Handler) CreateOrganization(
 	}), nil
 }
 
-// createDefaultFolder generates an identifier from the display name and creates
-// the folder namespace as a direct child of the organization. Returns the folder
-// identifier (slug).
-//
-// When the org carries default-share grants (seeded via seedOrgDefaultSharing
-// when populate_defaults=true), those grants are merged into the folder's
-// active grants only. The folder is NOT given its own default-share
-// annotations — descendants created under this folder pick up the current org
-// defaults dynamically via the ancestor walk performed by
-// folders.Handler.collectAncestorDefaultShares and
-// projects.ProjectGrantResolver.GetDefaultGrants. Persisting a snapshot on the
-// folder itself would cause later changes to org default sharing to be
-// shadowed by stale folder defaults.
-func (h *Handler) createDefaultFolder(ctx context.Context, orgName, displayName, creatorEmail, creatorSubject string, shareUsers, shareRoles []secrets.AnnotationGrant) (string, error) {
-	exists := func(ctx context.Context, nsName string) (bool, error) {
-		return h.folderCreator.NamespaceExists(ctx, nsName)
-	}
-	folderName, err := v1alpha2.GenerateIdentifier(ctx, displayName, h.folderPrefix, exists)
-	if err != nil {
-		return "", fmt.Errorf("generating folder identifier: %w", err)
-	}
-
-	// Read the org namespace so we can propagate any default-share grants
-	// (seeded earlier via seedOrgDefaultSharing when populate_defaults=true)
-	// into the default folder. When populate_defaults is false the org has
-	// no default-share annotations and these slices will be empty, which
-	// preserves the existing behaviour.
-	orgNs, err := h.k8s.GetOrganization(ctx, orgName)
-	if err != nil {
-		return "", fmt.Errorf("looking up org for default folder: %w", err)
-	}
-	orgDefaultUsers, _ := GetDefaultShareUsers(orgNs)
-	orgDefaultRoles, _ := GetDefaultShareRoles(orgNs)
-	folderShareUsers := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareUsers...), orgDefaultUsers...))
-	folderShareRoles := secrets.DeduplicateGrants(append(append([]secrets.AnnotationGrant{}, shareRoles...), orgDefaultRoles...))
-
-	orgNsName := h.k8s.resolver.OrgNamespace(orgName)
-	// Pass nil for the folder's own default-share grants. Descendants resolve
-	// the org defaults dynamically via the ancestor walk, so persisting a copy
-	// here would cause stale defaults to shadow future org changes.
-	if _, err := h.folderCreator.CreateFolder(ctx, folderName, displayName, "", orgName, orgNsName, creatorEmail, creatorSubject, folderShareUsers, folderShareRoles, nil, nil); err != nil {
-		return "", fmt.Errorf("creating folder namespace: %w", err)
-	}
-	return folderName, nil
-}
-
-// rollbackFolder deletes the folder namespace as part of org creation rollback.
-// Errors are logged but not propagated since this is best-effort cleanup.
-func (h *Handler) rollbackFolder(ctx context.Context, folderName string) {
-	if folderName == "" || h.folderCreator == nil {
-		return
-	}
-	if delErr := h.folderCreator.DeleteFolder(ctx, folderName); delErr != nil {
-		slog.ErrorContext(ctx, "folder rollback failed",
-			slog.String("folder", folderName),
-			slog.Any("error", delErr),
-		)
-	}
-}
-
 // defaultOrgRoleGrants returns the standard three-role default grant list
 // (Owner, Editor, Viewer) with no start restriction and no expiration. The
 // principal for each grant is the lowercase role name (e.g. "owner") — role
 // grants treat the role string as both the principal and the role. These are
 // seeded onto new organizations when populate_defaults=true so that the
-// default folder and default project inherit sensible org-level defaults via
-// GetOrgDefaultGrants() in projects/resolver.go.
+// default project inherits sensible org-level defaults via GetOrgDefaultGrants()
+// in projects/resolver.go.
 func defaultOrgRoleGrants() []secrets.AnnotationGrant {
 	return []secrets.AnnotationGrant{
 		{Principal: roleAnnotationString(rbac.RoleOwner), Role: roleAnnotationString(rbac.RoleOwner)},
@@ -412,11 +271,11 @@ func roleAnnotationString(r rbac.Role) string {
 
 // seedDefaults creates example resources for the new organization:
 //  1. An org-level platform template (HTTPRoute, enabled)
-//  2. A default project in the default folder
+//  2. A default project under the organization
 //  3. An example project-level deployment template in the new project
 //
 // Each step performs incremental rollback of resources it created on failure.
-// The caller is responsible for rolling back the org and folder namespaces.
+// The caller is responsible for rolling back the org namespace.
 func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail, creatorSubject string, shareUsers, shareRoles []secrets.AnnotationGrant) error {
 	if h.templateSeeder == nil || h.projectCreator == nil {
 		return fmt.Errorf("defaults seeder not configured")
@@ -427,19 +286,12 @@ func (h *Handler) seedDefaults(ctx context.Context, orgName, creatorEmail, creat
 		return fmt.Errorf("seeding org template: %w", err)
 	}
 
-	// Step 2: Create default project in the default folder.
-	// Resolve the default folder namespace from the org's annotation.
+	// Step 2: Create default project under the organization.
 	orgNs, err := h.k8s.GetOrganization(ctx, orgName)
 	if err != nil {
-		return fmt.Errorf("looking up org for default folder: %w", err)
+		return fmt.Errorf("looking up org for default project: %w", err)
 	}
-	defaultFolder := orgNs.Annotations[v1alpha2.AnnotationDefaultFolder]
-	if defaultFolder == "" {
-		return fmt.Errorf("organization %q has no default folder set", orgName)
-	}
-
-	// Derive the parent namespace from the default folder.
-	parentNs := h.k8s.resolver.FolderNamespace(defaultFolder)
+	parentNs := h.k8s.resolver.OrgNamespace(orgName)
 
 	projectDisplayName := "Default"
 	exists := func(ctx context.Context, nsName string) (bool, error) {

--- a/console/organizations/handler_test.go
+++ b/console/organizations/handler_test.go
@@ -59,7 +59,6 @@ type testHandlerOpts struct {
 	creatorUsers       []string
 	creatorRoles       []string
 	projectLister      ProjectLister
-	withFolderCreator  bool
 	withDefaultsSeeder bool
 	templateSeeder     TemplateSeeder
 	projectCreator     ProjectCreator
@@ -79,12 +78,6 @@ func newTestHandlerWithOpts(opts testHandlerOpts, namespaces ...*corev1.Namespac
 	k8s := NewK8sClient(fakeClient, r)
 	handler := NewHandler(k8s, opts.projectLister, opts.disableOrgCreation, opts.creatorUsers, opts.creatorRoles)
 
-	if opts.withFolderCreator {
-		fc := &k8sFolderCreator{client: fakeClient, resolver: r}
-		folderPrefix := r.NamespacePrefix + r.FolderPrefix
-		handler.WithFolderCreator(fc, fc, folderPrefix)
-	}
-
 	if opts.withDefaultsSeeder {
 		ts := opts.templateSeeder
 		if ts == nil {
@@ -100,84 +93,6 @@ func newTestHandlerWithOpts(opts testHandlerOpts, namespaces ...*corev1.Namespac
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	return handler
-}
-
-// k8sFolderCreator implements FolderCreator and FolderLister for tests.
-type k8sFolderCreator struct {
-	client   *fake.Clientset
-	resolver *resolver.Resolver
-	createFn func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error)
-}
-
-func (f *k8sFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
-	if f.createFn != nil {
-		return f.createFn(ctx, name, displayName, description, org, parentNs, creatorEmail, creatorSubject, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
-	}
-	usersJSON, _ := json.Marshal(shareUsers)
-	rolesJSON, _ := json.Marshal(shareRoles)
-	annotations := map[string]string{
-		v1alpha2.AnnotationShareUsers: string(usersJSON),
-		v1alpha2.AnnotationShareRoles: string(rolesJSON),
-	}
-	if len(defaultShareUsers) > 0 {
-		defaultUsersJSON, _ := json.Marshal(defaultShareUsers)
-		annotations[v1alpha2.AnnotationDefaultShareUsers] = string(defaultUsersJSON)
-	}
-	if len(defaultShareRoles) > 0 {
-		defaultRolesJSON, _ := json.Marshal(defaultShareRoles)
-		annotations[v1alpha2.AnnotationDefaultShareRoles] = string(defaultRolesJSON)
-	}
-	if displayName != "" {
-		annotations[v1alpha2.AnnotationDisplayName] = displayName
-	}
-	if creatorEmail != "" {
-		annotations[v1alpha2.AnnotationCreatorEmail] = creatorEmail
-	}
-	if creatorSubject != "" {
-		annotations[v1alpha2.AnnotationCreatorSubject] = creatorSubject
-	}
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: f.resolver.FolderNamespace(name),
-			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
-				v1alpha2.LabelOrganization: org,
-				v1alpha2.LabelFolder:       name,
-				v1alpha2.AnnotationParent:  parentNs,
-			},
-			Annotations: annotations,
-		},
-	}
-	return f.client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-}
-
-func (f *k8sFolderCreator) DeleteFolder(ctx context.Context, name string) error {
-	nsName := f.resolver.FolderNamespace(name)
-	return f.client.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
-}
-
-func (f *k8sFolderCreator) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
-	_, err := f.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
-func (f *k8sFolderCreator) GetFolder(ctx context.Context, name string) (*corev1.Namespace, error) {
-	nsName := f.resolver.FolderNamespace(name)
-	ns, err := f.client.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if ns.Labels == nil || ns.Labels[v1alpha2.LabelResourceType] != v1alpha2.ResourceTypeFolder {
-		return nil, fmt.Errorf("namespace %q is not a folder", nsName)
-	}
-	return ns, nil
 }
 
 // ---- ListOrganizations tests ----
@@ -763,159 +678,32 @@ func TestCreateOrganization_NamespacePrefixIncluded(t *testing.T) {
 	}
 }
 
-// ---- Default folder creation tests ----
+// ---- Default folder removal tests ----
 
-func TestCreateOrganization_CreatesDefaultFolder(t *testing.T) {
-	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true})
+func TestCreateOrganization_DoesNotCreateDefaultFolder(t *testing.T) {
+	handler := newTestHandler()
 	ctx := contextWithClaims("alice@example.com")
 
 	resp, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
-		Name:        "test-df-org",
+		Name:        "test-no-df-org",
 		DisplayName: "Test Org",
 	}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if resp.Msg.Name != "test-df-org" {
-		t.Errorf("expected org name 'test-df-org', got %q", resp.Msg.Name)
+	if resp.Msg.Name != "test-no-df-org" {
+		t.Errorf("expected org name 'test-no-df-org', got %q", resp.Msg.Name)
 	}
 
-	// Verify the default folder namespace was created with slug "default".
-	fc := handler.folderCreator.(*k8sFolderCreator)
-	folderNsName := handler.k8s.resolver.NamespacePrefix + handler.k8s.resolver.FolderPrefix + "default"
-	ns, err := fc.client.CoreV1().Namespaces().Get(context.Background(), folderNsName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected default folder namespace %q to exist, got %v", folderNsName, err)
-	}
-	if ns.Labels[v1alpha2.LabelOrganization] != "test-df-org" {
-		t.Errorf("expected folder org label 'test-df-org', got %q", ns.Labels[v1alpha2.LabelOrganization])
-	}
-	if ns.Labels[v1alpha2.AnnotationParent] != "holos-org-test-df-org" {
-		t.Errorf("expected folder parent 'holos-org-test-df-org', got %q", ns.Labels[v1alpha2.AnnotationParent])
-	}
-	if ns.Annotations[v1alpha2.AnnotationDisplayName] != "Default" {
-		t.Errorf("expected folder display name 'Default', got %q", ns.Annotations[v1alpha2.AnnotationDisplayName])
-	}
-
-	// Verify default folder annotation on the org namespace.
-	orgNs, err := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-test-df-org", metav1.GetOptions{})
+	orgNs, err := handler.k8s.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-test-no-df-org", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("expected org namespace to exist, got %v", err)
 	}
-	if orgNs.Annotations[v1alpha2.AnnotationDefaultFolder] != "default" {
-		t.Errorf("expected default-folder annotation 'default', got %q", orgNs.Annotations[v1alpha2.AnnotationDefaultFolder])
+	if len(orgNs.Annotations) == 0 {
+		return
 	}
-}
-
-func TestCreateOrganization_DefaultFolderCollisionAddsSuffix(t *testing.T) {
-	// Pre-create a namespace that would collide with the default folder slug.
-	existingFolder := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holos-fld-default",
-			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeFolder,
-			},
-		},
-	}
-	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true}, existingFolder)
-	ctx := contextWithClaims("alice@example.com")
-
-	resp, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
-		Name: "test-collision-org",
-	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if resp.Msg.Name != "test-collision-org" {
-		t.Errorf("expected org name 'test-collision-org', got %q", resp.Msg.Name)
-	}
-
-	// Verify the org has a default folder annotation with a suffixed identifier.
-	fc := handler.folderCreator.(*k8sFolderCreator)
-	orgNs, err := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-test-collision-org", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected org namespace to exist, got %v", err)
-	}
-	dfAnnotation := orgNs.Annotations[v1alpha2.AnnotationDefaultFolder]
-	if dfAnnotation == "" {
-		t.Fatal("expected default-folder annotation to be set")
-	}
-	if dfAnnotation == "default" {
-		t.Error("expected a suffixed folder identifier due to collision, got 'default'")
-	}
-	// Verify the suffixed folder namespace exists.
-	suffixedNsName := "holos-fld-" + dfAnnotation
-	if _, err := fc.client.CoreV1().Namespaces().Get(context.Background(), suffixedNsName, metav1.GetOptions{}); err != nil {
-		t.Fatalf("expected suffixed folder namespace %q to exist, got %v", suffixedNsName, err)
-	}
-}
-
-func TestCreateOrganization_DefaultFolderCreatorIsOwner(t *testing.T) {
-	handler := newTestHandlerWithOpts(testHandlerOpts{withFolderCreator: true})
-	ctx := contextWithClaims("alice@example.com")
-
-	_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
-		Name: "test-owner-org",
-	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	fc := handler.folderCreator.(*k8sFolderCreator)
-	ns, err := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-fld-default", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected default folder to exist, got %v", err)
-	}
-
-	var grants []secrets.AnnotationGrant
-	if err := json.Unmarshal([]byte(ns.Annotations[v1alpha2.AnnotationShareUsers]), &grants); err != nil {
-		t.Fatalf("failed to parse share-users: %v", err)
-	}
-	found := false
-	for _, g := range grants {
-		if g.Principal == "alice@example.com" && g.Role == "owner" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected creator as owner in folder share-users, got %v", grants)
-	}
-}
-
-func TestCreateOrganization_RollbackOnFolderFailure(t *testing.T) {
-	objs := []runtime.Object{}
-	fakeClient := fake.NewClientset(objs...)
-	r := testResolver()
-	k8s := NewK8sClient(fakeClient, r)
-	handler := NewHandler(k8s, nil, false, nil, nil)
-
-	// Use a folder creator that always fails.
-	failFC := &k8sFolderCreator{
-		client:   fakeClient,
-		resolver: r,
-		createFn: func(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
-			return nil, fmt.Errorf("simulated folder creation failure")
-		},
-	}
-	folderPrefix := r.NamespacePrefix + r.FolderPrefix
-	handler.WithFolderCreator(failFC, failFC, folderPrefix)
-
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx := contextWithClaims("alice@example.com")
-
-	_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
-		Name: "test-rollback-org",
-	}))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	// Verify the org namespace was cleaned up.
-	_, getErr := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-org-test-rollback-org", metav1.GetOptions{})
-	if !k8serrors.IsNotFound(getErr) {
-		t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
+	if _, ok := orgNs.Annotations["console.holos.run/default-folder"]; ok {
+		t.Fatalf("expected no default-folder annotation on org namespace")
 	}
 }
 
@@ -1186,7 +974,6 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 	t.Run("true creates all expected resources", func(t *testing.T) {
 		ts := &mockTemplateSeeder{}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1225,6 +1012,9 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 		if got, want := projectNs.Annotations[v1alpha2.AnnotationCreatorSubject], "sub-alice@example.com"; got != want {
 			t.Fatalf("expected default project creator-sub annotation %q, got %q", want, got)
 		}
+		if got, want := projectNs.Labels[v1alpha2.AnnotationParent], handler.k8s.resolver.OrgNamespace("seed-org"); got != want {
+			t.Fatalf("expected default project parent %q, got %q", want, got)
+		}
 
 		// Verify the seeded project inherited the org's default role grants
 		// (Owner, Editor, Viewer) both as its active role grants and as its
@@ -1260,62 +1050,11 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 		if len(projectDefaultRoles) != 3 {
 			t.Errorf("expected 3 default role grants copied from org, got %d", len(projectDefaultRoles))
 		}
-
-		// Verify the seeded default folder inherited the org's default role
-		// grants on both share-roles and default-share-roles, analogous to
-		// the project assertions above. This guards against regressions of
-		// the bootstrap path skipping the ancestor-default-share merge.
-		fc := handler.folderCreator.(*k8sFolderCreator)
-		orgNsForFolder, err := handler.k8s.GetOrganization(context.Background(), "seed-org")
-		if err != nil {
-			t.Fatalf("failed to get org namespace: %v", err)
-		}
-		folderName := orgNsForFolder.Annotations[v1alpha2.AnnotationDefaultFolder]
-		if folderName == "" {
-			t.Fatalf("expected default folder annotation on org namespace")
-		}
-		folderNsName := fc.resolver.FolderNamespace(folderName)
-		folderNs, err := fc.client.CoreV1().Namespaces().Get(context.Background(), folderNsName, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("expected default folder namespace %q to exist, got %v", folderNsName, err)
-		}
-
-		folderRolesAnnotation := folderNs.Annotations[v1alpha2.AnnotationShareRoles]
-		if folderRolesAnnotation == "" {
-			t.Fatalf("expected share-roles annotation on folder namespace")
-		}
-		var folderRoles []secrets.AnnotationGrant
-		if err := json.Unmarshal([]byte(folderRolesAnnotation), &folderRoles); err != nil {
-			t.Fatalf("invalid share-roles annotation on folder: %v", err)
-		}
-		wantFolderRoles := map[string]bool{"owner": false, "editor": false, "viewer": false}
-		for _, g := range folderRoles {
-			if _, ok := wantFolderRoles[g.Role]; ok && g.Principal == g.Role {
-				wantFolderRoles[g.Role] = true
-			}
-		}
-		for role, seen := range wantFolderRoles {
-			if !seen {
-				t.Errorf("expected seeded default folder to inherit org default role grant %q on share-roles", role)
-			}
-		}
-
-		// The seeded default folder must NOT carry its own default-share-*
-		// annotations. Descendants pick up the current org defaults dynamically
-		// via the ancestor walk, so persisting a snapshot on the folder would
-		// shadow later org-level changes. See issue #933.
-		if v, ok := folderNs.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
-			t.Errorf("expected no %q annotation on seeded default folder, got %q", v1alpha2.AnnotationDefaultShareRoles, v)
-		}
-		if v, ok := folderNs.Annotations[v1alpha2.AnnotationDefaultShareUsers]; ok {
-			t.Errorf("expected no %q annotation on seeded default folder, got %q", v1alpha2.AnnotationDefaultShareUsers, v)
-		}
 	})
 
 	t.Run("false behaves as before", func(t *testing.T) {
 		ts := &mockTemplateSeeder{}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1346,7 +1085,6 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 	t.Run("unset behaves as before", func(t *testing.T) {
 		ts := &mockTemplateSeeder{}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1375,7 +1113,6 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 	t.Run("rollback on org template seed failure", func(t *testing.T) {
 		ts := &mockTemplateSeeder{seedOrgErr: fmt.Errorf("simulated org template failure")}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1391,21 +1128,10 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 
-		fc := handler.folderCreator.(*k8sFolderCreator)
-
 		// Verify the org namespace was cleaned up.
-		_, getErr := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-seed-org", metav1.GetOptions{})
+		_, getErr := handler.k8s.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-seed-org", metav1.GetOptions{})
 		if !k8serrors.IsNotFound(getErr) {
 			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
-		}
-
-		// Verify the folder namespace was also cleaned up (namespaces are flat,
-		// deleting the org does not cascade to the folder).
-		nsList, _ := fc.client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
-		for _, ns := range nsList.Items {
-			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeFolder {
-				t.Errorf("expected folder namespace %q to be deleted after rollback", ns.Name)
-			}
 		}
 	})
 
@@ -1421,9 +1147,6 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 		r := testResolver()
 		k8s := NewK8sClient(fakeClient, r)
 		handler := NewHandler(k8s, nil, false, nil, nil)
-		fc := &k8sFolderCreator{client: fakeClient, resolver: r}
-		folderPrefix := r.NamespacePrefix + r.FolderPrefix
-		handler.WithFolderCreator(fc, fc, folderPrefix)
 		pc.client = fakeClient
 		projectPrefix := r.NamespacePrefix + r.ProjectPrefix
 		handler.WithDefaultsSeeder(ts, pc, projectPrefix)
@@ -1447,19 +1170,11 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
 		}
 
-		// Verify the folder namespace was also cleaned up.
-		nsList, _ := fakeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
-		for _, ns := range nsList.Items {
-			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeFolder {
-				t.Errorf("expected folder namespace %q to be deleted after rollback", ns.Name)
-			}
-		}
 	})
 
 	t.Run("rollback on project template seed failure", func(t *testing.T) {
 		ts := &mockTemplateSeeder{seedProjectErr: fmt.Errorf("simulated project template failure")}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1475,24 +1190,15 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 
-		fc := handler.folderCreator.(*k8sFolderCreator)
-
 		// Verify the org namespace was cleaned up.
-		_, getErr := fc.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-ptmpl-org", metav1.GetOptions{})
+		_, getErr := handler.k8s.client.CoreV1().Namespaces().Get(context.Background(), "holos-org-fail-ptmpl-org", metav1.GetOptions{})
 		if !k8serrors.IsNotFound(getErr) {
 			t.Errorf("expected org namespace to be deleted after rollback, got %v", getErr)
 		}
 
-		// Verify the folder namespace was cleaned up.
-		nsList, _ := fc.client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
-		for _, ns := range nsList.Items {
-			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeFolder {
-				t.Errorf("expected folder namespace %q to be deleted after rollback", ns.Name)
-			}
-		}
-
 		// Verify the project namespace was cleaned up by seedDefaults'
 		// incremental rollback (project was created in step 2, then step 3 failed).
+		nsList, _ := handler.k8s.client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 		for _, ns := range nsList.Items {
 			if ns.Labels != nil && ns.Labels[v1alpha2.LabelResourceType] == v1alpha2.ResourceTypeProject {
 				t.Errorf("expected project namespace %q to be deleted after rollback", ns.Name)
@@ -1503,13 +1209,12 @@ func TestCreateOrganization_PopulateDefaults(t *testing.T) {
 
 // TestCreateOrganization_SeedsDefaultRoleGrants verifies the org namespace's
 // AnnotationDefaultShareRoles is populated with the three standard role
-// grants (Owner, Editor, Viewer) *before* the default folder and default
-// project are created when populate_defaults=true.
+// grants (Owner, Editor, Viewer) before the default project is created when
+// populate_defaults=true.
 func TestCreateOrganization_SeedsDefaultRoleGrants(t *testing.T) {
 	t.Run("populate_defaults=true writes Owner/Editor/Viewer default role grants", func(t *testing.T) {
 		ts := &mockTemplateSeeder{}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1572,7 +1277,6 @@ func TestCreateOrganization_SeedsDefaultRoleGrants(t *testing.T) {
 	t.Run("populate_defaults=false does not seed default role grants", func(t *testing.T) {
 		ts := &mockTemplateSeeder{}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1600,7 +1304,6 @@ func TestCreateOrganization_SeedsDefaultRoleGrants(t *testing.T) {
 	t.Run("populate_defaults unset does not seed default role grants", func(t *testing.T) {
 		ts := &mockTemplateSeeder{}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1633,7 +1336,6 @@ func TestCreateOrganization_SeedsDefaultRoleGrants(t *testing.T) {
 		// ancestor-default merge.
 		ts := &mockTemplateSeeder{}
 		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
 			withDefaultsSeeder: true,
 			templateSeeder:     ts,
 		})
@@ -1689,71 +1391,6 @@ func TestCreateOrganization_SeedsDefaultRoleGrants(t *testing.T) {
 			}
 		}
 	})
-
-	t.Run("default role grants are written before default folder creation", func(t *testing.T) {
-		// Use a FolderCreator that records whether the
-		// default-share-roles annotation was present on the org namespace
-		// at the moment CreateFolder was invoked. This verifies the
-		// ordering guarantee (annotation-before-folder) described in the
-		// spec: "annotations must be visible on the org namespace
-		// *before* any folder/project creation call runs".
-		ts := &mockTemplateSeeder{}
-		handler := newTestHandlerWithOpts(testHandlerOpts{
-			withFolderCreator:  true,
-			withDefaultsSeeder: true,
-			templateSeeder:     ts,
-		})
-		fc := handler.folderCreator.(*k8sFolderCreator)
-
-		orderingProbe := &orderingFolderCreator{inner: fc, k8s: handler.k8s}
-		// Swap in the probe as the FolderCreator (leaving FolderLister intact).
-		folderPrefix := handler.folderPrefix
-		handler.WithFolderCreator(orderingProbe, fc, folderPrefix)
-
-		ctx := contextWithClaims("alice@example.com")
-		populateDefaults := true
-
-		_, err := handler.CreateOrganization(ctx, connect.NewRequest(&consolev1.CreateOrganizationRequest{
-			Name:             "ordering-org",
-			DisplayName:      "Ordering Org",
-			PopulateDefaults: &populateDefaults,
-		}))
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		if !orderingProbe.seenDefaultRolesAnnotation {
-			t.Errorf("expected default-share-roles annotation to be visible on the org namespace before CreateFolder was called")
-		}
-	})
-}
-
-// orderingFolderCreator wraps a FolderCreator and records, at the moment
-// CreateFolder is invoked, whether the org namespace already carries the
-// default-share-roles annotation. Used to assert the ordering invariant
-// from issue #920.
-type orderingFolderCreator struct {
-	inner                      FolderCreator
-	k8s                        *K8sClient
-	seenDefaultRolesAnnotation bool
-}
-
-func (o *orderingFolderCreator) CreateFolder(ctx context.Context, name, displayName, description, org, parentNs, creatorEmail, creatorSubject string, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles []secrets.AnnotationGrant) (*corev1.Namespace, error) {
-	ns, err := o.k8s.GetOrganization(ctx, org)
-	if err == nil && ns.Annotations != nil {
-		if _, ok := ns.Annotations[v1alpha2.AnnotationDefaultShareRoles]; ok {
-			o.seenDefaultRolesAnnotation = true
-		}
-	}
-	return o.inner.CreateFolder(ctx, name, displayName, description, org, parentNs, creatorEmail, creatorSubject, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles)
-}
-
-func (o *orderingFolderCreator) DeleteFolder(ctx context.Context, name string) error {
-	return o.inner.DeleteFolder(ctx, name)
-}
-
-func (o *orderingFolderCreator) NamespaceExists(ctx context.Context, nsName string) (bool, error) {
-	return o.inner.NamespaceExists(ctx, nsName)
 }
 
 // ---- Helpers ----

--- a/console/organizations/k8s.go
+++ b/console/organizations/k8s.go
@@ -264,35 +264,6 @@ func (c *K8sClient) DeleteOrganization(ctx context.Context, name string) error {
 	return c.clientset(ctx).CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
 }
 
-// SetDefaultFolder sets the default-folder annotation on the org namespace.
-func (c *K8sClient) SetDefaultFolder(ctx context.Context, name, folderName string) error {
-	ns, err := c.GetOrganization(ctx, name)
-	if err != nil {
-		return err
-	}
-	if ns.Annotations == nil {
-		ns.Annotations = make(map[string]string)
-	}
-	ns.Annotations[v1alpha2.AnnotationDefaultFolder] = folderName
-	// Locked annotation: the namespace-share-annotations-console-only
-	// ValidatingAdmissionPolicy denies writes to this annotation from any
-	// principal other than the holos-console service account, so the write
-	// must use the privileged client. The user-level authorization for the
-	// org-create flow that calls this method already happened upstream
-	// through the impersonated GetOrganization read above.
-	_, err = c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
-	return err
-}
-
-// GetDefaultFolder reads the default-folder annotation from an org namespace.
-// Returns empty string if not set.
-func GetDefaultFolder(ns *corev1.Namespace) string {
-	if ns.Annotations == nil {
-		return ""
-	}
-	return ns.Annotations[v1alpha2.AnnotationDefaultFolder]
-}
-
 // GetGatewayNamespace reads the gateway-namespace annotation from an org
 // namespace. Returns empty string if not set.
 func GetGatewayNamespace(ns *corev1.Namespace) string {
@@ -348,8 +319,8 @@ func (c *K8sClient) UpdateOrganizationSharing(ctx context.Context, name string, 
 	ns.Annotations[v1alpha2.AnnotationShareUsers] = string(usersJSON)
 	ns.Annotations[v1alpha2.AnnotationShareRoles] = string(rolesJSON)
 	ns.Annotations[v1alpha2.AnnotationRBACShareUsers] = string(rbacUsersJSON)
-	// Locked annotations (share-users / share-roles / rbac-share-users) — see
-	// SetDefaultFolder for why the write must use the privileged client.
+	// Locked annotations (share-users / share-roles / rbac-share-users) must
+	// use the privileged client because admission denies user writes.
 	updated, err := c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
@@ -408,7 +379,8 @@ func (c *K8sClient) UpdateOrganizationDefaultRoleGrants(ctx context.Context, nam
 		return nil, fmt.Errorf("marshaling default-share-roles: %w", err)
 	}
 	ns.Annotations[v1alpha2.AnnotationDefaultShareRoles] = string(rolesJSON)
-	// Locked annotation (default-share-roles) — see SetDefaultFolder.
+	// Locked annotation (default-share-roles) must use the privileged client
+	// because admission denies user writes.
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 
@@ -434,7 +406,8 @@ func (c *K8sClient) UpdateOrganizationDefaultSharing(ctx context.Context, name s
 	}
 	ns.Annotations[v1alpha2.AnnotationDefaultShareUsers] = string(usersJSON)
 	ns.Annotations[v1alpha2.AnnotationDefaultShareRoles] = string(rolesJSON)
-	// Locked annotations (default-share-*) — see SetDefaultFolder.
+	// Locked annotations (default-share-*) must use the privileged client
+	// because admission denies user writes.
 	return c.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 }
 

--- a/console/organizations/k8s_test.go
+++ b/console/organizations/k8s_test.go
@@ -688,62 +688,6 @@ func TestUpdateOrgDefaultSharing_RejectsNonOrg(t *testing.T) {
 	}
 }
 
-// ---- Default folder K8s tests ----
-
-func TestSetDefaultFolder_WritesAnnotation(t *testing.T) {
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holos-org-acme",
-			Labels: map[string]string{
-				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
-				resolver.ResourceTypeLabel: resolver.ResourceTypeOrganization,
-			},
-			Annotations: map[string]string{
-				v1alpha2.AnnotationShareUsers: `[{"principal":"alice@example.com","role":"owner"}]`,
-			},
-		},
-	}
-	fakeClient := fake.NewClientset(ns)
-	k8s := NewK8sClient(fakeClient, testResolver())
-
-	if err := k8s.SetDefaultFolder(context.Background(), "acme", "my-folder"); err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	updated, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-org-acme", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected namespace to exist, got %v", err)
-	}
-	if updated.Annotations[v1alpha2.AnnotationDefaultFolder] != "my-folder" {
-		t.Errorf("expected default-folder 'my-folder', got %q", updated.Annotations[v1alpha2.AnnotationDefaultFolder])
-	}
-}
-
-func TestGetDefaultFolder_ReadsAnnotation(t *testing.T) {
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holos-org-acme",
-			Annotations: map[string]string{
-				v1alpha2.AnnotationDefaultFolder: "engineering",
-			},
-		},
-	}
-	if got := GetDefaultFolder(ns); got != "engineering" {
-		t.Errorf("expected 'engineering', got %q", got)
-	}
-}
-
-func TestGetDefaultFolder_ReturnsEmptyWhenAbsent(t *testing.T) {
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holos-org-acme",
-		},
-	}
-	if got := GetDefaultFolder(ns); got != "" {
-		t.Errorf("expected empty string, got %q", got)
-	}
-}
-
 func TestUpdateOrgSharing_RejectsNonOrg(t *testing.T) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -242,7 +242,8 @@ func (h *Handler) CreateProject(
 	parentName := req.Msg.ParentName
 	parentType := req.Msg.ParentType
 	if parentName == "" {
-		parentName, parentType = h.resolveDefaultParent(ctx, req.Msg.Organization)
+		parentName = req.Msg.Organization
+		parentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
 	}
 	if parentType == consolev1.ParentType_PARENT_TYPE_UNSPECIFIED {
 		parentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
@@ -968,12 +969,6 @@ func (h *Handler) buildProject(ns *corev1.Namespace, shareUsers, shareRoles []se
 	p.CreatedAt = ns.CreationTimestamp.UTC().Format(time.RFC3339)
 
 	return p
-}
-
-// resolveDefaultParent determines the default parent for a new project when
-// no explicit parent is specified.
-func (h *Handler) resolveDefaultParent(ctx context.Context, org string) (string, consolev1.ParentType) {
-	return org, consolev1.ParentType_PARENT_TYPE_ORGANIZATION
 }
 
 // resolveParentNS converts a ParentType+ParentName pair to a Kubernetes namespace name.

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -238,8 +238,7 @@ func (h *Handler) CreateProject(
 	}
 
 	// Resolve the immediate parent namespace.
-	// When no explicit parent is specified, check the org's default folder.
-	// Falls back to org root if no default folder is configured or the folder is missing.
+	// When no explicit parent is specified, default to the organization.
 	parentName := req.Msg.ParentName
 	parentType := req.Msg.ParentType
 	if parentName == "" {
@@ -972,53 +971,9 @@ func (h *Handler) buildProject(ns *corev1.Namespace, shareUsers, shareRoles []se
 }
 
 // resolveDefaultParent determines the default parent for a new project when
-// no explicit parent is specified. It reads the org's default-folder annotation
-// and, if the referenced folder exists, returns it as the parent. Otherwise
-// it falls back to the organization as the parent (legacy behavior).
+// no explicit parent is specified.
 func (h *Handler) resolveDefaultParent(ctx context.Context, org string) (string, consolev1.ParentType) {
-	if org == "" {
-		return org, consolev1.ParentType_PARENT_TYPE_ORGANIZATION
-	}
-
-	// Look up the org namespace to read the default-folder annotation.
-	orgNsName := h.k8s.Resolver.OrgNamespace(org)
-	orgNs, err := h.k8s.GetNamespace(ctx, orgNsName)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to read org namespace for default folder resolution, falling back to org root",
-			slog.String("organization", org),
-			slog.Any("error", err),
-		)
-		return org, consolev1.ParentType_PARENT_TYPE_ORGANIZATION
-	}
-
-	defaultFolder := orgNs.Annotations[v1alpha2.AnnotationDefaultFolder]
-	if defaultFolder == "" {
-		// No default-folder annotation — legacy org, fall back to org root.
-		return org, consolev1.ParentType_PARENT_TYPE_ORGANIZATION
-	}
-
-	// Check that the referenced folder namespace actually exists.
-	folderNsName := h.k8s.Resolver.FolderNamespace(defaultFolder)
-	exists, err := h.k8s.NamespaceExists(ctx, folderNsName)
-	if err != nil {
-		slog.WarnContext(ctx, "error checking default folder existence, falling back to org root",
-			slog.String("action", "default_folder_not_found"),
-			slog.String("organization", org),
-			slog.String("default_folder", defaultFolder),
-			slog.Any("error", err),
-		)
-		return org, consolev1.ParentType_PARENT_TYPE_ORGANIZATION
-	}
-	if !exists {
-		slog.WarnContext(ctx, "default folder referenced by org does not exist, falling back to org root",
-			slog.String("action", "default_folder_not_found"),
-			slog.String("organization", org),
-			slog.String("default_folder", defaultFolder),
-		)
-		return org, consolev1.ParentType_PARENT_TYPE_ORGANIZATION
-	}
-
-	return defaultFolder, consolev1.ParentType_PARENT_TYPE_FOLDER
+	return org, consolev1.ParentType_PARENT_TYPE_ORGANIZATION
 }
 
 // resolveParentNS converts a ParentType+ParentName pair to a Kubernetes namespace name.

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1383,47 +1383,9 @@ func TestUpdateProject_Reparent_MoveFromFolderToOrg(t *testing.T) {
 	}
 }
 
-// ---- Default Folder Resolution Tests ----
+// ---- Default Parent Resolution Tests ----
 
-func TestCreateProject_DefaultsToOrgDefaultFolder(t *testing.T) {
-	// Org has a default-folder annotation pointing to a valid folder.
-	orgNs := orgNSWithGrants("df-org-a", `[{"principal":"alice@example.com","role":"owner"}]`)
-	orgNs.Annotations[v1alpha2.AnnotationDefaultFolder] = "df-folder-a"
-
-	folderNs := folderNSWithGrants("df-folder-a", "df-org-a", "holos-org-df-org-a", `[{"principal":"alice@example.com","role":"editor"}]`)
-
-	handler := newHandlerWithOrg(
-		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
-		orgNs, folderNs,
-	)
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx := contextWithClaims("alice@example.com")
-
-	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		Name:         "df-prj-a",
-		Organization: "df-org-a",
-		// No ParentType or ParentName — should default to the org's default folder.
-	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if resp.Msg.Name != "df-prj-a" {
-		t.Errorf("expected name 'df-prj-a', got %q", resp.Msg.Name)
-	}
-
-	// Verify the project's parent label points to the folder namespace.
-	ns, err := handler.k8s.GetProject(ctx, "df-prj-a")
-	if err != nil {
-		t.Fatalf("expected project to exist, got %v", err)
-	}
-	parentLabel := ns.Labels[v1alpha2.AnnotationParent]
-	if parentLabel != "holos-fld-df-folder-a" {
-		t.Errorf("expected parent label 'holos-fld-df-folder-a', got %q", parentLabel)
-	}
-}
-
-func TestCreateProject_FallsBackToOrgWhenNoDefaultFolderAnnotation(t *testing.T) {
-	// Org has no default-folder annotation (legacy org).
+func TestCreateProject_DefaultsToOrgParent(t *testing.T) {
 	orgNs := orgNSWithGrants("df-org-b", `[{"principal":"bob@example.com","role":"owner"}]`)
 
 	handler := newHandlerWithOrg(
@@ -1455,59 +1417,14 @@ func TestCreateProject_FallsBackToOrgWhenNoDefaultFolderAnnotation(t *testing.T)
 	}
 }
 
-func TestCreateProject_FallsBackToOrgWhenDefaultFolderDeleted(t *testing.T) {
-	// Org has a default-folder annotation, but the referenced folder does not exist.
-	orgNs := orgNSWithGrants("df-org-c", `[{"principal":"carol@example.com","role":"owner"}]`)
-	orgNs.Annotations[v1alpha2.AnnotationDefaultFolder] = "df-folder-gone"
-
-	// No folder namespace created — simulates a deleted folder.
-	logHandler := &testLogHandler{}
-	slog.SetDefault(slog.New(logHandler))
-
-	handler := newHandlerWithOrg(
-		&mockOrgResolver{users: map[string]string{"carol@example.com": "owner"}},
-		orgNs,
-	)
-	ctx := contextWithClaims("carol@example.com")
-
-	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		Name:         "df-prj-c",
-		Organization: "df-org-c",
-	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if resp.Msg.Name != "df-prj-c" {
-		t.Errorf("expected name 'df-prj-c', got %q", resp.Msg.Name)
-	}
-
-	// Verify the project's parent label falls back to the org namespace.
-	ns, err := handler.k8s.GetProject(ctx, "df-prj-c")
-	if err != nil {
-		t.Fatalf("expected project to exist, got %v", err)
-	}
-	parentLabel := ns.Labels[v1alpha2.AnnotationParent]
-	if parentLabel != "holos-org-df-org-c" {
-		t.Errorf("expected parent label 'holos-org-df-org-c', got %q", parentLabel)
-	}
-
-	// Verify a warning was logged about the missing default folder.
-	if r := logHandler.findRecord("default_folder_not_found"); r == nil {
-		t.Error("expected warning log with action 'default_folder_not_found'")
-	}
-}
-
-func TestCreateProject_ExplicitParentOverridesDefaultFolder(t *testing.T) {
-	// Org has a default-folder annotation, but the request specifies an explicit parent.
+func TestCreateProject_ExplicitFolderParentStillSupported(t *testing.T) {
 	orgNs := orgNSWithGrants("df-org-d", `[{"principal":"dave@example.com","role":"owner"}]`)
-	orgNs.Annotations[v1alpha2.AnnotationDefaultFolder] = "df-folder-d"
 
-	folderNs := folderNSWithGrants("df-folder-d", "df-org-d", "holos-org-df-org-d", `[{"principal":"dave@example.com","role":"editor"}]`)
 	explicitFolder := folderNSWithGrants("df-explicit-d", "df-org-d", "holos-org-df-org-d", `[{"principal":"dave@example.com","role":"editor"}]`)
 
 	handler := newHandlerWithOrg(
 		&mockOrgResolver{users: map[string]string{"dave@example.com": "owner"}},
-		orgNs, folderNs, explicitFolder,
+		orgNs, explicitFolder,
 	)
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := contextWithClaims("dave@example.com")

--- a/frontend/src/gen/holos/console/v1/projects_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/projects_pb.d.ts
@@ -272,8 +272,7 @@ export declare type CreateProjectRequest = Message<"holos.console.v1.CreateProje
 
   /**
    * parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-   * When unset, defaults to the organization's default folder (ADR 022 Decision 5).
-   * Falls back to the organization if no default folder is configured.
+   * When unset, defaults to the organization.
    *
    * @generated from field: string parent_name = 8;
    */

--- a/frontend/src/routes/_authenticated/organization/new.tsx
+++ b/frontend/src/routes/_authenticated/organization/new.tsx
@@ -160,7 +160,7 @@ export function OrganizationNewPage({ returnTo }: { returnTo?: string }) {
                     <Info className="h-4 w-4 text-muted-foreground cursor-default" />
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>Creates a default folder and project structure with example templates at each level, including an org-level HTTPRoute platform template and a project-level deployment template.</p>
+                    <p>Creates an org-level HTTPRoute platform template, a default project under the organization, and a project-level deployment template.</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/gen/holos/console/v1/projects.pb.go
+++ b/gen/holos/console/v1/projects.pb.go
@@ -400,8 +400,7 @@ type CreateProjectRequest struct {
 	// Defaults to PARENT_TYPE_ORGANIZATION when unset.
 	ParentType ParentType `protobuf:"varint,7,opt,name=parent_type,json=parentType,proto3,enum=holos.console.v1.ParentType" json:"parent_type,omitempty"`
 	// parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-	// When unset, defaults to the organization's default folder (ADR 022 Decision 5).
-	// Falls back to the organization if no default folder is configured.
+	// When unset, defaults to the organization.
 	ParentName    string `protobuf:"bytes,8,opt,name=parent_name,json=parentName,proto3" json:"parent_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/holos/console/v1/projects.proto
+++ b/proto/holos/console/v1/projects.proto
@@ -130,8 +130,7 @@ message CreateProjectRequest {
   // Defaults to PARENT_TYPE_ORGANIZATION when unset.
   ParentType parent_type = 7;
   // parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-  // When unset, defaults to the organization's default folder (ADR 022 Decision 5).
-  // Falls back to the organization if no default folder is configured.
+  // When unset, defaults to the organization.
   string parent_name = 8;
 }
 


### PR DESCRIPTION
## Summary
- Remove organization default-folder auto-creation, annotation writes, and k8s helper methods.
- Seed populate_defaults projects directly under the organization namespace.
- Remove console Go references to AnnotationDefaultFolder and update obsolete tests/wiring.

Fixes HOL-1093

## Test plan
- [x] go test ./console/organizations ./console/projects ./console/folders
- [x] make test-go