### PR TITLE
feat(controller): add Deployment reconciler skeleton

### DIFF
--- a/config/holos-console/rbac/rbac_test.go
+++ b/config/holos-console/rbac/rbac_test.go
@@ -92,6 +92,21 @@ func TestRoleGrantsImpersonationAndRBACReconciliation(t *testing.T) {
 	}
 }
 
+func TestRoleGrantsDeploymentControllerAccess(t *testing.T) {
+	var role rbacv1.ClusterRole
+	mustReadYAML(t, "role.yaml", &role)
+
+	if !hasResourceVerbs(role.Rules, "deployments.holos.run", "deployments", []string{"get", "list", "watch", "update"}) {
+		t.Fatalf("ClusterRole missing Deployment controller access to deployments.holos.run/deployments")
+	}
+	if !hasResourceVerbs(role.Rules, "deployments.holos.run", "deployments/status", []string{"get", "patch", "update"}) {
+		t.Fatalf("ClusterRole missing Deployment status update access")
+	}
+	if !hasResourceVerbs(role.Rules, "templates.holos.run", "templates", []string{"get", "list", "watch"}) {
+		t.Fatalf("ClusterRole missing read access to templates.holos.run/templates")
+	}
+}
+
 func TestClusterRoleBindingTargetsConsoleServiceAccount(t *testing.T) {
 	var serviceAccount corev1.ServiceAccount
 	mustReadYAML(t, "namespace/service_account.yaml", &serviceAccount)
@@ -171,6 +186,21 @@ func hasResource(rules []rbacv1.PolicyRule, apiGroup, resource string) bool {
 			if got == resource {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func hasResourceVerbs(rules []rbacv1.PolicyRule, apiGroup, resource string, verbs []string) bool {
+	for _, rule := range rules {
+		if !reflect.DeepEqual(rule.APIGroups, []string{apiGroup}) {
+			continue
+		}
+		if !containsAll(rule.Resources, []string{resource}) {
+			continue
+		}
+		if containsAll(rule.Verbs, verbs) {
+			return true
 		}
 	}
 	return false

--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller -- DeploymentReconciler.
+//
+// The Deployment reconciler is intentionally small in this phase. It watches
+// deployments.holos.run/v1alpha1.Deployment objects, acknowledges that the
+// spec was accepted, records the observed generation, and emits a Reconciled
+// event. Later phases plug the render/apply pipeline into the Pipeline field.
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+	"github.com/holos-run/holos-console/internal/deploymentrender"
+)
+
+const (
+	deploymentReasonAccepted   = "Accepted"
+	deploymentReasonReconciled = "Reconciled"
+)
+
+// DeploymentReconciler reconciles Deployment objects using the console
+// controller manager's cluster credentials.
+//
+// RBAC markers for this reconciler live on the package doc comment in
+// rbac.go -- controller-gen's rbac generator ignores markers on struct or
+// method doc comments.
+type DeploymentReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Pipeline *deploymentrender.Pipeline
+}
+
+// SetupWithManager registers the reconciler with the supplied manager.
+func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&deploymentsv1alpha1.Deployment{}).
+		Named("deployment-controller").
+		Complete(r)
+}
+
+// Reconcile acknowledges Deployment objects. Rendering and applying manifests
+// is deliberately deferred to the next phase; Pipeline may be nil here.
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var dep deploymentsv1alpha1.Deployment
+	if err := r.Get(ctx, req.NamespacedName, &dep); err != nil {
+		if err := client.IgnoreNotFound(err); err != nil {
+			return ctrl.Result{}, fmt.Errorf("get Deployment: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	gen := dep.Generation
+	target := dep.DeepCopy()
+	target.Status.ObservedGeneration = gen
+	conds := append([]metav1.Condition(nil), dep.Status.Conditions...)
+	meta.SetStatusCondition(&conds, metav1.Condition{
+		Type:               deploymentsv1alpha1.ConditionTypeAccepted,
+		Status:             metav1.ConditionTrue,
+		Reason:             deploymentReasonAccepted,
+		Message:            "deployment spec accepted; render/apply is not enabled yet",
+		ObservedGeneration: gen,
+	})
+	target.Status.Conditions = conds
+
+	if dep.Status.ObservedGeneration != gen ||
+		!conditionsEqualIgnoringTransitionTime(dep.Status.Conditions, target.Status.Conditions) {
+		if err := r.Status().Update(ctx, target); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("update Deployment status: %w", err)
+		}
+	} else {
+		logger.V(1).Info("Deployment status unchanged; skipping update", "generation", gen)
+	}
+
+	r.Recorder.Eventf(target, "Normal", deploymentReasonReconciled, "Deployment reconciled")
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -54,6 +54,10 @@ type DeploymentReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	// Pipeline is intentionally optional in this skeleton phase. Later phases
+	// wire render/apply here; nil means this reconciler only acknowledges spec
+	// acceptance and observedGeneration.
 	Pipeline *deploymentrender.Pipeline
 }
 
@@ -91,8 +95,9 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	})
 	target.Status.Conditions = conds
 
