### PR TITLE
chore(console): drop default-folder cleanup

### DIFF
--- a/api/v1alpha2/annotations.go
+++ b/api/v1alpha2/annotations.go
@@ -66,10 +66,6 @@ const (
 	AnnotationURL               = "console.holos.run/url"
 	AnnotationEnabled           = "console.holos.run/enabled"
 	AnnotationSettings          = "console.holos.run/project-settings"
-	// AnnotationDefaultFolder is a legacy organization annotation retained for
-	// admission and migration cleanup. Console handlers no longer write or read
-	// it when creating organizations or projects.
-	AnnotationDefaultFolder = "console.holos.run/default-folder"
 	// AnnotationGatewayNamespace stores the Kubernetes namespace that hosts
 	// the platform Gateway referenced by templates rendered for an
 	// organization. Lives on the organization namespace; surfaced to template

--- a/api/v1alpha2/schema_gen.cue
+++ b/api/v1alpha2/schema_gen.cue
@@ -73,11 +73,6 @@
 #AnnotationEnabled:           "console.holos.run/enabled"
 #AnnotationSettings:          "console.holos.run/project-settings"
 
-// AnnotationDefaultFolder is a legacy organization annotation retained for
-// admission and migration cleanup. Console handlers no longer write or read
-// it when creating organizations or projects.
-#AnnotationDefaultFolder: "console.holos.run/default-folder"
-
 // AnnotationGatewayNamespace stores the Kubernetes namespace that hosts
 // the platform Gateway referenced by templates rendered for an
 // organization. Lives on the organization namespace; surfaced to template

--- a/cmd/holos-console-migrate-default-folder/main.go
+++ b/cmd/holos-console-migrate-default-folder/main.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
@@ -92,7 +93,13 @@ func buildClient(kubeconfig string) (kubernetes.Interface, error) {
 	)
 	cfg, err := loader.ClientConfig()
 	if err != nil {
-		return nil, err
+		if kubeconfig != "" {
+			return nil, err
+		}
+		cfg, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return kubernetes.NewForConfig(cfg)
 }

--- a/cmd/holos-console-migrate-default-folder/main.go
+++ b/cmd/holos-console-migrate-default-folder/main.go
@@ -1,0 +1,219 @@
+// Command holos-console-migrate-default-folder is a one-shot operator-run
+// migration tool that strips the removed
+// `console.holos.run/default-folder` annotation from existing organization
+// namespaces.
+//
+// The tool runs in dry-run mode by default; pass --apply to perform writes. It
+// is idempotent: re-running it after a successful migration is a no-op once no
+// organization namespace carries the annotation.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+const defaultFolderAnnotation = "console.holos.run/default-folder"
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+type options struct {
+	apply      bool
+	kubeconfig string
+}
+
+func parseFlags(args []string, errOut io.Writer) (*options, error) {
+	fs := flag.NewFlagSet("holos-console-migrate-default-folder", flag.ContinueOnError)
+	fs.SetOutput(errOut)
+	fs.Usage = func() {
+		fmt.Fprintf(errOut, "Usage: %s [flags]\n\n", fs.Name())
+		fmt.Fprintln(errOut, "One-shot migration: strip the removed default-folder annotation from organization namespaces.")
+		fmt.Fprintln(errOut, "Runs as the operator-supplied kubeconfig identity.")
+		fmt.Fprintln(errOut)
+		fmt.Fprintln(errOut, "Flags:")
+		fs.PrintDefaults()
+	}
+	opts := &options{}
+	fs.BoolVar(&opts.apply, "apply", false, "Perform writes. Without --apply the tool only reports planned changes.")
+	fs.StringVar(&opts.kubeconfig, "kubeconfig", "", "Path to kubeconfig (defaults to KUBECONFIG env, then ~/.kube/config, then in-cluster config)")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return opts, nil
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	opts, err := parseFlags(args, stderr)
+	if err != nil {
+		return err
+	}
+	client, err := buildClient(opts.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("building kube client: %w", err)
+	}
+	ctx := context.Background()
+	report, err := Migrate(ctx, client, opts.apply)
+	if err != nil {
+		return err
+	}
+	return PrintReport(stdout, report, opts.apply)
+}
+
+func buildClient(kubeconfig string) (kubernetes.Interface, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		rules.ExplicitPath = kubeconfig
+	}
+	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules,
+		&clientcmd.ConfigOverrides{},
+	)
+	cfg, err := loader.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+type NamespaceReport struct {
+	Namespace             string
+	DefaultFolderFound    bool
+	DefaultFolderStripped bool
+}
+
+type Report struct {
+	Namespaces []NamespaceReport
+}
+
+// Migrate walks every console-managed organization namespace and strips the
+// removed default-folder annotation when apply is true. In apply mode it
+// verifies the invariant before returning: no organization namespace may still
+// carry the annotation.
+func Migrate(ctx context.Context, client kubernetes.Interface, apply bool) (*Report, error) {
+	nsList, err := listOrganizationNamespaces(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	report := &Report{}
+	for i := range nsList.Items {
+		ns := &nsList.Items[i]
+		nr := NamespaceReport{Namespace: ns.Name}
+		_, found := ns.Annotations[defaultFolderAnnotation]
+		nr.DefaultFolderFound = found
+		if found {
+			if apply {
+				if err := stripDefaultFolderAnnotation(ctx, client, ns); err != nil {
+					return nil, fmt.Errorf("stripping %s from namespace %q: %w", defaultFolderAnnotation, ns.Name, err)
+				}
+			}
+			nr.DefaultFolderStripped = true
+		}
+		report.Namespaces = append(report.Namespaces, nr)
+	}
+	if apply {
+		if err := assertNoDefaultFolderAnnotations(ctx, client); err != nil {
+			return nil, err
+		}
+	}
+	return report, nil
+}
+
+func listOrganizationNamespaces(ctx context.Context, client kubernetes.Interface) (*corev1.NamespaceList, error) {
+	selector := labels.SelectorFromSet(labels.Set{
+		v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+		v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+	})
+	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing organization namespaces: %w", err)
+	}
+	sort.Slice(nsList.Items, func(i, j int) bool {
+		return nsList.Items[i].Name < nsList.Items[j].Name
+	})
+	return nsList, nil
+}
+
+func stripDefaultFolderAnnotation(ctx context.Context, client kubernetes.Interface, ns *corev1.Namespace) error {
+	live, err := client.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if live.Annotations == nil {
+		return nil
+	}
+	if _, ok := live.Annotations[defaultFolderAnnotation]; !ok {
+		return nil
+	}
+	delete(live.Annotations, defaultFolderAnnotation)
+	_, err = client.CoreV1().Namespaces().Update(ctx, live, metav1.UpdateOptions{})
+	return err
+}
+
+func assertNoDefaultFolderAnnotations(ctx context.Context, client kubernetes.Interface) error {
+	nsList, err := listOrganizationNamespaces(ctx, client)
+	if err != nil {
+		return err
+	}
+	var remaining []string
+	for i := range nsList.Items {
+		ns := &nsList.Items[i]
+		if _, ok := ns.Annotations[defaultFolderAnnotation]; ok {
+			remaining = append(remaining, ns.Name)
+		}
+	}
+	if len(remaining) > 0 {
+		return fmt.Errorf("%s still present on organization namespaces: %v", defaultFolderAnnotation, remaining)
+	}
+	return nil
+}
+
+func PrintReport(w io.Writer, report *Report, applied bool) error {
+	if report == nil {
+		return nil
+	}
+	mode := "DRY-RUN"
+	if applied {
+		mode = "APPLIED"
+	}
+	if _, err := fmt.Fprintf(w, "holos-console-migrate-default-folder (%s)\n", mode); err != nil {
+		return err
+	}
+	if len(report.Namespaces) == 0 {
+		_, err := fmt.Fprintln(w, "no organization namespaces found.")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAMESPACE\tDEFAULT-FOLDER-FOUND\tDEFAULT-FOLDER-STRIPPED")
+	for _, nr := range report.Namespaces {
+		fmt.Fprintf(tw, "%s\t%t\t%t\n",
+			nr.Namespace,
+			nr.DefaultFolderFound,
+			nr.DefaultFolderStripped,
+		)
+	}
+	return tw.Flush()
+}

--- a/cmd/holos-console-migrate-default-folder/main_test.go
+++ b/cmd/holos-console-migrate-default-folder/main_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	v1alpha2 "github.com/holos-run/holos-console/api/v1alpha2"
+)
+
+func organizationNamespaceFixture(name string, annotations map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeOrganization,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+func projectNamespaceFixture(name string, annotations map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				v1alpha2.LabelManagedBy:    v1alpha2.ManagedByValue,
+				v1alpha2.LabelResourceType: v1alpha2.ResourceTypeProject,
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+func TestMigrate_DryRunReportsDefaultFolderWithoutStripping(t *testing.T) {
+	withAnnotation := organizationNamespaceFixture("holos-org-acme", map[string]string{
+		defaultFolderAnnotation:        "holos-fld-acme-default",
+		v1alpha2.AnnotationDisplayName: "Acme",
+	})
+	withoutAnnotation := organizationNamespaceFixture("holos-org-beta", nil)
+	client := fake.NewClientset(withAnnotation, withoutAnnotation)
+
+	report, err := Migrate(context.Background(), client, false)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if len(report.Namespaces) != 2 {
+		t.Fatalf("expected 2 namespace reports, got %d", len(report.Namespaces))
+	}
+	first := report.Namespaces[0]
+	if first.Namespace != withAnnotation.Name {
+		t.Fatalf("expected sorted first namespace %q, got %q", withAnnotation.Name, first.Namespace)
+	}
+	if !first.DefaultFolderFound || !first.DefaultFolderStripped {
+		t.Fatalf("expected dry-run to report planned strip, got %+v", first)
+	}
+	live, _ := client.CoreV1().Namespaces().Get(context.Background(), withAnnotation.Name, metav1.GetOptions{})
+	if _, ok := live.Annotations[defaultFolderAnnotation]; !ok {
+		t.Fatal("dry-run stripped default-folder annotation")
+	}
+}
+
+func TestMigrate_ApplyStripsDefaultFolderFromOrganizationNamespacesOnly(t *testing.T) {
+	org := organizationNamespaceFixture("holos-org-acme", map[string]string{
+		defaultFolderAnnotation:        "holos-fld-acme-default",
+		v1alpha2.AnnotationDisplayName: "Acme",
+	})
+	project := projectNamespaceFixture("holos-prj-acme-app", map[string]string{
+		defaultFolderAnnotation: "stale-but-not-an-org",
+	})
+	client := fake.NewClientset(org, project)
+
+	report, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if len(report.Namespaces) != 1 {
+		t.Fatalf("expected only organization namespace report, got %d", len(report.Namespaces))
+	}
+	if !report.Namespaces[0].DefaultFolderStripped {
+		t.Fatalf("expected organization annotation strip, got %+v", report.Namespaces[0])
+	}
+	liveOrg, _ := client.CoreV1().Namespaces().Get(context.Background(), org.Name, metav1.GetOptions{})
+	if _, ok := liveOrg.Annotations[defaultFolderAnnotation]; ok {
+		t.Fatal("default-folder annotation still present on organization namespace")
+	}
+	if got := liveOrg.Annotations[v1alpha2.AnnotationDisplayName]; got != "Acme" {
+		t.Fatalf("non-target annotation changed: %q", got)
+	}
+	liveProject, _ := client.CoreV1().Namespaces().Get(context.Background(), project.Name, metav1.GetOptions{})
+	if _, ok := liveProject.Annotations[defaultFolderAnnotation]; !ok {
+		t.Fatal("project namespace should not be part of the organization cleanup")
+	}
+}
+
+func TestMigrate_ApplyIsIdempotent(t *testing.T) {
+	org := organizationNamespaceFixture("holos-org-acme", map[string]string{
+		defaultFolderAnnotation: "holos-fld-acme-default",
+	})
+	client := fake.NewClientset(org)
+
+	if _, err := Migrate(context.Background(), client, true); err != nil {
+		t.Fatalf("first Migrate returned error: %v", err)
+	}
+	second, err := Migrate(context.Background(), client, true)
+	if err != nil {
+		t.Fatalf("second Migrate returned error: %v", err)
+	}
+	if second.Namespaces[0].DefaultFolderFound {
+		t.Fatalf("expected second run to find no annotation, got %+v", second.Namespaces[0])
+	}
+}
+
+func TestPrintReport_ApplyAndDryRunHeaders(t *testing.T) {
+	report := &Report{
+		Namespaces: []NamespaceReport{{
+			Namespace:             "holos-org-acme",
+			DefaultFolderFound:    true,
+			DefaultFolderStripped: true,
+		}},
+	}
+	var dry, applied bytes.Buffer
+	if err := PrintReport(&dry, report, false); err != nil {
+		t.Fatalf("PrintReport(dry): %v", err)
+	}
+	if err := PrintReport(&applied, report, true); err != nil {
+		t.Fatalf("PrintReport(applied): %v", err)
+	}
+	if !strings.Contains(dry.String(), "DRY-RUN") {
+		t.Errorf("dry-run output missing DRY-RUN marker: %s", dry.String())
+	}
+	if !strings.Contains(applied.String(), "APPLIED") {
+		t.Errorf("applied output missing APPLIED marker: %s", applied.String())
+	}
+}
+
+func TestParseFlags_DefaultsToDryRun(t *testing.T) {
+	opts, err := parseFlags(nil, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if opts.apply {
+		t.Errorf("expected --apply default false, got true")
+	}
+}
+
+func TestParseFlags_ApplyFlag(t *testing.T) {
+	opts, err := parseFlags([]string{"--apply"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if !opts.apply {
+		t.Errorf("expected --apply true, got false")
+	}
+}

--- a/config/holos-console/admission/admission_test.go
+++ b/config/holos-console/admission/admission_test.go
@@ -39,7 +39,6 @@ func TestNamespaceShareAnnotationsPolicyProtectsLabelsAndShares(t *testing.T) {
 		`console.holos.run/share-roles`,
 		`console.holos.run/default-share-users`,
 		`console.holos.run/default-share-roles`,
-		`console.holos.run/default-folder`,
 		`console.holos.run/rbac-share-users`,
 		`console.holos.run/creator-email`,
 		`console.holos.run/creator-sub`,
@@ -63,8 +62,6 @@ func TestNamespaceShareAnnotationsPolicyProtectsLabelsAndShares(t *testing.T) {
 		"newDefaultShareUsers",
 		"oldDefaultShareRoles",
 		"newDefaultShareRoles",
-		"oldDefaultFolder",
-		"newDefaultFolder",
 		"oldRBACShareUsers",
 		"newRBACShareUsers",
 		"oldCreatorEmail",
@@ -96,7 +93,6 @@ func TestNamespaceShareAnnotationsPolicyProtectsLabelsAndShares(t *testing.T) {
 		`variables.oldShareRoles == variables.newShareRoles`,
 		`variables.oldDefaultShareUsers == variables.newDefaultShareUsers`,
 		`variables.oldDefaultShareRoles == variables.newDefaultShareRoles`,
-		`variables.oldDefaultFolder == variables.newDefaultFolder`,
 		`variables.oldRBACShareUsers == variables.newRBACShareUsers`,
 		`variables.oldCreatorEmail == variables.newCreatorEmail`,
 		`variables.oldCreatorSubject == variables.newCreatorSubject`,
@@ -116,6 +112,12 @@ func TestNamespaceShareAnnotationsPolicyProtectsLabelsAndShares(t *testing.T) {
 		if !hasMatchCondition(policy, name) {
 			t.Fatalf("missing match condition %q", name)
 		}
+	}
+	if strings.Contains(matchExpression, "console.holos.run/default-folder") {
+		t.Fatalf("match condition still references default-folder: %s", matchExpression)
+	}
+	if strings.Contains(validation, "DefaultFolder") || strings.Contains(validation, "default-folder") {
+		t.Fatalf("validation still references default-folder: %s", validation)
 	}
 }
 

--- a/config/holos-console/admission/namespace-share-annotations-console-only.yaml
+++ b/config/holos-console/admission/namespace-share-annotations-console-only.yaml
@@ -53,7 +53,6 @@ spec:
           || "console.holos.run/share-roles" in oldObject.metadata.annotations
           || "console.holos.run/default-share-users" in oldObject.metadata.annotations
           || "console.holos.run/default-share-roles" in oldObject.metadata.annotations
-          || "console.holos.run/default-folder" in oldObject.metadata.annotations
           || "console.holos.run/rbac-share-users" in oldObject.metadata.annotations
           || "console.holos.run/creator-email" in oldObject.metadata.annotations
           || "console.holos.run/creator-sub" in oldObject.metadata.annotations
@@ -66,7 +65,6 @@ spec:
           || "console.holos.run/share-roles" in object.metadata.annotations
           || "console.holos.run/default-share-users" in object.metadata.annotations
           || "console.holos.run/default-share-roles" in object.metadata.annotations
-          || "console.holos.run/default-folder" in object.metadata.annotations
           || "console.holos.run/rbac-share-users" in object.metadata.annotations
           || "console.holos.run/creator-email" in object.metadata.annotations
           || "console.holos.run/creator-sub" in object.metadata.annotations
@@ -130,19 +128,6 @@ spec:
       has(object.metadata.annotations)
       && "console.holos.run/default-share-roles" in object.metadata.annotations
       ? object.metadata.annotations["console.holos.run/default-share-roles"]
-      : ""
-  - name: oldDefaultFolder
-    expression: >-
-      oldObject != null
-      && has(oldObject.metadata.annotations)
-      && "console.holos.run/default-folder" in oldObject.metadata.annotations
-      ? oldObject.metadata.annotations["console.holos.run/default-folder"]
-      : ""
-  - name: newDefaultFolder
-    expression: >-
-      has(object.metadata.annotations)
-      && "console.holos.run/default-folder" in object.metadata.annotations
-      ? object.metadata.annotations["console.holos.run/default-folder"]
       : ""
   - name: oldRBACShareUsers
     expression: >-
@@ -269,7 +254,6 @@ spec:
         && variables.newShareRoles == ""
         && variables.newDefaultShareUsers == ""
         && variables.newDefaultShareRoles == ""
-        && variables.newDefaultFolder == ""
         && variables.newRBACShareUsers == ""
         && variables.newCreatorSubject == ""
         && variables.newCreatorEmail == ""
@@ -285,7 +269,6 @@ spec:
         && variables.oldShareRoles == variables.newShareRoles
         && variables.oldDefaultShareUsers == variables.newDefaultShareUsers
         && variables.oldDefaultShareRoles == variables.newDefaultShareRoles
-        && variables.oldDefaultFolder == variables.newDefaultFolder
         && variables.oldRBACShareUsers == variables.newRBACShareUsers
         && variables.oldCreatorSubject == variables.newCreatorSubject
         && variables.oldCreatorEmail == variables.newCreatorEmail

--- a/docs/migration/default-folder-2026-04.md
+++ b/docs/migration/default-folder-2026-04.md
@@ -23,7 +23,7 @@ console-managed organization namespaces.
      -l console.holos.run/resource-type=organization -o name); do
      name="${ns#namespace/}"
      kubectl get namespace "$name" \
-       -o jsonpath='{.metadata.annotations}' \
+       -o json | jq '.metadata.annotations // {}' \
        > "/tmp/backup-${name}-annotations.json"
    done
    ```
@@ -33,7 +33,7 @@ console-managed organization namespaces.
 1. Dry-run the cleanup:
 
    ```bash
-   holos-console-migrate-default-folder
+   go run ./cmd/holos-console-migrate-default-folder
    ```
 
    The tool prints one row per console-managed organization namespace:
@@ -48,7 +48,7 @@ console-managed organization namespaces.
 2. Apply the cleanup:
 
    ```bash
-   holos-console-migrate-default-folder --apply
+   go run ./cmd/holos-console-migrate-default-folder --apply
    ```
 
 3. Validate manually:
@@ -81,8 +81,9 @@ organization namespaces:
 ```bash
 for f in /tmp/backup-*-annotations.json; do
   name="$(basename "$f" -annotations.json | sed 's/^backup-//')"
-  kubectl annotate --overwrite namespace "$name" \
-    "$(jq -r 'to_entries | map("\(.key)=\(.value)") | .[]' "$f")"
+  annotations="$(jq -c . "$f")"
+  kubectl patch namespace "$name" --type merge \
+    -p "{\"metadata\":{\"annotations\":${annotations}}}"
 done
 ```
 

--- a/docs/migration/default-folder-2026-04.md
+++ b/docs/migration/default-folder-2026-04.md
@@ -1,0 +1,98 @@
+# Default Folder Annotation Cleanup (2026-04)
+
+## Summary
+
+The `console.holos.run/default-folder` organization annotation was removed from
+the console contract when project namespaces became direct children of their
+organization namespace. Existing clusters may still have the stale annotation on
+organization namespaces created by older console versions.
+
+The cleanup tool ships as `cmd/holos-console-migrate-default-folder`. It is
+operator-run and strips only `console.holos.run/default-folder` from
+console-managed organization namespaces.
+
+## Preconditions
+
+1. Run this after deploying the console image that no longer reads or writes the
+   default-folder annotation.
+2. Capture the current organization namespace annotations before applying:
+
+   ```bash
+   for ns in $(kubectl get ns \
+     -l app.kubernetes.io/managed-by=console.holos.run \
+     -l console.holos.run/resource-type=organization -o name); do
+     name="${ns#namespace/}"
+     kubectl get namespace "$name" \
+       -o jsonpath='{.metadata.annotations}' \
+       > "/tmp/backup-${name}-annotations.json"
+   done
+   ```
+
+## Run Order
+
+1. Dry-run the cleanup:
+
+   ```bash
+   holos-console-migrate-default-folder
+   ```
+
+   The tool prints one row per console-managed organization namespace:
+
+   | NAMESPACE | DEFAULT-FOLDER-FOUND | DEFAULT-FOLDER-STRIPPED |
+   | --------- | -------------------- | ----------------------- |
+   | holos-org-acme | true | true |
+
+   In dry-run mode, `DEFAULT-FOLDER-STRIPPED=true` means the tool would remove
+   the annotation.
+
+2. Apply the cleanup:
+
+   ```bash
+   holos-console-migrate-default-folder --apply
+   ```
+
+3. Validate manually:
+
+   ```bash
+   kubectl get ns \
+     -l app.kubernetes.io/managed-by=console.holos.run \
+     -l console.holos.run/resource-type=organization \
+     -o json \
+     | jq -r '.items[]
+       | select(.metadata.annotations["console.holos.run/default-folder"] != null)
+       | .metadata.name'
+   ```
+
+   The command must print nothing.
+
+## Completion Assertion
+
+When `--apply` is set, the tool re-lists every console-managed organization
+namespace before exiting and fails if any still carries
+`console.holos.run/default-folder`. A successful apply therefore means the
+cluster has no remaining organization namespace tombstones for this annotation.
+
+## Rollback
+
+The migration removes one annotation key and does not create replacement
+objects. To roll back, restore the backed-up annotations for affected
+organization namespaces:
+
+```bash
+for f in /tmp/backup-*-annotations.json; do
+  name="$(basename "$f" -annotations.json | sed 's/^backup-//')"
+  kubectl annotate --overwrite namespace "$name" \
+    "$(jq -r 'to_entries | map("\(.key)=\(.value)") | .[]' "$f")"
+done
+```
+
+After rollback, investigate the failed run and re-run the cleanup once the
+cluster is healthy.
+
+## Related
+
+- Parent: [HOL-1091](https://linear.app/holos-run/issue/HOL-1091) — remove
+  default_folder functionality entirely.
+- This phase: [HOL-1096](https://linear.app/holos-run/issue/HOL-1096) —
+  drop the annotation constant, admission policy references, and migrate live
+  cluster state.


### PR DESCRIPTION
## Summary
- remove the legacy `AnnotationDefaultFolder` API constant and generated CUE schema export
- remove default-folder variables and lock checks from the namespace admission policy
- add `holos-console-migrate-default-folder` with dry-run/apply modes, fake-client tests, and an operator runbook

Fixes HOL-1096

## Test plan
- [x] make generate
- [x] go test ./cmd/holos-console-migrate-default-folder ./config/holos-console/admission ./api/v1alpha2
- [x] make test-go