### PR TITLE
refactor(console): require organization project parents

### DIFF
--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -237,21 +237,10 @@ func (h *Handler) CreateProject(
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("authentication required"))
 	}
 
-	// Resolve the immediate parent namespace.
-	// When no explicit parent is specified, default to the organization.
-	parentName := req.Msg.ParentName
-	parentType := req.Msg.ParentType
-	if parentName == "" {
-		parentName = req.Msg.Organization
-		parentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	if err := validateOrganizationProjectParent(req.Msg.ParentType, req.Msg.ParentName, req.Msg.Organization); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-	if parentType == consolev1.ParentType_PARENT_TYPE_UNSPECIFIED {
-		parentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
-	}
-	parentNs, err := h.resolveParentNS(parentType, parentName)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("resolving parent: %w", err))
-	}
+	parentNs := h.k8s.Resolver.OrgNamespace(req.Msg.Organization)
 	if rpc.HasImpersonatedClients(ctx) {
 		parentNamespace, err := h.k8s.GetNamespace(ctx, parentNs)
 		if err != nil {
@@ -305,6 +294,7 @@ func (h *Handler) CreateProject(
 	// covers both paths (existing typed Create and SSA-via-applier) with a
 	// single branch.
 	const maxCreateRetries = 3
+	var err error
 	for attempt := range maxCreateRetries + 1 {
 		err = h.createProjectOnce(ctx, name, req.Msg, parentNs, claims.Email, claims.Sub, shareUsers, shareRoles, defaultShareUsers, defaultShareRoles, rbacShareUsers, topResourceRBACUsers)
 		if err == nil {
@@ -919,18 +909,18 @@ func (h *Handler) buildProject(ns *corev1.Namespace, shareUsers, shareRoles []se
 	if ns.Labels != nil {
 		p.Organization = ns.Labels[v1alpha2.LabelOrganization]
 		p.Name = ns.Labels[v1alpha2.LabelProject]
+		p.ParentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+		p.ParentName = p.Organization
 
 		// Derive parent info from the parent label.
 		parentNs := ns.Labels[v1alpha2.AnnotationParent]
 		if parentNs != "" {
 			kind, name, err := h.k8s.Resolver.ResourceTypeFromNamespace(parentNs)
 			if err == nil {
-				p.ParentName = name
 				switch kind {
 				case v1alpha2.ResourceTypeOrganization:
+					p.ParentName = name
 					p.ParentType = consolev1.ParentType_PARENT_TYPE_ORGANIZATION
-				case v1alpha2.ResourceTypeFolder:
-					p.ParentType = consolev1.ParentType_PARENT_TYPE_FOLDER
 				}
 			}
 		}
@@ -971,16 +961,24 @@ func (h *Handler) buildProject(ns *corev1.Namespace, shareUsers, shareRoles []se
 	return p
 }
 
-// resolveParentNS converts a ParentType+ParentName pair to a Kubernetes namespace name.
+// resolveParentNS converts a project ParentType+ParentName pair to a Kubernetes namespace name.
 func (h *Handler) resolveParentNS(parentType consolev1.ParentType, parentName string) (string, error) {
 	switch parentType {
 	case consolev1.ParentType_PARENT_TYPE_ORGANIZATION:
 		return h.k8s.Resolver.OrgNamespace(parentName), nil
-	case consolev1.ParentType_PARENT_TYPE_FOLDER:
-		return h.k8s.Resolver.FolderNamespace(parentName), nil
 	default:
-		return "", fmt.Errorf("unknown parent_type %v", parentType)
+		return "", fmt.Errorf("projects can only be parented by organizations")
 	}
+}
+
+func validateOrganizationProjectParent(parentType consolev1.ParentType, parentName, organization string) error {
+	if parentType != consolev1.ParentType_PARENT_TYPE_UNSPECIFIED && parentType != consolev1.ParentType_PARENT_TYPE_ORGANIZATION {
+		return fmt.Errorf("projects can only be parented by organizations")
+	}
+	if parentName != "" && parentName != organization {
+		return fmt.Errorf("project parent_name must match organization")
+	}
+	return nil
 }
 
 // shareGrantsToAnnotations converts proto ShareGrant slices to annotation grants.

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -511,6 +511,9 @@ func (h *Handler) UpdateProject(
 
 	// Handle reparenting if parent_type and parent_name are set.
 	if req.Msg.ParentType != nil && req.Msg.ParentName != nil {
+		if err := validateOrganizationProjectParent(*req.Msg.ParentType, *req.Msg.ParentName, org); err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
 		if err := h.reparentProject(ctx, ns, claims, *req.Msg.ParentType, *req.Msg.ParentName); err != nil {
 			return nil, err
 		}

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -978,6 +978,9 @@ func (h *Handler) resolveParentNS(parentType consolev1.ParentType, parentName st
 }
 
 func validateOrganizationProjectParent(parentType consolev1.ParentType, parentName, organization string) error {
+	if organization == "" {
+		return fmt.Errorf("organization is required")
+	}
 	if parentType != consolev1.ParentType_PARENT_TYPE_UNSPECIFIED && parentType != consolev1.ParentType_PARENT_TYPE_ORGANIZATION {
 		return fmt.Errorf("projects can only be parented by organizations")
 	}

--- a/console/projects/handler.go
+++ b/console/projects/handler.go
@@ -510,6 +510,9 @@ func (h *Handler) UpdateProject(
 	org := GetOrganization(ns)
 
 	// Handle reparenting if parent_type and parent_name are set.
+	if (req.Msg.ParentType == nil) != (req.Msg.ParentName == nil) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("parent_type and parent_name must be set together"))
+	}
 	if req.Msg.ParentType != nil && req.Msg.ParentName != nil {
 		if err := validateOrganizationProjectParent(*req.Msg.ParentType, *req.Msg.ParentName, org); err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/console/projects/handler_reparent_authz_test.go
+++ b/console/projects/handler_reparent_authz_test.go
@@ -89,18 +89,17 @@ func TestUpdateProject_Reparent_ImpersonatedOwnerAuthorization(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
 			srcFolder := folderNSWithGrants("rp-authz-src", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
-			destFolder := folderNSWithGrants("rp-authz-dest", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
 			prj := projectNSWithParent("rp-authz-prj", "acme", "holos-fld-rp-authz-src", `[{"principal":"alice@example.com","role":"editor"}]`)
 
 			handler, ctx := newReparentAuthzHandler(t,
-				"holos-fld-rp-authz-src",  // source parent ns
-				"holos-fld-rp-authz-dest", // destination parent ns
+				"holos-fld-rp-authz-src", // source parent ns
+				"holos-org-acme",         // destination parent ns
 				tc.allowSrc, tc.allowDest,
-				orgNs, srcFolder, destFolder, prj,
+				orgNs, srcFolder, prj,
 			)
 
-			newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
-			newParentName := "rp-authz-dest"
+			newParentType := consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+			newParentName := "acme"
 			_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
 				Name:       "rp-authz-prj",
 				ParentType: &newParentType,

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1271,93 +1271,6 @@ func folderNSWithGrants(name, org, parentNs, shareUsersJSON string) *corev1.Name
 	}
 }
 
-func TestUpdateProject_Reparent_SuccessOrgOwner(t *testing.T) {
-	// Alice is org owner, so she can reparent projects within the org via cascade.
-	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
-	srcFolder := folderNSWithGrants("rp-prj-src", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
-	destFolder := folderNSWithGrants("rp-prj-dest", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
-	prj := projectNSWithParent("rp-prj-test", "acme", "holos-fld-rp-prj-src", `[{"principal":"alice@example.com","role":"editor"}]`)
-
-	handler := newHandlerWithOrg(
-		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
-		orgNs, srcFolder, destFolder, prj,
-	)
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx := contextWithClaims("alice@example.com")
-
-	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
-	newParentName := "rp-prj-dest"
-	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
-		Name:       "rp-prj-test",
-		ParentType: &newParentType,
-		ParentName: &newParentName,
-	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-}
-
-func TestUpdateProject_Reparent_SameParentIsNoop(t *testing.T) {
-	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
-	folder := folderNSWithGrants("rp-prj-noop", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
-	prj := projectNSWithParent("rp-prj-noop-test", "acme", "holos-fld-rp-prj-noop", `[{"principal":"alice@example.com","role":"editor"}]`)
-
-	handler := newHandlerWithOrg(
-		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
-		orgNs, folder, prj,
-	)
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx := contextWithClaims("alice@example.com")
-
-	// Move to same parent (folder rp-prj-noop).
-	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
-	newParentName := "rp-prj-noop"
-	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
-		Name:       "rp-prj-noop-test",
-		ParentType: &newParentType,
-		ParentName: &newParentName,
-	}))
-	if err != nil {
-		t.Fatalf("expected no error (no-op), got %v", err)
-	}
-}
-
-func TestUpdateProject_Reparent_SameParentSkipsK8sWrite(t *testing.T) {
-	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
-	folder := folderNSWithGrants("rp-prj-noop2", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"editor"}]`)
-	prj := projectNSWithParent("rp-prj-noop2-test", "acme", "holos-fld-rp-prj-noop2", `[{"principal":"alice@example.com","role":"editor"}]`)
-
-	handler, fakeClient := newHandlerWithOrgAndClient(
-		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
-		orgNs, folder, prj,
-	)
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx := contextWithClaims("alice@example.com")
-
-	// Record action count before the call.
-	beforeActions := len(fakeClient.Actions())
-
-	// Move to same parent with no metadata changes.
-	newParentType := consolev1.ParentType_PARENT_TYPE_FOLDER
-	newParentName := "rp-prj-noop2"
-	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
-		Name:       "rp-prj-noop2-test",
-		ParentType: &newParentType,
-		ParentName: &newParentName,
-	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	// Verify no update actions were issued after the initial get.
-	afterActions := fakeClient.Actions()
-	for _, action := range afterActions[beforeActions:] {
-		if action.GetVerb() == "update" {
-			t.Fatalf("expected no K8s update for same-parent reparent with no metadata changes, but got update action on %s", action.GetResource().Resource)
-		}
-	}
-}
-
 func TestUpdateProject_Reparent_MoveFromFolderToOrg(t *testing.T) {
 	// Move a project from a folder to the org root.
 	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
@@ -1417,7 +1330,7 @@ func TestCreateProject_DefaultsToOrgParent(t *testing.T) {
 	}
 }
 
-func TestCreateProject_ExplicitFolderParentStillSupported(t *testing.T) {
+func TestCreateProject_ExplicitFolderParentRejected(t *testing.T) {
 	orgNs := orgNSWithGrants("df-org-d", `[{"principal":"dave@example.com","role":"owner"}]`)
 
 	explicitFolder := folderNSWithGrants("df-explicit-d", "df-org-d", "holos-org-df-org-d", `[{"principal":"dave@example.com","role":"editor"}]`)
@@ -1429,26 +1342,21 @@ func TestCreateProject_ExplicitFolderParentStillSupported(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := contextWithClaims("dave@example.com")
 
-	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+	folderParentType := consolev1.ParentType(2)
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
 		Name:         "df-prj-d",
 		Organization: "df-org-d",
-		ParentType:   consolev1.ParentType_PARENT_TYPE_FOLDER,
+		ParentType:   folderParentType,
 		ParentName:   "df-explicit-d",
 	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if err == nil {
+		t.Fatal("expected explicit folder parent to be rejected, got nil")
 	}
-	if resp.Msg.Name != "df-prj-d" {
-		t.Errorf("expected name 'df-prj-d', got %q", resp.Msg.Name)
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T: %v", err, err)
 	}
-
-	// Verify the project's parent label points to the explicitly specified folder.
-	ns, err := handler.k8s.GetProject(ctx, "df-prj-d")
-	if err != nil {
-		t.Fatalf("expected project to exist, got %v", err)
-	}
-	parentLabel := ns.Labels[v1alpha2.AnnotationParent]
-	if parentLabel != "holos-fld-df-explicit-d" {
-		t.Errorf("expected parent label 'holos-fld-df-explicit-d', got %q", parentLabel)
+	if connectErr.Code() != connect.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v: %v", connectErr.Code(), err)
 	}
 }

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1296,6 +1296,37 @@ func TestUpdateProject_Reparent_MoveFromFolderToOrg(t *testing.T) {
 	}
 }
 
+func TestUpdateProject_ReparentRejectsDifferentOrganization(t *testing.T) {
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	otherOrgNs := orgNSWithGrants("other", `[{"principal":"alice@example.com","role":"owner"}]`)
+	prj := projectNSWithParent("rp-prj-cross-org", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
+		orgNs, otherOrgNs, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	newParentType := consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	newParentName := "other"
+	_, err := handler.UpdateProject(ctx, connect.NewRequest(&consolev1.UpdateProjectRequest{
+		Name:       "rp-prj-cross-org",
+		ParentType: &newParentType,
+		ParentName: &newParentName,
+	}))
+	if err == nil {
+		t.Fatal("expected cross-organization reparent to be rejected, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+	}
+	if connectErr.Code() != connect.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v: %v", connectErr.Code(), err)
+	}
+}
+
 // ---- Default Parent Resolution Tests ----
 
 func TestCreateProject_DefaultsToOrgParent(t *testing.T) {
@@ -1342,11 +1373,9 @@ func TestCreateProject_ExplicitFolderParentRejected(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ctx := contextWithClaims("dave@example.com")
 
-	folderParentType := consolev1.ParentType(2)
 	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
 		Name:         "df-prj-d",
 		Organization: "df-org-d",
-		ParentType:   folderParentType,
 		ParentName:   "df-explicit-d",
 	}))
 	if err == nil {

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -1327,6 +1327,56 @@ func TestUpdateProject_ReparentRejectsDifferentOrganization(t *testing.T) {
 	}
 }
 
+func TestUpdateProject_ReparentRejectsPartialParentInput(t *testing.T) {
+	orgNs := orgNSWithGrants("acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+	prj := projectNSWithParent("rp-prj-partial", "acme", "holos-org-acme", `[{"principal":"alice@example.com","role":"owner"}]`)
+
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"alice@example.com": "owner"}},
+		orgNs, prj,
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("alice@example.com")
+
+	parentType := consolev1.ParentType_PARENT_TYPE_ORGANIZATION
+	parentName := "acme"
+	cases := []struct {
+		name string
+		req  *consolev1.UpdateProjectRequest
+	}{
+		{
+			name: "parent_type only",
+			req: &consolev1.UpdateProjectRequest{
+				Name:       "rp-prj-partial",
+				ParentType: &parentType,
+			},
+		},
+		{
+			name: "parent_name only",
+			req: &consolev1.UpdateProjectRequest{
+				Name:       "rp-prj-partial",
+				ParentName: &parentName,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := handler.UpdateProject(ctx, connect.NewRequest(tc.req))
+			if err == nil {
+				t.Fatal("expected partial parent input to be rejected, got nil")
+			}
+			connectErr, ok := err.(*connect.Error)
+			if !ok {
+				t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+			}
+			if connectErr.Code() != connect.CodeInvalidArgument {
+				t.Fatalf("expected CodeInvalidArgument, got %v: %v", connectErr.Code(), err)
+			}
+		})
+	}
+}
+
 // ---- Default Parent Resolution Tests ----
 
 func TestCreateProject_DefaultsToOrgParent(t *testing.T) {

--- a/console/projects/handler_test.go
+++ b/console/projects/handler_test.go
@@ -203,9 +203,10 @@ func TestCreateProject_CreatesForAuthorizedUser(t *testing.T) {
 	ctx := contextWithClaims("alice@example.com")
 
 	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		Name:        "new-project",
-		DisplayName: "New Project",
-		Description: "A new project",
+		Name:         "new-project",
+		DisplayName:  "New Project",
+		Description:  "A new project",
+		Organization: "acme",
 	}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -231,7 +232,8 @@ func TestCreateProject_AutoGrantsOwnerToCreator(t *testing.T) {
 
 	// Create without explicit grants
 	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		Name: "new-project",
+		Name:         "new-project",
+		Organization: "acme",
 	}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -272,7 +274,8 @@ func TestCreateProject_DeriveNameFromDisplayName(t *testing.T) {
 	ctx := contextWithClaims("alice@example.com")
 
 	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		DisplayName: "My Frontend App",
+		DisplayName:  "My Frontend App",
+		Organization: "acme",
 	}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -289,7 +292,8 @@ func TestCreateProject_DeriveNameWithCollision(t *testing.T) {
 	ctx := contextWithClaims("alice@example.com")
 
 	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		DisplayName: "Frontend",
+		DisplayName:  "Frontend",
+		Organization: "acme",
 	}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -336,7 +340,8 @@ func TestCreateProject_RetriesOnAlreadyExistsRace(t *testing.T) {
 
 	ctx := contextWithClaims("alice@example.com")
 	resp, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		DisplayName: "Frontend",
+		DisplayName:  "Frontend",
+		Organization: "acme",
 	}))
 	if err != nil {
 		t.Fatalf("expected retry to succeed, got %v", err)
@@ -358,7 +363,8 @@ func TestCreateProject_ExplicitNameDoesNotRetry(t *testing.T) {
 	ctx := contextWithClaims("alice@example.com")
 
 	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		Name: "my-project",
+		Name:         "my-project",
+		Organization: "acme",
 	}))
 	if err == nil {
 		t.Fatal("expected AlreadyExists error for explicit name collision")
@@ -549,7 +555,8 @@ func TestCreateProject_NamespacePrefixIncluded(t *testing.T) {
 
 	ctx := contextWithClaims("alice@example.com")
 	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		Name: "new-project",
+		Name:         "new-project",
+		Organization: "acme",
 	}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -941,54 +948,6 @@ func TestCreateProject_RequestGrantsOverrideOrgDefaults(t *testing.T) {
 		}
 	}
 	t.Error("expected bob@example.com in share-users")
-}
-
-func TestCreateProject_WithoutOrg_BehavesAsBeforeNoDefaults(t *testing.T) {
-	existing := managedNS("existing", `[{"principal":"alice@example.com","role":"owner"}]`)
-	orgResolver := &mockOrgDefaultShareResolver{
-		users: map[string]string{"alice@example.com": "owner"},
-		defaultUsers: []secrets.AnnotationGrant{
-			{Principal: "should-not-appear@example.com", Role: "viewer"},
-		},
-	}
-
-	fakeClient := fake.NewClientset(existing)
-	k8s := NewK8sClient(fakeClient, testResolver())
-	handler := NewHandler(k8s, orgResolver)
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx := contextWithClaims("alice@example.com")
-
-	// Create without organization — org defaults should NOT be applied
-	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
-		Name: "standalone-project",
-	}))
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	if orgResolver.defaultCalled {
-		t.Error("expected org default resolver to NOT be called when no organization is specified")
-	}
-
-	ns, err := fakeClient.CoreV1().Namespaces().Get(context.Background(), "holos-prj-standalone-project", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected namespace to exist, got %v", err)
-	}
-
-	// Should only have creator as owner, no org defaults
-	users, err := GetShareUsers(ns)
-	if err != nil {
-		t.Fatalf("failed to parse share-users: %v", err)
-	}
-	if len(users) != 1 || users[0].Principal != "alice@example.com" {
-		t.Errorf("expected only creator alice, got %v", users)
-	}
-
-	// Should have no default sharing annotations
-	defaultUsers, _ := GetDefaultShareUsers(ns)
-	if len(defaultUsers) != 0 {
-		t.Errorf("expected no default-share-users, got %v", defaultUsers)
-	}
 }
 
 func assertInvalidArgument(t *testing.T, err error) {
@@ -1408,6 +1367,28 @@ func TestCreateProject_DefaultsToOrgParent(t *testing.T) {
 	parentLabel := ns.Labels[v1alpha2.AnnotationParent]
 	if parentLabel != "holos-org-df-org-b" {
 		t.Errorf("expected parent label 'holos-org-df-org-b', got %q", parentLabel)
+	}
+}
+
+func TestCreateProject_RejectsEmptyOrganization(t *testing.T) {
+	handler := newHandlerWithOrg(
+		&mockOrgResolver{users: map[string]string{"erin@example.com": "owner"}},
+	)
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := contextWithClaims("erin@example.com")
+
+	_, err := handler.CreateProject(ctx, connect.NewRequest(&consolev1.CreateProjectRequest{
+		Name: "df-prj-e",
+	}))
+	if err == nil {
+		t.Fatal("expected empty organization to be rejected, got nil")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+	}
+	if connectErr.Code() != connect.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v: %v", connectErr.Code(), err)
 	}
 }
 

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.test.tsx
@@ -15,7 +15,6 @@ if (!Element.prototype.releasePointerCapture) {
 
 vi.mock('@/queries/projects', () => ({
   useListProjects: vi.fn(),
-  useListProjectsByParent: vi.fn(),
 }))
 
 vi.mock('@/queries/deployments', () => ({
@@ -33,7 +32,7 @@ vi.mock('@/queries/templates', async () => {
 })
 
 import { MatchesPreview } from './MatchesPreview'
-import { useListProjects, useListProjectsByParent } from '@/queries/projects'
+import { useListProjects } from '@/queries/projects'
 import { useListDeployments } from '@/queries/deployments'
 import { useListTemplates } from '@/queries/templates'
 import { namespaceForProject } from '@/lib/scope-labels'
@@ -64,15 +63,6 @@ function stubLists({
     isPending: false,
     error: org ? listProjectsError : null,
   }))
-  ;(useListProjectsByParent as Mock).mockImplementation(
-    (org: string, _pt: unknown, parent: string | undefined) => ({
-      data:
-        org && parent && !listProjectsError ? projects : undefined,
-      isLoading: false,
-      isPending: false,
-      error: org && parent ? listProjectsError : null,
-    }),
-  )
   ;(useListTemplates as Mock).mockImplementation((namespace: string) => {
     if (!namespace) return { data: [], isLoading: false, error: null }
     const entry = Object.entries(perProjectTemplates).find(
@@ -255,12 +245,10 @@ describe('MatchesPreview', () => {
     )
   })
 
-  it('folder-scoped binding: literal out-of-folder project is excluded from preview', async () => {
-    // HOL-773 codex follow-up on PR #1084: under folder scope, only
-    // projects inside the folder are reachable. A target that points at
-    // a literal project outside the folder must NOT show matches (the
-    // backend rejects it with "project ... does not exist under binding
-    // scope ...").
+  it('folder-scoped binding: literal project is excluded from preview', async () => {
+    // Projects are organization-parented only. Folder-scoped bindings no
+    // longer enumerate projects by folder, so project targets under folder
+    // scope should preview as empty even if a same-named project exists.
     stubLists({
       projects: [{ name: 'in-folder', displayName: 'In Folder' }],
       perProjectTemplates: {
@@ -302,7 +290,7 @@ describe('MatchesPreview', () => {
     })
   })
 
-  it('folder-scoped binding: literal in-folder project still reports a match', async () => {
+  it('folder-scoped binding: literal formerly in-folder project is empty', async () => {
     stubLists({
       projects: [{ name: 'in-folder', displayName: 'In Folder' }],
       perProjectTemplates: {
@@ -329,9 +317,9 @@ describe('MatchesPreview', () => {
       />,
     )
     await waitFor(() => {
-      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
-        /Matches 1 target/i,
-      )
+      expect(
+        screen.getByTestId('matches-preview-empty'),
+      ).toBeInTheDocument()
     })
   })
 
@@ -470,7 +458,7 @@ describe('MatchesPreview', () => {
     })
   })
 
-  it('folder-scoped preview enumerates via useListProjectsByParent', async () => {
+  it('folder-scoped wildcard project preview is empty', async () => {
     stubLists({
       projects: [{ name: 'proj-folder-a', displayName: 'Project A' }],
       perProjectTemplates: {
@@ -497,10 +485,9 @@ describe('MatchesPreview', () => {
       />,
     )
     await waitFor(() => {
-      expect(useListProjectsByParent).toHaveBeenCalled()
-      expect(screen.getByTestId('matches-preview-toggle')).toHaveTextContent(
-        /Matches 1 target/i,
-      )
+      expect(
+        screen.getByTestId('matches-preview-empty'),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
@@ -198,17 +198,9 @@ export function MatchesPreview({
   parentScope,
   targets,
 }: MatchesPreviewProps) {
-  // Organization-wide and folder-scoped project enumerations are hoisted to
-  // the top of the component so hook order is invariant across renders.
-  // Both hooks are passed empty strings when not applicable which short-
-  // circuits via `enabled: !!organization` inside the hooks themselves.
-  //
-  // Folder-scoped bindings must *always* enumerate the folder's projects —
-  // not just when a wildcard row is present — because literal project
-  // names still need to be filtered through the scope ceiling. Otherwise
-  // the preview would happily probe an out-of-folder project and claim
-  // matches the backend will reject with "project ... does not exist
-  // under binding scope ..." (codex review on PR #1084).
+  // Organization-wide project enumeration is hoisted so hook order is
+  // invariant across renders. Folder-scoped bindings no longer enumerate
+  // projects because projects are always parented by their organization.
   const needsScopeProjectList =
     parentScope.kind === 'folder' ||
     targets.some((t) => t.projectName === WILDCARD)

--- a/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
+++ b/frontend/src/components/template-policy-bindings/MatchesPreview.tsx
@@ -14,9 +14,8 @@ import {
 } from '@/components/ui/collapsible'
 import { TemplatePolicyBindingTargetKind } from '@/queries/templatePolicyBindings'
 import { useListDeployments } from '@/queries/deployments'
-import { useListProjects, useListProjectsByParent } from '@/queries/projects'
+import { useListProjects } from '@/queries/projects'
 import { useListTemplates } from '@/queries/templates'
-import { ParentType } from '@/gen/holos/console/v1/folders_pb.js'
 import { namespaceForProject, scopeLabelFromNamespace } from '@/lib/scope-labels'
 import { WILDCARD, type TargetRefDraft } from './binding-draft'
 
@@ -218,18 +217,13 @@ export function MatchesPreview({
       ? organization
       : '',
   )
-  const folderProjectsQuery = useListProjectsByParent(
-    parentScope.kind === 'folder' && needsScopeProjectList ? organization : '',
-    parentScope.kind === 'folder' ? ParentType.FOLDER : undefined,
-    parentScope.kind === 'folder' ? parentScope.folderName : undefined,
-  )
 
   const enumeratedProjects: string[] = useMemo(() => {
     if (parentScope.kind === 'organization') {
       return (orgProjectsQuery.data?.projects ?? []).map((p) => p.name)
     }
-    return (folderProjectsQuery.data ?? []).map((p) => p.name)
-  }, [parentScope.kind, orgProjectsQuery.data, folderProjectsQuery.data])
+    return []
+  }, [parentScope.kind, orgProjectsQuery.data])
 
   // Folder scope is the only kind that hard-limits literal project names.
   // Org scope lets a binding reach every project the caller can see, so
@@ -240,8 +234,8 @@ export function MatchesPreview({
 
   const enumeratedProjectsPending =
     needsScopeProjectList &&
-    ((parentScope.kind === 'organization' && orgProjectsQuery.isLoading) ||
-      (parentScope.kind === 'folder' && folderProjectsQuery.isLoading))
+    parentScope.kind === 'organization' &&
+    orgProjectsQuery.isLoading
 
   // Resolve per-row plans to a flat set of probes. Each probe is a (kind,
   // projectName) pair that a per-project probe component owns one hook
@@ -297,12 +291,12 @@ export function MatchesPreview({
   const store = useProbeStore()
   const probeData = useProbeSnapshot(store)
 
-  // Aggregate parent-scope project enumeration error too — if the org or
-  // folder listing itself fails, we cannot honestly render anything.
+  // Aggregate parent-scope project enumeration error too — if the org listing
+  // itself fails, we cannot honestly render anything.
   const scopeEnumerationError =
     parentScope.kind === 'organization'
       ? orgProjectsQuery.error
-      : folderProjectsQuery.error
+      : null
 
   // Reduce row plans + live probe data to a dedup'd list of matches.
   // `errorCount` counts probes that failed so the UI can surface an

--- a/frontend/src/gen/holos/console/v1/projects_pb.d.ts
+++ b/frontend/src/gen/holos/console/v1/projects_pb.d.ts
@@ -63,7 +63,6 @@ export declare type Project = Message<"holos.console.v1.Project"> & {
 
   /**
    * organization is the root organization this project belongs to.
-   * Retained for convenience — use parent_type + parent_name for the immediate parent.
    *
    * @generated from field: string organization = 7;
    */
@@ -98,7 +97,8 @@ export declare type Project = Message<"holos.console.v1.Project"> & {
   createdAt: string;
 
   /**
-   * parent_type identifies whether the immediate parent is an org or folder (v1alpha2).
+   * parent_type identifies the immediate parent scope. Projects are always
+   * parented by their organization.
    *
    * @generated from field: holos.console.v1.ParentType parent_type = 12;
    */
@@ -106,8 +106,7 @@ export declare type Project = Message<"holos.console.v1.Project"> & {
 
   /**
    * parent_name is the name of the immediate parent scope (v1alpha2).
-   * For a project directly under an org this is the org name.
-   * For a project under a folder this is the folder name.
+   * For projects this is the organization name.
    *
    * @generated from field: string parent_name = 13;
    */
@@ -263,16 +262,16 @@ export declare type CreateProjectRequest = Message<"holos.console.v1.CreateProje
   organization: string;
 
   /**
-   * parent_type identifies whether the immediate parent is an org or folder (v1alpha2).
-   * Defaults to PARENT_TYPE_ORGANIZATION when unset.
+   * parent_type is retained only for legacy clients. When set, it must be
+   * PARENT_TYPE_ORGANIZATION.
    *
    * @generated from field: holos.console.v1.ParentType parent_type = 7;
    */
   parentType: ParentType;
 
   /**
-   * parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-   * When unset, defaults to the organization.
+   * parent_name is retained only for legacy clients. When set, it must match
+   * organization.
    *
    * @generated from field: string parent_name = 8;
    */
@@ -334,6 +333,7 @@ export declare type UpdateProjectRequest = Message<"holos.console.v1.UpdateProje
 
   /**
    * parent_type is the new parent type for reparenting. When unset, no reparenting occurs.
+   * When set, it must be PARENT_TYPE_ORGANIZATION.
    * Requires PERMISSION_REPARENT on both source and destination parents (ADR 022 Decision 5).
    *
    * @generated from field: optional holos.console.v1.ParentType parent_type = 4;
@@ -342,7 +342,7 @@ export declare type UpdateProjectRequest = Message<"holos.console.v1.UpdateProje
 
   /**
    * parent_name is the new parent name for reparenting. When unset, no reparenting occurs.
-   * Must be set together with parent_type.
+   * Must be set together with parent_type and must name the organization.
    *
    * @generated from field: optional string parent_name = 5;
    */

--- a/frontend/src/queries/projects.ts
+++ b/frontend/src/queries/projects.ts
@@ -53,7 +53,7 @@ export function useCreateProject() {
   const client = useMemo(() => createClient(ProjectService, transport), [transport])
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (params: { name: string; displayName?: string; description?: string; organization: string; parentType?: number; parentName?: string }) =>
+    mutationFn: (params: { name: string; displayName?: string; description?: string; organization: string }) =>
       client.createProject(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: keys.connect.all() })

--- a/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
+++ b/frontend/src/routes/_authenticated/organizations/$orgName/projects/index.tsx
@@ -6,10 +6,9 @@
  * `creatorEmail` as a hidden searchable field via `extraSearch` so operators
  * can find projects by their creator without crowding the visible columns.
  *
- * The Parent column is supplied via `parentLabel` (the immediate parent's
- * name). Projects directly under an org all share the same parent, so the
- * column is hidden by ResourceGrid until folder-scoped projects are
- * introduced.
+ * The Parent column is supplied via `parentLabel` (the organization name).
+ * Projects all share the organization as their parent, so the column is hidden
+ * by ResourceGrid for the usual organization-scoped listing.
  */
 
 import { useCallback, useMemo } from 'react'

--- a/frontend/src/routes/_authenticated/project/-new.test.tsx
+++ b/frontend/src/routes/_authenticated/project/-new.test.tsx
@@ -163,35 +163,8 @@ describe('ProjectNewPage', () => {
           organization: 'my-org',
         }),
       )
-    })
-  })
-
-  it('passes ORGANIZATION parentType when no folderName', async () => {
-    const mutateAsync = vi.fn().mockResolvedValue({ name: 'my-project' })
-    setupMocks(mutateAsync)
-    render(<ProjectNewPage orgName="my-org" />)
-
-    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Project' } })
-    fireEvent.click(screen.getByRole('button', { name: /create project/i }))
-
-    await waitFor(() => {
-      const call = mutateAsync.mock.calls[0][0]
-      // ParentType.ORGANIZATION = 1
-      expect(call.parentName).toBe('my-org')
-    })
-  })
-
-  it('passes FOLDER parentType and folderName when folderName is provided', async () => {
-    const mutateAsync = vi.fn().mockResolvedValue({ name: 'my-project' })
-    setupMocks(mutateAsync)
-    render(<ProjectNewPage orgName="my-org" folderName="payments" />)
-
-    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'My Project' } })
-    fireEvent.click(screen.getByRole('button', { name: /create project/i }))
-
-    await waitFor(() => {
-      const call = mutateAsync.mock.calls[0][0]
-      expect(call.parentName).toBe('payments')
+      expect(mutateAsync.mock.calls[0][0]).not.toHaveProperty('parentType')
+      expect(mutateAsync.mock.calls[0][0]).not.toHaveProperty('parentName')
     })
   })
 
@@ -267,12 +240,7 @@ describe('ProjectNewPage', () => {
     expect(screen.getByText('my-org')).toBeInTheDocument()
   })
 
-  it('displays folder context when folderName is provided', () => {
-    render(<ProjectNewPage orgName="my-org" folderName="payments" />)
-    expect(screen.getByText('payments')).toBeInTheDocument()
-  })
-
-  it('does not display folder context when no folderName', () => {
+  it('does not display folder context', () => {
     render(<ProjectNewPage orgName="my-org" />)
     expect(screen.queryByText(/folder/i)).not.toBeInTheDocument()
   })

--- a/frontend/src/routes/_authenticated/project/new.tsx
+++ b/frontend/src/routes/_authenticated/project/new.tsx
@@ -3,7 +3,6 @@
  *
  * Accepts parent context via search params:
  *   - orgName    (required) — the organization that owns the project
- *   - folderName (optional) — the folder under which the project is nested
  *   - returnTo   (optional) — post-create redirect (validated by resolveReturnTo)
  *
  * On success navigates to `resolveReturnTo(search.returnTo, '/projects/$name')`.
@@ -21,7 +20,6 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { useCreateProject } from '@/queries/projects'
-import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import { toSlug } from '@/lib/slug'
 import { resolveReturnTo } from '@/lib/return-to'
 import { useOrg } from '@/lib/org-context'
@@ -32,11 +30,9 @@ export const Route = createFileRoute('/_authenticated/project/new')({
     search: Record<string, unknown>,
   ): {
     orgName?: string
-    folderName?: string
     returnTo?: string
   } => ({
     orgName: typeof search.orgName === 'string' ? search.orgName : undefined,
-    folderName: typeof search.folderName === 'string' ? search.folderName : undefined,
     returnTo: typeof search.returnTo === 'string' ? search.returnTo : undefined,
   }),
   component: ProjectNewRoute,
@@ -51,7 +47,6 @@ function ProjectNewRoute() {
   return (
     <ProjectNewPage
       orgName={orgName}
-      folderName={search.folderName}
       returnTo={search.returnTo}
     />
   )
@@ -59,16 +54,11 @@ function ProjectNewRoute() {
 
 export interface ProjectNewPageProps {
   orgName?: string
-  folderName?: string
   returnTo?: string
 }
 
-export function ProjectNewPage({ orgName, folderName, returnTo }: ProjectNewPageProps) {
+export function ProjectNewPage({ orgName, returnTo }: ProjectNewPageProps) {
   const navigate = useNavigate()
-
-  // Parent context: folder takes precedence over org root.
-  const parentType = folderName ? ParentType.FOLDER : ParentType.ORGANIZATION
-  const parentName = folderName ?? orgName ?? ''
 
   // Cancel destination: honour returnTo, fall back to /organizations.
   const cancelTarget = resolveReturnTo(returnTo, '/organizations')
@@ -109,8 +99,6 @@ export function ProjectNewPage({ orgName, folderName, returnTo }: ProjectNewPage
         displayName,
         description,
         organization: orgName,
-        parentType,
-        parentName,
       })
       // Default fallback: navigate to the newly created project's home page.
       const fallback = `/projects/${response.name}`
@@ -203,11 +191,6 @@ export function ProjectNewPage({ orgName, folderName, returnTo }: ProjectNewPage
               <p>
                 Organization: <span className="font-medium text-foreground">{orgName}</span>
               </p>
-              {folderName && (
-                <p>
-                  Folder: <span className="font-medium text-foreground">{folderName}</span>
-                </p>
-              )}
             </div>
           </div>
           <div className="flex items-center gap-3 pt-4">

--- a/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings-deployments.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings-deployments.test.tsx
@@ -32,17 +32,12 @@ vi.mock('@/queries/organizations', () => ({
   useGetOrganization: vi.fn(),
 }))
 
-vi.mock('@/queries/folders', () => ({
-  useListFolders: vi.fn(),
-}))
-
 vi.mock('@/lib/auth', () => ({ useAuth: vi.fn() }))
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 import { useGetProject, useUpdateProject, useUpdateProjectSharing, useUpdateProjectDefaultSharing, useDeleteProject } from '@/queries/projects'
 import { useGetProjectSettings, useGetProjectSettingsRaw, useUpdateProjectSettings } from '@/queries/project-settings'
 import { useGetOrganization } from '@/queries/organizations'
-import { useListFolders } from '@/queries/folders'
 import { useAuth } from '@/lib/auth'
 import { namespaceForOrg } from '@/lib/scope-labels'
 import { Role } from '@/gen/holos/console/v1/rbac_pb'
@@ -104,11 +99,6 @@ function setupMocks(overrides: {
     isAuthenticated: true,
     isLoading: false,
     user: { profile: { email: 'alice@example.com', groups: [] } },
-  })
-  ;(useListFolders as Mock).mockReturnValue({
-    data: [],
-    isPending: false,
-    error: null,
   })
 }
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/settings/-settings.test.tsx
@@ -22,10 +22,6 @@ vi.mock('@/queries/projects', () => ({
   useDeleteProject: vi.fn(),
 }))
 
-vi.mock('@/queries/folders', () => ({
-  useListFolders: vi.fn(),
-}))
-
 vi.mock('@/queries/project-settings', () => ({
   useGetProjectSettings: vi.fn(),
   useGetProjectSettingsRaw: vi.fn(),
@@ -42,7 +38,6 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 import { useGetProject, useUpdateProject, useUpdateProjectSharing, useUpdateProjectDefaultSharing, useDeleteProject } from '@/queries/projects'
 import { useGetProjectSettings, useGetProjectSettingsRaw, useUpdateProjectSettings } from '@/queries/project-settings'
 import { useGetOrganization } from '@/queries/organizations'
-import { useListFolders } from '@/queries/folders'
 import { useAuth } from '@/lib/auth'
 import { namespaceForOrg } from '@/lib/scope-labels'
 import {
@@ -72,11 +67,6 @@ const mockOrg = {
   displayName: 'My Org',
   userRole: 3, // OWNER
 }
-
-const mockFolders = [
-  { name: 'default', displayName: 'Default', parentType: 1, parentName: 'my-org' },
-  { name: 'engineering', displayName: 'Engineering', parentType: 1, parentName: 'my-org' },
-]
 
 function setupMocks(overrides: Partial<typeof mockProject> = {}, orgOverrides: Partial<typeof mockOrg> = {}) {
   const project = { ...mockProject, ...overrides }
@@ -133,11 +123,6 @@ function setupMocks(overrides: Partial<typeof mockProject> = {}, orgOverrides: P
     isLoading: false,
     user: { profile: { email: 'alice@example.com', groups: [] } },
   })
-  ;(useListFolders as Mock).mockReturnValue({
-    data: mockFolders,
-    isPending: false,
-    error: null,
-  })
 }
 
 describe('ProjectSettingsPage', () => {
@@ -169,7 +154,6 @@ describe('ProjectSettingsPage', () => {
     ;(useUpdateProjectSettings as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
     ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true, isLoading: false, user: null })
-    ;(useListFolders as Mock).mockReturnValue({ data: [], isPending: false, error: null })
 
     render(<ProjectSettingsPage />)
     const skeletons = document.querySelectorAll('[data-slot="skeleton"]')
@@ -187,7 +171,6 @@ describe('ProjectSettingsPage', () => {
     ;(useUpdateProjectSettings as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     ;(useGetOrganization as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
     ;(useAuth as Mock).mockReturnValue({ isAuthenticated: true, isLoading: false, user: null })
-    ;(useListFolders as Mock).mockReturnValue({ data: [], isPending: false, error: null })
 
     render(<ProjectSettingsPage />)
     expect(screen.getByText('Not found')).toBeInTheDocument()
@@ -407,76 +390,29 @@ describe('ProjectSettingsPage', () => {
   })
 
   describe('Parent section', () => {
-    it('displays current parent as Organization when parentType is ORGANIZATION', () => {
+    it('displays the project organization as the parent', () => {
       setupMocks({ parentType: 1, parentName: 'my-org' })
       render(<ProjectSettingsPage />)
       expect(screen.getByText('Parent')).toBeInTheDocument()
       expect(screen.getByText(/Organization: My Org/)).toBeInTheDocument()
     })
 
-    it('displays current parent as Folder when parentType is FOLDER', () => {
-      setupMocks({ parentType: 2, parentName: 'engineering' })
+    it('falls back to the organization name when display name is unavailable', () => {
+      setupMocks({ parentName: 'my-org' }, { displayName: '' })
       render(<ProjectSettingsPage />)
-      expect(screen.getByText(/Folder: Engineering/)).toBeInTheDocument()
+      expect(screen.getByText(/Organization: my-org/)).toBeInTheDocument()
     })
 
-    it('renders Change Parent button for OWNERs', () => {
+    it('does not render Change Parent button for owners', () => {
       setupMocks({ userRole: 3 })
-      render(<ProjectSettingsPage />)
-      expect(screen.getByRole('button', { name: /change parent/i })).toBeInTheDocument()
-    })
-
-    it('does not render Change Parent button for non-OWNERs', () => {
-      setupMocks({ userRole: 1 }) // VIEWER
       render(<ProjectSettingsPage />)
       expect(screen.queryByRole('button', { name: /change parent/i })).not.toBeInTheDocument()
     })
 
-    it('shows confirmation dialog when selecting a new parent', async () => {
-      setupMocks()
+    it('does not render Change Parent button for non-owners', () => {
+      setupMocks({ userRole: 1 }) // VIEWER
       render(<ProjectSettingsPage />)
-      fireEvent.click(screen.getByRole('button', { name: /change parent/i }))
-      // Open the combobox popover
-      fireEvent.click(screen.getByRole('combobox', { name: /parent picker/i }))
-      // Select "Engineering" folder from the combobox list
-      await waitFor(() => {
-        expect(screen.getByText('Engineering')).toBeInTheDocument()
-      })
-      fireEvent.click(screen.getByText('Engineering'))
-      await waitFor(() => {
-        expect(screen.getByText(/Move project/i)).toBeInTheDocument()
-      })
-    })
-
-    it('calls updateProject with parentType and parentName on confirmation', async () => {
-      setupMocks()
-      render(<ProjectSettingsPage />)
-      fireEvent.click(screen.getByRole('button', { name: /change parent/i }))
-      fireEvent.click(screen.getByRole('combobox', { name: /parent picker/i }))
-      await waitFor(() => {
-        expect(screen.getByText('Engineering')).toBeInTheDocument()
-      })
-      fireEvent.click(screen.getByText('Engineering'))
-      await waitFor(() => {
-        expect(screen.getByText(/Move project/i)).toBeInTheDocument()
-      })
-      fireEvent.click(screen.getByRole('button', { name: /^move$/i }))
-      const mutateAsync = (useUpdateProject as Mock).mock.results[0].value.mutateAsync
-      await waitFor(() => {
-        expect(mutateAsync).toHaveBeenCalledWith(
-          expect.objectContaining({ name: 'test-project', parentType: 2, parentName: 'engineering' }),
-        )
-      })
-    })
-
-    it('shows org root option in parent picker', async () => {
-      setupMocks({ parentType: 2, parentName: 'default' })
-      render(<ProjectSettingsPage />)
-      fireEvent.click(screen.getByRole('button', { name: /change parent/i }))
-      fireEvent.click(screen.getByRole('combobox', { name: /parent picker/i }))
-      await waitFor(() => {
-        expect(screen.getByText(/My Org \(organization root\)/i)).toBeInTheDocument()
-      })
+      expect(screen.queryByRole('button', { name: /change parent/i })).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/routes/_authenticated/projects/$projectName/settings/index.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/settings/index.tsx
@@ -18,26 +18,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
-import { Combobox, type ComboboxItem } from '@/components/ui/combobox'
 import { Check, Pencil, X, Table2, Braces } from 'lucide-react'
 import { SharingPanel, type Grant } from '@/components/sharing-panel'
 import { ViewModeToggle } from '@/components/view-mode-toggle'
 import { RawView } from '@/components/raw-view'
-import { ParentType } from '@/gen/holos/console/v1/folders_pb'
 import { useGetProject, useUpdateProject, useUpdateProjectSharing, useUpdateProjectDefaultSharing, useDeleteProject } from '@/queries/projects'
 import { useGetProjectSettings, useGetProjectSettingsRaw, useUpdateProjectSettings } from '@/queries/project-settings'
 import { useGetOrganization } from '@/queries/organizations'
-import { useListFolders } from '@/queries/folders'
 import { useResourcePermissions } from '@/queries/permissions'
 import { connectErrorMessage } from '@/lib/connect-toast'
 import {
@@ -76,7 +63,7 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
   const { data: projectSettings } = useGetProjectSettings(projectName)
   const updateProjectSettings = useUpdateProjectSettings(projectName)
 
-  // Fetch org data for display and parent picker context.
+  // Fetch org data for display.
   const { data: org } = useGetOrganization(project?.organization ?? '')
   const projectNamespace = namespaceForProject(projectName)
   const orgNamespace = project?.organization ? namespaceForOrg(project.organization) : ''
@@ -101,9 +88,6 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
   const canDelete = hasPermission(permissionsQuery.data, deleteProjectPermission)
   const canUpdateProjectSettings = hasPermission(permissionsQuery.data, updateOrgPermission)
 
-  // Fetch all folders in the org for the parent picker
-  const { data: allFolders } = useListFolders(project?.organization ?? '')
-
   // View mode: data or raw
   const [viewMode, setViewMode] = useState<'data' | 'raw'>('data')
   const { data: rawJson } = useGetProjectSettingsRaw(projectName)
@@ -120,65 +104,11 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
   // Delete dialog
   const [deleteOpen, setDeleteOpen] = useState(false)
 
-  // Parent picker
-  const [parentPickerOpen, setParentPickerOpen] = useState(false)
-  const [pendingParent, setPendingParent] = useState<{ type: ParentType; name: string; displayLabel: string } | null>(null)
-  const [reparentDialogOpen, setReparentDialogOpen] = useState(false)
-
-  // Build parent picker options: org root + all folders in the org
-  const parentOptions: ComboboxItem[] = [
-    { value: `org:${project?.organization ?? ''}`, label: `${org?.displayName || project?.organization || ''} (organization root)` },
-    ...(allFolders ?? []).map((f) => ({ value: `folder:${f.name}`, label: f.displayName || f.name })),
-  ]
-
   // Resolve the current parent display text
   const currentParentDisplay = (() => {
     if (!project) return ''
-    if (project.parentType === ParentType.ORGANIZATION) {
-      return `Organization: ${org?.displayName || project.parentName}`
-    }
-    if (project.parentType === ParentType.FOLDER) {
-      const parentFolder = allFolders?.find((f) => f.name === project.parentName)
-      return `Folder: ${parentFolder?.displayName || project.parentName}`
-    }
-    return project.parentName
+    return `Organization: ${org?.displayName || project.parentName || project.organization}`
   })()
-
-  const handleParentSelect = (comboValue: string) => {
-    let type: ParentType
-    let name: string
-    let displayLabel: string
-    if (comboValue.startsWith('org:')) {
-      type = ParentType.ORGANIZATION
-      name = comboValue.slice(4)
-      displayLabel = org?.displayName || name
-    } else {
-      type = ParentType.FOLDER
-      name = comboValue.slice(7)
-      const f = allFolders?.find((fld) => fld.name === name)
-      displayLabel = f?.displayName || name
-    }
-    // Only show confirmation if the parent is actually changing
-    if (type === project?.parentType && name === project?.parentName) {
-      setParentPickerOpen(false)
-      return
-    }
-    setPendingParent({ type, name, displayLabel })
-    setReparentDialogOpen(true)
-  }
-
-  const handleConfirmReparent = async () => {
-    if (!pendingParent) return
-    try {
-      await updateProject.mutateAsync({ name: projectName, parentType: pendingParent.type, parentName: pendingParent.name })
-      setReparentDialogOpen(false)
-      setParentPickerOpen(false)
-      setPendingParent(null)
-      toast.success('Parent changed')
-    } catch (err) {
-      toast.error(connectErrorMessage(err))
-    }
-  }
 
   const handleSaveDisplayName = async () => {
     try {
@@ -339,45 +269,7 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
               {/* Parent */}
               <div className="flex items-center gap-2">
                 <span className="w-32 text-sm text-muted-foreground shrink-0">Parent</span>
-                {parentPickerOpen ? (
-                  <div className="flex-1 flex items-center gap-2">
-                    <Combobox
-                      items={parentOptions}
-                      value={
-                        project?.parentType === ParentType.ORGANIZATION
-                          ? `org:${project.parentName}`
-                          : `folder:${project?.parentName ?? ''}`
-                      }
-                      onValueChange={handleParentSelect}
-                      placeholder="Select parent..."
-                      searchPlaceholder="Search folders..."
-                      aria-label="parent picker"
-                      className="flex-1"
-                    />
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="cancel parent change"
-                      onClick={() => setParentPickerOpen(false)}
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ) : (
-                  <>
-                    <span className="flex-1 text-sm">{currentParentDisplay}</span>
-                    {canWrite && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        aria-label="change parent"
-                        onClick={() => setParentPickerOpen(true)}
-                      >
-                        Change Parent
-                      </Button>
-                    )}
-                  </>
-                )}
+                <span className="flex-1 text-sm">{currentParentDisplay}</span>
               </div>
 
               {/* Name (slug) - read-only */}
@@ -535,24 +427,6 @@ export function ProjectSettingsPage({ projectName: propProjectName }: { projectN
         </DialogContent>
       </Dialog>
 
-      <AlertDialog open={reparentDialogOpen} onOpenChange={setReparentDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Move project?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Moving this project to {pendingParent?.displayLabel} will change permission inheritance for it. This cannot be undone automatically.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => { setReparentDialogOpen(false); setPendingParent(null) }}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmReparent} disabled={updateProject.isPending}>
-              Move
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </Card>
   )
 }

--- a/gen/holos/console/v1/projects.pb.go
+++ b/gen/holos/console/v1/projects.pb.go
@@ -37,7 +37,6 @@ type Project struct {
 	// user_role is the calling user's effective role on this project.
 	UserRole Role `protobuf:"varint,6,opt,name=user_role,json=userRole,proto3,enum=holos.console.v1.Role" json:"user_role,omitempty"`
 	// organization is the root organization this project belongs to.
-	// Retained for convenience — use parent_type + parent_name for the immediate parent.
 	Organization string `protobuf:"bytes,7,opt,name=organization,proto3" json:"organization,omitempty"`
 	// default_user_grants are the per-user sharing grants applied by default to new secrets in this project.
 	DefaultUserGrants []*ShareGrant `protobuf:"bytes,8,rep,name=default_user_grants,json=defaultUserGrants,proto3" json:"default_user_grants,omitempty"`
@@ -47,11 +46,11 @@ type Project struct {
 	CreatorEmail string `protobuf:"bytes,10,opt,name=creator_email,json=creatorEmail,proto3" json:"creator_email,omitempty"`
 	// created_at is the RFC3339-formatted timestamp when this project was created.
 	CreatedAt string `protobuf:"bytes,11,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	// parent_type identifies whether the immediate parent is an org or folder (v1alpha2).
+	// parent_type identifies the immediate parent scope. Projects are always
+	// parented by their organization.
 	ParentType ParentType `protobuf:"varint,12,opt,name=parent_type,json=parentType,proto3,enum=holos.console.v1.ParentType" json:"parent_type,omitempty"`
 	// parent_name is the name of the immediate parent scope (v1alpha2).
-	// For a project directly under an org this is the org name.
-	// For a project under a folder this is the folder name.
+	// For projects this is the organization name.
 	ParentName    string `protobuf:"bytes,13,opt,name=parent_name,json=parentName,proto3" json:"parent_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -396,11 +395,11 @@ type CreateProjectRequest struct {
 	RoleGrants []*ShareGrant `protobuf:"bytes,5,rep,name=role_grants,json=roleGrants,proto3" json:"role_grants,omitempty"`
 	// organization is the root organization to create this project in.
 	Organization string `protobuf:"bytes,6,opt,name=organization,proto3" json:"organization,omitempty"`
-	// parent_type identifies whether the immediate parent is an org or folder (v1alpha2).
-	// Defaults to PARENT_TYPE_ORGANIZATION when unset.
+	// parent_type is retained only for legacy clients. When set, it must be
+	// PARENT_TYPE_ORGANIZATION.
 	ParentType ParentType `protobuf:"varint,7,opt,name=parent_type,json=parentType,proto3,enum=holos.console.v1.ParentType" json:"parent_type,omitempty"`
-	// parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-	// When unset, defaults to the organization.
+	// parent_name is retained only for legacy clients. When set, it must match
+	// organization.
 	ParentName    string `protobuf:"bytes,8,opt,name=parent_name,json=parentName,proto3" json:"parent_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -548,10 +547,11 @@ type UpdateProjectRequest struct {
 	// description is the new description. When unset, preserves the existing value.
 	Description *string `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	// parent_type is the new parent type for reparenting. When unset, no reparenting occurs.
+	// When set, it must be PARENT_TYPE_ORGANIZATION.
 	// Requires PERMISSION_REPARENT on both source and destination parents (ADR 022 Decision 5).
 	ParentType *ParentType `protobuf:"varint,4,opt,name=parent_type,json=parentType,proto3,enum=holos.console.v1.ParentType,oneof" json:"parent_type,omitempty"`
 	// parent_name is the new parent name for reparenting. When unset, no reparenting occurs.
-	// Must be set together with parent_type.
+	// Must be set together with parent_type and must name the organization.
 	ParentName    *string `protobuf:"bytes,5,opt,name=parent_name,json=parentName,proto3,oneof" json:"parent_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/holos/console/v1/projects.proto
+++ b/proto/holos/console/v1/projects.proto
@@ -65,7 +65,6 @@ message Project {
   // user_role is the calling user's effective role on this project.
   Role user_role = 6;
   // organization is the root organization this project belongs to.
-  // Retained for convenience — use parent_type + parent_name for the immediate parent.
   string organization = 7;
   // default_user_grants are the per-user sharing grants applied by default to new secrets in this project.
   repeated ShareGrant default_user_grants = 8;
@@ -75,11 +74,11 @@ message Project {
   string creator_email = 10;
   // created_at is the RFC3339-formatted timestamp when this project was created.
   string created_at = 11;
-  // parent_type identifies whether the immediate parent is an org or folder (v1alpha2).
+  // parent_type identifies the immediate parent scope. Projects are always
+  // parented by their organization.
   ParentType parent_type = 12;
   // parent_name is the name of the immediate parent scope (v1alpha2).
-  // For a project directly under an org this is the org name.
-  // For a project under a folder this is the folder name.
+  // For projects this is the organization name.
   string parent_name = 13;
 }
 
@@ -126,11 +125,11 @@ message CreateProjectRequest {
   repeated ShareGrant role_grants = 5;
   // organization is the root organization to create this project in.
   string organization = 6;
-  // parent_type identifies whether the immediate parent is an org or folder (v1alpha2).
-  // Defaults to PARENT_TYPE_ORGANIZATION when unset.
+  // parent_type is retained only for legacy clients. When set, it must be
+  // PARENT_TYPE_ORGANIZATION.
   ParentType parent_type = 7;
-  // parent_name is the name of the immediate parent (org name or folder name) (v1alpha2).
-  // When unset, defaults to the organization.
+  // parent_name is retained only for legacy clients. When set, it must match
+  // organization.
   string parent_name = 8;
 }
 
@@ -149,10 +148,11 @@ message UpdateProjectRequest {
   // description is the new description. When unset, preserves the existing value.
   optional string description = 3;
   // parent_type is the new parent type for reparenting. When unset, no reparenting occurs.
+  // When set, it must be PARENT_TYPE_ORGANIZATION.
   // Requires PERMISSION_REPARENT on both source and destination parents (ADR 022 Decision 5).
   optional ParentType parent_type = 4;
   // parent_name is the new parent name for reparenting. When unset, no reparenting occurs.
-  // Must be set together with parent_type.
+  // Must be set together with parent_type and must name the organization.
   optional string parent_name = 5;
 }
 


### PR DESCRIPTION
## Summary
- make project creation always use the organization namespace as the parent and reject legacy folder-parent create input
- remove project settings/create UI paths that could place or move projects under folders
- update project parent proto comments and generated code to document organization-only project parents

Fixes HOL-1094

## Test plan
- [x] make generate
- [x] make test-go
- [x] make test-ui