-	if dep.Status.ObservedGeneration != gen ||
-		!conditionsEqualIgnoringTransitionTime(dep.Status.Conditions, target.Status.Conditions) {
+	statusChanged := dep.Status.ObservedGeneration != gen ||
+		!conditionsEqualIgnoringTransitionTime(dep.Status.Conditions, target.Status.Conditions)
+	if statusChanged {
 		if err := r.Status().Update(ctx, target); err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
@@ -103,6 +108,8 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		logger.V(1).Info("Deployment status unchanged; skipping update", "generation", gen)
 	}
 
-	r.Recorder.Eventf(target, "Normal", deploymentReasonReconciled, "Deployment reconciled")
+	if statusChanged {
+		r.Recorder.Eventf(target, "Normal", deploymentReasonReconciled, "Deployment reconciled")
+	}
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/deployment_controller_test.go
+++ b/internal/controller/deployment_controller_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Holos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deploymentsv1alpha1 "github.com/holos-run/holos-console/api/deployments/v1alpha1"
+)
+
+func waitForDeploymentCondition(
+	t *testing.T,
+	c client.Client,
+	key types.NamespacedName,
+	condType string,
+	want metav1.ConditionStatus,
+) *deploymentsv1alpha1.Deployment {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	var last *metav1.Condition
+	for time.Now().Before(deadline) {
+		var obj deploymentsv1alpha1.Deployment
+		if err := c.Get(context.Background(), key, &obj); err != nil {
+			if !errors.IsNotFound(err) {
+				t.Fatalf("get Deployment %s: %v", key, err)
+			}
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if cond := meta.FindStatusCondition(obj.Status.Conditions, condType); cond != nil {
+			last = cond
+			if cond.Status == want {
+				return &obj
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if last == nil {
+		t.Fatalf("condition %q never appeared on Deployment %s", condType, key)
+	}
+	t.Fatalf("condition %q on Deployment %s did not reach %s; last=%+v", condType, key, want, last)
+	return nil
+}
+
+func TestDeploymentReconciler_AcceptsDeployment(t *testing.T) {
+	e := startEnv(t)
+	_, cancel, errCh := startManager(t, e.cfg)
+	t.Cleanup(func() { stopManager(t, cancel, errCh) })
+
+	ns := "holos-prj-deployment-reconcile"
+	mustCreateNamespace(t, e.client, ns, "project")
+
+	dep := &deploymentsv1alpha1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      "web",
+		},
+		Spec: deploymentsv1alpha1.DeploymentSpec{
+			ProjectName: "deployment-reconcile",
+			TemplateRef: deploymentsv1alpha1.DeploymentTemplateRef{
+				Namespace: ns,
+				Name:      "httpbin",
+			},
+		},
+	}
+	if err := e.client.Create(context.Background(), dep); err != nil {
+		t.Fatalf("create Deployment: %v", err)
+	}
+
+	got := waitForDeploymentCondition(
+		t,
+		e.client,
+		client.ObjectKeyFromObject(dep),
+		deploymentsv1alpha1.ConditionTypeAccepted,
+		metav1.ConditionTrue,
+	)
+	if got.Status.ObservedGeneration != got.Generation {
+		t.Fatalf("observedGeneration=%d want %d", got.Status.ObservedGeneration, got.Generation)
+	}
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -303,6 +303,14 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme, opts Options) (*Manage
 		return nil, fmt.Errorf("controller.NewManager: registering TemplateRequirementReconciler: %w", err)
 	}
 
+	if err := (&DeploymentReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("deployment-controller"), //nolint:staticcheck // Controller-runtime still accepts this recorder in the pinned version.
+	}).SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("controller.NewManager: registering DeploymentReconciler: %w", err)
+	}
+
 	if err := resourcerbac.SetupTemplateReconciler(mgr, rbacClientset); err != nil {
 		return nil, fmt.Errorf("controller.NewManager: registering Template RBAC reconciler: %w", err)
 	}


### PR DESCRIPTION
## Summary
- add a DeploymentReconciler skeleton that accepts Deployment CRs, records observedGeneration, and emits Reconciled events
- register the reconciler in the embedded controller manager
- add envtest coverage and RBAC regression coverage for Deployment controller access

Fixes HOL-1100

## Test plan
- [x] go test ./internal/controller ./config/holos-console/rbac
- [x] make test-go