### PR TITLE
fix(deployments): drop dead IsNotFound wrapper, add isFetching toggle test

### DIFF
--- a/console/deployments/dependency_edge_writer.go
+++ b/console/deployments/dependency_edge_writer.go
@@ -131,11 +131,3 @@ func cascadeDeleteWithDefault(p *bool) bool {
 	}
 	return *p
 }
-
-// IsNotFound reports whether the error from a DependencyEdgeWriter call is a
-// 404. The deployments handler maps this to connect.CodeNotFound so the
-// frontend can show a clear "edge no longer exists" message instead of an
-// internal-server error.
-func IsNotFound(err error) bool {
-	return k8serrors.IsNotFound(err)
-}

--- a/console/deployments/dependency_edge_writer_test.go
+++ b/console/deployments/dependency_edge_writer_test.go
@@ -415,10 +415,10 @@ func TestDependencyEdgeCRDWriter_RoundTrip(t *testing.T) {
 		t.Error("expected error for unsupported kind")
 	}
 
-	// NotFound surfaces through IsNotFound.
+	// Missing object surfaces as a k8s NotFound error.
 	_, err = w.GetCascadeDelete(ctx, KindTemplateDependency, "prj-alpha", "missing")
-	if !IsNotFound(err) {
-		t.Errorf("missing object: IsNotFound(err)=false, err=%v", err)
+	if !k8serrors.IsNotFound(err) {
+		t.Errorf("missing object: k8serrors.IsNotFound(err)=false, err=%v", err)
 	}
 }
 
@@ -473,17 +473,4 @@ func TestDependencyEdgeCRDWriter_SetRetriesOnConflict(t *testing.T) {
 			t.Fatalf("err = %v, want IsConflict=true", err)
 		}
 	})
-}
-
-func TestIsNotFound(t *testing.T) {
-	if IsNotFound(nil) {
-		t.Error("nil should not be NotFound")
-	}
-	if IsNotFound(errors.New("boom")) {
-		t.Error("generic error should not be NotFound")
-	}
-	notFoundErr := k8serrors.NewNotFound(schema.GroupResource{Group: "x", Resource: "y"}, "z")
-	if !IsNotFound(notFoundErr) {
-		t.Error("k8s NotFound should be reported as NotFound")
-	}
 }

--- a/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
+++ b/frontend/src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx
@@ -202,7 +202,7 @@ function setupMocks(userRole = Role.OWNER) {
   ;(useListNamespaceConfigMaps as Mock).mockReturnValue({ data: [], isLoading: false })
   ;(useGetDeploymentPolicyState as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
   ;(useGetDeploymentRenderPreview as Mock).mockReturnValue({ data: undefined, isPending: false, error: null })
-  ;(useGetDependencyEdgeCascadeDelete as Mock).mockReturnValue({ data: true, isPending: false, error: null })
+  ;(useGetDependencyEdgeCascadeDelete as Mock).mockReturnValue({ data: true, isPending: false, isFetching: false, error: null })
   ;(useSetDependencyEdgeCascadeDelete as Mock).mockReturnValue({ mutate: vi.fn(), isPending: false, error: null })
 }
 
@@ -1541,6 +1541,24 @@ describe('DeploymentDetailPage', () => {
       render(<DeploymentDetailPage />)
       await user.click(screen.getByTestId('cascade-delete-TemplateDependency-prj-test-edge-1'))
       expect(mutate).not.toHaveBeenCalled()
+    })
+
+    it('disables the switch while a background refetch is in flight', () => {
+      setupMocks()
+      ;(useGetDeployment as Mock).mockReturnValue({
+        data: { ...mockDeployment, dependencies: [edgeOne] },
+        isPending: false,
+        error: null,
+      })
+      ;(useGetDependencyEdgeCascadeDelete as Mock).mockReturnValue({
+        data: true,
+        isPending: false,
+        isFetching: true,
+        error: null,
+      })
+      render(<DeploymentDetailPage />)
+      const sw = screen.getByTestId('cascade-delete-TemplateDependency-prj-test-edge-1') as HTMLButtonElement
+      expect(sw.disabled).toBe(true)
     })
 
     it('surfaces the mutation error', () => {


### PR DESCRIPTION
## Summary
- Delete the unused exported `IsNotFound` wrapper in `console/deployments/dependency_edge_writer.go`. The deployments handler routes every writer error through `mapK8sError`, which already covers `IsNotFound`, `IsForbidden`, and `IsAlreadyExists`; the wrapper was a dead-code attractor that invited future callers to bypass `mapK8sError`.
- Inline `k8serrors.IsNotFound` directly in `TestDependencyEdgeCRDWriter_RoundTrip` and remove `TestIsNotFound` (it tested the wrapper itself).
- Fill the frontend test coverage gap for the cascade-delete toggle: include `isFetching: false` in the default `useGetDependencyEdgeCascadeDelete` mock and add a new test that sets `isFetching: true` and asserts the switch is disabled. This pins the production wire `disabled={!canWrite || isPending || isFetching || mutation.isPending}` so a future refactor cannot silently drop `isFetching`.

Fixes HOL-1026

## Test plan
- [x] `go test ./console/deployments/...` passes.
- [x] `pnpm vitest run 'src/routes/_authenticated/projects/$projectName/deployments/-$deploymentName.test.tsx'` passes (102/102), including the new "disables the switch while a background refetch is in flight" case.